### PR TITLE
Use public github URL for BOSH repo so deploying BOSH does not require w...

### DIFF
--- a/release/config/repos.yml
+++ b/release/config/repos.yml
@@ -1,6 +1,6 @@
 ---
 bosh:
-  uri: git@github.com:cloudfoundry/bosh.git
+  uri: https://github.com/cloudfoundry/bosh.git
   roles:
   - blobstore
   - director


### PR DESCRIPTION
...rite access to the repo
