### PR TITLE
[openstack_cpi] Improve dealing with some OpenStack API errors

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/helpers.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/helpers.rb
@@ -13,8 +13,10 @@ module Bosh::OpenStackCloud
     # Raises CloudError exception
     #
     # @param [String] message Message about what went wrong
-    def cloud_error(message)
+    # @param [Exception] exception Exception to be logged (optional)
+    def cloud_error(message, exception = nil)
       @logger.error(message) if @logger
+      @logger.error(exception) if @logger && exception
       raise Bosh::Clouds::CloudError, message
     end
 
@@ -24,29 +26,43 @@ module Bosh::OpenStackCloud
         yield
       rescue Excon::Errors::RequestEntityTooLarge => e
         # If we find a rate limit error, parse message, wait, and retry
-        unless e.response.body.empty? || retries >= MAX_RETRIES
-          begin
-            message = JSON.parse(e.response.body)
-            overlimit = message["overLimit"] || message["overLimitFault"]
-            if overlimit
-              task_checkpoint
-              wait_time = overlimit["retryAfter"] || e.response.headers["Retry-After"] || DEFAULT_RETRY_TIMEOUT
-              details = "#{overlimit["message"]} - #{overlimit["details"]}"
-              @logger.debug("OpenStack API overLimit (#{details}), waiting #{wait_time} seconds before retrying") if @logger
-              sleep(wait_time.to_i)
-              retries += 1
-              retry
-            end
-          rescue JSON::ParserError
-            # do nothing
-          end
+        overlimit = parse_openstack_response(e.response, "overLimit", "overLimitFault")
+        unless overlimit.nil? || retries >= MAX_RETRIES
+          task_checkpoint
+          wait_time = overlimit["retryAfter"] || e.response.headers["Retry-After"] || DEFAULT_RETRY_TIMEOUT
+          details = "#{overlimit["message"]} - #{overlimit["details"]}"
+          @logger.debug("OpenStack API Over Limit (#{details}), waiting #{wait_time} seconds before retrying") if @logger
+          sleep(wait_time.to_i)
+          retries += 1
+          retry
         end
-        @logger.error(e) if @logger
-        cloud_error("OpenStack API returned a RequestEntityTooLarge error. Check task debug log for details.")
+        cloud_error("OpenStack API Request Entity Too Large error. Check task debug log for details.", e)
+      rescue Excon::Errors::BadRequest => e
+        badrequest = parse_openstack_response(e.response, "badRequest")
+        details = badrequest.nil? ? "" : " (#{badrequest["message"]})"   
+        cloud_error("OpenStack API Bad Request#{details}. Check task debug log for details.", e)
       rescue Excon::Errors::InternalServerError => e
-        @logger.error(e) if @logger
-        cloud_error("OpenStack API returned a Internal Server error. Check task debug log for details.")
+        cloud_error("OpenStack API Internal Server error. Check task debug log for details.", e)
       end
+    end
+    
+    ##
+    # Parses and look ups for keys in an OpenStack response 
+    #
+    # @param [Excon::Response] response Response from OpenStack API
+    # @param [Array<String>] keys Keys to look up in response
+    # @return [Hash] Contents at the first key found, or nil if not found
+    def parse_openstack_response(response, *keys)
+      unless response.body.empty?
+        begin
+          body = JSON.parse(response.body)
+          key = keys.detect { |k| body.has_key?(k)}
+          return body[key] if key
+        rescue JSON::ParserError
+          # do nothing
+        end
+      end
+      nil
     end
 
     ##

--- a/bosh_openstack_cpi/spec/unit/helpers_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/helpers_spec.rb
@@ -119,50 +119,7 @@ describe Bosh::OpenStackCloud::Helpers do
       }.to raise_error(NoMemoryError)
     end
 
