### PR TITLE
provide director.proxy_timeout option and set it to 15 mins by default

### DIFF
--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -37,7 +37,10 @@ properties:
     description: Number of nginx workers for director
   director.timeout:
     default: 7200
-    description: Timeout for nginx
+    description: Timeout for connection from bosh CLI to nginx
+  director.proxy_timeout:
+    default: 900
+    description: Timeout for proxy connection from nginx to director
   director.max_upload_size:
     default: 5000m
     description: Max allowed file size for upload

--- a/release/jobs/director/templates/nginx.conf.erb
+++ b/release/jobs/director/templates/nginx.conf.erb
@@ -19,6 +19,8 @@ http {
 
     location / {
       proxy_pass         http://127.0.0.1:<%= p('director.backend_port') %>;
+      proxy_read_timeout <%= p('director.timeout') %>;
+
       proxy_set_header   Host             $host;
       proxy_set_header   X-Real-IP        $remote_addr;
       proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Currently director does not use nginx upload module and reads/write uploaded blobs in Ruby.
This causes 504 Gateway Timeout for particular requests (upload release, etc)
