### PR TITLE
add rsyslog-relp pkg for debian and centos

### DIFF
--- a/stemcell_builder/stages/base_apt/apply.sh
+++ b/stemcell_builder/stages/base_apt/apply.sh
@@ -52,7 +52,7 @@ curl wget libcurl3 libcurl3-dev bison libreadline6-dev \
 libxml2 libxml2-dev libxslt1.1 libxslt1-dev zip unzip \
 nfs-common flex psmisc apparmor-utils iptables sysstat \
 rsync openssh-server traceroute libncurses5-dev quota \
-libaio1 gdb tripwire libcap2-bin libyaml-dev cmake"
+libaio1 gdb tripwire libcap2-bin libyaml-dev cmake rsyslog-relp"
 pkg_mgr install $debs
 
 # Lifted from bosh_debs

--- a/stemcell_builder/stages/base_centos/apply.sh
+++ b/stemcell_builder/stages/base_centos/apply.sh
@@ -24,6 +24,7 @@ rpm --force --nodeps --install http://mirror.centos.org/centos/6/os/x86_64/Packa
 rpm --force --nodeps --install http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 yum --assumeyes groupinstall Base
 yum --assumeyes groupinstall 'Development Tools'
+yum --assumeyes install rsyslog-relp
 "
 
 touch ${chroot}/etc/sysconfig/network # must be present for network to be configured


### PR DESCRIPTION
Signed-off-by: Nick Wade nwade@pivotallabs.com

We need this to fix the incorrect hack of adding this in the job template's ctl script.... which is not portable and not 'internet-less' safe.   Thanks.
