### PR TITLE
[micro] allow micro deploy --update where only disk_cid exists

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/aws.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/aws.rb
@@ -125,7 +125,7 @@ module Bosh::Deployer
       end
 
       def discover_bosh_ip
-        if exists?
+        if state.vm_cid
           # choose elastic IP over public, as any agent connecting to the
           # deployed micro bosh will be cut off from the public IP when
           # we re-deploy micro bosh

--- a/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/openstack.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/openstack.rb
@@ -120,7 +120,7 @@ module Bosh::Deployer
       end
 
       def discover_bosh_ip
-        if exists?
+        if state.vm_cid
           floating_ip = cloud.openstack.servers.get(state.vm_cid).floating_ip_address
           ip = floating_ip || service_ip
 

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/aws/instance_manager_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/aws/instance_manager_spec.rb
@@ -146,6 +146,47 @@ describe Bosh::Deployer::InstanceManager do
     load_deployment.should == @deployer.state.values
   end
 
+  it 'should update a Bosh instance with existing disk_cid where vm_cid missing' do
+    @deployer.stub(:service_ip).and_return('10.0.0.10')
+    spec = Psych.load_file(spec_asset('apply_spec_aws.yml'))
+    Bosh::Deployer::Specification.should_receive(:load_apply_spec).and_return(spec)
+
+    disk_cid = '22'
+    @deployer.stub(:run_command)
+    @deployer.stub(:wait_until_agent_ready)
+    @deployer.stub(:wait_until_director_ready)
+    @deployer.stub(:load_apply_spec).and_return(spec)
+    @deployer.stub(:load_stemcell_manifest).and_return('cloud_properties' => {})
+    @deployer.stub(:persistent_disk_changed?).and_return(false)
+
+    @deployer.state.stemcell_cid = 'SC-CID-UPDATE'
+    @deployer.state.vm_cid = nil
+    @deployer.state.disk_cid = disk_cid
+
+    @agent.should_receive(:run_task).with(:stop)
+    @agent.should_not_receive(:run_task).with(:unmount_disk, disk_cid)
+    @cloud.should_not_receive(:detach_disk)
+    @cloud.should_not_receive(:delete_vm)
+    @cloud.should_receive(:delete_stemcell).with('SC-CID-UPDATE')
+    @cloud.should_receive(:create_stemcell).and_return('SC-CID')
+    @cloud.should_receive(:create_vm).and_return('NEW-VM-CID')
+    @cloud.should_receive(:attach_disk).with('NEW-VM-CID', disk_cid)
+    @agent.should_receive(:run_task).with(:mount_disk, disk_cid).and_return({})
+    @agent.should_receive(:list_disk).and_return([disk_cid])
+    @agent.should_not_receive(:run_task).with(:stop)
+    @agent.should_receive(:run_task).with(:apply, spec)
+    @agent.should_receive(:run_task).with(:start)
+
+    discover_bosh_ip('10.0.0.2', 'NEW-VM-CID')
+    @deployer.update(BOSH_STEMCELL_TGZ, nil)
+
+    @deployer.state.stemcell_cid.should == 'SC-CID'
+    @deployer.state.vm_cid.should_not be_nil
+    @deployer.state.disk_cid.should == disk_cid
+
+    load_deployment.should == @deployer.state.values
+  end
+
   it 'should fail to create a Bosh instance if stemcell CID exists' do
     @deployer.state.stemcell_cid = 'SC-CID'
 

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/vsphere/instance_manager_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/vsphere/instance_manager_spec.rb
@@ -242,6 +242,13 @@ module Bosh
             it_keeps_config_sha1 'fake-config-sha1'
           end
 
+          context 'with no vm_cid but existing disk_id and same config' do
+            before { deployer.state.vm_cid = nil }
+            it_updates_deployed_instance 'fake-stemcell-cid', will_create_stemcell: true
+            it_updates_stemcell_sha1 'fake-stemcell-sha1'
+            it_keeps_config_sha1 'fake-config-sha1'
+          end
+
           context 'with a different stemcell (determined via sha1 difference) and same config' do
             before { deployer.state.stemcell_sha1 = 'fake-different-stemcell-sha1' }
             before { deployer.state.config_sha1 = 'fake-config-sha1' }


### PR DESCRIPTION
If microbosh deployment gets into bad state and only the persistent disk (disk_cid) remains, still allow `bosh micro deploy --update/--update-if-exists` to continue successfully.

PR created against develop branch where tests are actually running ok on travis
