### PR TITLE
Fix `bosh aws create` for multiple regions by setting ec2_endpoint.

### DIFF
--- a/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/aws_provider.rb
+++ b/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/aws_provider.rb
@@ -8,7 +8,7 @@ module Bosh
       end
 
       def ec2
-        @ec2 ||= ::AWS::EC2.new(credentials)
+        @ec2 ||= ::AWS::EC2.new(credentials.merge('ec2_endpoint' => ec2_endpoint))
       end
 
       def elb
@@ -40,6 +40,10 @@ module Bosh
       end
 
       private
+
+      def ec2_endpoint
+        "ec2.#{region}.amazonaws.com"
+      end
 
       def elb_endpoint
         "elasticloadbalancing.#{region}.amazonaws.com"

--- a/bosh_cli_plugin_aws/spec/unit/aws_provider_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/aws_provider_spec.rb
@@ -13,9 +13,15 @@ module Bosh::Aws
 
     describe '#ec2' do
       let(:ec2) { instance_double('AWS::EC2') }
+      let(:expected_arguments) do
+        {
+          'region' => 'FAKE_AWS_REGION',
+          'ec2_endpoint' => 'ec2.FAKE_AWS_REGION.amazonaws.com'
+        }
+      end
 
       it 'returns a correctly configured AWS::EC2 object' do
-        AWS::EC2.should_receive(:new).with(credentials).and_return(ec2)
+        AWS::EC2.should_receive(:new).with(expected_arguments).and_return(ec2)
 
         expect(aws_provider.ec2).to eq(ec2)
       end


### PR DESCRIPTION
I was unable to `bosh aws create` in the AWS `eu-west-1` region. It turned out that the `ec2_endpoint` needed to be set. Using this commit I was able to deploy microbosh in the `eu-west-1` region.
