### PR TITLE
Bypass `remote_tunnel()` for vSphere (Bug Report)

### DIFF
--- a/bosh_cli_plugin_micro/lib/deployer/instance_manager/vsphere.rb
+++ b/bosh_cli_plugin_micro/lib/deployer/instance_manager/vsphere.rb
@@ -5,6 +5,9 @@ module Bosh::Deployer
 
     class Vsphere < InstanceManager
 
+      def remote_tunnel(port)
+      end
+
       def disk_model
         if @disk_model.nil?
           require "cloud/vsphere"


### PR DESCRIPTION
I realized that the latest micro plugin does not work with vSphere. It stops on waiting for the agent.
It seems that the loop in `remote_tunnel()` never breaks because `IO.select` in `socket_readable?` always fails. This is caused by that some instance variables (e.g. @ssh_*) are missing for the subclass for vSphere.

I created an ad-hock patch for this issue. I'm not sure if SSH tunneling is required for vSphere too, so I simply added a overiding method to bypass it.