-    context "InternalServerError" do
-      it "should raise a CloudError exception when OpenStack API returns a InternalServerError" do  
-        @openstack.should_receive(:servers).and_raise(Excon::Errors::InternalServerError.new("InternalServerError"))
-  
-        expect {
-          @cloud.with_openstack do
-            @openstack.servers
-          end
-        }.to raise_error(Bosh::Clouds::CloudError, 
-                         "OpenStack API returned a Internal Server error. Check task debug log for details.")
-      end
-    end
-    
-    context "RequestEntityTooLarge" do
-      it "should raise a CloudError exception if response has no body" do
-        response = Excon::Response.new(:body => "")
-  
-        @openstack.should_receive(:servers)
-          .and_raise(Excon::Errors::RequestEntityTooLarge.new("", "", response))
-        @cloud.should_not_receive(:sleep)
-  
-        expect {
-          @cloud.with_openstack do
-            @openstack.servers
-          end
-        }.to raise_error(Bosh::Clouds::CloudError, 
-                         "OpenStack API returned a RequestEntityTooLarge error. Check task debug log for details.")
-      end
-  
-      it "should raise a CloudError exception if response is not JSON" do
-        response = Excon::Response.new(:body => "foo = bar")
-  
-        @openstack.should_receive(:servers)
-          .and_raise(Excon::Errors::RequestEntityTooLarge.new("", "", response))
-        @cloud.should_not_receive(:sleep)
-  
-        expect {
-          @cloud.with_openstack do
-            @openstack.servers
-          end
-        }.to raise_error(Bosh::Clouds::CloudError, 
-                         "OpenStack API returned a RequestEntityTooLarge error. Check task debug log for details.")
-      end
-  
+    context "RequestEntityTooLarge" do  
       it "should retry the amount of seconds received at the response body" do
         body = { "overLimit" => {
             "message" => "This request was rate-limited.",
@@ -237,8 +194,86 @@ describe Bosh::OpenStackCloud::Helpers do
             @openstack.servers
           end
         }.to raise_error(Bosh::Clouds::CloudError, 
-                         "OpenStack API returned a RequestEntityTooLarge error. Check task debug log for details.")
+                         "OpenStack API Request Entity Too Large error. Check task debug log for details.")
+      end
+    end    
+    
+    context "BadRequest" do
+      it "should raise a CloudError exception with OpenStack API message if there is a BadRequest" do  
+        message = "Invalid volume: Volume still has 1 dependent snapshots"
+        response = Excon::Response.new(:body => JSON.dump({"badRequest" => {"message" => message}}))
+        @openstack.should_receive(:servers).and_raise(Excon::Errors::BadRequest.new("", "", response))
+  
+        expect {
+          @cloud.with_openstack do
+            @openstack.servers
+          end
+        }.to raise_error(Bosh::Clouds::CloudError, 
+                         "OpenStack API Bad Request (#{message}). Check task debug log for details.")
+      end
+
+      it "should raise a CloudError exception without OpenStack API message if there is a BadRequest" do  
+        response = Excon::Response.new(:body => "")
+        @openstack.should_receive(:servers).and_raise(Excon::Errors::BadRequest.new("", "", response))
+  
+        expect {
+          @cloud.with_openstack do
+            @openstack.servers
+          end
+        }.to raise_error(Bosh::Clouds::CloudError, 
+                         "OpenStack API Bad Request. Check task debug log for details.")
       end
     end
+
+    context "InternalServerError" do
+      it "should raise a CloudError exception when OpenStack API returns a InternalServerError" do  
+        @openstack.should_receive(:servers).and_raise(Excon::Errors::InternalServerError.new("InternalServerError"))
+  
+        expect {
+          @cloud.with_openstack do
+            @openstack.servers
+          end
+        }.to raise_error(Bosh::Clouds::CloudError, 
+                         "OpenStack API Internal Server error. Check task debug log for details.")
+      end
+    end
+  end
+
+  describe "parse_openstack_response" do    
+    it "should return nil if response has no body" do
+      response = Excon::Response.new()
+
+      expect(@cloud.parse_openstack_response(response, "key")).to be_nil
+    end
+
+    it "should return nil if response has an empty body" do
+      response = Excon::Response.new(:body => JSON.dump(""))
+
+      expect(@cloud.parse_openstack_response(response, "key")).to be_nil
+    end
+    
+    it "should return nil if response is not JSON" do
+      response = Excon::Response.new(:body => "foo = bar")
+      
+      expect(@cloud.parse_openstack_response(response, "key")).to be_nil
+    end      
+
+    it "should return nil if response is no key is found" do
+      response = Excon::Response.new(:body => JSON.dump({"foo" => "bar"}))
+      
+      expect(@cloud.parse_openstack_response(response, "key")).to be_nil
+    end 
+
+    it "should return the contents if key is found" do
+      response = Excon::Response.new(:body => JSON.dump({"key" => "foo"}))
+      
+      expect(@cloud.parse_openstack_response(response, "key")).to eql("foo")
+    end 
+
+    it "should return the contents of the first key found" do
+      response = Excon::Response.new(:body => JSON.dump({"key1" => "foo", "key2" => "bar"}))
+      
+      expect(@cloud.parse_openstack_response(response, "key2", "key1")).to eql("bar")
+    end 
   end
 end


### PR DESCRIPTION
- Retry-After messages in Folsom come on response headers
- Raise the default retry after to 3 seconds if doesn't come in OpenStack API message
- Provide a better error message when there's a BadRequest error
