### PR TITLE
[director] Track failed job updates in event log

### DIFF
--- a/director/lib/director/deployment_plan/job.rb
+++ b/director/lib/director/deployment_plan/job.rb
@@ -63,10 +63,6 @@ module Bosh::Director
       # @return [Hash<Integer, String>] Individual instance expected states
       attr_accessor :instance_states
 
-      # @return [Exception] Exception that requires job update process to be
-      #   interrupted
-      attr_accessor :halt_exception
-
       # @param [Bosh::Director::DeploymentPlan] deployment Deployment plan
       # @param [Hash] job_spec Raw job spec from the deployment manifest
       # @return [Bosh::Director::DeploymentPlan::Job]
@@ -87,9 +83,7 @@ module Bosh::Director
         @all_properties = nil # All properties available to job
         @properties = nil # Actual job properties
 
-        @error_mutex = Mutex.new
         @packages = {}
-        @halt = false
         @unneeded_instances = []
       end
 
@@ -201,17 +195,6 @@ module Bosh::Director
       def use_compiled_package(compiled_package_model)
         compiled_package = CompiledPackage.new(compiled_package_model)
         @packages[compiled_package.name] = compiled_package
-      end
-
-      def should_halt?
-        @halt
-      end
-
-      def record_update_error(error, options = {})
-        @error_mutex.synchronize do
-          @halt = true
-          @halt_exception = error
-        end
       end
 
       def parse_name

--- a/director/spec/unit/job_updater_spec.rb
+++ b/director/spec/unit/job_updater_spec.rb
@@ -1,167 +1,149 @@
-# Copyright (c) 2009-2012 VMware, Inc.
+# -*- encoding: utf-8 -*-
 
-require File.expand_path("../../spec_helper", __FILE__)
+require 'spec_helper'
 
 describe Bosh::Director::JobUpdater do
+  let(:subject) { described_class.new(deployment_plan, job) }
+  let(:deployment_plan) { double(Bosh::Director::DeploymentPlan) }
+  let(:canaries) { 2 }
+  let(:max_in_flight) { 1 }
+  let(:update_config) { double(Bosh::Director::DeploymentPlan::UpdateConfig,
+                               canaries: canaries, max_in_flight: max_in_flight) }
+  let(:job) { double(Bosh::Director::DeploymentPlan::Job, name: 'job_name', update: update_config) }
+  let(:instance_1) { double(Bosh::Director::DeploymentPlan::Instance, index: 1, changed?: instance_1_changed) }
+  let(:instance_1_changed) { true }
+  let(:instance_2) { double(Bosh::Director::DeploymentPlan::Instance, index: 2, changed?: instance_2_changed) }
+  let(:instance_2_changed) { true }
+  let(:instance_3) { double(Bosh::Director::DeploymentPlan::Instance, index: 3, changed?: instance_3_changed) }
+  let(:instance_3_changed) { true }
+  let(:instance_4) { double(Bosh::Director::DeploymentPlan::Instance, index: 4, changed?: instance_4_changed) }
+  let(:instance_4_changed) { true }
+  let(:instance_5) { double(Bosh::Director::DeploymentPlan::Instance, index: 5, changed?: instance_5_changed) }
+  let(:instance_5_changed) { false }
 
-  before(:each) do
-    @deployment_plan = double("deployment_plan")
-    @job_spec = double("job_spec")
-    @update_spec = double("update_spec")
-    @job_spec.stub(:update).and_return(@update_spec)
-    @job_spec.stub(:name).and_return("job_name")
-    @update_spec.stub(:max_in_flight).and_return(5)
-    @update_spec.stub(:canaries).and_return(1)
+  before do
     Bosh::Director::Config.stub(:cloud).and_return(nil)
   end
 
