### PR TITLE
[director] Use new Resque logging and signaling properties [fixes #48285613]

### DIFF
--- a/director/bin/worker
+++ b/director/bin/worker
@@ -48,13 +48,18 @@ end
 
 Bosh::Director::Config.configure(config)
 
+resque_logging = config.fetch('resque', {}).fetch('logging', {})
+resque_log_device = Logger::LogDevice.new(resque_logging.fetch('file', STDOUT))
+resque_logger_level = resque_logging.fetch('level', 'info').upcase
+Resque.logger = Logger.new(resque_log_device)
+Resque.logger.level = Logger.const_get(resque_logger_level)
+
 worker = nil
 queues = (ENV['QUEUES'] || ENV['QUEUE']).to_s.split(',')
 
 begin
   worker = Resque::Worker.new(*queues)
-  worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
-  worker.very_verbose = ENV['VVERBOSE']
+  worker.term_child = true
 rescue Resque::NoQueueError
   abort "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
 end

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -62,6 +62,9 @@ properties:
   director.auto_fix_stateful_nodes:
     description: Enable/Disable auto resolution for stateful nodes for scan_and_fix (true|false)
     default: true
+  resque.loglevel:
+    description: Level of log messages for Resque workers (fatal, error, warn, info, debug)
+    default: info
   redis.address:
     description: Address of the redis server
   redis.port:

--- a/release/jobs/director/templates/director.yml.erb
+++ b/release/jobs/director/templates/director.yml.erb
@@ -11,6 +11,11 @@ max_threads: <%= max_threads %>
 logging:
   level: DEBUG
   file: /var/vcap/sys/log/director/<%%= ENV["COMPONENT"] %>.debug.log
+<% if_p("resque.loglevel") do |resque_loglevel| %>
+resque:
+  logging:
+    level: <%= resque_loglevel %>
+<% end %>    
 redis:
   host: <%= p('redis.address') %>
   port: <%= p('redis.port') %>


### PR DESCRIPTION
- Change deprecated VERBOSE and VVERBOSE logging properties with new Resque Logger
- Use Resque new signal handling path (see http://hone.heroku.com/resque/2012/08/21/resque-signals.html)
