### PR TITLE
Add missing submodule mapping for go-smtpd to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "go_agent/src/github.com/nu7hatch/gouuid"]
 	path = go_agent/src/github.com/nu7hatch/gouuid
 	url = https://github.com/nu7hatch/gouuid.git
+[submodule "go_agent/src/github.com/pivotal/go-smtpd"]
+	path = go_agent/src/github.com/pivotal/go-smtpd
+	url = https://github.com/pivotal/go-smtpd.git


### PR DESCRIPTION
Hi,

The submodule mapping for go-smtp seems missing in .gitmodules.
`git submodule update --init --recursive` shows:

```
No submodule mapping found in .gitmodules for path 'go_agent/src/github.com/pivotal/go-smtpd'
```
