### PR TITLE
Show step message before long-running block result

### DIFF
--- a/bosh_cli/lib/cli/validation.rb
+++ b/bosh_cli/lib/cli/validation.rb
@@ -29,9 +29,11 @@ module Bosh::Cli
     private
 
     def step(name, error_message, kind = :non_fatal, &block)
+      say("%-60s " % [name], "")
+
       passed = yield
 
-      say("%-60s %s" % [name, passed ? "OK".make_green : "FAILED".make_red])
+      say("%s" % [passed ? "OK".make_green : "FAILED".make_red])
 
       unless passed
         errors << error_message


### PR DESCRIPTION
This means #step can be used to display what is currently happening whilst
determining OK/FAILED.
