### PR TITLE
Fix `bosh aws create` for multiple regions by setting ec2_endpoint.

### DIFF
--- a/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/aws_provider.rb
+++ b/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/aws_provider.rb
@@ -8,7 +8,7 @@ module Bosh
       end
 
       def ec2
-        @ec2 ||= ::AWS::EC2.new(credentials)
+        @ec2 ||= ::AWS::EC2.new(credentials.merge('ec2_endpoint' => ec2_endpoint))
       end
 
       def elb
@@ -40,6 +40,10 @@ module Bosh
       end
 
       private
+
+      def ec2_endpoint
+        "ec2.#{region}.amazonaws.com"
+      end
 
       def elb_endpoint
         "elasticloadbalancing.#{region}.amazonaws.com"


### PR DESCRIPTION
I was unable to `bosh aws create` in the AWS `eu-west-1` region. It turned out that the `ec2_endpoint` needed to be set. Using this commit I was able to deploy microbosh in the `eu-west-1` region.
