### PR TITLE
[openstack_cpi] Use new method to get server volume attachments

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -718,7 +718,7 @@ module Bosh::OpenStackCloud
     # @param [Fog::Compute::OpenStack::Volume] volume OpenStack volume
     # @return [String] Device name
     def attach_volume(server, volume)
-      volume_attachments = with_openstack { @openstack.get_server_volumes(server.id).body['volumeAttachments'] }
+      volume_attachments = with_openstack { server.volume_attachments }
       device_names = Set.new(volume_attachments.collect! { |v| v["device"] })
 
       new_attachment = nil
@@ -747,7 +747,7 @@ module Bosh::OpenStackCloud
     # @param [Fog::Compute::OpenStack::Volume] volume OpenStack volume
     # @return [void]
     def detach_volume(server, volume)
-      volume_attachments = with_openstack { @openstack.get_server_volumes(server.id).body['volumeAttachments'] }
+      volume_attachments = with_openstack { server.volume_attachments }
       device_map = volume_attachments.collect! { |v| v["volumeId"] }
 
       unless device_map.include?(volume.id)

--- a/bosh_openstack_cpi/spec/unit/attach_disk_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/attach_disk_spec.rb
@@ -12,20 +12,16 @@ describe Bosh::OpenStackCloud::Cloud do
   it "attaches an OpenStack volume to a server" do
     server = double("server", :id => "i-test", :name => "i-test")
     volume = double("volume", :id => "v-foobar")
-    volume_attachments = double("body", :body => {"volumeAttachments" => []})
+    volume_attachments = []
     attachment = double("attachment", :device => "/dev/vdc")
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).
-        with("i-test").and_return(server)
-      openstack.volumes.should_receive(:get).
-        with("v-foobar").and_return(volume)
-      openstack.should_receive(:get_server_volumes).
-        and_return(volume_attachments)
+      openstack.servers.should_receive(:get).with("i-test").and_return(server)
+      openstack.volumes.should_receive(:get).with("v-foobar").and_return(volume)
     end
 
-    volume.should_receive(:attach).
-      with(server.id, "/dev/vdc").and_return(attachment)
+    server.should_receive(:volume_attachments).and_return(volume_attachments)
+    volume.should_receive(:attach).with(server.id, "/dev/vdc").and_return(attachment)
     cloud.should_receive(:wait_resource).with(volume, :"in-use")
 
     old_settings = { "foo" => "bar" }
@@ -38,10 +34,8 @@ describe Bosh::OpenStackCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).
-      with("i-test").and_return(old_settings)
-    @registry.should_receive(:update_settings).
-      with("i-test", new_settings)
+    @registry.should_receive(:read_settings).with("i-test").and_return(old_settings)
+    @registry.should_receive(:update_settings).with("i-test", new_settings)
 
     cloud.attach_disk("i-test", "v-foobar")
   end
@@ -49,22 +43,16 @@ describe Bosh::OpenStackCloud::Cloud do
   it "picks available device name" do
     server = double("server", :id => "i-test", :name => "i-test")
     volume = double("volume", :id => "v-foobar")
-    volume_attachments = double("body", :body => {"volumeAttachments" =>
-                                                  [{"device" => "/dev/vdc"},
-                                                   {"device" => "/dev/vdd"}]})
+    volume_attachments = [{"device" => "/dev/vdc"}, {"device" => "/dev/vdd"}]
     attachment = double("attachment", :device => "/dev/vdd")
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).
-        with("i-test").and_return(server)
-      openstack.volumes.should_receive(:get).
-        with("v-foobar").and_return(volume)
-      openstack.should_receive(:get_server_volumes).
-        and_return(volume_attachments)
+      openstack.servers.should_receive(:get).with("i-test").and_return(server)
+      openstack.volumes.should_receive(:get).with("v-foobar").and_return(volume)
     end
 
-    volume.should_receive(:attach).
-      with(server.id, "/dev/vde").and_return(attachment)
+    server.should_receive(:volume_attachments).and_return(volume_attachments)
+    volume.should_receive(:attach).with(server.id, "/dev/vde").and_return(attachment)
     cloud.should_receive(:wait_resource).with(volume, :"in-use")
 
     old_settings = { "foo" => "bar" }
