### PR TITLE
[plugin_micro] renamed .agent -> .agent_client

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/cli/commands/micro.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/cli/commands/micro.rb
@@ -250,7 +250,7 @@ module Bosh::Cli::Command
         end
       end
 
-      say(deployer.agent.send(message.to_sym, *args).pretty_inspect)
+      say(deployer.agent_client.send(message.to_sym, *args).pretty_inspect)
     end
 
     usage "micro apply"

--- a/bosh_cli_plugin_micro/lib/deployer/config.rb
+++ b/bosh_cli_plugin_micro/lib/deployer/config.rb
@@ -71,7 +71,7 @@ module Bosh::Deployer
         @cloud
       end
 
-      def agent
+      def agent_client
         uri = URI.parse(agent_url)
         user, password = uri.userinfo.split(":", 2)
         uri.userinfo = nil

--- a/bosh_cli_plugin_micro/lib/deployer/instance_manager.rb
+++ b/bosh_cli_plugin_micro/lib/deployer/instance_manager.rb
@@ -67,8 +67,8 @@ module Bosh::Deployer
       Config.cloud
     end
 
-    def agent
-      Config.agent
+    def agent_client
+      Config.agent_client
     end
 
     def logger

--- a/bosh_cli_plugin_micro/spec/functional/deployer_test_spec.rb
+++ b/bosh_cli_plugin_micro/spec/functional/deployer_test_spec.rb
@@ -34,7 +34,7 @@ describe Bosh::Deployer do
 
     it "should respond to agent ping" do
       pending "VM cid" unless @deployer.state.vm_cid
-      @deployer.agent.ping.should == "pong"
+      @deployer.agent_client.ping.should == "pong"
     end
 
     it "should destroy the Bosh deployment" do

--- a/bosh_cli_plugin_micro/spec/unit/aws/config_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/aws/config_spec.rb
@@ -72,8 +72,8 @@ describe Bosh::Deployer::Config do
     config = Psych.load_file(spec_asset("test-bootstrap-config-aws.yml"))
     config["dir"] = @dir
     Bosh::Deployer::Config.configure(config)
-    agent = Bosh::Deployer::Config.agent
-    agent.should be_kind_of(Bosh::Agent::HTTPClient)
+    agent_client = Bosh::Deployer::Config.agent_client
+    agent_client.should be_kind_of(Bosh::Agent::HTTPClient)
   end
 
   it "should have ec2 and registry object access" do

--- a/bosh_cli_plugin_micro/spec/unit/config_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/config_spec.rb
@@ -71,7 +71,7 @@ describe Bosh::Deployer::Config do
     config = Psych.load_file(spec_asset("test-bootstrap-config.yml"))
     config["dir"] = @dir
     Bosh::Deployer::Config.configure(config)
-    agent = Bosh::Deployer::Config.agent
-    agent.should be_kind_of(Bosh::Agent::HTTPClient)
+    agent_client = Bosh::Deployer::Config.agent_client
+    agent_client.should be_kind_of(Bosh::Agent::HTTPClient)
   end
 end

--- a/bosh_cli_plugin_micro/spec/unit/openstack/config_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/openstack/config_spec.rb
@@ -73,8 +73,8 @@ describe Bosh::Deployer::Config do
     config = Psych.load_file(spec_asset("test-bootstrap-config-openstack.yml"))
     config["dir"] = @dir
     Bosh::Deployer::Config.configure(config)
-    agent = Bosh::Deployer::Config.agent
-    agent.should be_kind_of(Bosh::Agent::HTTPClient)
+    agent_client = Bosh::Deployer::Config.agent_client
+    agent_client.should be_kind_of(Bosh::Agent::HTTPClient)
   end
 
   it "should have openstack and registry object access" do

--- a/bosh_cli_plugin_micro/spec/unit/vcloud/config_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/vcloud/config_spec.rb
@@ -72,8 +72,8 @@ describe Bosh::Deployer::Config do
     config = Psych.load_file(spec_asset("test-bootstrap-config-vcloud.yml"))
     config["dir"] = @dir
     Bosh::Deployer::Config.configure(config)
-    agent = Bosh::Deployer::Config.agent
-    agent.should be_kind_of(Bosh::Agent::HTTPClient)
+    agent_client = Bosh::Deployer::Config.agent_client
+    agent_client.should be_kind_of(Bosh::Agent::HTTPClient)
   end
 
 end


### PR DESCRIPTION
Clarifying that the method returns an agent_client
(`Bosh::Agent::HTTPClient`) object by renaming the generic "agent" method to
"agent_client".
