### PR TITLE
Making BOSH docs more apparent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Cloud Foundry OSS Resources #
+# BOSH 
+
+BOSH is an open source tool chain for release engineering, deployment and lifecycle management of large scale distributed services. BOSH was originally developed in the context of the Cloud Foundry but the framework is general purpose and can be used to deploy other distributed services on top of Infrastructure-as-a-Service (IaaS) products such as VMware vSphere, Amazon Web Services, or OpenStack.
+
+Comprehensive documentation for BOSH can be found [here](https://github.com/cloudfoundry/oss-docs/blob/master/bosh/documentation/documentation.md).
+
+## Cloud Foundry OSS Resources
 
 _Cloud Foundry Open Source Platform as a Service_
 


### PR DESCRIPTION
I poured over this repo for a while but couldn't find any actual docs on BOSH itself. Mr. Watters was kind enough to point me at them [1] but I suspect you'll want to make it easier to find them. This README tweak makes their location more apparent. 

[1] https://twitter.com/#!/wattersjames/status/190156684130398208