-  it "should do nothing when the job is up to date" do
-    instance_1 = double("instance-1")
-    instance_1.stub(:index).and_return(1)
-    instance_2 = double("instance-1")
-    instance_2.stub(:index).and_return(2)
+  describe :update do
+    let(:instances) { [instance_1, instance_2, instance_3, instance_4, instance_5] }
+    let(:instance_updater_1) { double(Bosh::Director::InstanceUpdater) }
+    let(:instance_updater_2) { double(Bosh::Director::InstanceUpdater) }
+    let(:instance_updater_3) { double(Bosh::Director::InstanceUpdater) }
+    let(:instance_updater_4) { double(Bosh::Director::InstanceUpdater) }
+    let(:instance_updater_5) { double(Bosh::Director::InstanceUpdater) }
+    let(:update_error) { RuntimeError.new('update failed')}
 
-    instances = [instance_1, instance_2]
+    before do
+      subject.stub(:delete_unneeded_instances)
+      job.should_receive(:instances).and_return(instances)
+      Bosh::Director::InstanceUpdater.stub(:new).with(instance_1, anything).and_return(instance_updater_1)
+      Bosh::Director::InstanceUpdater.stub(:new).with(instance_2, anything).and_return(instance_updater_2)
+      Bosh::Director::InstanceUpdater.stub(:new).with(instance_3, anything).and_return(instance_updater_3)
+      Bosh::Director::InstanceUpdater.stub(:new).with(instance_4, anything).and_return(instance_updater_4)
+      Bosh::Director::InstanceUpdater.stub(:new).with(instance_5, anything).and_return(instance_updater_5)
+    end
 
-    @job_spec.should_receive(:instances).and_return(instances)
-    @job_spec.should_receive(:unneeded_instances).and_return([])
-    instance_1.should_receive(:changed?).and_return(false)
-    instance_2.should_receive(:changed?).and_return(false)
+    context 'when job is up to date' do
+      let(:instance_1_changed) { false }
+      let(:instance_2_changed) { false }
+      let(:instance_3_changed) { false }
+      let(:instance_4_changed) { false }
 
-    job_updater = Bosh::Director::JobUpdater.new(@deployment_plan, @job_spec)
-    job_updater.update
-  end
-
-  it "should update the job with canaries" do
-    instance_1 = double("instance-1")
-    instance_1.stub(:index).and_return(1)
-    instance_2 = double("instance-1")
-    instance_2.stub(:index).and_return(2)
-    instances = [instance_1, instance_2]
-
-    instance_updater_1 = double("instance_updater_1")
-    instance_updater_2 = double("instance_updater_2")
-
-    @job_spec.should_receive(:instances).and_return(instances)
-    @job_spec.should_receive(:unneeded_instances).and_return([])
-    @job_spec.stub(:should_halt?).and_return(false)
-
-    instance_1.should_receive(:changed?).and_return(true)
-    instance_2.should_receive(:changed?).and_return(true)
-
-    instance_updater_1.should_receive(:update).with(:canary => true)
-    instance_updater_2.should_receive(:update).with(no_args)
-
-    Bosh::Director::InstanceUpdater.stub(:new).and_return do |instance, _|
-      case instance
-        when instance_1
-          instance_updater_1
-        when instance_2
-          instance_updater_2
-        else
-          raise "unknown instance"
+      it 'should do nothing' do
+        subject.update
       end
     end
 
-    job_updater = Bosh::Director::JobUpdater.new(@deployment_plan, @job_spec)
-    job_updater.update
+    context 'when job needs to be updated' do
+      it 'should update changed job instances with canaries' do
+        instance_updater_1.should_receive(:update).with(:canary => true)
+        instance_updater_2.should_receive(:update).with(:canary => true)
+        instance_updater_3.should_receive(:update).with(no_args)
+        instance_updater_4.should_receive(:update).with(no_args)
+        instance_updater_5.should_not_receive(:update)
 
-    check_event_log do |events|
-      events.size.should == 4
-      events.map { |e| e["stage"] }.uniq.should == ["Updating job"]
-      events.map { |e| e["tags"] }.uniq.should == [ ["job_name"] ]
-      events.map { |e| e["total"] }.uniq.should == [2]
-      events.map { |e| e["task"] }.should == ["job_name/1 (canary)", "job_name/1 (canary)", "job_name/2", "job_name/2"]
-    end
-  end
+        subject.update
 
