### PR TITLE
[agent] Post prepare network changes should restart agent [fixes #52275897]

### DIFF
--- a/bosh_agent/spec/unit/handler_spec.rb
+++ b/bosh_agent/spec/unit/handler_spec.rb
@@ -332,7 +332,7 @@ describe Bosh::Agent::Handler do
     let(:udev_file) { '/etc/udev/rules.d/70-persistent-net.rules' }
     let(:settings_file) { Tempfile.new('test') }
     
-    it 'should reboot the instance' do      
+    it 'should delete the settings file and restart the agent' do      
       handler = Bosh::Agent::Handler.new
       handler.start
       Bosh::Agent::Config.configure = true
@@ -342,7 +342,7 @@ describe Bosh::Agent::Handler do
       @nats.should_receive(:publish).and_yield
       File.should_receive(:exist?).with(udev_file).and_return(false)
       File.should_receive(:delete).with(settings_file)
-      handler.should_receive(:sh).with('/sbin/reboot', :on_error => :return)
+      handler.should_receive(:kill_main_thread_in).with(1)
       
       handler.handle_message(Yajl::Encoder.encode('method' => 'prepare_network_change', 
                                                   'reply_to' => 'inbox.client_id',

--- a/director/lib/director/instance_updater.rb
+++ b/director/lib/director/instance_updater.rb
@@ -439,6 +439,10 @@ module Bosh::Director
         update_resource_pool
         return
       end
+
+      # Give some time to the agent to restart before pinging if it's ready
+      sleep(5)
+
       agent.wait_until_ready
     end
 


### PR DESCRIPTION
When there's a network change on an existing vm, director sends a prepare_network_change message to the vm
agent. After agent replies to director with a `true` message, the post_prepare_network_change method is called
(via EM callback).

The post_prepare_network_change  method will delete the udev network persistent rules, delete the agent settings
and then it should restart the agent to get the new agent settings (set by director-cpi). For a simple network
change (i.e. dns changes) this is enough, as when the agent is restarted it will apply the new network settings.
But for other network changes (i.e. IP change), the CPI will be responsible to reboot or recreate the vm if needed.
