### PR TITLE
"bosh ssh" prompts for which instance to ssh

### DIFF
--- a/bosh_cli/lib/cli/commands/ssh.rb
+++ b/bosh_cli/lib/cli/commands/ssh.rb
@@ -16,7 +16,13 @@ module Bosh::Cli::Command
     option '--default_password PASSWORD',
            'Use default ssh password (NOT RECOMMENDED)'
     def shell(*args)
-      job, index, command = parse_args(args)
+      if args.size > 0
+        job, index, command = parse_args(args)
+      else
+        job, index = user_select_job_index
+        command = ""
+      end
+
       job_must_exist_in_deployment(job)
       index = valid_index_for(job, index, integer_index: true)
 

--- a/bosh_cli/lib/cli/deployment_helper.rb
+++ b/bosh_cli/lib/cli/deployment_helper.rb
@@ -242,6 +242,31 @@ module Bosh::Cli
       err("Job `#{job}' doesn't exist") unless job_exists_in_deployment?(job)
     end
 
+    # Allow user to view the list of VMs (JOB/INDEX) and choose one
+    # If deployment only has a single VM, then automatically returns it
+    #
+    # returns [job, index] of a selected VM
+    def user_select_job_index
+      jobs = prepare_deployment_manifest.fetch("jobs")
+      if jobs.size == 1 && jobs.first.fetch("instances") == 1
+        [jobs.first.fetch("name"), 0]
+      else
+        choose do |menu|
+          menu.prompt = "Choose an instance: "
+          jobs.each do |job|
+            job_name = job.fetch("name")
+            instances = job.fetch("instances")
+            1.upto(instances.to_i) do |n|
+              index = n - 1
+              menu.choice("#{job_name}/#{index}") do
+                return [ job_name, index ]
+              end
+            end
+          end
+        end
+      end
+    end
+
     def cancel_deployment
       quit("Deployment canceled".make_red)
     end

--- a/bosh_cli/spec/unit/commands/ssh_spec.rb
+++ b/bosh_cli/spec/unit/commands/ssh_spec.rb
@@ -47,12 +47,6 @@ describe Bosh::Cli::Command::Ssh do
         }.to raise_error(Bosh::Cli::CliError, 'Please choose deployment first')
       end
 
-      it 'should fail to setup ssh when a job name is not given' do
-        expect {
-          command.shell
-        }.to raise_error(Bosh::Cli::CliError, 'Please provide job name')
-      end
-
       it 'should fail to setup ssh when a job index is not an Integer' do
         expect {
           command.shell('dea/dea')
@@ -104,10 +98,16 @@ describe Bosh::Cli::Command::Ssh do
           }
         end
 
-        it 'should implicitly chooses the only instance' do
+        it 'should implicitly chooses the only instance if job index not provided' do
           command.should_receive(:setup_interactive_shell).with('dea', 0)
           command.shell('dea')
         end
+
+        it 'should implicitly chooses the only instance if job name not provided' do
+          command.should_receive(:setup_interactive_shell).with('dea', 0)
+          command.shell
+        end
+
       end
 
       context 'when there are many instances with that job name in the deployment' do
@@ -130,6 +130,13 @@ describe Bosh::Cli::Command::Ssh do
           }.to raise_error(Bosh::Cli::CliError,
                            'You should specify the job index. There is more than one instance of this job type.')
         end
+
+        it 'should prompt for an instance if job name not given' do
+          command.should_receive(:choose).and_return(["dea", 3])
+          command.should_receive(:setup_interactive_shell).with('dea', 3)
+          command.shell
+        end
+
       end
     end
 


### PR DESCRIPTION
Usage:

```
$ bosh ssh
1. service_gateways/0
2. postgresql_service_node/0
3. redis_service_node/0
Choose an instance: 2
Enter password (use it to sudo on remote host): *
Target deployment is `cf-services-dfw2-prod-alt'

Setting up ssh artifacts

Director task 7791

Task 7791 done
Starting interactive shell on job postgresql_service_node/0
```
