### PR TITLE
[director] Fix tracking preparing package compilation stage

### DIFF
--- a/director/lib/director/package_compiler.rb
+++ b/director/lib/director/package_compiler.rb
@@ -70,7 +70,7 @@ module Bosh::Director
     # in the jobs defined by deployment plan
     # @return [void]
     def prepare_tasks
-      @event_log.begin_stage("Preparing package compilation")
+      @event_log.begin_stage("Preparing package compilation", 1)
 
       @event_log.track("Finding packages to compile") do
         @deployment_plan.jobs.each do |job|

--- a/director/spec/unit/package_compiler_spec.rb
+++ b/director/spec/unit/package_compiler_spec.rb
@@ -145,6 +145,15 @@ describe Bosh::Director::PackageCompiler do
     compiler.compile_tasks_count.should == 6 + 5
     # But they are already compiled!
     compiler.compilations_performed.should == 0
+
+    check_event_log do |events|
+      expect(events.size).to eql(2)
+      expect(events.map { |e| e['stage'] }.uniq).to match_array(['Preparing package compilation'])
+      expect(events.map { |e| e['task'] }.uniq).to match_array(['Finding packages to compile'])
+      expect(events.map { |e| e['index'] }.uniq).to match_array([1])
+      expect(events.map { |e| e['total'] }.uniq).to match_array([1])
+      expect(events.map { |e| e['state'] }.uniq).to match_array(['started', 'finished'])
+    end
   end
 
   it "compiles all packages" do
@@ -233,6 +242,23 @@ describe Bosh::Director::PackageCompiler do
 
     @package_set_b.each do |package|
       package.compiled_packages.size.should >= 1
+    end
+
+    check_event_log do |events|
+      expect(events.size).to eql(24)
+      expect(events.map { |e| e['stage'] }.uniq).to match_array(['Preparing package compilation',
+                                                                 'Compiling packages'])
+      expect(events.map { |e| e['task'] }.uniq).to match_array(['Finding packages to compile',
+                                                                'common/0.1-dev',
+                                                                'p_syslog/0.1-dev',
+                                                                'warden/0.1-dev',
+                                                                'nginx/0.1-dev',
+                                                                'ruby/0.1-dev',
+                                                                'p_router/0.1-dev',
+                                                                'dea/0.1-dev'])
+      expect(events.map { |e| e['index'] }.uniq).to match_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+      expect(events.map { |e| e['total'] }.uniq).to match_array([1, 11])
+      expect(events.map { |e| e['state'] }.uniq).to eql(['started', 'finished'])
     end
   end
 


### PR DESCRIPTION
Actually the "Preparing package compilation" stage doesn't behave like the rest of stages (it does not print the stage tasks):

```
Preparing deployment
  binding deployment (00:00:00)                                                                     
  binding releases (00:00:01)                                                                       
  binding existing deployment (00:00:00)                                                            
  binding resource pools (00:00:00)                                                                 
  binding stemcells (00:00:00)                                                                      
  binding templates (00:00:00)                                                                      
  binding properties (00:00:00)                                                                     
  binding unallocated VMs (00:00:00)                                                                
  binding instance networks (00:00:00)                                                              
Done                    9/9 00:00:01                                                                

Preparing package compilation

Compiling packages
```

This PR will fix this, so the output will be:

```
Preparing deployment
  binding deployment (00:00:00)                                                                     
  binding releases (00:00:00)                                                                       
  binding existing deployment (00:00:00)                                                            
  binding resource pools (00:00:00)                                                                 
  binding stemcells (00:00:00)                                                                      
  binding templates (00:00:00)                                                                      
  binding properties (00:00:00)                                                                     
  binding unallocated VMs (00:00:00)                                                                
  binding instance networks (00:00:00)                                                              
Done                    9/9 00:00:00                                                                

Preparing package compilation
  finding packages to compile (00:00:07)                                                            
Done                    1/1 00:00:07                                                                

Compiling packages
```
