### PR TITLE
Fix network settings for dynamic networks

### DIFF
--- a/bosh_agent/lib/bosh_agent/message/apply.rb
+++ b/bosh_agent/lib/bosh_agent/message/apply.rb
@@ -37,8 +37,6 @@ module Bosh::Agent
             logger.debug("current network settings from VM: #{network_settings.inspect}")
             logger.debug("new network settings to be applied: #{properties.inspect}")
             if network_settings
-              # This merge is messing with the DNS server list!
-              # It will overwrite the custom resolver which
               @new_spec["networks"][network].merge!(network_settings)
               logger.debug("merged network settings: #{@new_spec["networks"].inspect}")
             end

--- a/bosh_agent/lib/bosh_agent/util.rb
+++ b/bosh_agent/lib/bosh_agent/util.rb
@@ -181,9 +181,6 @@ module Bosh::Agent
         properties = {}
         properties["ip"] = ifconfig.address
         properties["netmask"] = ifconfig.netmask
-        properties["dns"] = []
-        properties["dns"] << net_info.primary_dns if net_info.primary_dns && !net_info.primary_dns.empty?
-        properties["dns"] << net_info.secondary_dns if net_info.secondary_dns && !net_info.secondary_dns.empty?
         properties["gateway"] = net_info.default_gateway
         properties
       end

--- a/bosh_agent/spec/unit/infrastructure/aws/settings_spec.rb
+++ b/bosh_agent/spec/unit/infrastructure/aws/settings_spec.rb
@@ -37,7 +37,7 @@ describe Bosh::Agent::Infrastructure::Aws::Settings do
 
     properties.should have_key("ip")
     properties.should have_key("netmask")
-    properties.should have_key("dns")
+    properties.should_not have_key("dns")
     properties.should have_key("gateway")
   end
 

--- a/bosh_agent/spec/unit/util_spec.rb
+++ b/bosh_agent/spec/unit/util_spec.rb
@@ -99,4 +99,23 @@ describe Bosh::Agent::Util do
     expect { Bosh::Agent::Util.block_device_size(block_device) }.to raise_error(Bosh::Agent::MessageHandlerError, "Unable to determine disk size")
   end
 
+  it 'should return the network info' do
+    sigar = double('SigarBox')
+    net_info = double('net_info')
+    ifconfig = double('ifconfig')
+    Bosh::Agent::SigarBox.stub(:create_sigar).and_return(sigar)
+
+    sigar.should_receive(:net_info).and_return(net_info)
+    sigar.should_receive(:net_interface_config).with('eth0').and_return(ifconfig)
+    net_info.should_receive(:default_gateway_interface).and_return('eth0')
+    net_info.should_receive(:default_gateway)
+    ifconfig.should_receive(:address)
+    ifconfig.should_receive(:netmask)
+
+    network_info = Bosh::Agent::Util.get_network_info
+    expect(network_info).to have_key('ip')
+    expect(network_info).to have_key('netmask')
+    expect(network_info).to have_key('gateway')
+  end
+
 end

--- a/director/lib/director/deployment_plan/instance.rb
+++ b/director/lib/director/deployment_plan/instance.rb
@@ -161,21 +161,20 @@ module Bosh::Director
         network_settings = {}
         @network_reservations.each do |name, reservation|
           network = @job.deployment.network(name)
-          network_settings[name] = network.network_settings(
-              reservation, default_properties[name])
-
-          # Somewhat of a hack: for dynamic networks we might know IP address
-          # if it's featured in agent state, in that case we put it into
-          # network spec to satisfy ConfigurationHasher in both agent
-          # and director.
-          if @current_state.is_a?(Hash) &&
-              @current_state["networks"].is_a?(Hash) &&
-              @current_state["networks"][name].is_a?(Hash) &&
-              network_settings[name]["type"] == "dynamic"
-            network_settings[name] = @current_state["networks"][name]
-          end
-
+          network_settings[name] = network.network_settings(reservation, default_properties[name])
           network_settings[name]['dns_record_name'] = dns_record_name(name)
+
+          # Somewhat of a hack: for dynamic networks we might know IP address, Netmask & Gateway
+          # if they're featured in agent state, in that case we put them into network spec to satisfy
+          # ConfigurationHasher in both agent and director.
+          if @current_state.is_a?(Hash) &&
+              @current_state['networks'].is_a?(Hash) &&
+              @current_state['networks'][name].is_a?(Hash) &&
+              network_settings[name]['type'] == 'dynamic'
+            %w(ip netmask gateway).each do |key|
+              network_settings[name][key] = @current_state['networks'][name][key]
+            end
+          end
         end
         network_settings
       end


### PR DESCRIPTION
When using dynamic networks, all network settings set at the deployment manifest are overrided by the current vm network settings. This behaviour prevents to modify the dns list or the cloud properties.

Instead of overriding all settings, this change will override only those settings needed for dynamic networks that are not present at the deployment manifest (ip, netmask & gateway).

This fix is related to #383.
