### PR TITLE
-n/--non-interactive no longer disables color automatically

### DIFF
--- a/cli/lib/cli/runner.rb
+++ b/cli/lib/cli/runner.rb
@@ -121,7 +121,6 @@ module Bosh::Cli
       end
       opts.on("-n", "--non-interactive", "Don't ask for user input") do
         @options[:non_interactive] = true
-        Config.colorize = false
       end
       opts.on("-N", "--no-track", "Return Task ID and don't track") do
         @options[:no_track] = true


### PR DESCRIPTION
If a user wants non-interactive, no-color, they can use `bosh -n --no-color`
