### PR TITLE
Use file:// prefix for blobstore_path like configure_micro_bosh.sh

### DIFF
--- a/stemcell_builder/stages/bosh_micro/assets/configure_micro_bosh_for_mcf.sh
+++ b/stemcell_builder/stages/bosh_micro/assets/configure_micro_bosh_for_mcf.sh
@@ -14,7 +14,7 @@ infrastructure=$1
 
 bosh_src_dir=/var/vcap/bosh/src/micro_bosh
 bosh_app_dir=/var/vcap
-blobstore_path=${bosh_app_dir}/micro_bosh/data/cache
+blobstore_path=file://${bosh_app_dir}/micro_bosh/data/cache
 agent_host=localhost
 agent_port=6969
 agent_uri=https://vcap:vcap@${agent_host}:${agent_port}


### PR DESCRIPTION
This makes configure_micro_bosh_for_mcf.sh & configure_micro_bosh.sh more
similar.
