### PR TITLE
Add libicu-dev to Ubuntu image to resolve node-stringprep compilation

### DIFF
--- a/bosh_agent/misc/stemcell/build2/stages/base_apt/apply.sh
+++ b/bosh_agent/misc/stemcell/build2/stages/base_apt/apply.sh
@@ -13,7 +13,7 @@ curl wget libcurl3 libcurl3-dev bison libreadline6-dev \
 libxml2 libxml2-dev libxslt1.1 libxslt1-dev zip unzip \
 nfs-common flex psmisc apparmor-utils iptables sysstat \
 rsync openssh-server traceroute libncurses5-dev quota \
-libaio1 gdb tripwire libcap2-bin libyaml-dev"
+libaio1 gdb tripwire libcap2-bin libyaml-dev libicu-dev"
 
 # Disable interactive dpkg
 debconf="debconf debconf/frontend select noninteractive"


### PR DESCRIPTION
Closes https://www.pivotaltracker.com/s/projects/166935/stories/42668301
