### PR TITLE
Error if latest alias is used when no releases are found on director.

### DIFF
--- a/bosh_cli/lib/cli/deployment_helper.rb
+++ b/bosh_cli/lib/cli/deployment_helper.rb
@@ -218,7 +218,11 @@ module Bosh::Cli
 
       releases.each do |release|
         if release["version"] == "latest"
-          release["version"] = latest_release_versions[release["name"]]
+          latest_release_version = latest_release_versions[release["name"]]
+          unless latest_release_version
+            err("Release '#{release['name']}' not found on director. Unable to resolve 'latest' alias in manifest.")
+          end
+          release["version"] = latest_release_version
         end
 
         # TODO: why do we care about casting to Integer when possible?

--- a/bosh_cli/spec/unit/deployment_helper_spec.rb
+++ b/bosh_cli/spec/unit/deployment_helper_spec.rb
@@ -171,6 +171,16 @@ describe Bosh::Cli::DeploymentHelper do
         @manifest["releases"].detect { |release| release["name"] == "bat" }["version"].should == "3.1-dev"
         @manifest["releases"].detect { |release| release["name"] == "bosh" }["version"].should == 2
       end
+
+      context 'when the release is not found on the director' do
+        let(:release_list) { [] }
+
+        it 'raises an error' do
+          expect { tester.resolve_release_aliases(@manifest) }.to raise_error(Bosh::Cli::CliError,
+                                                                              "Release 'bosh' not found on director. Unable to resolve 'latest' alias in manifest.")
+        end
+      end
+
     end
 
     it "casts final release versions to Integer" do

--- a/bosh_cli_plugin_aws/spec/functional/bootstrap_spec.rb
+++ b/bosh_cli_plugin_aws/spec/functional/bootstrap_spec.rb
@@ -309,7 +309,10 @@ describe "AWS Bootstrap commands" do
 
         stub_request(:get, "http://127.0.0.1:25555/releases").
             with(:headers => {'Content-Type' => 'application/json'}).
-            to_return(:status => 200, :body => "[]")
+            to_return(
+            {:status => 200, :body => "[]"},
+            {:status => 200, :body => '[{"name" : "bosh", "release_versions" : [{"version" : "1"}]}]'}
+        )
 
         stub_request(:get, %r{http://blob.cfblob.com/rest/objects}).
             to_return(:status => 200)


### PR DESCRIPTION
Because of release name mismatches, manifests with an empty version
were being uploaded to the director and causing validation errors
during deployment.
