### PR TITLE
Change Gemfile source to https://rubygems.org to stop warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2009-2012 VMware, Inc.
 
-source :rubygems
+source 'https://rubygems.org' 
 
 gem "agent_client", path: "agent_client"
 gem "blobstore_client", path: "blobstore_client"


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or
'http://rubygems.org' if not.
