### PR TITLE
Remove duplicate Config instance

### DIFF
--- a/bosh_agent/lib/bosh_agent/configuration.rb
+++ b/bosh_agent/lib/bosh_agent/configuration.rb
@@ -109,6 +109,4 @@ module Bosh::Agent
       ip
     end
   end
-
-  Config = Configuration.new
 end


### PR DESCRIPTION
Currently if you run bosh, you may receive a warning
/home/vagrant/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/gems/1.9.1/bundler/gems/bosh-a1cde60d8ff7/bosh_agent/lib/bosh_agent/config.rb:4: warning: already initialized constant Config

Both config.rb and configuration.rb create a Configuration instance named Config.
