### PR TITLE
[agent] move agent mount disk function into platform related class

### DIFF
--- a/bosh_agent/lib/bosh_agent/message/disk.rb
+++ b/bosh_agent/lib/bosh_agent/message/disk.rb
@@ -20,7 +20,7 @@ module Bosh::Agent
 
         DiskUtil.umount_guard(store_path)
 
-        mount_store(@old_cid, "-o ro") #read-only
+        Bosh::Agent::Config.platform.mount_persistent_disk(@old_cid, '-o ro')
 
         if check_mountpoints
           logger.info("Copy data from old to new store disk")
@@ -30,21 +30,11 @@ module Bosh::Agent
         DiskUtil.umount_guard(store_path)
         DiskUtil.umount_guard(store_migration_target)
 
-        mount_store(@new_cid)
+        Bosh::Agent::Config.platform.mount_persistent_disk(@new_cid)
       end
 
       def check_mountpoints
         Pathname.new(store_path).mountpoint? && Pathname.new(store_migration_target).mountpoint?
-      end
-
-      def mount_store(cid, options="")
-        disk = Bosh::Agent::Config.platform.lookup_disk_by_cid(cid)
-        partition = "#{disk}1"
-        logger.info("Mounting: #{partition} #{store_path}")
-        `mount #{options} #{partition} #{store_path}`
-        unless $?.exitstatus == 0
-          raise Bosh::Agent::MessageHandlerError, "Failed to mount: #{partition} #{store_path} (exit code #{$?.exitstatus})"
-        end
       end
 
     end
@@ -62,7 +52,7 @@ module Bosh::Agent
 
         cids.each_key do |cid|
           disk = Bosh::Agent::Config.platform.lookup_disk_by_cid(cid)
-          partition = "#{disk}1"
+          partition = Bosh::Agent::Config.platform.is_disk_blockdev?? "#{disk}1" : "#{disk}"
           disk_info << cid unless DiskUtil.mount_entry(partition).nil?
         end
         disk_info
@@ -82,8 +72,15 @@ module Bosh::Agent
         if Bosh::Agent::Config.configure
           update_settings
           logger.info("MountDisk: #{@cid} - #{settings['disks'].inspect}")
+          if Bosh::Agent::Config.platform.is_disk_blockdev?
+            partition = setup_disk
+          else
+            disk = Bosh::Agent::Config.platform.lookup_disk_by_cid(@cid)
+            partition = "#{disk}"
+          end
 
-          setup_disk
+          mount_persistent_disk(partition)
+          {}
         end
       end
 
@@ -140,8 +137,7 @@ module Bosh::Agent
           raise Bosh::Agent::MessageHandlerError, "Unable to format #{disk}"
         end
 
-        mount_persistent_disk(partition)
-        {}
+        partition
       end
 
       def mount_persistent_disk(partition)
@@ -159,10 +155,7 @@ module Bosh::Agent
         FileUtils.chmod(0700, mountpoint)
 
         logger.info("Mount #{partition} #{mountpoint}")
-        `mount #{partition} #{mountpoint}`
-        unless $?.exitstatus == 0
-          raise Bosh::Agent::MessageHandlerError, "Failed mount #{partition} on #{mountpoint} #{$?.exitstatus}"
-        end
+        Bosh::Agent::Config.platform.mount_partition(partition, mountpoint)
       end
 
       def self.long_running?; true; end

--- a/bosh_agent/spec/unit/message/disk_spec.rb
+++ b/bosh_agent/spec/unit/message/disk_spec.rb
@@ -46,6 +46,7 @@ describe Bosh::Agent::Message::ListDisk do
     platform = double(:platform)
     Bosh::Agent::Config.stub(:platform).and_return(platform)
     platform.stub(:lookup_disk_by_cid).and_return("/dev/sdy")
+    platform.stub(:is_disk_blockdev?).and_return(true)
     Bosh::Agent::Message::DiskUtil.stub(:mount_entry).and_return('/dev/sdy1 /foomount fstype')
 
     settings = { "disks" => { "persistent" => { 199 => 2 }}}

--- a/bosh_agent/spec/unit/platform/linux/disk_spec.rb
+++ b/bosh_agent/spec/unit/platform/linux/disk_spec.rb
@@ -51,7 +51,7 @@ describe Bosh::Agent::Platform::Linux::Disk do
       Dir.should_receive(:glob).with(dev_path, 0).and_return(['/dev/sdy'])
       File.should_receive(:blockdev?).with('/dev/sdy1').and_return(true)
       disk_wrapper.stub(:mount_exists?).and_return false
-      disk_wrapper.should_receive(:sh).with("mount /dev/sdy1 #{store_path}")
+      disk_wrapper.should_receive(:sh).with("mount  /dev/sdy1 #{store_path}")
 
       disk_wrapper.mount_persistent_disk(2)
     end
@@ -60,7 +60,7 @@ describe Bosh::Agent::Platform::Linux::Disk do
       Dir.should_receive(:glob).twice.with(dev_path, 0).and_return(['/dev/sdy'])
       File.should_receive(:blockdev?).twice.with('/dev/sdy1').and_return(true)
       disk_wrapper.should_receive(:mount_exists?).and_return false
-      disk_wrapper.should_receive(:sh).with("mount /dev/sdy1 #{store_path}")
+      disk_wrapper.should_receive(:sh).with("mount  /dev/sdy1 #{store_path}")
 
       disk_wrapper.mount_persistent_disk(2)
 


### PR DESCRIPTION
This PR try refactoring agent before trying merge warden-cpi.

The current agent think all persistent disk are block dev and setup/mount it in message class. which is not properly.
this PR move the mount operation to platform dependent class. and add a stub is_disk_blockdev which will be reused in warden-cpi.
