### PR TITLE
Add bosh.dev local dev executable

### DIFF
--- a/bosh_cli/bin/bosh.dev
+++ b/bosh_cli/bin/bosh.dev
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+$:.unshift("../../lib", __FILE__)
+require "cli"
+
+begin
+  Thread.abort_on_exception = true
+  Bosh::Cli::Runner.run(ARGV.dup)
+rescue Errno::EPIPE
+  puts("pipe closed, exiting...")
+  exit(0)
+rescue Interrupt
+  puts "\nExiting..."
+  exit(1)
+end


### PR DESCRIPTION
This allows developers to do dev/test on CLI code; and for PMs to confirm
stories of CLI code without having to install the gem from source.

The `cf` gem has a similar `cf.dev` CLI -
https://github.com/cloudfoundry/cf/blob/master/bin/cf.dev
