### PR TITLE
[agent] Fallback to user_data injected file for OpenStack

### DIFF
--- a/bosh_agent/lib/bosh_agent/infrastructure/openstack/registry.rb
+++ b/bosh_agent/lib/bosh_agent/infrastructure/openstack/registry.rb
@@ -1,170 +1,220 @@
-# Copyright (c) 2009-2012 VMware, Inc.
+# Copyright (c) 2009-2013 VMware, Inc.
 
 module Bosh::Agent
   class Infrastructure::Openstack::Registry
     class << self
 
-      API_TIMEOUT     = 86400 * 3
-      CONNECT_TIMEOUT = 30
-      SERVER_DATA_URI = "http://169.254.169.254/latest"
+      attr_accessor :user_data
 
-      def get_uri(uri)
-        client = HTTPClient.new
-        client.send_timeout = API_TIMEOUT
-        client.receive_timeout = API_TIMEOUT
-        client.connect_timeout = CONNECT_TIMEOUT
+      HTTP_API_TIMEOUT     = 300
+      HTTP_CONNECT_TIMEOUT = 30
+      META_DATA_URI = "http://169.254.169.254/latest"
+      USER_DATA_FILE = File.join(File::SEPARATOR, "var", BOSH_APP_USER, "bosh", "user_data.json")
 
-        response = client.get(SERVER_DATA_URI + uri)
-        unless response.status == 200
-          raise(LoadSettingsError, "Server metadata endpoint returned " \
-                      "HTTP #{response.status}")
-        end
-
-        response.body
-      rescue HTTPClient::BadResponseError => e
-        raise(LoadSettingsError,
-              "Received bad HTTP response for #{uri}: #{e.inspect}")
-      rescue HTTPClient::TimeoutError
-        raise(LoadSettingsError, "Timed out reading uri #{uri}, " \
-                    "please make sure agent is running on OpenStack server")
-      rescue URI::Error, SocketError, Errno::ECONNREFUSED, SystemCallError => e
-        raise(LoadSettingsError,
-              "Error requesting current server id from #{uri} #{e.inspect}")
+      ##
+      # Returns the logger.
+      #
+      # @return [Logger] Bosh Agent logger
+      def logger
+        Bosh::Agent::Config.logger
       end
 
       ##
-      # Reads current server name from OpenStack user-data. We are assuming
-      # server name cannot change while current process is running
-      # and thus memoizing it.
-      def current_server_id
-        return @current_server_id if @current_server_id
-        user_data = get_json_from_url(SERVER_DATA_URI + "/user-data")
-        unless user_data.has_key?("server") &&
-               user_data["server"].has_key?("name")
-          raise(LoadSettingsError,
-                "Cannot parse user data for endpoint #{user_data.inspect}")
+      # Gets the OpenSSH public key. First we try to get it from the OpenStack meta data endpoint, if we fail,
+      # then we fallback to the injected user data file.
+      #
+      # @return [String] OpenSSH key
+      def get_openssh_key
+        get_uri(META_DATA_URI + "/meta-data/public-keys/0/openssh-key")
+      rescue LoadSettingsError => e
+        logger.info("Failed to get OpenSSH public key from OpenStack meta data endpoint: #{e.message}")
+        user_data = parse_user_data(get_user_data_from_file)
+        unless user_data.has_key?("openssh") && user_data["openssh"].has_key?("public_key")
+          raise LoadSettingsError, "Cannot get OpenSSH public key from injected user data file: #{user_data.inspect}"
         end
-        @current_server_id = user_data["server"]["name"]
+        user_data["openssh"]["public_key"]
       end
 
-      def get_json_from_url(url)
-        client = HTTPClient.new
-        client.send_timeout = API_TIMEOUT
-        client.receive_timeout = API_TIMEOUT
-        client.connect_timeout = CONNECT_TIMEOUT
+      ##
+      # Gets the settings for this agent from the Bosh registry.
+      #
+      # @return [Hash] Agent Settings
+      def get_settings
+        @registry_endpoint ||= get_registry_endpoint
+        url = "#{@registry_endpoint}/instances/#{get_server_name}/settings"
+        raw_response = get_uri(url)
 
