### PR TITLE
Fix #497 - remove outdated properties for director

### DIFF
--- a/release/examples/bosh-openstack-dynamic.yml
+++ b/release/examples/bosh-openstack-dynamic.yml
@@ -145,8 +145,6 @@ properties:
     name: bosh
     address: 0.director.default.bosh-openstack.microbosh
     db: *bosh_db
-    snapshot_schedule: false
-    self_snapshot_schedule: false
 
   registry:
     address: 0.registry.default.bosh-openstack.microbosh

--- a/release/examples/bosh-openstack-manual.yml
+++ b/release/examples/bosh-openstack-manual.yml
@@ -167,8 +167,6 @@ properties:
     name: bosh
     address: <ip_address_for_director> # CHANGE
     db: *bosh_db
-    snapshot_schedule: false
-    self_snapshot_schedule: false
 
   registry:
     address: <ip_address_for_registry> # CHANGE


### PR DESCRIPTION
Using some of the examples will give you a non working director.
Accroding to https://groups.google.com/a/cloudfoundry.org/forum/#!msg/bosh-users/w8AqGFBBqsY/MzUpp2K2cL4J
these properties are outdated and can be removed.
