### PR TITLE
Fix to use path separator in bosh-registry check

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/aws.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/aws.rb
@@ -166,7 +166,7 @@ module Bosh::Deployer
       private
 
       def has_bosh_registry?(path = ENV['PATH'])
-        path.split(':').each do |dir|
+        path.split(File::PATH_SEPARATOR).each do |dir|
           return true if File.exist?(File.join(dir, 'bosh-registry'))
         end
         false

--- a/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/openstack.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/openstack.rb
@@ -155,7 +155,7 @@ module Bosh::Deployer
       private
 
       def has_bosh_registry?(path = ENV['PATH'])
-        path.split(':').each do |dir|
+        path.split(File::PATH_SEPARATOR).each do |dir|
           return true if File.exist?(File.join(dir, 'bosh-registry'))
         end
         false


### PR DESCRIPTION
Current fix makes code not to fail in Windows OS.Please find detailed description in Bosh issue 442: https://github.com/cloudfoundry/bosh/issues/442
