### PR TITLE
[PR provided] Should raise NetworkReservationNotEnoughCapacity exception; but get "undefined local variable or method `name' for #<Bosh::Director::ResourcePoolUpdater>" instead

### DIFF
--- a/bosh-director/lib/bosh/director/resource_pool_updater.rb
+++ b/bosh-director/lib/bosh/director/resource_pool_updater.rb
@@ -142,21 +142,16 @@ module Bosh::Director
           network.reserve(reservation)
 
           unless reservation.reserved?
-            case reservation.error
-              when NetworkReservation::CAPACITY
-                raise NetworkReservationNotEnoughCapacity,
-                      "`#{name}/#{index}' asked for a dynamic IP " +
-                      "but there were no more available"
-              else
-                raise NetworkReservationError,
-                      "`#{name}/#{index}' failed to reserve " +
-                      "dynamic IP: #{reservation.error}"
-            end
+            reservation.handle_error(network_reservation_origin)
           end
 
           idle_vm.network_reservation = reservation
         end
       end
+    end
+
+    def network_reservation_origin
+      "resource-pool-updater"
     end
 
     def generate_agent_id


### PR DESCRIPTION
During the `Bosh::Director::ResourcePoolUpdater#reserve_networks` method, if there is a `NetworkReservation::CAPACITY` error, then a `NetworkReservationNotEnoughCapacity` exception should be raised but its failing because it tries to put name/index in the error message; but these methods/variables (no longer?) exist in the scope.

https://github.com/cloudfoundry/bosh/blob/master/bosh-director/lib/bosh/director/resource_pool_updater.rb#L146-L153 in this code block, afaict there is no definition of `name` or `index` variables/methods, which is the cause of this error.

Did this ever work?
