### PR TITLE
Split module statement.

### DIFF
--- a/health_monitor/lib/health_monitor/version.rb
+++ b/health_monitor/lib/health_monitor/version.rb
@@ -1,3 +1,5 @@
-module Bosh::HealthMonitor
-  VERSION = '1.5.0.pre'
+module Bosh
+  module HealthMonitor
+    VERSION = '1.5.0.pre'
+  end
 end


### PR DESCRIPTION
Version is required before Bosh module has been defined.
