### PR TITLE
[openstack_cpi] Always take volume snapshots with force option

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -502,7 +502,8 @@ module Bosh::OpenStackCloud
         }
 
         @logger.info("Creating new snapshot for volume `#{disk_id}'...")
-        snapshot = with_openstack { @openstack.snapshots.create(snapshot_params) }
+        snapshot = @openstack.snapshots.new(snapshot_params)
+        with_openstack { snapshot.save(true) }
 
         @logger.info("Creating new snapshot `#{snapshot.id}' for volume `#{disk_id}'...")
         wait_resource(snapshot, :available)

--- a/bosh_openstack_cpi/spec/unit/snapshot_disk_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/snapshot_disk_spec.rb
@@ -16,9 +16,10 @@ describe Bosh::OpenStackCloud::Cloud do
 
     cloud = mock_cloud do |openstack|
       openstack.volumes.should_receive(:get).with("v-foobar").and_return(volume)
-      openstack.snapshots.should_receive(:create).with(snapshot_params).and_return(snapshot)
+      openstack.snapshots.should_receive(:new).with(snapshot_params).and_return(snapshot)
     end
 
+    snapshot.should_receive(:save).with(true)
     cloud.should_receive(:generate_unique_name).and_return(unique_name)
     cloud.should_receive(:wait_resource).with(snapshot, :available)
 


### PR DESCRIPTION
If volume is in use, we should use the force option when taking a snapshot.
