### PR TITLE
Load Bundler inside Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,9 @@
 # encoding: UTF-8
+begin 
+  require 'bundler'
+  Bundler.require
+rescue
+end
 
 require 'bosh/dev/tasks'
 


### PR DESCRIPTION
What do you think about requiring bundler in the beginning of `Rakefile` ? It will allow to run `rake` task without `bundle exec` prefix. 

Currently I have this backtrace after calling `rake -T`.

```
~/github/bosh [master] → rake -T
rake aborted!
cannot load such file -- bosh/dev/tasks
/home/lomov/work/github/bosh/Rakefile:3:in `<top (required)>'
(See full trace by running task with --trace)
```

This PR solves it.
