### PR TITLE
bosh vms states are nicely colored (excepted with --no-color)

### DIFF
--- a/bosh_cli/lib/cli/commands/vms.rb
+++ b/bosh_cli/lib/cli/commands/vms.rb
@@ -61,7 +61,7 @@ module Bosh::Cli::Command
           dns_records = Array(vm['dns']).join("\n")
           vitals = vm['vitals']
 
-          row = [job, vm['job_state'], vm['resource_pool'], ips]
+          row = [job, colorize_state(vm['job_state']), vm['resource_pool'], ips]
 
           if options[:details]
             row += [vm['vm_cid'], vm['agent_id'], vm['resurrection_paused'] ? 'paused' : 'active']
@@ -110,5 +110,17 @@ module Bosh::Cli::Command
       say('VMs total: %d' % vms.size)
     end
 
+    def colorize_state(state_label)
+      case state_label
+      when "failing"
+        state_label.make_red
+      when "unknown", "starting"
+        state_label.make_yellow
+      when "running"
+        state_label.make_green
+      else
+        state_label
+      end
+    end
   end
 end


### PR DESCRIPTION
And here's a picture!

![different
states](https://www.evernote.com/shard/s3/sh/ba56fe74-3528-46ac-9bc8-a5ef91a17d2c/314cf5c21ee019bcc044441dca25272e/deep/0/drnic@drnic----gems-cloudfoundry-bosh---zsh---204-54.png)

![no-color](https://www.evernote.com/shard/s3/sh/cf7218e6-f748-4eeb-9c72-79fccf71fc8e/af0822fa2cdfb77e5b8939f2916d681e/deep/0/drnic@drnic----gems-cloudfoundry-bosh---zsh---204-54.png)
