### PR TITLE
first 5 and last 1 IP addresses in a VPC subnet are reserved

### DIFF
--- a/bosh_aws_bootstrap/spec/assets/config.yml
+++ b/bosh_aws_bootstrap/spec/assets/config.yml
@@ -28,7 +28,7 @@ vpc:
   dhcp_options:
     domain_name: dev102.cf.com
     domain_name_servers:
-      - 10.10.0.5
+      - 10.10.0.6
       - 172.16.0.23
   security_groups:
     - name: open

--- a/bosh_aws_bootstrap/spec/assets/config_with_override.yml
+++ b/bosh_aws_bootstrap/spec/assets/config_with_override.yml
@@ -21,7 +21,7 @@ vpc:
   dhcp_options:
     domain_name: dev102.cf.com
     domain_name_servers:
-      - 10.10.0.5
+      - 10.10.0.6
       - 172.16.0.23
   security_groups:
     - name: open

--- a/bosh_aws_bootstrap/spec/assets/create_all.yml
+++ b/bosh_aws_bootstrap/spec/assets/create_all.yml
@@ -15,7 +15,7 @@ vpc:
   dhcp_options:
     domain_name: CHANGEME.cf-app.com
     domain_name_servers:
-      - 10.10.0.5
+      - 10.10.0.6
       - 172.16.0.23
   security_groups:
     - name: open

--- a/bosh_aws_bootstrap/spec/assets/test-output.yml
+++ b/bosh_aws_bootstrap/spec/assets/test-output.yml
@@ -50,7 +50,7 @@ original_configuration:
     dhcp_options:
       domain_name: dev102.cf.com
       domain_name_servers:
-        - 10.10.0.5
+        - 10.10.0.6
         - 172.16.0.23
     security_groups:
       - name: open

--- a/bosh_aws_bootstrap/spec/unit/bosh_manifest_spec.rb
+++ b/bosh_aws_bootstrap/spec/unit/bosh_manifest_spec.rb
@@ -31,7 +31,7 @@ networks:
   - range: 10.10.0.0/24
     gateway: 10.10.0.1
     dns:
-    - 10.10.0.5
+    - 10.10.0.6
     cloud_properties:
       subnet: subnet-4bdf6c26
 - name: vip_network

--- a/bosh_aws_bootstrap/templates/aws_configuration_template.yml.erb
+++ b/bosh_aws_bootstrap/templates/aws_configuration_template.yml.erb
@@ -34,7 +34,7 @@ vpc:
       availability_zone: <%= ENV["BOSH_VPC_SECONDARY_AZ"] || raise("Missing ENV variable BOSH_VPC_SECONDARY_AZ") %>
   dhcp_options:
     domain_name_servers:
-      - 10.10.0.5  # IP of the BOSH DNS server?
+      - 10.10.0.6  # IP of the BOSH DNS server?
       - 10.10.0.2  # local amazon public DNS server
   security_groups:
     - name: open

--- a/bosh_aws_bootstrap/templates/bosh.yml.erb
+++ b/bosh_aws_bootstrap/templates/bosh.yml.erb
@@ -9,7 +9,7 @@ networks:
   - range: 10.10.0.0/24
     gateway: 10.10.0.1
     dns:
-    - 10.10.0.5
+    - 10.10.0.6
     cloud_properties:
       subnet: <%= subnet %>
 - name: vip_network

--- a/bosh_aws_bootstrap/templates/micro_bosh.yml.erb
+++ b/bosh_aws_bootstrap/templates/micro_bosh.yml.erb
@@ -7,7 +7,7 @@ logging:
 network:
   type: manual
   vip:  <%= vip %>
-  ip: 10.10.0.5
+  ip: 10.10.0.6
   cloud_properties:
     subnet: <%= subnet %>
 
@@ -31,12 +31,12 @@ cloud:
 apply_spec:
   agent:
     blobstore:
-      address: 10.10.0.5
+      address: 10.10.0.6
     nats:
-      address: 10.10.0.5
+      address: 10.10.0.6
   properties:
     registry:
-      address: 10.10.0.5
+      address: 10.10.0.6
     aws:
       access_key_id: <%= access_key_id %>
       secret_access_key: <%= secret_access_key %>

--- a/spec/assets/aws/deployments/micro/micro_bosh.yml
+++ b/spec/assets/aws/deployments/micro/micro_bosh.yml
@@ -6,7 +6,7 @@ logging:
 
 network:
   type: manual
-  ip: 10.10.0.5
+  ip: 10.10.0.6
   vip:  <%= ENV["MICROBOSH_IP"] %>
   cloud_properties:
     subnet: <%= ENV["BOSH_SUBNET_ID"] %>

--- a/spec/external/aws_bootstrap_spec.rb
+++ b/spec/external/aws_bootstrap_spec.rb
@@ -96,7 +96,7 @@ describe 'bosh_aws_bootstrap_external' do
     end
 
     it "assigns DHCP options" do
-      vpc.dhcp_options.configuration[:domain_name_servers].should =~ ['10.10.0.5', '10.10.0.2']
+      vpc.dhcp_options.configuration[:domain_name_servers].should =~ ['10.10.0.6', '10.10.0.2']
     end
 
     it "assigns security groups" do


### PR DESCRIPTION
- moved micro bosh IP to .6 instead of .5
