### PR TITLE
Use cross-platform /dev/null file

### DIFF
--- a/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws.rb
+++ b/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws.rb
@@ -5,7 +5,7 @@ require 'logger'
 # task_checkpoint & logger is available when ResourceWait.for_resource is called
 require "cloud"
 Config = Struct.new(:task_checkpoint, :logger)
-Bosh::Clouds::Config.configure(Config.new(true, Logger.new('/dev/null')))
+Bosh::Clouds::Config.configure(Config.new(true, Logger.new(File::NULL)))
 
 require "cloud/aws/resource_wait"
 require "common/ssl"


### PR DESCRIPTION
Issue raised in this Stack Overflow question:
http://stackoverflow.com/questions/17602148/how-to-deploy-cloudfoundry-to-aws

Answer from here:
http://stackoverflow.com/a/8682009/126042
