### PR TITLE
Add director/spec to load path.

### DIFF
--- a/director/spec/spec_helper.rb
+++ b/director/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # Copyright (c) 2009-2012 VMware, Inc.
+$: << File.expand_path('..', __FILE__)
 
 require "digest/sha1"
 require "fileutils"


### PR DESCRIPTION
When running director specs from the bosh root dir, require blueprints
failed because director/spec was not in the load path.