-        headers = {"Accept" => "application/json"}
-        response = client.get(url, {}, headers)
-
-        if response.status != 200
-          raise(LoadSettingsError,
-                "Cannot read settings for `#{url}' from registry, " \
-                "got HTTP #{response.status}")
+        registry_data = Yajl::Parser.parse(raw_response)
+        unless registry_data.is_a?(Hash) && registry_data.has_key?("settings")
+          raise LoadSettingsError, "Invalid response received from Bosh registry, " \
+                                   "got #{registry_data.class}: #{registry_data}"
         end
 
-        body = Yajl::Parser.parse(response.body)
-        unless body.is_a?(Hash)
-          raise(LoadSettingsError,
-                "Invalid response from #{url} , Hash expected, " \
-                "got #{body.class}: #{body}")
+        settings = Yajl::Parser.parse(registry_data["settings"])
+        unless settings.is_a?(Hash)
+          raise(LoadSettingsError, "Invalid settings received from Bosh registry, " \
+                                   "got #{settings.class}: #{settings}")
         end
 
-        body
-
-      rescue HTTPClient::BadResponseError => e
-        raise(LoadSettingsError,
-              "Received bad HTTP response from server registry: #{e.inspect}")
-      rescue HTTPClient::TimeoutError
-        raise(LoadSettingsError,
-              "Timed out reading json from #{url}, " \
-              "please make sure agent is running on OpenStack server")
-      rescue URI::Error, SocketError, Errno::ECONNREFUSED, SystemCallError => e
-        raise(LoadSettingsError,
-              "Error requesting registry information #{e.inspect}")
+        settings
       rescue Yajl::ParseError => e
-        raise(LoadSettingsError,
-              "Cannot parse settings for from registry #{e.inspect}")
-      end
-
-      def get_registry_endpoint
-        user_data = get_json_from_url(SERVER_DATA_URI + "/user-data")
-        unless user_data.has_key?("registry") &&
-               user_data["registry"].has_key?("endpoint")
-          raise("Cannot parse user data for endpoint #{user_data.inspect}")
-        end
-        Bosh::Agent::Config.logger.info("got user_data: #{user_data}")
-        lookup_registry(user_data)
+        raise LoadSettingsError, "Cannot parse settings from Bosh registry, got #{raw_response} - #{e.message}"
       end
 
       ##
-      # If the registry endpoint is specified with a bosh dns name, e.g.
-      # 0.registry.default.openstack.bosh, then the agent needs to lookup the
-      # name and insert the IP address, as the agent doesn't update
+      # Gets the server name from OpenStack user data.
+      #
+      # @return [String] OpenStack server name
+      def get_server_name
+        user_data = get_user_data
+        unless user_data.has_key?("server") && user_data["server"].has_key?("name")
+          raise LoadSettingsError, "Cannot get OpenStack server name from user data #{user_data.inspect}"
+        end
+        user_data["server"]["name"]
+      end
+
+      ##
+      # Gets the Bosh registry endpoint from OpenStack user data.
+      #
+      # @return [String] Bosh registry endpoint
+      def get_registry_endpoint
+        user_data = get_user_data
+        unless user_data.has_key?("registry") && user_data["registry"].has_key?("endpoint")
+          raise LoadSettingsError, "Cannot get Bosh registry endpoint from user data #{user_data.inspect}"
+        end
+        lookup_registry_endpoint(user_data)
+      end
+
+      ##
+      # If the Bosh registry endpoint is specified with a Bosh DNS name, i.e. 0.registry.default.openstack.bosh,
+      # then the agent needs to lookup the name and insert the IP address, as the agent doesn't update
       # resolv.conf until after the bootstrap is run.
-      def lookup_registry(user_data)
-        endpoint = user_data["registry"]["endpoint"]
+      #
+      # @param [Hash] user_data OpenStack user data (generated by the CPI)
+      # @return [String] Bosh registry endpoint
+      def lookup_registry_endpoint(user_data)
+        registry_endpoint = user_data["registry"]["endpoint"]
 
-        # if we get data from an old director which doesn't set dns
-        # info, there is noting we can do, so just return the endpoint
-        if user_data["dns"].nil? || user_data["dns"]["nameserver"].nil?
-          return endpoint
-        end
+        # If user data doesn't contain dns info, there is noting we can do, so just return the endpoint
+        return registry_endpoint if user_data["dns"].nil? || user_data["dns"]["nameserver"].nil?
 
