### PR TITLE
Use some defaults from ENV

### DIFF
--- a/bosh-dev/lib/bosh/dev/tasks/stemcell.rake
+++ b/bosh-dev/lib/bosh/dev/tasks/stemcell.rake
@@ -27,6 +27,14 @@ namespace :stemcell do
   task :micro, [:tarball, :infrastructure, :version, :disk_size] do |t, args|
     require 'bosh/dev/micro_bosh_release'
 
+    defaults = {
+      tarball: ENV['tarball'],
+      infrastructure: ENV['infrastructure'],
+      version: ENV['version'],
+      disk_size: ENV['disk_size']
+    }
+    args.with_defaults(defaults)
+
     manifest =
       File.join(
         File.expand_path(


### PR DESCRIPTION
Hello!

I kept running into this issue while trying to build a micro BOSH stemcell:

```
$ bundle exec rake stemcell:micro[/tmp/micro.tgz,vsphere,1,4096]
rake aborted!
key not found: "AWS_ACCESS_KEY_ID_FOR_STEMCELLS_JENKINS_ACCOUNT"
/home/lbakken/src/cf/bosh/bosh-dev/lib/bosh/dev/pipeline.rb:12:in `fetch'
/home/lbakken/src/cf/bosh/bosh-dev/lib/bosh/dev/pipeline.rb:12:in `block in initialize'
/home/lbakken/src/cf/bosh/bosh-dev/lib/bosh/dev/pipeline.rb:9:in `fetch'
/home/lbakken/src/cf/bosh/bosh-dev/lib/bosh/dev/pipeline.rb:9:in `initialize'
/home/lbakken/src/cf/bosh/bosh-dev/lib/bosh/dev/tasks/stemcell.rake:50:in `new'
/home/lbakken/src/cf/bosh/bosh-dev/lib/bosh/dev/tasks/stemcell.rake:50:in `block (2 levels) in <top (required)>'
Tasks: TOP => stemcell:micro
(See full trace by running task with --trace)
```

In the rakefile (`bosh-dev/lib/bosh/dev/tasks/stemcell.rake`), `:tarball` is the first task argument. Using standard task argument passing on the command line, I couldn't figure out a way to _not_ pass the `:tarball` argument.

The supplied patch will allow calling this task in this manner to skip the `:tarball` argument:

`bundle exec rake stemcell:micro infrastructure=tier3 version=1 disk_size=4096`

Thanks
