### PR TITLE
Fix spec for job manifest path in error messages.

### DIFF
--- a/bosh_agent/spec/unit/apply_plan/job_spec.rb
+++ b/bosh_agent/spec/unit/apply_plan/job_spec.rb
@@ -173,7 +173,7 @@ describe Bosh::Agent::ApplyPlan::Job do
           job.install
         }.to raise_error(Bosh::Agent::ApplyPlan::Job::InstallationError,
                          "Failed to install job 'ccdb.postgres': " +
-                         "cannot find job manifest")
+                         "cannot find job manifest #{manifest_path}")
       end
 
       it "fails if job manifest is malformed" do
@@ -187,7 +187,7 @@ describe Bosh::Agent::ApplyPlan::Job do
           job.install
         }.to raise_error(Bosh::Agent::ApplyPlan::Job::InstallationError,
                          "Failed to install job 'ccdb.postgres': " +
-                         "malformed job manifest")
+                         "malformed job manifest #{manifest_path}")
       end
 
       it "fails if job manifest is not a Hash" do


### PR DESCRIPTION
For the previous pull request I forgot to fix the specs so they were failing locally.

They passed on Travis but I'm not sure why.
