### PR TITLE
[bosh_aws_cpi] clean up code quality of Bosh::AwsCloud::Cloud#initialize

### DIFF
--- a/bosh_aws_cpi/README.md
+++ b/bosh_aws_cpi/README.md
@@ -19,14 +19,14 @@ These options are passed to the AWS CPI when it is instantiated.
   list of AWS security group to assign to created virtual machines
 * `ec2_private_key` (required)  
   local path to the ssh private key, must match `default_key_name`
-* `region` (optional)  
-  EC2 region, defaults to `us-east-1`
+* `region` (required)
+  EC2 region
 * `ec2_endpoint` (optional)  
   URL of the EC2 endpoint to connect to, defaults to the endpoint corresponding to the selected region,
-  or `DEFAULT_EC2_ENDPOINT` if no region has been selected
+  or `default_ec2_endpoint` if no region has been selected
 * `elb_endpoint` (optional)  
   URL of the ELB endpoint to connect to, default to the endpoint corresponding to the selected region,
-  or `DEFAULT_ELB_ENDPOINT` if no region has been selected
+  or `default_elb_endpoint` if no region has been selected
 * `max_retries` (optional)  
   maximum number of time to retry an AWS API call, defaults to `DEFAULT_MAX_RETRIES`
 

--- a/bosh_aws_cpi/spec/unit/cloud_spec.rb
+++ b/bosh_aws_cpi/spec/unit/cloud_spec.rb
@@ -1,45 +1,45 @@
 # Copyright (c) 2009-2012 VMware, Inc.
 
-require "spec_helper"
+require 'spec_helper'
 
 describe Bosh::AwsCloud::Cloud do
-  describe "creating via provider" do
+  describe 'creating via provider' do
 
-    it "can be created using Bosh::Cloud::Provider" do
+    it 'can be created using Bosh::Cloud::Provider' do
       cloud = Bosh::Clouds::Provider.create(:aws, mock_cloud_options)
       cloud.should be_an_instance_of(Bosh::AwsCloud::Cloud)
     end
 
   end
 
-  describe "validating initialization options" do
-    it "raises an error warning the user of all the missing required configurations" do
+  describe 'validating initialization options' do
+    it 'raises an error warning the user of all the missing required configurations' do
       expect {
         described_class.new(
             {
-                "aws" => {
-                    "access_key_id" => "keys to my heart",
-                    "secret_access_key" => "open sesame"
+                'aws' => {
+                    'access_key_id' => 'keys to my heart',
+                    'secret_access_key' => 'open sesame'
                 }
             }
         )
-      }.to raise_error(ArgumentError, "missing configuration parameters > aws:region, aws:default_key_name, registry:endpoint, registry:user, registry:password")
+      }.to raise_error(ArgumentError, 'missing configuration parameters > aws:region, aws:default_key_name, registry:endpoint, registry:user, registry:password')
     end
 