@@ -77,10 +65,8 @@ describe Bosh::OpenStackCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).
-      with("i-test").and_return(old_settings)
-    @registry.should_receive(:update_settings).
-      with("i-test", new_settings)
+    @registry.should_receive(:read_settings).with("i-test").and_return(old_settings)
+    @registry.should_receive(:update_settings).with("i-test", new_settings)
 
     cloud.attach_disk("i-test", "v-foobar")
   end
@@ -88,21 +74,17 @@ describe Bosh::OpenStackCloud::Cloud do
   it "raises an error when vdc..vdz are all reserved" do
     server = double("server", :id => "i-test", :name => "i-test")
     volume = double("volume", :id => "v-foobar")
-    all_mappings = ("c".."z").inject([]) do |array, char|
+    volume_attachments = ("c".."z").inject([]) do |array, char|
       array << {"device" => "/dev/vd#{char}"}
       array
     end
-    volume_attachments = double("body", :body => {"volumeAttachments" =>
-                                                   all_mappings})
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).
-        with("i-test").and_return(server)
-      openstack.volumes.should_receive(:get).
-        with("v-foobar").and_return(volume)
-      openstack.should_receive(:get_server_volumes).
-        and_return(volume_attachments)
+      openstack.servers.should_receive(:get).with("i-test").and_return(server)
+      openstack.volumes.should_receive(:get).with("v-foobar").and_return(volume)
     end
+
+    server.should_receive(:volume_attachments).and_return(volume_attachments)
 
     expect {
       cloud.attach_disk("i-test", "v-foobar")

--- a/bosh_openstack_cpi/spec/unit/detach_disk_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/detach_disk_spec.rb
@@ -12,19 +12,14 @@ describe Bosh::OpenStackCloud::Cloud do
   it "detaches an OpenStack volume from a server" do
     server = double("server", :id => "i-test", :name => "i-test")
     volume = double("volume", :id => "v-foobar")
-    volume_attachments = double("body", :body => {"volumeAttachments" =>
-                                                   [{"volumeId" => "v-foobar"},
-                                                   {"volumeId" => "v-barfoo"}]})
+    volume_attachments = [{"volumeId" => "v-foobar"}, {"volumeId" => "v-barfoo"}]
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).
-        with("i-test").and_return(server)
-      openstack.volumes.should_receive(:get).
-        with("v-foobar").and_return(volume)
-      openstack.should_receive(:get_server_volumes).
-        and_return(volume_attachments)
+      openstack.servers.should_receive(:get).with("i-test").and_return(server)
+      openstack.volumes.should_receive(:get).with("v-foobar").and_return(volume)
     end
 
+    server.should_receive(:volume_attachments).and_return(volume_attachments)
     volume.should_receive(:detach).with(server.id, "v-foobar").and_return(true)
     cloud.should_receive(:wait_resource).with(volume, :available)
 
@@ -47,10 +42,8 @@ describe Bosh::OpenStackCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).
-      with("i-test").and_return(old_settings)
-    @registry.should_receive(:update_settings).
-      with("i-test", new_settings)
+    @registry.should_receive(:read_settings).with("i-test").and_return(old_settings)
+    @registry.should_receive(:update_settings).with("i-test", new_settings)
 
     cloud.detach_disk("i-test", "v-foobar")
   end
@@ -58,18 +51,14 @@ describe Bosh::OpenStackCloud::Cloud do
   it "raises an error when volume is not attached to a server" do
     server = double("server", :id => "i-test", :name => "i-test")
     volume = double("volume", :id => "v-barfoo")
-    volume_attachments = double("body",
-                                :body => {"volumeAttachments" =>
-                                            [{"volumeId" => "v-foobar"}]})
+    volume_attachments = [{"volumeId" => "v-foobar"}]
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).
-        with("i-test").and_return(server)
-      openstack.volumes.should_receive(:get).
-        with("v-barfoo").and_return(volume)
-      openstack.should_receive(:get_server_volumes).
-        and_return(volume_attachments)
+      openstack.servers.should_receive(:get).with("i-test").and_return(server)
+      openstack.volumes.should_receive(:get).with("v-barfoo").and_return(volume)
     end
+
+    server.should_receive(:volume_attachments).and_return(volume_attachments)
 
     expect {
       cloud.detach_disk("i-test", "v-barfoo")


### PR DESCRIPTION
Implemented in fog 1.11.0.
