### PR TITLE
Add ability to change elb endpoint for director

### DIFF
--- a/bosh_aws_cpi/lib/cloud/aws/cloud.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/cloud.rb
@@ -8,7 +8,7 @@ module Bosh::AwsCloud
     # default maximum number of times to retry an AWS API call
     DEFAULT_MAX_RETRIES = 2
     DEFAULT_EC2_ENDPOINT = "ec2.amazonaws.com"
-    DEFAULT_ELB_ENDPOINT = ""
+    DEFAULT_ELB_ENDPOINT = "elasticloadbalancing.amazonaws.com"
     METADATA_TIMEOUT = 5 # in seconds
     DEVICE_POLL_TIMEOUT = 60 # in seconds
 


### PR DESCRIPTION
If you are a deploying to a region other than us-east-1 this is needed to allow looking up elb instances.