-  it "should rollback the job if the canaries failed" do
-    instance_1 = double("instance-1")
-    instance_1.stub(:index).and_return(1)
-    instance_2 = double("instance-1")
-    instance_2.stub(:index).and_return(2)
-    instances = [instance_1, instance_2]
+        check_event_log do |events|
+          expect(events.size).to eql(8)
+          expect(events.map { |e| e['stage'] }.uniq).to eql(['Updating job'])
+          expect(events.map { |e| e['tags'] }.uniq).to eql([['job_name']])
+          expect(events.map { |e| e['index'] }.uniq).to eql([1, 2, 3, 4])
+          expect(events.map { |e| e['total'] }.uniq).to eql([4])
+          expect(events.map { |e| e['task'] }.uniq).to eql(['job_name/1 (canary)', 'job_name/2 (canary)',
+                                                            'job_name/3', 'job_name/4'])
+          expect(events.map { |e| e['state'] }.uniq).to eql(['started', 'finished'])
+        end
+      end
 
-    instance_updater_1 = double("instance_updater_1")
-    instance_updater_2 = double("instance_updater_2")
+      it 'should not continue updating changed job instances if canaries failed' do
+        instance_updater_1.should_receive(:update).with(:canary => true).and_raise(update_error)
+        instance_updater_2.should_not_receive(:update)
+        instance_updater_3.should_not_receive(:update)
+        instance_updater_4.should_not_receive(:update)
+        instance_updater_5.should_not_receive(:update)
 
-    @job_spec.stub(:should_halt?).and_return(false, true)
-    @job_spec.should_receive(:instances).and_return(instances)
-    @job_spec.should_receive(:record_update_error).with(anything, :canary => true)
-    @job_spec.should_receive(:unneeded_instances).and_return([])
-    @job_spec.stub(:halt_exception).and_return("bad update")
+        expect do
+          subject.update
+        end.to raise_error(update_error)
 
-    instance_1.should_receive(:changed?).and_return(true)
-    instance_2.should_receive(:changed?).and_return(true)
+        check_event_log do |events|
+          expect(events.size).to eql(2)
+          expect(events.map { |e| e['stage'] }.uniq).to eql(['Updating job'])
+          expect(events.map { |e| e['tags'] }.uniq).to eql([['job_name']])
+          expect(events.map { |e| e['index'] }.uniq).to eql([1])
+          expect(events.map { |e| e['total'] }.uniq).to eql([4])
+          expect(events.map { |e| e['task'] }.uniq).to eql(['job_name/1 (canary)'])
+          expect(events.map { |e| e['state'] }.uniq).to eql(['started', 'failed'])
+        end
+      end
 
-    instance_updater_1.should_receive(:update).with(:canary => true).and_throw("bad update")
-    instance_updater_2.should_not_receive(:update).with(no_args)
+      it 'should raise an error if updating changed jobs instances failed' do
+        instance_updater_1.should_receive(:update).with(:canary => true)
+        instance_updater_2.should_receive(:update).with(:canary => true)
+        instance_updater_3.should_receive(:update).with(no_args).and_raise(update_error)
+        instance_updater_4.should_not_receive(:update)
+        instance_updater_5.should_not_receive(:update)
 
-    Bosh::Director::InstanceUpdater.stub(:new).and_return do |instance, ticker|
-      case instance
-        when instance_1
-          instance_updater_1
-        when instance_2
-          instance_updater_2
-        else
-          raise "unknown instance"
+        expect do
+          subject.update
+        end.to raise_error(update_error)
+
+        check_event_log do |events|
+          expect(events.size).to eql(6)
+          expect(events.map { |e| e['stage'] }.uniq).to eql(['Updating job'])
+          expect(events.map { |e| e['tags'] }.uniq).to eql([['job_name']])
+          expect(events.map { |e| e['index'] }.uniq).to eql([1, 2, 3])
+          expect(events.map { |e| e['total'] }.uniq).to eql([4])
+          expect(events.map { |e| e['task'] }.uniq).to eql(['job_name/1 (canary)', 'job_name/2 (canary)',
+                                                            'job_name/3'])
+          expect(events.map { |e| e['state'] }.uniq).to eql(['started', 'finished', 'failed'])
+        end
       end
     end
