### PR TITLE
Fix OpenStack external tests

### DIFF
--- a/spec/external/openstack_cpi_spec.rb
+++ b/spec/external/openstack_cpi_spec.rb
@@ -74,12 +74,12 @@ describe Bosh::OpenStackCloud::Cloud do
 
     cpi.attach_disk(@server_id, @volume_id)
 
+    cpi.detach_disk(@server_id, @volume_id)
+
     snapshot_id = cpi.snapshot_disk(@volume_id)
     snapshot_id.should_not be_nil
 
     cpi.delete_snapshot(snapshot_id)
-
-    cpi.detach_disk(@server_id, @volume_id)
   end
 
   describe "dynamic network" do


### PR DESCRIPTION
On OpenStack Folsom we cannot take a snapshot of a volume that
is attached to a server. On OpenStack Grizzly this has been fixed.
So we take the snapshot once the volume has been deattached from
the server.
