### PR TITLE
[blobstore_client] extra help if misinvoked

### DIFF
--- a/blobstore_client/bin/blobstore_client_console
+++ b/blobstore_client/bin/blobstore_client_console
@@ -32,6 +32,15 @@ opts_parser.parse!
 
 unless @provider && config_file
   puts opts_parser
+  puts "\nExample config file:"
+  puts <<-YAML
+---
+endpoint: http://1.2.3.4:25250
+user: agent
+password: agent
+bucket: resources
+
+  YAML
   exit(1)
 end
 


### PR DESCRIPTION
Output now looks like:

```
$ bin/blobstore_client_console
```

   Usage: blobstore_client_console [options]
       -p, --provider PROVIDER
       -c, --config FILE

```
Example config file:
```

---

   endpoint: http://1.2.3.4:25250
   user: agent
   password: agent
   bucket: resources
