### PR TITLE
[agent] move agent mount disk function into platform related class

### DIFF
--- a/bosh_agent/spec/unit/message/disk_spec.rb
+++ b/bosh_agent/spec/unit/message/disk_spec.rb
@@ -46,6 +46,7 @@ describe Bosh::Agent::Message::ListDisk do
     platform = double(:platform)
     Bosh::Agent::Config.stub(:platform).and_return(platform)
     platform.stub(:lookup_disk_by_cid).and_return("/dev/sdy")
+    platform.stub(:is_disk_blockdev?).and_return(true)
     Bosh::Agent::Message::DiskUtil.stub(:mount_entry).and_return('/dev/sdy1 /foomount fstype')
 
     settings = { "disks" => { "persistent" => { 199 => 2 }}}

--- a/bosh_agent/spec/unit/platform/linux/disk_spec.rb
+++ b/bosh_agent/spec/unit/platform/linux/disk_spec.rb
@@ -51,7 +51,7 @@ describe Bosh::Agent::Platform::Linux::Disk do
       Dir.should_receive(:glob).with(dev_path, 0).and_return(['/dev/sdy'])
       File.should_receive(:blockdev?).with('/dev/sdy1').and_return(true)
       disk_wrapper.stub(:mount_exists?).and_return false
-      disk_wrapper.should_receive(:sh).with("mount /dev/sdy1 #{store_path}")
+      disk_wrapper.should_receive(:sh).with("mount  /dev/sdy1 #{store_path}")
 
       disk_wrapper.mount_persistent_disk(2)
     end
@@ -60,7 +60,7 @@ describe Bosh::Agent::Platform::Linux::Disk do
       Dir.should_receive(:glob).twice.with(dev_path, 0).and_return(['/dev/sdy'])
       File.should_receive(:blockdev?).twice.with('/dev/sdy1').and_return(true)
       disk_wrapper.should_receive(:mount_exists?).and_return false
-      disk_wrapper.should_receive(:sh).with("mount /dev/sdy1 #{store_path}")
+      disk_wrapper.should_receive(:sh).with("mount  /dev/sdy1 #{store_path}")
 
       disk_wrapper.mount_persistent_disk(2)
 


### PR DESCRIPTION
This PR try refactoring agent before trying merge warden-cpi.

The current agent think all persistent disk are block dev and setup/mount it in message class. which is not properly.
this PR move the mount operation to platform dependent class. and add a stub is_disk_blockdev which will be reused in warden-cpi.
