### PR TITLE
Enable provisioned iops EBS volume support for service nodes

### DIFF
--- a/bosh_aws_cpi/README.md
+++ b/bosh_aws_cpi/README.md
@@ -52,6 +52,10 @@ These options are specified under `cloud_options` in the `resource_pools` sectio
   the EC2 availability zone the VMs should be created in
 * `instance_type` (required)  
   which [type of instance](http://aws.amazon.com/ec2/instance-types/) the VMs should belong to
+* 'disk_properties' (optional)
+  the EBS properties that the disk was created.
+  'provisioned_iops'
+    the [provisioned iops] EBS (http://aws.amazon.com/ebs/) the VMs should be using
 
 ### Network options
 

--- a/bosh_cpi/lib/cloud.rb
+++ b/bosh_cpi/lib/cloud.rb
@@ -147,8 +147,9 @@ module Bosh
     # @param [Integer] size disk size in MB
     # @param [optional, String] vm_locality vm id if known of the VM that this disk will
     #                           be attached to
+    # @param [optional, Hash] disk_properties Disk properties for provisioned disk
     # @return [String] opaque id later used by {#attach_disk}, {#detach_disk}, and {#delete_disk}
-    def create_disk(size, vm_locality = nil)
+    def create_disk(size, vm_locality = nil, disk_properties = nil)
       not_implemented(:create_disk)
     end
 

--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -368,7 +368,7 @@ module Bosh::OpenStackCloud
     # @param [optional, String] server_id OpenStack server UUID of the VM that
     #   this disk will be attached to
     # @return [String] OpenStack volume UUID
-    def create_disk(size, server_id = nil)
+    def create_disk(size, server_id = nil, _ = nil)
       with_thread_name("create_disk(#{size}, #{server_id})") do
         raise ArgumentError, "Disk size needs to be an integer" unless size.kind_of?(Integer)
         cloud_error("Minimum disk size is 1 GiB") if (size < 1024)

--- a/bosh_vcloud_cpi/lib/cloud/vcloud/cloud.rb
+++ b/bosh_vcloud_cpi/lib/cloud/vcloud/cloud.rb
@@ -323,7 +323,7 @@ module VCloudCloud
       raise e
     end
 
-    def create_disk(size_mb, vm_locality = nil)
+    def create_disk(size_mb, vm_locality = nil, _ = nil)
       @client = client
 
       with_thread_name("create_disk(#{size_mb}, vm_locality)") do

--- a/bosh_vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/bosh_vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -617,7 +617,7 @@ module VSphereCloud
       end
     end
 
-    def create_disk(size, _ = nil)
+    def create_disk(size, _ = nil, _ = nil)
       with_thread_name("create_disk(#{size}, _)") do
         @logger.info("Creating disk with size: #{size}")
         disk = Models::Disk.new

--- a/director/lib/cloud/dummy.rb
+++ b/director/lib/cloud/dummy.rb
@@ -91,7 +91,7 @@ module Bosh
         raise NotImplemented, "detach_disk"
       end
 
-      def create_disk(size, vm_locality = nil)
+      def create_disk(size, vm_locality = nil, disk_properties = nil)
         raise NotImplemented, "create_disk"
       end
 

--- a/director/lib/director/instance_updater.rb
+++ b/director/lib/director/instance_updater.rb
@@ -354,7 +354,8 @@ module Bosh::Director
 
       if @job.persistent_disk > 0
         @instance.model.db.transaction do
-          disk_cid = @cloud.create_disk(@job.persistent_disk, @vm.cid)
+          disk_properties = @resource_pool_spec.cloud_properties.nil? ? nil:@resource_pool_spec.cloud_properties["disk_properties"]
+          disk_cid = @cloud.create_disk(@job.persistent_disk, @vm.cid, disk_properties)
           disk =
             Models::PersistentDisk.create(:disk_cid => disk_cid,
                                           :active => false,


### PR DESCRIPTION
- pass disk_properties to CPI
- support provisioned iops EBS for aws CPI

this is a new attempt according to comments in this pull request

https://github.com/cloudfoundry/bosh/pull/102 
