### PR TITLE
[openstack_cpi] Add new state when deleting vm

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -303,7 +303,7 @@ module Bosh::OpenStackCloud
         server = with_openstack { @openstack.servers.get(server_id) }
         if server
           with_openstack { server.destroy }
-          wait_resource(server, :terminated, :state, true)
+          wait_resource(server, [:terminated, :deleted], :state, true)
 
           @logger.info("Deleting settings for server `#{server.id}'...")
           @registry.delete_settings(server.name)

--- a/bosh_openstack_cpi/spec/unit/delete_vm_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/delete_vm_spec.rb
@@ -17,7 +17,7 @@ describe Bosh::OpenStackCloud::Cloud do
     end
 
     server.should_receive(:destroy).and_return(true)
-    cloud.should_receive(:wait_resource).with(server, :terminated, :state, true)
+    cloud.should_receive(:wait_resource).with(server, [:terminated, :deleted], :state, true)
 
     @registry.should_receive(:delete_settings).with("i-foobar")
 

--- a/bosh_openstack_cpi/spec/unit/helpers_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/helpers_spec.rb
@@ -32,6 +32,16 @@ describe Bosh::OpenStackCloud::Helpers do
       @cloud.wait_resource(resource, :stop, :status, false, 0.1)
     end
 
+    it "should accept an Array of target states" do
+      resource = double("resource")
+      resource.stub(:id).and_return("foobar")
+      resource.stub(:reload).and_return(@cloud)
+      resource.stub(:status).and_return(:start, :stop)
+      @cloud.stub(:sleep)
+
+      @cloud.wait_resource(resource, [:stop, :deleted], :status, false, 0.1)
+    end
+
     it "should raise Bosh::Clouds::CloudError if state is error" do
       resource = double("resource")
       resource.stub(:id).and_return("foobar")


### PR DESCRIPTION
When deleting a vm, the state could be also :deleted (besides :terminated)
