### PR TITLE
[director] Check for available space before uploading archives

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ PATH
       resque (~> 1.23.0)
       sequel (~> 3.43.0)
       sinatra (~> 1.4.2)
+      sys-filesystem (~> 1.1.0)
       thin (~> 1.5.0)
       yajl-ruby (~> 1.1.0)
 

--- a/director/director.gemspec
+++ b/director/director.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency  "resque", "~>1.23.0"
   s.add_dependency  "sequel", "~>3.43.0"
   s.add_dependency  "sinatra", "~>1.4.2"
+  s.add_dependency  'sys-filesystem', "~> 1.1.0"
   s.add_dependency  "thin", "~>1.5.0"
   s.add_dependency  "yajl-ruby", "~>1.1.0"
 

--- a/director/lib/director/api/api_helper.rb
+++ b/director/lib/director/api/api_helper.rb
@@ -1,4 +1,6 @@
 # Copyright (c) 2009-2012 VMware, Inc.
+require 'sys/filesystem'
+include Sys
 
 module Bosh::Director
   module Api
@@ -54,6 +56,16 @@ module Bosh::Director
           raise "Block didn't return Task object"
         end
         redirect "/tasks/#{task.id}"
+      end
+
+      def check_available_disk_space(dir, size)
+        begin
+          stat = Sys::Filesystem.stat(dir)
+          available_space = stat.block_size * stat.blocks_available
+          available_space > size ? true : false
+        rescue
+          false
+        end
       end
 
       def write_file(path, stream, chunk_size = READ_CHUNK_SIZE)

--- a/director/lib/director/api/deployment_manager.rb
+++ b/director/lib/director/api/deployment_manager.rb
@@ -20,7 +20,12 @@ module Bosh::Director
 
       def create_deployment(user, deployment_manifest, options = {})
         random_name = "deployment-#{SecureRandom.uuid}"
-        deployment_manifest_file = File.join(Dir::tmpdir, random_name)
+        deployment_manifest_dir = Dir::tmpdir
+        deployment_manifest_file = File.join(deployment_manifest_dir, random_name)
+        unless check_available_disk_space(deployment_manifest_dir, deployment_manifest.size)
+          raise NotEnoughDiskSpace, "Uploading deployment manifest failed. " +
+            "Insufficient space on BOSH director in #{deployment_manifest_dir}"
+        end
 
         write_file(deployment_manifest_file, deployment_manifest)
         task = create_task(user, :update_deployment, "create deployment")

--- a/director/lib/director/api/release_manager.rb
+++ b/director/lib/director/api/release_manager.rb
@@ -38,6 +38,10 @@ module Bosh::Director
       def create_release(user, release_bundle, options = {})
         release_dir = Dir.mktmpdir("release")
         release_tgz = File.join(release_dir, RELEASE_TGZ)
+        unless check_available_disk_space(release_dir, release_bundle.size)
+          raise NotEnoughDiskSpace, "Uploading release archive failed. " +
+            "Insufficient space on BOSH director in #{release_dir}"
+        end
 
         write_file(release_tgz, release_bundle)
         task = create_task(user, :update_release, "create release")

--- a/director/lib/director/errors.rb
+++ b/director/lib/director/errors.rb
@@ -193,4 +193,5 @@ module Bosh::Director
   RpcTimeout = err(450002)
 
   SystemError = err(500000, INTERNAL_SERVER_ERROR)
+  NotEnoughDiskSpace = err(500001, INTERNAL_SERVER_ERROR)
 end

--- a/director/lib/director/jobs/update_stemcell.rb
+++ b/director/lib/director/jobs/update_stemcell.rb
@@ -25,9 +25,10 @@ module Bosh::Director
         track_and_log("Extracting stemcell archive") do
           result = Bosh::Exec.sh("tar -C #{stemcell_dir} -xzf #{@stemcell_file} 2>&1", :on_error => :return)
           if result.failed?
-            raise StemcellInvalidArchive,
-                  "Invalid stemcell archive, tar returned #{result.exit_status}, " +
-                  "output: #{result.output}"
+            logger.error("Extracting stemcell archive failed in dir #{stemcell_dir}, " +
+                         "tar returned #{result.exit_status}, " +
+                         "output: #{result.output}")
+            raise StemcellInvalidArchive, "Extracting stemcell archive failed. Check task debug log for details."
           end
         end
 

--- a/director/spec/unit/api/api_helper_spec.rb
+++ b/director/spec/unit/api/api_helper_spec.rb
@@ -9,6 +9,30 @@ describe Bosh::Director::Api::ApiHelper do
     @tmpdir = Dir.mktmpdir("base_dir")
   end
 
+  describe :check_available_disk_space do
+    before :each do
+      @stat = double("stat")
+      Sys::Filesystem.stub(:stat).and_return(@stat)
+    end
+
+    it "should return true if there is available disk space" do
+      @stat.should_receive(:block_size).and_return(1024)
+      @stat.should_receive(:blocks_available).and_return(1024)
+      check_available_disk_space(@tmpdir, 1048).should be_true
+    end
+
+    it "should return false if there is no available disk space" do
+      @stat.should_receive(:block_size).and_return(1024)
+      @stat.should_receive(:blocks_available).and_return(1)
+      check_available_disk_space(@tmpdir, 1048).should be_false
+    end
+
+    it "should return false if there is an exception when checking dir stats"do
+      @stat.should_receive(:block_size).and_raise(Errno::EACCES)
+      check_available_disk_space(@tmpdir, 1048).should be_false
+    end
+  end
+
   describe :write_file do
     it "should write a file" do
       file_in = StringIO.new("contents")


### PR DESCRIPTION
- Check for available space before uploading deployments, releases and stemcells.
- Provide better error messages when extracting packages, jobs, releases and stemcells.
- Use common SH and add test

Fixes #46398849 and #45964327
