### PR TITLE
Adding is_public option to openstack cpi for image upload

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -78,6 +78,7 @@ module Bosh::OpenStackCloud
     # @option cloud_properties [String] infrastructure Stemcell infraestructure
     # @option cloud_properties [String] disk_format Image disk format
     # @option cloud_properties [String] container_format Image container format
+    # @option cloud_properties [String] is_public should the image be public
     # @option cloud_properties [optional, String] kernel_file Name of the
     #   kernel image file provided at the stemcell archive
     # @option cloud_properties [optional, String] ramdisk_file Name of the
@@ -138,13 +139,16 @@ module Bosh::OpenStackCloud
               ramdisk_id = upload_image(ramdisk_params)
             end
 
+            # All images should be private on glacnce by default
+            cloud_properties["is_public"] ||= false
+
             # 4. Upload image using Glance service
             image_params = {
               :name => image_name,
               :disk_format => cloud_properties["disk_format"],
               :container_format => cloud_properties["container_format"],
               :location => root_image,
-              :is_public => true
+              :is_public => cloud_properties["is_public"]
             }
             image_properties = {}
             image_properties[:kernel_id] = kernel_id if kernel_id

--- a/bosh_openstack_cpi/spec/unit/create_stemcell_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/create_stemcell_spec.rb
@@ -33,11 +33,72 @@ describe Bosh::OpenStackCloud::Cloud do
 
       sc_id = cloud.create_stemcell("/tmp/foo", {
         "container_format" => "ami",
-        "disk_format" => "ami"
+        "disk_format" => "ami",
+        "is_public" => true
       })
 
       sc_id.should == "i-bar"
     end
+
+    it "creates stemcell using an image without kernel nor ramdisk and private state" do
+      image = double("image", :id => "i-bar", :name => "i-bar")
+      unique_name = SecureRandom.uuid
+      image_params = {
+        :name => "BOSH-#{unique_name}",
+        :disk_format => "ami",
+        :container_format => "ami",
+        :location => "#{@tmp_dir}/root.img",
+        :is_public => false
+      }
+
+      cloud = mock_glance do |glance|
+        glance.images.should_receive(:create).
+          with(image_params).and_return(image)
+      end
+
+      Dir.should_receive(:mktmpdir).and_yield(@tmp_dir)
+      cloud.should_receive(:unpack_image).with(@tmp_dir, "/tmp/foo")
+      cloud.should_receive(:generate_unique_name).and_return(unique_name)
+
+      sc_id = cloud.create_stemcell("/tmp/foo", {
+        "container_format" => "ami",
+        "disk_format" => "ami",
+        "is_public" => false
+      })
+
+      sc_id.should == "i-bar"
+    end
+
+    it "creates stemcell using an image without kernel nor ramdisk and private state as default value" do
+      image = double("image", :id => "i-bar", :name => "i-bar")
+      unique_name = SecureRandom.uuid
+      image_params = {
+        :name => "BOSH-#{unique_name}",
+        :disk_format => "ami",
+        :container_format => "ami",
+        :location => "#{@tmp_dir}/root.img",
+        :is_public => false
+      }
+
+      cloud = mock_glance do |glance|
+        glance.images.should_receive(:create).
+          with(image_params).and_return(image)
+      end
+
+      Dir.should_receive(:mktmpdir).and_yield(@tmp_dir)
+      cloud.should_receive(:unpack_image).with(@tmp_dir, "/tmp/foo")
+      cloud.should_receive(:generate_unique_name).and_return(unique_name)
+
+      
+      sc_id = cloud.create_stemcell("/tmp/foo", {
+        "container_format" => "ami",
+        "disk_format" => "ami",
+      })
+
+      sc_id.should == "i-bar"
+    end
+
+
 
     it "creates stemcell using an image with kernel and ramdisk files" do
       image = double("image", :id => "i-bar", :name => "i-bar")
@@ -92,7 +153,8 @@ describe Bosh::OpenStackCloud::Cloud do
         "container_format" => "ami",
         "disk_format" => "ami",
         "kernel_file" => "kernel.img",
-        "ramdisk_file" => "initrd.img"
+        "ramdisk_file" => "initrd.img",
+        "is_public" => true
       })
 
       sc_id.should == "i-bar"
@@ -164,7 +226,8 @@ describe Bosh::OpenStackCloud::Cloud do
         "container_format" => "ami",
         "disk_format" => "ami",
         "kernel_file" => "kernel.img",
-        "ramdisk_file" => "initrd.img"
+        "ramdisk_file" => "initrd.img",
+        "is_public" => true
       })
 
       sc_id.should == "i-bar"


### PR DESCRIPTION
I've set the default state of the image visability to false because it's a security break if all cloud users can see all Bosh images.
The value can configure in cloud_properties with both boolean values (true|false)

In addition i've added two tests to check if the default is working and the private state (is_public = false)
