### PR TITLE
[bosh_agent] /tmp is world-accessible

### DIFF
--- a/bosh_agent/lib/bosh_agent/bootstrap.rb
+++ b/bosh_agent/lib/bosh_agent/bootstrap.rb
@@ -253,7 +253,7 @@ module Bosh::Agent
 
     def tmp_permissions
       %x[chown root:#{BOSH_APP_USER} /tmp]
-      %x[chmod 0770 /tmp]
+      %x[chmod 0777 /tmp]
       %x[chmod 0700 /var/tmp]
     end
 


### PR DESCRIPTION
When testing bosh_agent via vagrant, the act of running bosh_agent disables
the ability for vagrant user to access /tmp. So, need to ensure /tmp is
world-accessible
