### PR TITLE
Update error message to more accurate

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/vip_network.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/vip_network.rb
@@ -42,7 +42,7 @@ module Bosh::OpenStackCloud
                        "with floating IP `#{@ip}'")
           address.server = server
         else
-          cloud_error("Floating IP #{@ip} not allocated")
+          cloud_error("Floating IP #{@ip} not allocated as it's not found in IP pool")
         end
       end
     end


### PR DESCRIPTION
Update error message to more accurate and user-friendly.
If users misconfigure floating IP addresses in deployment file which causes IP address not found in IP pool, we should remind that instead of throwing a general information!