-        hostname = extract_registry_hostname(endpoint)
-
-        # if the registry endpoint is an IP address, just return the endpoint
-        unless (IPAddr.new(hostname) rescue(nil)).nil?
-          return endpoint
-        end
+        # If the endpoint is an IP address, just return the endpoint
+        registry_hostname = extract_registry_hostname(registry_endpoint)
+        return registry_endpoint unless (IPAddr.new(registry_hostname) rescue(nil)).nil?
 
         nameservers = user_data["dns"]["nameserver"]
-        ip = bosh_lookup(hostname, nameservers)
-        inject_registry_ip(ip, endpoint)
+        registry_ip = lookup_registry_ip_address(registry_hostname, nameservers)
+        inject_registry_ip_address(registry_ip, registry_endpoint)
       rescue Resolv::ResolvError => e
-        raise(LoadSettingsError,
-              "Cannot lookup #{hostname} using #{nameservers.join(', ')}" +
-                  "\n#{e.inspect}")
+        raise LoadSettingsError, "Cannot lookup #{registry_hostname} using #{nameservers.join(", ")}: #{e.inspect}"
       end
 
+      ##
+      # Extracts the hostname from the Bosh registry endpoint.
+      #
+      # @param [String] endpoint Bosh registry endpoint
+      # @return [String] Bosh registry hostname
       def extract_registry_hostname(endpoint)
         match = endpoint.match(%r{https*://([^:]+):})
-        unless match.size == 2
-          raise LoadSettingsError, "Could not extract registry hostname"
+        unless match && match.size == 2
+          raise LoadSettingsError, "Cannot extract Bosh registry hostname from #{endpoint}"
         end
         match[1]
       end
 
-      def bosh_lookup(hostname, nameservers)
+      ##
+      # Lookups for the Bosh registry IP address.
+      #
+      # @param [String] hostname Bosh registry hostname
+      # @param [Array] nameservers Array containing nameserver address
+      # @return [Resolv::IPv4] Bosh registry IP address
+      def lookup_registry_ip_address(hostname, nameservers)
         resolver = Resolv::DNS.new(:nameserver => nameservers)
         resolver.getaddress(hostname)
       end
 
-      def inject_registry_ip(ip, endpoint)
+      ##
+      # Injects an IP address in the Bosh registry endpoint.
+      #
+      # @param [Resolv::IPv4] ip Bosh registry IP address
+      # @param [String] endpoint Bosh registry endpoint
+      # @return [String] Bosh registry endpoint
+      def inject_registry_ip_address(ip, endpoint)
         endpoint.sub(%r{//[^:]+:}, "//#{ip}:")
       end
 
-      def get_openssh_key
-        get_uri("/meta-data/public-keys/0/openssh-key")
-      end
-
-      def get_settings
-        @registry_endpoint ||= get_registry_endpoint
-        url = "#{@registry_endpoint}/instances/#{current_server_id}/settings"
-        body = get_json_from_url(url)
-
-        settings = Yajl::Parser.parse(body["settings"])
-        unless settings.is_a?(Hash)
-          raise(LoadSettingsError, "Invalid settings format, " \
-                "Hash expected, got #{settings.class}: #{settings}")
+      ##
+      # Gets the OpenStack user data. First we try to get it from the OpenStack user data endpoint, if we fail,
+      # then we fallback to the injected user data file.
+      #
+      # @return [Hash] OpenStack user data
+      def get_user_data
+        return @user_data if @user_data
+        begin
+          raw_user_data = get_uri(META_DATA_URI + "/user-data")
+        rescue LoadSettingsError => e
+          logger.info("Failed to get user data from OpenStack user data endpoint: #{e.message}")
+          raw_user_data = get_user_data_from_file
         end
 
-        settings
-
-      rescue Yajl::ParseError
-        raise(LoadSettingsError,
-              "Cannot parse settings from registry #{@registry_endpoint}")
+        logger.info("OpenStack user data: #{raw_user_data.inspect}")
+        @user_data = parse_user_data(raw_user_data)
       end
 
+      ##
+      # Gets the OpenStack user data from the injected user data file.
+      #
+      # @return [String] OpenStack user data
+      def get_user_data_from_file
+        File.read(USER_DATA_FILE)
+      rescue SystemCallError => e
+        raise LoadSettingsError, "Failed to get user data from OpenStack injected user data file: #{e.message}"
+      end
+
+      ##
+      # Parses the OpenStack user data.
+      #
+      # @param [String] raw_user_data Raw OpenStack user data
+      # @return [Hash] OpenStack user data
+      def parse_user_data(raw_user_data)
+        begin
+          user_data = Yajl::Parser.parse(raw_user_data)
+        rescue Yajl::ParseError => e
+          raise LoadSettingsError, "Cannot parse user data #{raw_user_data.inspect}: #{e.message}"
+        end
+
+        unless user_data.is_a?(Hash)
+          raise LoadSettingsError, "Invalid user data format, Hash expected, got #{user_data.class}: #{user_data}"
+        end
+
+        user_data
+      end
+
+      ##
+      # Sends GET request to an specified URI.
+      #
+      # @param [String] uri URI to request
+      # @return [String] Response body
+      def get_uri(uri)
+        client = HTTPClient.new
+        client.send_timeout = HTTP_API_TIMEOUT
+        client.receive_timeout = HTTP_API_TIMEOUT
+        client.connect_timeout = HTTP_CONNECT_TIMEOUT
+
+        headers = {"Accept" => "application/json"}
+        response = client.get(uri, {}, headers)
+        unless response.status == 200
+          raise LoadSettingsError, "Endpoint #{uri} returned HTTP #{response.status}"
+        end
+
+        response.body
+      rescue HTTPClient::TimeoutError
+        raise LoadSettingsError, "Timed out reading endpoint #{uri}"
+      rescue HTTPClient::BadResponseError => e
+        raise LoadSettingsError, "Received bad HTTP response from endpoint #{uri}: #{e.inspect}"
+      rescue URI::Error, SocketError, Errno::ECONNREFUSED, SystemCallError => e
+        raise LoadSettingsError, "Error requesting endpoint #{uri}: #{e.inspect}"
+      end
     end
   end
 end

--- a/bosh_agent/lib/bosh_agent/infrastructure/openstack/settings.rb
+++ b/bosh_agent/lib/bosh_agent/infrastructure/openstack/settings.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2012 VMware, Inc.
+# Copyright (c) 2009-2013 VMware, Inc.
 
 module Bosh::Agent
   class Infrastructure::Openstack::Settings
@@ -11,42 +11,59 @@ module Bosh::Agent
         VIP_NETWORK_TYPE, DHCP_NETWORK_TYPE, MANUAL_NETWORK_TYPE
     ]
 
-    AUTHORIZED_KEYS = File.join("/home/", BOSH_APP_USER, ".ssh/authorized_keys")
-
+    ##
+    # Returns the logger
+    #
+    # @return [Logger] Bosh Agent logger
     def logger
       Bosh::Agent::Config.logger
     end
 
-    def authorized_keys
-      AUTHORIZED_KEYS
-    end
-
-    def setup_openssh_key
-      public_key = Infrastructure::Openstack::Registry.get_openssh_key
-      if public_key.nil? || public_key.empty?
-        return
-      end
-      FileUtils.mkdir_p(File.dirname(authorized_keys))
-      FileUtils.chmod(0700, File.dirname(authorized_keys))
-      FileUtils.chown(Bosh::Agent::BOSH_APP_USER, Bosh::Agent::BOSH_APP_GROUP,
-                      File.dirname(authorized_keys))
-      File.open(authorized_keys, "w") { |f| f.write(public_key) }
-      FileUtils.chown(Bosh::Agent::BOSH_APP_USER, Bosh::Agent::BOSH_APP_GROUP,
-                      authorized_keys)
-      FileUtils.chmod(0644, authorized_keys)
-    end
-
+    ##
+    # Loads the the settings for this agent and set ups the public OpenSSH key.
+    #
+    # @return [Hash] Agent Settings
     def load_settings
       setup_openssh_key
       Infrastructure::Openstack::Registry.get_settings
     end
 
-    def get_network_settings(network_name, properties)
-      type = properties["type"] || "manual"
+    ##
+    # Returns the authorized keys filename for the Bosh user.
+    #
+    # @return [String] authorized keys filename
+    def authorized_keys
+      File.join(File::SEPARATOR, "home", BOSH_APP_USER, ".ssh", "authorized_keys")
+    end
+
+    ##
+    # Retrieves the public OpenSSH key and stores it at the authorized_keys file.
+    #
+    # @return [void]
+    def setup_openssh_key
+      public_key = Infrastructure::Openstack::Registry.get_openssh_key
+      return if public_key.nil? || public_key.empty?
+
+      FileUtils.mkdir_p(File.dirname(authorized_keys))
+      FileUtils.chmod(0700, File.dirname(authorized_keys))
+      FileUtils.chown(Bosh::Agent::BOSH_APP_USER, Bosh::Agent::BOSH_APP_GROUP, File.dirname(authorized_keys))
+
+      File.open(authorized_keys, "w") { |f| f.write(public_key) }
+      FileUtils.chown(Bosh::Agent::BOSH_APP_USER, Bosh::Agent::BOSH_APP_GROUP, authorized_keys)
+      FileUtils.chmod(0644, authorized_keys)
+    end
+
+    ##
+    # Gets the network settings for this agent.
+    #
+    # @param [String] network_name Network name
+    # @param [Hash] network_properties Network properties
+    # @return [Hash] Network settings
+    def get_network_settings(network_name, network_properties)
+      type = network_properties["type"] || "manual"
       unless type && SUPPORTED_NETWORK_TYPES.include?(type)
-        raise Bosh::Agent::StateError,
-              "Unsupported network type '%s', valid types are: %s" %
-                  [type, SUPPORTED_NETWORK_TYPES.join(', ')]
+        raise Bosh::Agent::StateError, "Unsupported network type '%s', valid types are: %s" %
+                                       [type, SUPPORTED_NETWORK_TYPES.join(", ")]
       end
 
       # Nothing to do for "vip" and "manual" networks

--- a/bosh_agent/spec/unit/infrastructure/openstack/settings_spec.rb
+++ b/bosh_agent/spec/unit/infrastructure/openstack/settings_spec.rb
@@ -1,74 +1,77 @@
-# Copyright (c) 2009-2012 VMware, Inc.
+# Copyright (c) 2009-2013 VMware, Inc.
 
-require File.dirname(__FILE__) + '/../../../spec_helper'
+require "spec_helper"
 
 Bosh::Agent::Infrastructure.new("openstack").infrastructure
 
 describe Bosh::Agent::Infrastructure::Openstack::Settings do
-  before(:all) do
-    @test_authorized_dir = Dir.mktmpdir
-    @test_authorized_keys = File.join(@test_authorized_dir, "test_auth")
+  let(:openstack_settings) { Bosh::Agent::Infrastructure::Openstack::Settings.new }
+
+  describe :get_settings do
+    let(:settings) { {"vm" => "test_vm", "disks" => "test_disks"} }
+
+    it "should load settings" do
+      openstack_settings.should_receive(:setup_openssh_key)
+      Bosh::Agent::Infrastructure::Openstack::Registry.should_receive(:get_settings).and_return(settings)
+
+      loaded_settings = openstack_settings.load_settings
+      loaded_settings.should == settings
+    end
   end
 
-  before(:each) do
-    Bosh::Agent::Config.settings_file = File.join(base_dir, 'settings.json')
-    @settings = {"vm" => "test_vm", "disks" => "test_disks"}
+  describe :setup_openssh_key do
+    let(:test_authorized_keys) { File.join(Dir.mktmpdir, "test_auth") }
+
+    it "should setup the public OpenSSH key" do
+      Bosh::Agent::Infrastructure::Openstack::Registry.should_receive(:get_openssh_key).and_return("test_key")
+      openstack_settings.stub(:authorized_keys).and_return(test_authorized_keys)
+      FileUtils.should_receive(:mkdir_p).with(File.dirname(test_authorized_keys))
+      FileUtils.should_receive(:chmod).twice.and_return(true)
+      FileUtils.should_receive(:chown).twice.and_return(true)
+
+      openstack_settings.setup_openssh_key
+      File.open(test_authorized_keys, "r") { |f| f.read.should == "test_key" }
+    end
+
+    it "should do nothing if registry doesn't returns a public OpenSSH key" do
+      Bosh::Agent::Infrastructure::Openstack::Registry.should_receive(:get_openssh_key).and_return(nil)
+      FileUtils.should_not_receive(:mkdir_p)
+      FileUtils.should_not_receive(:chown)
+
+      openstack_settings.setup_openssh_key
+    end
   end
 
-  it 'should load settings' do
-    Bosh::Agent::Infrastructure::Openstack::Registry.stub(:get_settings).and_return(@settings)
-    Bosh::Agent::Infrastructure::Openstack::Registry.stub(:get_openssh_key).and_return("test_key")
-    settings_wrapper = Bosh::Agent::Infrastructure::Openstack::Settings.new
-    settings_wrapper.stub(:authorized_keys).and_return(@test_authorized_keys)
-    FileUtils.stub(:chown).and_return(true)
-    settings = settings_wrapper.load_settings
-    settings.should == @settings
+  describe :get_network_settings do
+    it "should raise unsupported network exception for unknown  network" do
+      network_properties = { "type" => "unknown" }
+      expect {
+        network_settings = openstack_settings.get_network_settings("test", network_properties)
+      }.to raise_error Bosh::Agent::StateError, /Unsupported network type/
+    end
+
+    it "should get nothing for manual networks" do
+      network_properties = {}
+      network_settings = openstack_settings.get_network_settings("test", network_properties)
+      network_settings.should be_nil
+    end
+
+    it "should get nothing for vip networks" do
+      network_properties = { "type" => "vip" }
+      network_settings = openstack_settings.get_network_settings("test", network_properties)
+      network_settings.should be_nil
+    end
+
+    it "should get network settings for dhcp networks" do
+      net_info = double("net_info", default_gateway_interface: "eth0",
+                                    default_gateway: "1.2.3.1",
+                                    primary_dns: "1.1.1.1",
+                                    secondary_dns: "2.2.2.2")
+      Bosh::Agent::Util.should_receive(:get_network_info).and_return(net_info)
+
+      network_properties = { "type" => "dynamic" }
+      network_settings = openstack_settings.get_network_settings("test", network_properties)
+      network_settings.should_not be_nil
+    end
   end
-
-  it 'should get network settings for dhcp network' do
-    net_info = double('net_info', default_gateway_interface: 'eth0', default_gateway: '1.2.3.1',
-                      primary_dns: '1.1.1.1', secondary_dns: '2.2.2.2')
-    net_interface_config = double('net_interface_config', address:'1.2.3.4', netmask: '255.255.255.0')
-    sigar = double(Sigar, net_info: net_info, net_interface_config: net_interface_config, :logger= => nil)
-    Sigar.stub(new: sigar)
-    settings_wrapper = Bosh::Agent::Infrastructure::Openstack::Settings.new
-    network_properties = {"type" => "dynamic"}
-    properties = settings_wrapper.get_network_settings("test", network_properties)
-
-    properties.should have_key("ip")
-    properties.should have_key("netmask")
-    properties.should have_key("dns")
-    properties.should have_key("gateway")
-  end
-
-  it 'should get nothing for manual network' do
-    settings_wrapper = Bosh::Agent::Infrastructure::Openstack::Settings.new
-    network_properties = {}
-    properties = settings_wrapper.get_network_settings("test", network_properties)
-    properties.should be_nil
-  end
-
-  it 'should get nothing for vip network' do
-    settings_wrapper = Bosh::Agent::Infrastructure::Openstack::Settings.new
-    network_properties = {"type" => "vip"}
-    properties = settings_wrapper.get_network_settings("test", network_properties)
-    properties.should be_nil
-  end
-
-  it 'should raise unsupported network exception for unknown  network' do
-    settings_wrapper = Bosh::Agent::Infrastructure::Openstack::Settings.new
-    lambda {
-      properties = settings_wrapper.get_network_settings("test", {"type" => "unknown"})
-    }.should raise_error(Bosh::Agent::StateError, /Unsupported network/)
-  end
-
-  it 'should setup the ssh public key' do
-    Bosh::Agent::Infrastructure::Openstack::Registry.stub!(:get_openssh_key).and_return("test_key")
-    settings_wrapper = Bosh::Agent::Infrastructure::Openstack::Settings.new
-    settings_wrapper.stub(:authorized_keys).and_return(@test_authorized_keys)
-    FileUtils.stub(:chown).and_return(true)
-    settings_wrapper.setup_openssh_key
-    File.open(@test_authorized_keys, "r") { |f| f.read.should == "test_key" }
-  end
-
 end


### PR DESCRIPTION
- If agent cannot get user data from the OpenStack user data service,
  then fallback to the user_data injected file.
- Added some more unit tests to OpenStack registry.
- Refactored the OpenStack Registry and Settings.
