### PR TITLE
Remove unuseful max_errors from the universe

### DIFF
--- a/bat/templates/aws.yml.erb
+++ b/bat/templates/aws.yml.erb
@@ -21,7 +21,6 @@ update:
   canary_watch_time: 3000-90000
   update_watch_time: 3000-90000
   max_in_flight: <%= properties.max_in_flight || 1 %>
-  max_errors: 1
 
 networks:
 

--- a/bat/templates/openstack.yml.erb
+++ b/bat/templates/openstack.yml.erb
@@ -21,7 +21,6 @@ update:
   canary_watch_time: 3000-90000
   update_watch_time: 3000-90000
   max_in_flight: <%= properties.max_in_flight || 1 %>
-  max_errors: 1
 
 networks:
 

--- a/bat/templates/vsphere.yml.erb
+++ b/bat/templates/vsphere.yml.erb
@@ -20,7 +20,6 @@ update:
   canary_watch_time: 3000-90000
   update_watch_time: 3000-90000
   max_in_flight: <%= properties.max_in_flight || 1 %>
-  max_errors: 1
 
 networks:
 - name: static

--- a/bosh_cli_plugin_aws/spec/unit/bat_manifest_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/bat_manifest_spec.rb
@@ -71,7 +71,6 @@ update:
   canary_watch_time: 3000-90000
   update_watch_time: 3000-90000
   max_in_flight: 1
-  max_errors: 1
 
 networks:
 

--- a/bosh_cli_plugin_aws/templates/bat.yml.erb
+++ b/bosh_cli_plugin_aws/templates/bat.yml.erb
@@ -31,7 +31,6 @@ update:
   canary_watch_time: 3000-90000
   update_watch_time: 3000-90000
   max_in_flight: 1
-  max_errors: 1
 
 networks:
 

--- a/bosh_cli_plugin_aws/templates/bosh.yml.erb
+++ b/bosh_cli_plugin_aws/templates/bosh.yml.erb
@@ -58,7 +58,6 @@ update:
   canary_watch_time: 30000 - 90000
   update_watch_time: 30000 - 90000
   max_in_flight: 1
-  max_errors: 1
 
 jobs:
 - name: bosh

--- a/release/examples/bosh-aws-dns.yml
+++ b/release/examples/bosh-aws-dns.yml
@@ -18,7 +18,6 @@ update:
   canary_watch_time: 3000-120000
   update_watch_time: 3000-120000
   max_in_flight: 4
-  max_errors: 1
 
 networks:
   - name: elastic

--- a/release/examples/bosh-aws-solo.yml
+++ b/release/examples/bosh-aws-solo.yml
@@ -27,7 +27,6 @@ update:
   canary_watch_time: 3000-120000
   update_watch_time: 3000-120000
   max_in_flight: 4
-  max_errors: 1
 
 networks:
   - name: elastic

--- a/release/examples/bosh-aws-vip.yml
+++ b/release/examples/bosh-aws-vip.yml
@@ -18,7 +18,6 @@ update:
   canary_watch_time: 3000-120000
   update_watch_time: 3000-120000
   max_in_flight: 4
-  max_errors: 1
 
 networks:
   - name: elastic

--- a/release/examples/bosh-openstack-dynamic.yml
+++ b/release/examples/bosh-openstack-dynamic.yml
@@ -18,7 +18,6 @@ update:
   canary_watch_time: 3000-120000
   update_watch_time: 3000-120000
   max_in_flight: 4
-  max_errors: 1
 
 networks:
   - name: floating

--- a/release/examples/bosh-openstack-manual.yml
+++ b/release/examples/bosh-openstack-manual.yml
@@ -18,7 +18,6 @@ update:
   canary_watch_time: 3000-120000
   update_watch_time: 3000-120000
   max_in_flight: 4
-  max_errors: 1
 
 networks:
   - name: floating

--- a/release/examples/bosh-openstack-solo.yml
+++ b/release/examples/bosh-openstack-solo.yml
@@ -27,7 +27,6 @@ update:
   canary_watch_time: 3000-120000
   update_watch_time: 3000-120000
   max_in_flight: 4
-  max_errors: 1
 
 networks:
   - name: elastic

--- a/release/spec/director_yml_erb_spec.rb
+++ b/release/spec/director_yml_erb_spec.rb
@@ -67,7 +67,6 @@ update:
   canary_watch_time: 30000 - 90000
   update_watch_time: 30000 - 90000
   max_in_flight: 1
-  max_errors: 1
 jobs:
 - name: bosh
   template:


### PR DESCRIPTION
max_errors option has been removed from Bosh a long time ago (https://github.com/cloudfoundry/bosh/commit/a38c8fb4097a86f6cb6dcab078d0ef50231b0aff)
