### PR TITLE
Do not specify Ruby patch level in .rvmrc

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm --create 1.9.3-p327@bosh
+rvm --create 1.9.3@bosh


### PR DESCRIPTION
My understanding is that .rvmrc is only used by Jenkins and we'd like to
get rid of this file eventually.
