### PR TITLE
Proof of concept for allowing sudo without a password for bosh ssh.

### DIFF
--- a/bosh_agent/spec/unit/message/ssh_spec.rb
+++ b/bosh_agent/spec/unit/message/ssh_spec.rb
@@ -4,48 +4,103 @@ require File.dirname(__FILE__) + '/../../spec_helper'
 require 'fileutils'
 
 describe Bosh::Agent::Message::Ssh do
-  def ssh_create_args
-    ["setup", {"user" => "spec_user", "password" => "test", "public_key" => "PUBLIC"}]
+  let(:command_runner) { double('command runner') }
+  let(:ssh) { described_class.new(args, passwd_file: @passwd_file, sudoers_dir: @sudoers_dir,
+                                  command_runner: command_runner) }
+
+  before do
+    @passwd_file = Tempfile.new('passwd')
+    @sudoers_dir = Dir.mktmpdir('sudoersd')
   end
 
-  def ssh_cleanup_args
-    ["cleanup", {"user_regex" => "root", "password" => "test", "public_key" => "PUBLIC"}]
+  after do
+    @passwd_file.close
+    @passwd_file.unlink
+    FileUtils.rm_rf @sudoers_dir
   end
 
-  it "should return a failure when shell commands fail" do
-    ssh = Bosh::Agent::Message::Ssh.new(ssh_create_args)
-    ssh.stub!(:shell_cmd).and_raise("Command failed")
-    rtn = ssh.setup
-    rtn["status"].should == "failure"
+  describe '#setup' do
+    let(:user) { 'spec_user' }
+    let(:args) { ['setup', {'user' => user, 'password' => 'test', 'public_key' => 'PUBLIC'}] }
+
+    it 'should return a failure when shell commands fail' do
+      command_runner.stub(:sh).and_raise('Command failed')
+
+      rtn = ssh.setup
+      expect(rtn['status']).to eq 'failure'
+    end
+
+    it 'should return success when create succeeds' do
+      FileUtils.stub(:chown_R)
+      sshd_started = false
+      Bosh::Agent::SshdMonitor.stub(:start_sshd) { sshd_started = true }
+      Bosh::Agent::Config.stub(default_ip: '127.0.0.1')
+      command_runner.stub(:sh)
+
+      rtn = ssh.setup
+      expect(rtn['status']).to eq 'success'
+      expect(sshd_started).to be_true
+    end
+
+    it "creates the user's sudoers.d file" do
+      FileUtils.stub(:chown_R)
+      Bosh::Agent::SshdMonitor.stub(:start_sshd)
+      Bosh::Agent::Config.stub(default_ip: '127.0.0.1')
+      command_runner.stub(:sh)
+      sudoers_file = File.join(@sudoers_dir, user)
+
+      ssh.setup
+      expect(File.read(sudoers_file)).to eq "\n#{user} ALL=(ALL) NOPASSWD:ALL\n"
+    end
+
+    it "should copy the public key into the user's director" do
+      FileUtils.stub(:chown_R)
+      Bosh::Agent::SshdMonitor.stub(:start_sshd)
+      Bosh::Agent::Config.stub(default_ip: '127.0.0.1')
+      command_runner.stub(:sh)
+
+      rtn = ssh.setup
+      authorized_keys = File.read(File.join(ssh.ssh_base_dir, 'spec_user/.ssh/authorized_keys'))
+      expect(rtn['status']).to eq 'success'
+      expect(authorized_keys).to eq 'PUBLIC'
+    end
+
   end
 
-  it "should return success when create succeeds" do
-    ssh = Bosh::Agent::Message::Ssh.new(ssh_create_args)
-    FileUtils.stub!(:chown_R)
-    @sshd_started = false
-    Bosh::Agent::SshdMonitor.stub!(:start_sshd) { @sshd_started = true }
-    Bosh::Agent::Config.stub!(:default_ip).and_return("127.0.0.1")
-    ssh.stub!(:shell_cmd)
-    rtn = ssh.setup
-    rtn["status"].should == "success" && @sshd_started.should == true
+  describe '#cleanup' do
+    let(:args) { ['cleanup', {'user_regex' => 'root', 'password' => 'test', 'public_key' => 'PUBLIC'}] }
+
+    it 'should not cleanup privileged users' do
+      Bosh::Agent::SshdMonitor.stub(:stop_sshd)
+      command_runner.stub(:sh).with('userdel -r root').and_raise('Unexpected results')
+
+      rtn = ssh.cleanup
+      expect(rtn["status"]).to eq 'success'
+    end
+
+    context "removing the user's sudoers.d file" do
+      let(:user_suffix) { 'foo' }
+      let(:args) { ['cleanup', {'user_regex' => user_suffix}] }
+
+      it "removes the user's sudoers.d file" do
+        user = "bosh_#{user_suffix}"
+        sudoers_file = File.join(@sudoers_dir, user)
+
+        open(sudoers_file, 'w') do |f|
+          f.write 'test'
+        end
+
+        @passwd_file.write "#{user}:\n"
+        @passwd_file.flush
+
+        Bosh::Agent::SshdMonitor.stub(:stop_sshd)
+        command_runner.stub(:sh)
+
+        ssh.cleanup
+        expect(File.exists?(sudoers_file)).to be_false
+      end
+    end
+
   end
 
