### PR TITLE
/stemcells returns non-JSON value for deployments

### DIFF
--- a/bosh-director/lib/bosh/director/api/controllers/stemcells_controller.rb
+++ b/bosh-director/lib/bosh/director/api/controllers/stemcells_controller.rb
@@ -20,7 +20,7 @@ module Bosh::Director
             'name' => stemcell.name,
             'version' => stemcell.version,
             'cid' => stemcell.cid,
-            'deployments' => stemcell.deployments
+            'deployments_count' => stemcell.deployments.size
           }
         end
         json_encode(stemcells)

--- a/bosh-director/spec/unit/api/controllers/stemcells_controller_spec.rb
+++ b/bosh-director/spec/unit/api/controllers/stemcells_controller_spec.rb
@@ -98,11 +98,11 @@ module Bosh::Director
               body.size.should == 10
 
               response_collection = body.map do |e|
-                [e['name'], e['version'], e['cid'], e['deployments']]
+                [e['name'], e['version'], e['cid'], e['deployments_count']]
               end
 
               expected_collection = stemcells.sort_by { |e| e.name }.map do |e|
-                [e.name.to_s, e.version.to_s, e.cid.to_s, e.deployments]
+                [e.name.to_s, e.version.to_s, e.cid.to_s, e.deployments.size]
               end
 
               response_collection.should == expected_collection

--- a/bosh_cli/lib/cli/commands/stemcell.rb
+++ b/bosh_cli/lib/cli/commands/stemcell.rb
@@ -155,9 +155,13 @@ module Bosh::Cli
     end
 
     def get_stemcell_table_record(sc)
-      deployments = sc.fetch('deployments', [])
+      any_deployments = deployments_count(sc) > 0
 
-      [sc['name'], "#{sc['version']}#{deployments.empty? ? '' : '*'}", sc['cid']]
+      [sc['name'], "#{sc['version']}#{any_deployments ? '*' : ''}", sc['cid']]
+    end
+
+    def deployments_count(sc)
+      sc.fetch('deployments_count', nil) || sc.fetch('deployments', []).size
     end
   end
 end

--- a/bosh_cli/spec/unit/commands/stemcell_spec.rb
+++ b/bosh_cli/spec/unit/commands/stemcell_spec.rb
@@ -125,8 +125,10 @@ module Bosh::Cli
     end
 
     describe 'list' do
+      # stemcell1 uses director v1798 and earlier API format
       let(:stemcell1) { { 'name' => 'fake stemcell 1', 'version' => '123', 'cid' => '123456', 'deployments' => [] } }
-      let(:stemcell2) { { 'name' => 'fake stemcell 2', 'version' => '456', 'cid' => '789012', 'deployments' => [] } }
+      # stemcell2 uses director v1798 and newer API format
+      let(:stemcell2) { { 'name' => 'fake stemcell 2', 'version' => '456', 'cid' => '789012', 'deployments_count' => 0 } }
       let(:stemcells) { [stemcell1, stemcell2] }
       let(:buffer) { StringIO.new }
 
@@ -153,9 +155,25 @@ module Bosh::Cli
         end
       end
 
-      context 'when there are stemcells in use' do
+      context 'when there are stemcells in use (director v1798 and earlier)' do
         let(:stemcell2) { { 'name' => 'fake stemcell 2', 'version' => '456',
                             'cid' => '789012', 'deployments' => ['fake deployment'] } }
+
+        it 'adds a star for stemcells that are in use' do
+          command.list
+
+          buffer.rewind
+          output = buffer.read
+
+          expect(output).to include('| fake stemcell 1 | 123     | 123456 |')
+          expect(output).to include('| fake stemcell 2 | 456*    | 789012 |')
+          expect(output).to include('(*) Currently in-use')
+        end
+      end
+
+      context 'when there are stemcells in use (director v1798 and newer)' do
+        let(:stemcell2) { { 'name' => 'fake stemcell 2', 'version' => '456',
+                            'cid' => '789012', 'deployments_count' => 1 } }
 
         it 'adds a star for stemcells that are in use' do
           command.list


### PR DESCRIPTION
```
curl -k -u admin:admin https://192.168.50.4:25555/stemcells | jazor
[
  {
    "name": "bosh-stemcell",
    "version": "993",
    "cid": "stemcell-6e6b9689-8b03-42cd-a6de-7784e3c421ec",
    "deployments": [
      "#<Bosh::Director::Models::Deployment:0x00000004696c30>"
    ]
  },
  {
    "name": "bosh-warden-boshlite-ubuntu",
    "version": "24",
    "cid": "stemcell-6936d497-b8cd-4e12-af0a-5f2151834a1a",
    "deployments": [

    ]
  }
]
```
