### PR TITLE
future proof the last_successful_NAME_ami to give a duplicate regionalised url

### DIFF
--- a/rake/spec.rake
+++ b/rake/spec.rake
@@ -205,6 +205,14 @@ namespace :spec do
 
         if stemcell_properties['cloud_properties']['ami']
           ami_id = stemcell_properties['cloud_properties']['ami']['us-east-1']
+
+          obj = bucket.objects["last_successful_#{stemcell_S3_name}_ami_us-east-1"]
+
+          obj.write(ami_id)
+          obj.acl = :public_read
+          puts "AMI name written to: #{obj.public_url :secure => false}"
+
+          # NOTE: this URL is deprecated
           obj = bucket.objects["last_successful_#{stemcell_S3_name}_ami"]
 
           obj.write(ami_id)


### PR DESCRIPTION
Currently the ami endpoint doesn't specify a region; you just have to assume 
it is us-east-1. This commit adds a second, permanent url, that includes the
region information.

The former url last_successful_#{stemcell_S3_name}_ami can be deprecated.
