### PR TITLE
Set floating IP address to dns if available

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/deployer/specification.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/specification.rb
@@ -31,17 +31,7 @@ module Bosh::Deployer
         @properties['director']['name'] = Config.name
       end
 
-      # on AWS blobstore and nats need to use an elastic IP (if available),
-      # as when the micro bosh instance is re-created during a deployment,
-      # it might get a new private IP
-      %w{blobstore nats}.each do |service|
-        update_agent_service_address(service, bosh_ip)
-      end
-
-      services = %w{director redis blobstore nats registry dns}
-      services.each do |service|
-        update_service_address(service, service_ip)
-      end
+      update_addresses(bosh_ip, service_ip)
 
       # health monitor does not listen to any ports, so there is no
       # need to update the service address, but we still want to
@@ -70,6 +60,24 @@ module Bosh::Deployer
     end
 
     private
+
+    def update_addresses(bosh_ip, service_ip)
+      # on AWS blobstore and nats need to use an elastic IP (if available),
+      # as when the micro bosh instance is re-created during a deployment,
+      # it might get a new private IP
+      %w{blobstore nats}.each do |service|
+        update_agent_service_address(service, bosh_ip)
+      end
+
+      %w{dns}.each do |service|
+        update_service_address(service, bosh_ip)
+      end
+
+      services = %w{director redis blobstore nats registry}
+      services.each do |service|
+        update_service_address(service, service_ip)
+      end
+    end
 
     # update the agent service section from the contents of the apply_spec
     def update_agent_service_address(service, address)

--- a/bosh_cli_plugin_micro/spec/assets/apply_spec.yml
+++ b/bosh_cli_plugin_micro/spec/assets/apply_spec.yml
@@ -39,6 +39,8 @@ properties:
     address: 127.0.0.1
     name: micro
     port: 25555
+  dns:
+    address: 127.0.0.1
   hm:
     http:
       port: 25923

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/specification_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/specification_spec.rb
@@ -24,6 +24,11 @@ describe Bosh::Deployer::Specification do
     expect(spec.properties['agent']['blobstore']['address']).to eq '1.1.1.1'
   end
 
+  it 'should update dns address' do
+    spec.update('1.1.1.1', '2.2.2.2')
+    expect(spec.properties['dns']['address']).to eq '1.1.1.1'
+  end
+
   describe 'agent override' do
     let(:agent_properties) { { 'blobstore' => { 'address' => '3.3.3.3' } } }
     let(:spec_properties) { { 'ntp' => %w[1.2.3.4] } }


### PR DESCRIPTION
HI,

I found that a private IP address is set to the `adress` of `dns` even when a floating IP address is assigned to a MicroBOSH. This `dns.address` value will be passed to VMs created by the MicroBOSH and at last it will be saved in /etc/resolve.conf. When you update the stemcell and its private ip is changed, VMs already deployed continuously cannot resolve `.microbosh` domain names.
This commit fixes the problem by setting the given floating IP address to `dns.address`.