-
-    job_updater = Bosh::Director::JobUpdater.new(@deployment_plan, @job_spec)
-
-    lambda { job_updater.update }.should raise_exception(RuntimeError, "bad update")
   end
 
-  it "should rollback the job if it exceeded max number of errors" do
-    instance_1 = double("instance-1")
-    instance_1.stub(:index).and_return(1)
-    instance_2 = double("instance-1")
-    instance_2.stub(:index).and_return(2)
-    instances = [instance_1, instance_2]
+  describe :delete_unneeded_instances do
+    let(:instance_deleter) { double(Bosh::Director::InstanceDeleter) }
 
-    instance_updater_1 = double("instance_updater_1")
-    instance_updater_2 = double("instance_updater_2")
-
-    @job_spec.stub(:should_halt?).and_return(false, false, false, true)
-    @job_spec.should_receive(:unneeded_instances).and_return([])
-    @job_spec.should_receive(:instances).and_return(instances)
-    @job_spec.should_receive(:record_update_error).with(anything)
-    @job_spec.stub(:halt_exception).and_return("zb")
-
-    instance_1.should_receive(:changed?).and_return(true)
-    instance_2.should_receive(:changed?).and_return(true)
-
-    instance_updater_1.should_receive(:update).with(:canary => true)
-    instance_updater_2.should_receive(:update).with(no_args).and_throw("bad update")
-
-    Bosh::Director::InstanceUpdater.stub(:new).and_return do |instance, ticker|
-      case instance
-        when instance_1
-          instance_updater_1
-        when instance_2
-          instance_updater_2
-        else
-          raise "unknown instance"
-      end
+    before do
+      Bosh::Director::InstanceDeleter.stub(:new).and_return(instance_deleter)
     end
 
-    job_updater = Bosh::Director::JobUpdater.new(@deployment_plan, @job_spec)
+    it 'should delete the unneeded instances' do
+      job.stub(:unneeded_instances).and_return([instance_1])
+      instance_deleter.should_receive(:delete_instances).with([instance_1], { max_threads: max_in_flight })
 
-    lambda { job_updater.update }.should raise_exception(RuntimeError, "zb")
-  end
+      subject.delete_unneeded_instances
+    end
 
-  it "should delete the unneeded instances" do
-    instance = double("instance")
-    @job_spec.stub(:instances).and_return([])
-    @job_spec.stub(:unneeded_instances).and_return([instance])
+    it 'should not delete instances if there are not any unneeded instances' do
+      job.stub(:unneeded_instances).and_return([])
+      instance_deleter.should_not_receive(:delete_instances)
 
-    instance_deleter = double("instance_deleter")
-    instance_deleter.should_receive(:delete_instances).with([instance], {:max_threads => 5})
-    Bosh::Director::InstanceDeleter.stub(:new).and_return(instance_deleter)
-
-    job_updater = Bosh::Director::JobUpdater.new(@deployment_plan, @job_spec)
-    job_updater.update
+      subject.delete_unneeded_instances
+    end
   end
 
 end


### PR DESCRIPTION
This commit fixes a bug that prevented failed instance updates to be
recorded in the event log. Instead of rescuing the error (so event_log
doesn't notice there has been an error and it will record a success update),
now we log the error and raise the exception. In this way, the track method
in event_log will trap the error and it will record it in the event log file.

Also, instead of using a custom logic to check if the job update should be halted
(due to an error, canary or not), use the standard ThreadPool mechanism: if it
detects an exception, it will stop processing new actions.

Refactored also job_updater spec in order to detect all situatuibs and to check
the event log.
