### PR TITLE
Use run_in_chroot to suppress the shell not found error

### DIFF
--- a/stemcell_builder/stages/image_install_grub/apply.sh
+++ b/stemcell_builder/stages/image_install_grub/apply.sh
@@ -31,20 +31,20 @@ cat > $mnt/tmp/grub/device.map <<EOS
 (hd0) $disk_image_name
 EOS
 
-chroot $mnt <<EO1
+run_in_chroot $mnt "
 cd /tmp/grub
-grub --device-map=device.map --batch <<EO2
+grub --device-map=device.map --batch <<EOF
 root (hd0,0)
 setup (hd0)
-EO2
-EO1
+EOF
+"
 
 # Figure out uuid of partition
 uuid=$(blkid -c /dev/null -sUUID -ovalue /dev/mapper/$dev)
 
 # Recreate vanilla menu.lst
 rm -f $mnt/boot/grub/menu.lst*
-chroot $mnt update-grub -y
+run_in_chroot $mnt "update-grub -y"
 
 # Modify root disk parameters to use the root partition's UUID
 sed -i -e "s/^# kopt=root=\([^ ]*\)/# kopt=root=UUID=$uuid/" $mnt/boot/grub/menu.lst
@@ -54,7 +54,7 @@ sed -i -e "s/^# kopt=root=\([^ ]*\)/# kopt=root=UUID=$uuid/" $mnt/boot/grub/menu
 # understand "root (hd0,0)", which is the default.
 
 # Regenerate menu.lst
-chroot $mnt update-grub
+run_in_chroot $mnt "update-grub"
 rm -f $mnt/boot/grub/menu.lst~
 
 # Clean up bootloader stuff


### PR DESCRIPTION
This commit fixes the following error that caused by additionally installed shells such as ZSH on the host environment.
- `chroot: failed to run command`/bin/zsh': No such file or directory`

I confirmed I could create a stemcell on my zsh-installed host by adding this fix.
