### PR TITLE
Relax multi_json dependency version in blobstore_client

### DIFF
--- a/blobstore_client/blobstore_client.gemspec
+++ b/blobstore_client/blobstore_client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "aws-sdk", "~>1.8.0"
   s.add_dependency "fog", "~> 1.9.0"
   s.add_dependency "httpclient", "=2.2.4"
-  s.add_dependency "multi_json", "~> 1.1.0"
+  s.add_dependency "multi_json", "~> 1.1"
   s.add_dependency "ruby-atmos-pure", "~> 1.0.5"
   s.add_dependency "uuidtools", "~> 2.1.2"
   s.add_dependency "bosh_common", "~>#{version}"


### PR DESCRIPTION
For micro cloud foundry we need cfoundry and blobstore client gems and they conflict on multi_json dependency.
