### PR TITLE
Bypass remote_tunnel() for vCloud

### DIFF
--- a/bosh_cli_plugin_micro/lib/deployer/instance_manager/vcloud.rb
+++ b/bosh_cli_plugin_micro/lib/deployer/instance_manager/vcloud.rb
@@ -5,6 +5,9 @@ module Bosh::Deployer
 
     class Vcloud < InstanceManager
 
+      def remote_tunnel(port)
+      end
+
       def update_spec(spec)
         properties = spec.properties
 


### PR DESCRIPTION
As in #187 for vSphere, the remote_tunnel() function needs to be bypassed for vCloud, too.
With this patch micro bosh deploys cleanly.
