### PR TITLE
[openstack_cpi] Check security groups exists

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -184,7 +184,11 @@ module Bosh::OpenStackCloud
 
         network_configurator = NetworkConfigurator.new(network_spec)
 
+        openstack_security_groups = with_openstack { @openstack.security_groups }.collect { |sg| sg.name }
         security_groups = network_configurator.security_groups(@default_security_groups)
+        security_groups.each do |sg|
+          cloud_error("Security group `#{sg}' not found") unless openstack_security_groups.include?(sg)
+        end
         @logger.debug("Using security groups: `#{security_groups.join(', ')}'")
 
         nics = network_configurator.nics

--- a/bosh_openstack_cpi/spec/spec_helper.rb
+++ b/bosh_openstack_cpi/spec/spec_helper.rb
@@ -62,6 +62,7 @@ def mock_cloud(options = nil)
   addresses = double("addresses")
   snapshots = double("snapshots")
   key_pairs = double("key_pairs")
+  security_groups = double("security_groups")
 
   glance = double(Fog::Image)
   Fog::Image.stub(:new).and_return(glance)
@@ -75,6 +76,7 @@ def mock_cloud(options = nil)
   openstack.stub(:addresses).and_return(addresses)
   openstack.stub(:snapshots).and_return(snapshots)
   openstack.stub(:key_pairs).and_return(key_pairs)
+  openstack.stub(:security_groups).and_return(security_groups)
 
   Fog::Compute.stub(:new).and_return(openstack)
 


### PR DESCRIPTION
Provide a better error message when creating a server and one of the security groups doesn't exists.
