### PR TITLE
[agent] remove unused gems from agent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,17 +33,13 @@ PATH
       blobstore_client (~> 1.5.0.pre.3)
       bosh_common (~> 1.5.0.pre.3)
       bosh_encryption (~> 1.5.0.pre.3)
-      highline (~> 1.6.2)
       httpclient (= 2.2.4)
       monit_api (~> 1.5.0.pre.3)
       nats (~> 0.4.28)
       netaddr (~> 1.5.0)
-      ruby-atmos-pure (~> 1.0.5)
       sigar (~> 0.7.2)
       sinatra (~> 1.4.2)
-      sys-filesystem (~> 1.1.0)
       thin (~> 1.5.0)
-      uuidtools (~> 2.1.2)
       yajl-ruby (~> 1.1.0)
 
 PATH

--- a/bosh_agent/bosh_agent.gemspec
+++ b/bosh_agent/bosh_agent.gemspec
@@ -16,17 +16,13 @@ Gem::Specification.new do |s|
   s.required_ruby_version   = Gem::Requirement.new('>= 1.9.3')
 
   # Third party dependencies
-  s.add_dependency          'highline',         '~>1.6.2'
   s.add_dependency          'netaddr',          '~>1.5.0'
-  s.add_dependency          'ruby-atmos-pure',  '~>1.0.5'
   s.add_dependency          'thin',             '~>1.5.0'
   s.add_dependency          'yajl-ruby',        '~>1.1.0'
   s.add_dependency          'sinatra',          '~>1.4.2'
   s.add_dependency          'nats',             '~>0.4.28'
   s.add_dependency          'sigar',            '~>0.7.2'
   s.add_dependency          'httpclient',       '=2.2.4'
-  s.add_dependency          'uuidtools',        '~> 2.1.2'
-  s.add_dependency          'sys-filesystem',   '~> 1.1.0'
 
   # Bosh Dependencies
   s.add_dependency          'bosh_common',      "~>#{version}"


### PR DESCRIPTION
while looking through the agent code I noticed that we have a bunch of unused gems in the gemspec - should be ok to remove (passes all unit & integration tests)
