### PR TITLE
[agent] Don't fetch network info for manual networks. Fixes #46679321

### DIFF
--- a/bosh_agent/lib/bosh_agent/infrastructure/aws/settings.rb
+++ b/bosh_agent/lib/bosh_agent/infrastructure/aws/settings.rb
@@ -49,23 +49,10 @@ module Bosh::Agent
                   [type, SUPPORTED_NETWORK_TYPES.join(', ')]
       end
 
-      # Nothing to do for "vip" networks
-      return nil if properties["type"] == VIP_NETWORK_TYPE
+      # Nothing to do for "vip" and "manual" networks
+      return nil if [VIP_NETWORK_TYPE, MANUAL_NETWORK_TYPE].include? type
 
-      sigar = SigarBox.create_sigar
-      net_info = sigar.net_info
-      ifconfig = sigar.net_interface_config(net_info.default_gateway_interface)
-
-      properties = {}
-      properties["ip"] = ifconfig.address
-      properties["netmask"] = ifconfig.netmask
-      properties["dns"] = []
-      properties["dns"] << net_info.primary_dns if net_info.primary_dns &&
-                                                   !net_info.primary_dns.empty?
-      properties["dns"] << net_info.secondary_dns if net_info.secondary_dns &&
-                                                     !net_info.secondary_dns.empty?
-      properties["gateway"] = net_info.default_gateway
-      properties
+      Bosh::Agent::Util.get_network_info
     end
 
   end

--- a/bosh_agent/lib/bosh_agent/infrastructure/openstack/settings.rb
+++ b/bosh_agent/lib/bosh_agent/infrastructure/openstack/settings.rb
@@ -49,23 +49,10 @@ module Bosh::Agent
                   [type, SUPPORTED_NETWORK_TYPES.join(', ')]
       end
 
-      # Nothing to do for "vip" networks
-      return nil if properties["type"] == VIP_NETWORK_TYPE
+      # Nothing to do for "vip" and "manual" networks
+      return nil if [VIP_NETWORK_TYPE, MANUAL_NETWORK_TYPE].include? type
 
-      sigar = SigarBox.create_sigar
-      net_info = sigar.net_info
-      ifconfig = sigar.net_interface_config(net_info.default_gateway_interface)
-
-      properties = {}
-      properties["ip"] = ifconfig.address
-      properties["netmask"] = ifconfig.netmask
-      properties["dns"] = []
-      properties["dns"] << net_info.primary_dns if net_info.primary_dns &&
-                                                   !net_info.primary_dns.empty?
-      properties["dns"] << net_info.secondary_dns if net_info.secondary_dns &&
-                                                     !net_info.secondary_dns.empty?
-      properties["gateway"] = net_info.default_gateway
-      properties
+      Bosh::Agent::Util.get_network_info
     end
 
   end

--- a/bosh_agent/lib/bosh_agent/util.rb
+++ b/bosh_agent/lib/bosh_agent/util.rb
@@ -174,6 +174,21 @@ module Bosh::Agent
         end
       end
 
+      def get_network_info
+        sigar = SigarBox.create_sigar
+        net_info = sigar.net_info
+        ifconfig = sigar.net_interface_config(net_info.default_gateway_interface)
+
+        properties = {}
+        properties["ip"] = ifconfig.address
+        properties["netmask"] = ifconfig.netmask
+        properties["dns"] = []
+        properties["dns"] << net_info.primary_dns if net_info.primary_dns && !net_info.primary_dns.empty?
+        properties["dns"] << net_info.secondary_dns if net_info.secondary_dns && !net_info.secondary_dns.empty?
+        properties["gateway"] = net_info.default_gateway
+        properties
+      end
+
     end
   end
 end

--- a/bosh_agent/spec/unit/infrastructure/aws/settings_spec.rb
+++ b/bosh_agent/spec/unit/infrastructure/aws/settings_spec.rb
@@ -41,6 +41,13 @@ describe Bosh::Agent::Infrastructure::Aws::Settings do
     properties.should have_key("gateway")
   end
 
+  it 'should get nothing for manual network' do
+    settings_wrapper = Bosh::Agent::Infrastructure::Aws::Settings.new
+    network_properties = {}
+    properties = settings_wrapper.get_network_settings("test", network_properties)
+    properties.should be_nil
+  end
+
   it 'should get nothing for vip network' do
     settings_wrapper = Bosh::Agent::Infrastructure::Aws::Settings.new
     network_properties = {"type" => "vip"}

--- a/bosh_agent/spec/unit/infrastructure/openstack/settings_spec.rb
+++ b/bosh_agent/spec/unit/infrastructure/openstack/settings_spec.rb
@@ -25,23 +25,6 @@ describe Bosh::Agent::Infrastructure::Openstack::Settings do
     settings.should == @settings
   end
 
-  it 'should get network settings for manual network' do
-    net_info = double('net_info', default_gateway_interface: 'eth0', default_gateway: '1.2.3.1',
-                      primary_dns: '1.1.1.1', secondary_dns: '2.2.2.2')
-    net_interface_config = double('net_interface_config', address:'1.2.3.4', netmask: '255.255.255.0')
-    sigar = double(Sigar, net_info: net_info, net_interface_config: net_interface_config, :logger= => nil)
-    Sigar.stub(new: sigar)
-    settings_wrapper = Bosh::Agent::Infrastructure::Openstack::Settings.new
-    network_properties = {}
-    properties = settings_wrapper.get_network_settings("test", network_properties)
-
-    properties.should have_key("ip")
-    properties.should have_key("netmask")
-    properties.should have_key("dns")
-    properties.should have_key("gateway")
-  end
-
-
   it 'should get network settings for dhcp network' do
     net_info = double('net_info', default_gateway_interface: 'eth0', default_gateway: '1.2.3.1',
                       primary_dns: '1.1.1.1', secondary_dns: '2.2.2.2')
@@ -56,6 +39,13 @@ describe Bosh::Agent::Infrastructure::Openstack::Settings do
     properties.should have_key("netmask")
     properties.should have_key("dns")
     properties.should have_key("gateway")
+  end
+
+  it 'should get nothing for manual network' do
+    settings_wrapper = Bosh::Agent::Infrastructure::Openstack::Settings.new
+    network_properties = {}
+    properties = settings_wrapper.get_network_settings("test", network_properties)
+    properties.should be_nil
   end
 
   it 'should get nothing for vip network' do


### PR DESCRIPTION
- For manual networks we've the network info at the apply spec, so
  we don't need to fetch the current network info.
- Moved get network info to the common Util class.
