### PR TITLE
Adding Swift blobstore configuration properties

### DIFF
--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -151,8 +151,45 @@ properties:
 
   # Blobstore
   blobstore.provider:
-    description: Provider of the blobstore used by director and agent (dav|simple|s3)
+    description: Provider of the blobstore used by director and agent (dav|simple|s3|swift)
     default: 'dav'
+
+  blobstore.options.bucket_name:
+    description: AWS S3 Bucket used for the compiled package cache
+  blobstore.options.access_key_id:
+    description: AWS access_key_id used for the compiled package cache
+  blobstore.options.secret_access_key:
+    description: AWS secret_access_key used for the compiled package cache
+  blobstore.options.swift_provider:
+    description:  OpenStack Swift provider (supported providers are hp, openstack and rackspace)
+  blobstore.options.container_name:
+    description: Name of the container
+  blobstore.options.hp_access_key:
+    description: HP Object Storage Access Key
+  blobstore.options.hp_secret_key:
+    description: HP Object Storage Secret Key
+  blobstore.options.hp_tenant_id:
+    description: HP Object Storage Project ID
+  blobstore.options.hp_avl_zone:
+    description: HP Object Storage Availability Zone (region-a.geo-1 or region-b.geo-1)
+  blobstore.options.openstack_auth_url:
+    description: URL of the OpenStack Identity endpoint to connect to
+  blobstore.options.openstack_username:
+    description: OpenStack user name
+  blobstore.options.openstack_api_key:
+    description: OpenStack API key
+  blobstore.options.openstack_tenant:
+    description: OpenStack tenant name
+  blobstore.options.openstack_region:
+    description: OpenStack region (optional)
+  blobstore.options.rackspace_username:
+    description: Rackspace Cloud Files Username
+  blobstore.options.rackspace_api_key:
+    description: Rackspace Cloud Files API Key
+  blobstore.options.rackspace_region:
+    description: Rackspace Cloud Files Region (optional, dfw or ord)
+
+
   blobstore.bucket_name:
     description: AWS S3 Bucket used by s3 blobstore plugin
   blobstore.access_key_id:

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -78,6 +78,41 @@ blobstore:
     bucket_name: <%= p('blobstore.bucket_name') %>
     access_key_id: <%= p('blobstore.access_key_id') %>
     secret_access_key: <%= p('blobstore.secret_access_key') %>
+<% elsif p('blobstore.provider') == 'swift' %>
+    swift_provider: <%= p('blobstore.options.swift_provider') %>
+    container_name: <%= p('blobstore.options.container_name') %>
+    <% if_p('blobstore.options.hp_access_key',
+            'blobstore.options.hp_secret_key',
+            'blobstore.options.hp_tenant_id',
+            'blobstore.options.hp_avl_zone') do |hp_access_key, hp_secret_key, hp_tenant_id, hp_avl_zone| %>
+    hp:
+      hp_access_key: <%= hp_access_key %>
+      hp_secret_key: <%= hp_secret_key %>
+      hp_tenant_id: <%= hp_tenant_id %>
+      hp_avl_zone: <%= hp_avl_zone %>
+    <% end %>
+    <% if_p('blobstore.options.openstack_auth_url',
+            'blobstore.options.openstack_username',
+            'blobstore.options.openstack_api_key',
+            'blobstore.options.openstack_tenant') do |openstack_auth_url, openstack_username, openstack_api_key, openstack_tenant| %>
+    openstack:
+      openstack_auth_url: <%= openstack_auth_url %>
+      openstack_username: <%= openstack_username %>
+      openstack_api_key: <%= openstack_api_key %>
+      openstack_tenant: <%= openstack_tenant %>
+      <% if_p('blobstore.options.openstack_region') do |openstack_region| %>
+      openstack_region: <%= openstack_region %>
+      <% end %>
+    <% end %>
+    <% if_p('blobstore.options.rackspace_username',
+            'blobstore.options.rackspace_api_key') do |rackspace_username, rackspace_api_key| %>
+    rackspace:
+      rackspace_username: <%= rackspace_username %>
+      rackspace_api_key: <%= rackspace_api_key %>
+      <% if_p('blobstore.options.rackspace_region') do |rackspace_region| %>
+      rackspace_region: <%= rackspace_region %>
+      <% end %>
+    <% end %>
 <% else %>
     endpoint: http://<%= p('blobstore.address') %>:<%= p('blobstore.port') %>
     user: <%= p('blobstore.director.user') %>
