### PR TITLE
fixes to bosh_deployer

### DIFF
--- a/bosh_deployer/lib/deployer/config.rb
+++ b/bosh_deployer/lib/deployer/config.rb
@@ -99,7 +99,8 @@ module Bosh::Deployer
         if @net_conf["vip"]
           @networks["vip"] = {
               "ip" => @net_conf["vip"],
-              "type" => "vip"
+              "type" => "vip",
+              "cloud_properties" => {}
           }
         end
 


### PR DESCRIPTION
- only delete stemcell if stemcell creation failed, not vm creation
- networks should always have cloud_properties
