### PR TITLE
[spec] Delete volume after server deletion in OpenStack tests

### DIFF
--- a/spec/external/openstack_cpi_spec.rb
+++ b/spec/external/openstack_cpi_spec.rb
@@ -45,11 +45,11 @@ describe Bosh::OpenStackCloud::Cloud do
   end
 
   after(:each) do
-    cpi.delete_disk(@volume_id) if @volume_id
     if @server_id
       cpi.delete_vm(@server_id)
       cpi.has_vm?(@server_id).should be_false
     end
+    cpi.delete_disk(@volume_id) if @volume_id
   end
 
   def vm_lifecycle(stemcell_id, network_spec, disk_locality)


### PR DESCRIPTION
Prevent volume garbage when volume cannot be detached from server,
so volume cannot be deleted. If we delete the server before, then
we can delete the volume safely.
