### PR TITLE
Make S3 endpoint configurable

### DIFF
--- a/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
@@ -35,7 +35,8 @@ module Bosh
           :access_key_id     => @options[:access_key_id],
           :secret_access_key => @options[:secret_access_key],
           :use_ssl           => true,
-          :port              => 443
+          :port              => 443,
+          :s3_endpoint       => URI.parse(@options[:endpoint] || S3BlobstoreClient::ENDPOINT).host,
         }
 
         # using S3 without credentials is a special case:

--- a/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
+++ b/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
@@ -33,6 +33,22 @@ describe Bosh::Blobstore::S3BlobstoreClient do
       }.to raise_error Bosh::Blobstore::BlobstoreError,
                        "can't use read-only with an encryption key"
     end
+
+    it "should be processed and passed to the AWS::S3 class" do
+      options = {"bucket_name"       => "test",
+                 "access_key_id"     => "KEY",
+                 "secret_access_key" => "SECRET",
+                 "endpoint"          => "https://s3.example.com"}
+      @s3 = double(AWS::S3)
+      AWS::S3.should_receive(:new)
+        .with({:access_key_id     => "KEY",
+               :secret_access_key => "SECRET",
+               :use_ssl           => true,
+               :port              => 443,
+               :s3_endpoint       => "s3.example.com"})
+        .and_return(@s3)
+      Bosh::Blobstore::S3BlobstoreClient.new(options)
+    end
   end
 
   describe "create" do


### PR DESCRIPTION
The endpoint of the S3 blobstore client is currently fixed to s3.amazon.com. This commit makes it configurable to store blob files in S3-compatible blobstores such as Cloudian and RiakCS.
