### PR TITLE
Add /proc to fstab

### DIFF
--- a/stemcell_builder/stages/base_debootstrap/apply.sh
+++ b/stemcell_builder/stages/base_debootstrap/apply.sh
@@ -30,6 +30,8 @@ fi
 echo "Running debootstrap"
 debootstrap --arch=$base_debootstrap_arch $base_debootstrap_suite $chroot $mirror
 
+echo "proc            /proc           proc    nodev,noexec,nosuid 0       0" >> $chroot/etc/fstab
+
 # Shady work around vmbuilder in combination with ubuntu iso cache corrupting
 # the debian list caches. There is a discussion in:
 # https://bugs.launchpad.net/ubuntu/+source/update-manager/+bug/24061


### PR DESCRIPTION
As BOSH will inject a file to "BOSH_APP_DIR}/user_data.json", in openstack grizzly it using guestfs to do inject file into vms which need reading /etc/fstab which should not be empty