-  it "should copy public key into users director" do
-    ssh = Bosh::Agent::Message::Ssh.new(ssh_create_args)
-    FileUtils.stub!(:chown_R)
-    Bosh::Agent::SshdMonitor.stub!(:start_sshd)
-    Bosh::Agent::Config.stub!(:default_ip).and_return("127.0.0.1")
-    ssh.stub!(:shell_cmd)
-    rtn = ssh.setup
-    authorized_keys =  File.read(File.join(ssh.ssh_base_dir, "spec_user/.ssh/authorized_keys"))
-    rtn["status"].should == "success" && authorized_keys.should == "PUBLIC"
-  end
-
-  it "should not cleanup privileged users" do
-    ssh = Bosh::Agent::Message::Ssh.new(ssh_cleanup_args)
-    Bosh::Agent::SshdMonitor.stub!(:stop_sshd)
-    ssh.stub(:shell_cmd).with("userdel -r root") { raise "Unexpected results" }
-    rtn = ssh.cleanup
-    rtn["status"].should == "success"
-  end
 end

--- a/bosh_cli/lib/cli/commands/ssh.rb
+++ b/bosh_cli/lib/cli/commands/ssh.rb
@@ -14,8 +14,6 @@ module Bosh::Cli::Command
     option "--public_key FILE", "Public key"
     option "--gateway_host HOST", "Gateway host"
     option "--gateway_user USER", "Gateway user"
-    option "--default_password PASSWORD",
-           "Use default ssh password (NOT RECOMMENDED)"
     def shell(*args)
       job, index, command = parse_args(args)
 
@@ -157,14 +155,6 @@ module Bosh::Cli::Command
     def setup_interactive_shell(job, index)
       deployment_required
       password = options[:default_password]
-
-      if password.nil?
-        password = ask(
-          "Enter password (use it to " +
-          "sudo on remote host): ") { |q| q.echo = "*" }
-
-        err("Please provide ssh password") if password.blank?
-      end
 
       setup_ssh(job, index, password) do |sessions, user, gateway|
         session = sessions.first

--- a/bosh_cli/spec/unit/cli_commands/ssh_spec.rb
+++ b/bosh_cli/spec/unit/cli_commands/ssh_spec.rb
@@ -107,7 +107,6 @@ describe Bosh::Cli::Command::Base do
         Bosh::Cli::Director.should_receive(:new).and_return(director)
         Process.stub(:waitpid)
         
-        ssh.add_option(:default_password, 'password')
         ssh.stub(:job_exists_in_deployment?).and_return(true)
         ssh.stub(:deployment_required)      
         ssh.stub(:get_public_key).and_return('PUBKEY')
@@ -128,7 +127,6 @@ describe Bosh::Cli::Command::Base do
         Process.stub(:waitpid)
         
         ssh.add_option(:gateway_host, gw_host)
-        ssh.add_option(:default_password, 'password')
         ssh.stub(:job_exists_in_deployment?).and_return(true)
         ssh.stub(:deployment_required)      
         ssh.stub(:get_public_key).and_return('PUBKEY')
@@ -154,7 +152,6 @@ describe Bosh::Cli::Command::Base do
         
         ssh.add_option(:gateway_host, gw_host)
         ssh.add_option(:gateway_user, gw_user)
-        ssh.add_option(:default_password, 'password')
         ssh.stub(:job_exists_in_deployment?).and_return(true)
         ssh.stub(:deployment_required)      
         ssh.stub(:get_public_key).and_return('PUBKEY')
@@ -179,7 +176,6 @@ describe Bosh::Cli::Command::Base do
         
         ssh.add_option(:gateway_host, gw_host)
         ssh.add_option(:gateway_user, gw_user)
-        ssh.add_option(:default_password, 'password')
         ssh.stub(:job_exists_in_deployment?).and_return(true)
         ssh.stub(:deployment_required)      
         ssh.stub(:get_public_key).and_return('PUBKEY')


### PR DESCRIPTION
This pull request is just for discussion and a little more work would need to be done.

Is there any reason not to allow sudo with no password during bosh ssh sessions? This would make it easier to run single commands that require sudo.

It would also eliminate a step during bosh ssh where most people type a dummy password like 'p' and retype it again a few minutes later. The username and password of the ssh user are already random and only used during that session.

Any thoughts?
