### PR TITLE
bosh releases --jobs - shows available job names

### DIFF
--- a/bosh_cli/spec/unit/cli_commands/cli_commands_spec.rb
+++ b/bosh_cli/spec/unit/cli_commands/cli_commands_spec.rb
@@ -295,9 +295,9 @@ describe Bosh::Cli::Command::Base do
           {
               'name' => 'release-1',
               'release_versions' => [
-                  {'version' => '2.1-dev', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => true},
-                  {'version' => '15', 'commit_hash' => '1a2b3c4d', 'uncommitted_changes' => true, 'currently_deployed' => false},
-                  {'version' => '2', 'commit_hash' => '00000000', 'uncommitted_changes' => true, 'currently_deployed' => false},
+                  {'version' => '2.1-dev', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => true, 'job_names' => ['job-1']},
+                  {'version' => '15', 'commit_hash' => '1a2b3c4d', 'uncommitted_changes' => true, 'currently_deployed' => false, 'job_names' => ['job-1']},
+                  {'version' => '2', 'commit_hash' => '00000000', 'uncommitted_changes' => true, 'currently_deployed' => false, 'job_names' => ['job-1']},
                   {'version' => '1', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => false}
               ]
           }
@@ -316,6 +316,19 @@ describe Bosh::Cli::Command::Base do
           OUT
         end
 
+        let(:releases_with_jobs_table) do
+          <<-OUT.gsub(/^\s*/, '').chomp
+      +-----------+----------+-------------+-------+
+      | Name      | Versions | Commit Hash | Jobs  |
+      +-----------+----------+-------------+-------+
+      | release-1 | 1        | unknown     | n/a   |
+      |           | 2        | 00000000+   | job-1 |
+      |           | 2.1-dev* | unknown     | job-1 |
+      |           | 15       | 1a2b3c4d+   | job-1 |
+      +-----------+----------+-------------+-------+
+          OUT
+        end
+
         it "lists releases in a nice table and includes information about current deployments and uncommitted changes" do
           @director.stub(list_releases: [release])
 
@@ -324,6 +337,18 @@ describe Bosh::Cli::Command::Base do
           @cmd.should_receive(:say).with("(+) Uncommitted changes")
           @cmd.should_receive(:say).with("Releases total: 1")
 
+          @cmd.list
+        end
+
+        it "lists releases in a nice table and includes job names if available" do
+          @director.stub(list_releases: [release])
+
+          @cmd.should_receive(:say).with(releases_with_jobs_table)
+          @cmd.should_receive(:say).with("(*) Currently deployed")
+          @cmd.should_receive(:say).with("(+) Uncommitted changes")
+          @cmd.should_receive(:say).with("Releases total: 1")
+
+          @cmd.add_option(:jobs, true)
           @cmd.list
         end
       end

--- a/director/lib/director.rb
+++ b/director/lib/director.rb
@@ -274,7 +274,8 @@ module Bosh::Director
           Hash["version", rv.version.to_s,
                "commit_hash", rv.commit_hash,
                "uncommitted_changes", rv.uncommitted_changes,
-               "currently_deployed", !rv.deployments.empty?]
+               "currently_deployed", !rv.deployments.empty?,
+               "job_names", rv.templates.map(&:name)]
         end
 
         Hash["name", release.name,

--- a/director/spec/functional/director_controller_spec.rb
+++ b/director/spec/functional/director_controller_spec.rb
@@ -274,7 +274,7 @@ describe Bosh::Director::ApiController do
         BD::Models::ReleaseVersion.
             create(release: release1, version: 1)
         deployment1 = BD::Models::Deployment.create(name: 'deployment-1')
-        deployment1.add_release_version(release1.versions.first) # release-1 is now currently_deployed
+        release1 = deployment1.add_release_version(release1.versions.first) # release-1 is now currently_deployed
         release2 = BD::Models::Release.create(name: 'release-2')
         BD::Models::ReleaseVersion.
             create(release: release2, version: 2, commit_hash: '0b2c3d', uncommitted_changes: true)
@@ -286,9 +286,9 @@ describe Bosh::Director::ApiController do
         expected_collection =
           [
               {"name"=>"release-1",
-               "release_versions"=> [Hash["version", "1", "commit_hash", "unknown", "uncommitted_changes", false, "currently_deployed", true]]},
+               "release_versions"=> [Hash["version", "1", "commit_hash", "unknown", "uncommitted_changes", false, "currently_deployed", true, "job_names", []]]},
               {"name"=>"release-2",
-               "release_versions"=> [Hash["version", "2", "commit_hash", "0b2c3d", "uncommitted_changes", true, "currently_deployed", false]]}
+               "release_versions"=> [Hash["version", "2", "commit_hash", "0b2c3d", "uncommitted_changes", true, "currently_deployed", false, "job_names", []]]}
           ]
 
         body.should == Yajl::Encoder.encode(expected_collection)


### PR DESCRIPTION
Optional --jobs flag shows the available job template names in each release
version; if the director returns the "job_names" key in its GET /releases
endpoint.

Targeting director without API support:

```
   +-------+-----------+-------------+-------+
   | Name  | Versions  | Commit Hash | Jobs  |
   +-------+-----------+-------------+-------+
   | bosh  | 13.1-dev  | d380ee49+   | n/a   |
   |       | 13.2-dev  | d380ee49+   | n/a   |
   |       | 13.3-dev  | d380ee49+   | n/a   |
   |       | 13.4-dev  | ec1936b7+   | n/a   |
   |       | 13.5-dev* | d380ee49+   | n/a   |
   | redis | 1         | 59e77715+   | n/a   |
   +-------+-----------+-------------+-------+
```

Targeting director with API support:

```
+-------+----------+-------------+--------------------------------------------------------------------------------+
| Name  | Versions | Commit Hash | Jobs                                   
+-------+----------+-------------+--------------------------------------------------------------------------------+
| bosh  | 13.4-dev | ec1936b7+   | blobstore, director, health_monitor, nats, postgres, powerdns, redis, registry |
| redis | 1        | 59e77715+   | redis                                                                          |
+-------+----------+-------------+--------------------------------------------------------------------------------+
```
