### PR TITLE
Call `flush()` after downloading a remote file to write out the buffered...

### DIFF
--- a/blobstore_client/lib/blobstore_client/base.rb
+++ b/blobstore_client/lib/blobstore_client/base.rb
@@ -48,6 +48,7 @@ module Bosh
       def get(id, file = nil)
         if file
           get_file(id, file)
+          file.flush
         else
           result = nil
           temp_path do |path|


### PR DESCRIPTION
... data to the filesystem

I found when I copied a downloaded file to another path after `get(id, file)`, the copied file was sometimes broken. This caused by buffered data.

I added a `flush()` after `get_file()` to ensure writing out all the data to the underlaying file system.
