### PR TITLE
[director] Reorder instance update steps [fixes #52547427]

### DIFF
--- a/director/lib/director/instance_updater.rb
+++ b/director/lib/director/instance_updater.rb
@@ -70,9 +70,9 @@ module Bosh::Director
       end
 
       step { update_resource_pool }
-      step { update_persistent_disk }
       step { update_networks }
       step { update_dns }
+      step { update_persistent_disk }
 
       update_vm_metadata(@vm)
 

--- a/director/spec/unit/instance_updater_spec.rb
+++ b/director/spec/unit/instance_updater_spec.rb
@@ -164,6 +164,52 @@ describe Bosh::Director::InstanceUpdater do
       end
     end
 
+    context 'when a vm needs to be recreated' do
+      let(:networks_changed) { true }
+
+      context 'without persistent disk' do
+        let(:persistent_disk_changed) { false }
+
+        it 'should recreate vm' do
+          agent_client.should_receive(:prepare_network_change)
+          cloud.should_receive(:configure_networks).and_raise(Bosh::Clouds::NotSupported)
+          instance.should_receive(:recreate=)
+
+          subject.stub(:stop)
+          subject.stub(:update_resource_pool)
+          subject.stub(:start!)
+          subject.stub(:apply_state)
+          subject.stub(:wait_until_running)
+          subject.stub(current_state: {'job_state' => 'running'})
+
+          subject.update
+        end
+      end
+
+      context 'with persistent disk' do
+        let(:persistent_disk_changed) { true }
+
+        it 'should recreate vm and attach disk' do
+          agent_client.should_receive(:prepare_network_change)
+          cloud.should_receive(:configure_networks).and_raise(Bosh::Clouds::NotSupported)
+          instance.should_receive(:recreate=)
+          job.should_receive(:persistent_disk).exactly(3).times.and_return(1024)
+          cloud.should_receive(:create_disk).and_return('disk-cid')
+          cloud.should_receive(:attach_disk)
+          agent_client.should_receive(:mount_disk)
+
+          subject.stub(:stop)
+          subject.stub(:update_resource_pool)
+          subject.stub(:start!)
+          subject.stub(:apply_state)
+          subject.stub(:wait_until_running)
+          subject.stub(current_state: {'job_state' => 'running'})
+
+          subject.update
+        end
+      end
+    end
+
     describe 'canary' do
       before do
         subject.stub(:stop)


### PR DESCRIPTION
When updating an instance, sometimes we need to recreate the vm
(eg when IP changed). If the job has a persistent disk, that means
attaching a disk to the vm, detaching the disk, recreate the vm, and
reattach the disk again.

In this commit we are reordering the update steps, so the persistent
disk step is executed after any network change. In this way, we are
only attaching the disk once.

It also fixes a bug that prevented to reattach the disk when the vm
was recreated.
