### PR TITLE
[aws] use latest api endpoint instead of version 1.0

### DIFF
--- a/bosh_agent/lib/bosh_agent/infrastructure/aws/registry.rb
+++ b/bosh_agent/lib/bosh_agent/infrastructure/aws/registry.rb
@@ -6,7 +6,7 @@ module Bosh::Agent
 
       API_TIMEOUT           = 86400 * 3
       CONNECT_TIMEOUT       = 30
-      INSTANCE_DATA_URI = "http://169.254.169.254/1.0"
+        INSTANCE_DATA_URI = "http://169.254.169.254/latest"
 
       def get_uri(uri)
         client = HTTPClient.new

--- a/bosh_aws_cpi/lib/cloud/aws/cloud.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/cloud.rb
@@ -435,7 +435,7 @@ module Bosh::AwsCloud
         client.connect_timeout = METADATA_TIMEOUT
         # Using 169.254.169.254 is an EC2 convention for getting
         # instance metadata
-        uri = "http://169.254.169.254/1.0/meta-data/instance-id/"
+        uri = "http://169.254.169.254/latest/meta-data/instance-id/"
 
         response = client.get(uri)
         unless response.status == 200


### PR DESCRIPTION
fixes #133
