### PR TITLE
Make dummy infrastructure and platform workable

### DIFF
--- a/bosh_agent/lib/bosh_agent/infrastructure/dummy.rb
+++ b/bosh_agent/lib/bosh_agent/infrastructure/dummy.rb
@@ -4,6 +4,17 @@ module Bosh::Agent
   class Infrastructure::Dummy
 
     def load_settings
+      {
+        "blobstore" => {
+          "provider" => Bosh::Agent::Config.blobstore_provider,
+          "options" => Bosh::Agent::Config.blobstore_options,
+        },
+        "ntp" => [],
+        "disks" => {
+          "persistent" => {},
+        },
+        "mbus" => Bosh::Agent::Config.mbus,
+      }
     end
 
     def get_network_settings(network_name, properties)

--- a/bosh_agent/lib/bosh_agent/platform/dummy.rb
+++ b/bosh_agent/lib/bosh_agent/platform/dummy.rb
@@ -10,6 +10,10 @@ module Bosh::Agent
     end
 
     def get_data_disk_device_name
+      "dummy"
+    end
+
+    def setup_networking
     end
 
   end


### PR DESCRIPTION
BOSH Agent does not work correctly when given dummy classes.
This patch fixes the dummy infrastructure and platform classes to make the Agent workable even when it is `configured` (`bosh_agent -c -I dummy -P dummy ...`).
The workable dummy classes are sometimes useful to test bosh components.