-    it "doesn't raise an error if all the required configuraitons are present" do
+    it 'does not raise an error if all the required configuraitons are present' do
       expect {
         described_class.new(
             {
-                "aws" => {
-                    "access_key_id" => "keys to my heart",
-                    "secret_access_key" => "open sesame",
-                    "region" => "fupa",
-                    "default_key_name" => "sesame"
+                'aws' => {
+                    'access_key_id' => 'keys to my heart',
+                    'secret_access_key' => 'open sesame',
+                    'region' => 'fupa',
+                    'default_key_name' => 'sesame'
                 },
-                "registry" => {
-                    "user" => "abuser",
-                    "password" => "hard2gess",
-                    "endpoint" => "http://websites.com"
+                'registry' => {
+                    'user' => 'abuser',
+                    'password' => 'hard2gess',
+                    'endpoint' => 'http://websites.com'
                 }
             }
         )

--- a/bosh_aws_cpi/spec/unit/configure_networks_spec.rb
+++ b/bosh_aws_cpi/spec/unit/configure_networks_spec.rb
@@ -96,8 +96,7 @@ describe Bosh::AwsCloud::Cloud do
     it "checks that at least one dynamic or manual network is defined" do
       expect {
         mock_cloud { |ec2| ec2.instances.stub(:[]).with("i-foobar").and_return(instance) }.
-            configure_networks("i-foobar",
-                               "net_a" => vip_network_spec)
+            configure_networks("i-foobar", "net_a" => vip_network_spec)
       }.to raise_error(Bosh::Clouds::CloudError,
                        "Exactly one dynamic or manual network must be defined")
     end

--- a/bosh_aws_cpi/spec/unit/delete_disk_spec.rb
+++ b/bosh_aws_cpi/spec/unit/delete_disk_spec.rb
@@ -1,12 +1,12 @@
 # Copyright (c) 2009-2012 VMware, Inc.
 
-require "spec_helper"
+require 'spec_helper'
 
 describe Bosh::AwsCloud::Cloud do
-  let(:volume) { double(AWS::EC2::Volume, :id => "v-foo") }
+  let(:volume) { double(AWS::EC2::Volume, id: 'v-foo') }
   let(:cloud) do
     mock_cloud do |ec2|
-      ec2.volumes.stub(:[]).with("v-foo").and_return(volume)
+      ec2.volumes.stub(:[]).with('v-foo').and_return(volume)
     end
   end
 
@@ -14,45 +14,45 @@ describe Bosh::AwsCloud::Cloud do
     Bosh::AwsCloud::ResourceWait.stub(sleep_callback: 0)
   end
 
-  it "deletes an EC2 volume" do
-    Bosh::AwsCloud::ResourceWait.stub(:for_volume).with(volume: volume, state: :deleted)
+  it 'deletes an EC2 volume' do
+    Bosh::AwsCloud::ResourceWait.stub(for_volume: {volume: volume, state: :deleted})
 
     volume.should_receive(:delete)
 
-    cloud.delete_disk("v-foo")
+    cloud.delete_disk('v-foo')
   end
 
-  it "retries deleting the volume if it's in use" do
-    Bosh::AwsCloud::ResourceWait.stub(:for_volume).with(volume: volume, state: :deleted)
+  it 'retries deleting the volume if it is in use' do
+    Bosh::AwsCloud::ResourceWait.stub(for_volume: {volume: volume, state: :deleted})
     Bosh::Clouds::Config.stub(:task_checkpoint)
 
     volume.should_receive(:delete).once.ordered.and_raise(AWS::EC2::Errors::Client::VolumeInUse)
     volume.should_receive(:delete).ordered
 
-    cloud.delete_disk("v-foo")
+    cloud.delete_disk('v-foo')
   end
 
-  it "raises an error if the volume remains in use after every deletion retry" do
+  it 'raises an error if the volume remains in use after every deletion retry' do
     Bosh::Clouds::Config.stub(:task_checkpoint)
 
     volume.should_receive(:delete).exactly(10).times.and_raise(AWS::EC2::Errors::Client::VolumeInUse)
 
     expect {
-      cloud.delete_disk("v-foo")
+      cloud.delete_disk('v-foo')
     }.to raise_error("Timed out waiting to delete volume `v-foo'")
   end
 
-  it "does a fast path delete when asked to" do
+  it 'does a fast path delete when asked to' do
     options = mock_cloud_options
-    options["aws"]["fast_path_delete"] = "yes"
+    options['aws']['fast_path_delete'] = 'yes'
     cloud = mock_cloud(options) do |ec2|
-      ec2.volumes.stub(:[]).with("v-foo").and_return(volume)
+      ec2.volumes.stub(:[]).with('v-foo').and_return(volume)
     end
 
     volume.should_receive(:delete)
-    volume.should_receive(:add_tag).with("Name", {:value => "to be deleted"})
+    volume.should_receive(:add_tag).with('Name', {value: 'to be deleted'})
     Bosh::AwsCloud::ResourceWait.should_not_receive(:for_volume)
 
-    cloud.delete_disk("v-foo")
+    cloud.delete_disk('v-foo')
   end
 end

--- a/bosh_aws_cpi/spec/unit/delete_vm_spec.rb
+++ b/bosh_aws_cpi/spec/unit/delete_vm_spec.rb
@@ -1,12 +1,12 @@
 # Copyright (c) 2009-2012 VMware, Inc.
 
-require "spec_helper"
+require 'spec_helper'
 
 describe Bosh::AwsCloud::Cloud do
 
-  it "deletes an EC2 instance" do
-    instance_manager = double("InstanceManager")
-    instance_manager.should_receive(:terminate).with("i-foobar", nil)
+  it 'deletes an EC2 instance' do
+    instance_manager = double('InstanceManager')
+    instance_manager.should_receive(:terminate).with('i-foobar', false)
 
     registry = mock_registry
     region = nil
@@ -16,6 +16,6 @@ describe Bosh::AwsCloud::Cloud do
 
     Bosh::AwsCloud::InstanceManager.should_receive(:new).with(region, registry).and_return(instance_manager)
 
-    ec2.delete_vm("i-foobar")
+    ec2.delete_vm('i-foobar')
   end
 end


### PR DESCRIPTION
Add accessors and replace explicit reference to instance variables
Convert unnecessary double-quoted strings to single-quotes