@@ -270,9 +305,45 @@ cloud:
           bucket_name: <%= p('blobstore.bucket_name') %>
           access_key_id: <%= p(['agent.blobstore.access_key_id', 'blobstore.access_key_id']) %>
           secret_access_key: <%= p(['agent.blobstore.secret_access_key', 'blobstore.secret_access_key']) %>
+      <% elsif p('blobstore.provider') == 'swift' %>
+          swift_provider: <%= p('blobstore.options.swift_provider') %>
+          container_name: <%= p('blobstore.options.container_name') %>
+          <% if_p('blobstore.options.hp_access_key',
+                  'blobstore.options.hp_secret_key',
+                  'blobstore.options.hp_tenant_id',
+                  'blobstore.options.hp_avl_zone') do |hp_access_key, hp_secret_key, hp_tenant_id, hp_avl_zone| %>
+          hp:
+            hp_access_key: <%= hp_access_key %>
+            hp_secret_key: <%= hp_secret_key %>
+            hp_tenant_id: <%= hp_tenant_id %>
+            hp_avl_zone: <%= hp_avl_zone %>
+          <% end %>
+          <% if_p('blobstore.options.openstack_auth_url',
+                  'blobstore.options.openstack_username',
+                  'blobstore.options.openstack_api_key',
+                  'blobstore.options.openstack_tenant') do |openstack_auth_url, openstack_username, openstack_api_key, openstack_tenant| %>
+          openstack:
+            openstack_auth_url: <%= openstack_auth_url %>
+            openstack_username: <%= openstack_username %>
+            openstack_api_key: <%= openstack_api_key %>
+            openstack_tenant: <%= openstack_tenant %>
+            <% if_p('blobstore.options.openstack_region') do |openstack_region| %>
+            openstack_region: <%= openstack_region %>
+            <% end %>
+          <% end %>
+          <% if_p('blobstore.options.rackspace_username',
+                  'blobstore.options.rackspace_api_key') do |rackspace_username, rackspace_api_key| %>
+          rackspace:
+            rackspace_username: <%= rackspace_username %>
+            rackspace_api_key: <%= rackspace_api_key %>
+            <% if_p('blobstore.options.rackspace_region') do |rackspace_region| %>
+            rackspace_region: <%= rackspace_region %>
+            <% end %>
+          <% end %>
       <% else %>
           endpoint: 'http://<%= p(['agent.blobstore.address', 'blobstore.address']) %>:<%= p('blobstore.port') %>'
           user: <%= p('blobstore.agent.user') %>
           password: <%= p('blobstore.agent.password') %>
       <% end %>
       mbus: nats://<%= p('nats.user') %>:<%= p('nats.password') %>@<%= p(['agent.nats.address', 'nats.address']) %>:<%= p('nats.port') %>
+


### PR DESCRIPTION
Source blob storage (stored during bosh upload release) can now utilise Swift interface.

Example usage in BOSH deploy manifest:

```
  blobstore_endpoint: &blobstore_endpoint
    swift_provider: openstack
    openstack_auth_url: http://xxx.xxx.xxx.xxx:5000/v2.0
    openstack_username: <user>
    openstack_api_key: <key>
    openstack_tenant: <tenant>

  blobstore:
    provider: swift
    options:
      <<: *blobstore_endpoint
      container_name: bosh-source-blobs

  compiled_package_cache:
    options:
      <<: *blobstore_endpoint
      container_name: bosh-compiled-package-cache
```
