### PR TITLE
blobstore_client.gemspec had a hardcoded reference to deleted README file

### DIFF
--- a/blobstore_client/blobstore_client.gemspec
+++ b/blobstore_client/blobstore_client.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
 
 
-  s.files        = `git ls-files -- bin/* lib/*`.split("\n") + %w(README)
+  s.files        = `git ls-files -- bin/* lib/* config/*`.split("\n") + %w(README.md)
   s.require_path = "lib"
   s.bindir       = "bin"
   s.executables  = %w(blobstore_client_console)


### PR DESCRIPTION
https://github.com/cloudfoundry/bosh/blob/master/blobstore_client/blobstore_client.gemspec#L17

Needs to change to README.md
