### PR TITLE
HM should alert once resurrector detect melting down

### DIFF
--- a/health_monitor/lib/health_monitor.rb
+++ b/health_monitor/lib/health_monitor.rb
@@ -25,6 +25,7 @@ require 'sinatra'
 require 'thin'
 require 'securerandom'
 require 'yajl'
+require 'singleton'
 
 # Helpers
 require 'health_monitor/yaml_helper'

--- a/health_monitor/lib/health_monitor/agent_manager.rb
+++ b/health_monitor/lib/health_monitor/agent_manager.rb
@@ -19,7 +19,7 @@ module Bosh::HealthMonitor
       @alerts_received = 0
       @alerts_processed = 0
 
-      @processor = EventProcessor.new
+      @processor = EventProcessor.instance
     end
 
     # Get a hash of agent id -> agent object for all agents associated with the deployment

--- a/health_monitor/lib/health_monitor/event_processor.rb
+++ b/health_monitor/lib/health_monitor/event_processor.rb
@@ -1,6 +1,12 @@
 module Bosh::HealthMonitor
   class EventProcessor
+    include Singleton
+
     def initialize
+      self.reset
+    end
+
+    def reset
       @events = {}
       @plugins = {}
 

--- a/health_monitor/lib/health_monitor/plugins/resurrector.rb
+++ b/health_monitor/lib/health_monitor/plugins/resurrector.rb
@@ -16,7 +16,9 @@ module Bosh::HealthMonitor
         @url           = URI(director['endpoint'])
         @user          = director['user']
         @password      = director['password']
+        @processor     = EventProcessor.instance
         @alert_tracker = ResurrectorHelper::AlertTracker.new(@options)
+
       end
 
       def run
@@ -52,6 +54,13 @@ module Bosh::HealthMonitor
 
           if @alert_tracker.melting_down?(deployment)
             # freak out
+            ts = Time.now.to_i
+            @processor.process(:alert,
+                               severity: 1,
+                               source: "HM plugin resurrector",
+                               title: "We are in meltdown. You have 15 minutes to reach minimum safe distance.",
+                               created_at: ts)
+
             logger.error("(Resurrector) we are in meltdown. You have 15 minutes to reach minimum safe distance.")
           else
             # queue instead, and only queue if it isn't already in the queue

--- a/health_monitor/spec/unit/agent_manager_spec.rb
+++ b/health_monitor/spec/unit/agent_manager_spec.rb
@@ -128,7 +128,7 @@ describe Bhm::AgentManager do
     end
 
     it "can analyze all agents" do
-      processor = Bhm::EventProcessor.new
+      processor = Bhm::EventProcessor.instance
       manager = make_manager
       manager.processor = processor
 

--- a/health_monitor/spec/unit/event_processor_spec.rb
+++ b/health_monitor/spec/unit/event_processor_spec.rb
@@ -14,7 +14,8 @@ describe Bhm::EventProcessor do
     }
 
     Bhm.logger = Logging.logger(StringIO.new)
-    @processor = Bhm::EventProcessor.new
+    @processor = Bhm::EventProcessor.instance
+    @processor.reset
 
     @logger_plugin = Bhm::Plugins::Logger.new
     @email_plugin = Bhm::Plugins::Email.new(email_options)


### PR DESCRIPTION
[finish #49310871]

send alert through EventProcessor so Datadog plugin will handle it, plus we could also get email alerting etc from other plugins.
