### PR TITLE
Jobs all using static ip should working correctly

### DIFF
--- a/director/lib/director/deployment_plan/idle_vm.rb
+++ b/director/lib/director/deployment_plan/idle_vm.rb
@@ -54,7 +54,7 @@ module Bosh::Director
       # @return [void]
       def release_reservation
         if has_network_reservation?
-          @resource_pool.network.release(@network_reservation)
+          @resource_pool.network.release(@network_reservation) if @network_reservation.ip
           @network_reservation = nil
         end
       end
@@ -78,6 +78,23 @@ module Bosh::Director
               @network_reservation)
           network_settings
         end
+      end
+
+      def network_valid?
+        network_valid = true
+        if @bound_instance
+          @bound_instance.network_reservations.each_value do |network_reservation|
+            if network_reservation.nil? || network_reservation.ip.nil?
+              network_valid = false
+              break
+            end
+          end
+        else
+          if @network_reservation.nil? || @network_reservation.ip.nil?
+            network_valid = false
+          end
+        end
+        network_valid
       end
 
       ##

--- a/director/lib/director/deployment_plan/resource_pool.rb
+++ b/director/lib/director/deployment_plan/resource_pool.rb
@@ -96,7 +96,12 @@ module Bosh::Director
       # @return [NetworkReservation] Obtained reservation
       def reserve_dynamic_network
         reservation = NetworkReservation.new_dynamic
-        @network.reserve!(reservation, "Resource pool `#{@name}'")
+        begin
+          @network.reserve!(reservation, "Resource pool `#{@name}'")
+        rescue NetworkReservationNotEnoughCapacity 
+          # it doesn't matter becasue network reservation will be done when parse a job
+          reservation.ip = nil
+        end
         reservation
       end
 

--- a/director/spec/unit/deployment_plan/idle_vm_spec.rb
+++ b/director/spec/unit/deployment_plan/idle_vm_spec.rb
@@ -36,6 +36,38 @@ describe Bosh::Director::DeploymentPlan::IdleVm do
     end
   end
 
+  describe :network_valid? do
+    it "should return false when there is bound instance and its network without an IP" do
+      network_reservation = stub(BD::NetworkReservation)
+      network_reservation.stub(:ip).and_return(nil)
+      bound_instance = stub(BD::DeploymentPlan::Instance)
+      bound_instance.stub(:network_reservations).and_return({ "net_a" => network_reservation})
+      @vm.bound_instance = bound_instance
+      @vm.network_valid?.should == false
+    end
+
+    it "should return true when there is bound instance and its bound instance network is valid" do
+      network_reservation = stub(BD::NetworkReservation)
+      network_reservation.stub(:ip).and_return(1)
+      bound_instance = stub(BD::DeploymentPlan::Instance)
+      bound_instance.stub(:network_reservations).and_return({ "net_a" => network_reservation})
+      @vm.bound_instance = bound_instance
+      @vm.network_valid?.should == true
+    end
+
+    it "should return false when network settings is not valid and there is no bound instance" do
+      @reservation.stub(:ip).and_return(nil)
+      @vm.use_reservation(@reservation)
+      @vm.network_valid?.should == false
+    end
+
+    it "should return true when network settings is valid and there is no bound instance" do
+      @reservation.stub(:ip).and_return(1)
+      @vm.use_reservation(@reservation)
+      @vm.network_valid?.should == true
+    end
+  end
+
   describe :networks_changed? do
     before(:each) do
       @vm.use_reservation(@reservation)

--- a/director/spec/unit/resource_pool_updater_spec.rb
+++ b/director/spec/unit/resource_pool_updater_spec.rb
@@ -65,6 +65,7 @@ describe Bosh::Director::ResourcePoolUpdater do
     before(:each) do
       @idle_vm = stub(:IdleVm)
       @network_settings = {"network" => "settings"}
+      @idle_vm.stub(:network_valid?).and_return(true)
       @idle_vm.stub(:network_settings).and_return(@network_settings)
       @deployment = BD::Models::Deployment.make
       @deployment_plan = stub(:DeploymentPlan)
@@ -94,6 +95,7 @@ describe Bosh::Director::ResourcePoolUpdater do
       BD::AgentClient.stub(:new).with("agent-1").and_return(agent)
 
       @resource_pool_updater.should_receive(:update_state).with(agent, @vm, @idle_vm)
+      @idle_vm.should_receive(:network_valid?).once
       @idle_vm.should_receive(:vm=).with(@vm)
       @idle_vm.should_receive(:current_state=).with({"state" => "foo"})
 
@@ -106,7 +108,7 @@ describe Bosh::Director::ResourcePoolUpdater do
       BD::AgentClient.stub(:new).with("agent-1").and_return(agent)
 
       @cloud.should_receive(:delete_vm).with("vm-1")
-
+      @idle_vm.should_receive(:network_valid?).once
       lambda {
         @resource_pool_updater.create_missing_vm(@idle_vm)
       }.should raise_error("timeout")


### PR DESCRIPTION
For issue https://github.com/cloudfoundry/bosh/issues/373

We catch `NetworkReservationNotEnoughCapacity` exception (only manual network will raise this exception) and make it not throw out and set network reservation ip to nil when reserve ip for idle vms. 

what I did - 

When idle vm reserve network, no ip will be reserve if there is not enough dynamic ip.
When create vm, we should have a check whether the vm has an valid network
When refill resource pools, will not create vms if there is not enough dynamic ups

This will be worked because :
1. When first boot up vms for instance, the vm will using instance network reservation (reversed when bind instance network)
2. When bind instance network, the exception will still be thrown out (this is what we want)
3. When resource pool updater refill the pool, when there is not enough ip in dynamic ip pool, the ip will be set as nil and will not boot vms (the info will be logged).
