### PR TITLE
add configuration options for s3 blobstore client.

### DIFF
--- a/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
@@ -34,8 +34,8 @@ module Bosh
         aws_options = {
           access_key_id: @options[:access_key_id],
           secret_access_key: @options[:secret_access_key],
-          use_ssl: true,
-          port: 443,
+          use_ssl: @options[:use_ssl].nil? ? true : @options[:use_ssl],
+          port: @options[:port].nil? ? 443 : @options[:port],
           s3_endpoint: URI.parse(@options[:endpoint] || S3BlobstoreClient::ENDPOINT).host,
         }
 

--- a/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
+++ b/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
@@ -46,21 +46,44 @@ module Bosh::Blobstore
           BlobstoreError, "can't use read-only with an encryption key")
       end
 
-      it 'should be processed and passed to the AWS::S3 class' do
-        options = { 'bucket_name' => 'test',
-                    'access_key_id' => 'KEY',
-                    'secret_access_key' => 'SECRET',
-                    'endpoint' => 'https://s3.example.com' }
+      context 'should be processed and passed to the AWS::S3 class' do
+        it 'should use user defined values' do
+          options = { 'bucket_name' => 'test',
+                      'access_key_id' => 'KEY',
+                      'secret_access_key' => 'SECRET',
+                      'use_ssl' => false,
+                      'port' => 8080,
+                      'endpoint' => 'http://our.userdefined.com'
+          }
 
-        expect(AWS::S3).to receive(:new).
-          with(access_key_id: 'KEY',
-               secret_access_key: 'SECRET',
-               use_ssl: true,
-               port: 443,
-               s3_endpoint: 's3.example.com').
-          and_return(s3)
+          expect(AWS::S3).to receive(:new).
+                                 with(access_key_id: 'KEY',
+                                      secret_access_key: 'SECRET',
+                                      use_ssl: false,
+                                      port: 8080,
+                                      s3_endpoint: 'our.userdefined.com').
+                                 and_return(s3)
 
-        S3BlobstoreClient.new(options)
+          S3BlobstoreClient.new(options)
+
+        end
+
+        it 'should use the default values for undefined use_ssl, port, and s3_endpoint' do
+          options = { 'bucket_name' => 'test',
+                      'access_key_id' => 'KEY',
+                      'secret_access_key' => 'SECRET',
+          }
+
+          expect(AWS::S3).to receive(:new).
+                                 with(access_key_id: 'KEY',
+                                      secret_access_key: 'SECRET',
+                                      use_ssl: true,
+                                      port: 443,
+                                      s3_endpoint: 's3.amazonaws.com').
+                                 and_return(s3)
+
+          S3BlobstoreClient.new(options)
+        end
       end
     end
 

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -78,6 +78,18 @@ blobstore:
     bucket_name: <%= p('blobstore.bucket_name') %>
     access_key_id: <%= p('blobstore.access_key_id') %>
     secret_access_key: <%= p('blobstore.secret_access_key') %>
+<% if_p('blobstore.use_ssl') do |use_ssl| %>
+    use_ssl: <%= use_ssl %>
+<% end %>
+ <% if_p('blobstore.port') do |port| %>
+    port: <%= p('blobstore.port') %>
+<% end %>
+<% if_p('blobstore.host') do |host| %>
+    endpoint: <%=
+        protocol = p('blobstore.use_ssl', nil) ? 'https' : 'http'
+        "#{protocol}://#{p('blobstore.host')}"
+    %>
+<% end %>
 <% else %>
     endpoint: http://<%= p('blobstore.address') %>:<%= p('blobstore.port') %>
     user: <%= p('blobstore.director.user') %>
@@ -270,6 +282,18 @@ cloud:
           bucket_name: <%= p('blobstore.bucket_name') %>
           access_key_id: <%= p(['agent.blobstore.access_key_id', 'blobstore.access_key_id']) %>
           secret_access_key: <%= p(['agent.blobstore.secret_access_key', 'blobstore.secret_access_key']) %>
+      <% if_p('blobstore.use_ssl') do |use_ssl| %>
+          use_ssl: <%= use_ssl %>
+      <% end %>
+      <% if_p('blobstore.port') do |port| %>
+          port: <%= p('blobstore.port') %>
+      <% end %>
+      <% if_p('blobstore.host') do |port| %>
+          endpoint: <%=
+              protocol = p('blobstore.use_ssl', nil) ? 'https' : 'http'
+              "#{protocol}://#{p('blobstore.host')}"
+          %>
+      <% end %>
       <% else %>
           endpoint: 'http://<%= p(['agent.blobstore.address', 'blobstore.address']) %>:<%= p('blobstore.port') %>'
           user: <%= p('blobstore.agent.user') %>

--- a/release/spec/director.yml.erb.erb_spec.rb
+++ b/release/spec/director.yml.erb.erb_spec.rb
@@ -6,51 +6,51 @@ require 'json'
 describe 'director.yml.erb.erb' do
   let(:deployment_manifest_fragment) do
     {
-      'properties' => {
-        'ntp' => [
-          '0.north-america.pool.ntp.org',
-          '1.north-america.pool.ntp.org',
-        ],
-        'blobstore' => {
-          'address' => '10.10.0.7',
-          'port' => 25251,
-          'agent' => { 'user' => 'agent', 'password' => '75d1605f59b60' },
-          'director' => {
-            'user' => 'user',
-            'password' => 'password'
-          },
-          'provider' => 'dav',
-        },
-        'nats' => {
-          'user' => 'nats',
-          'password' => '1a0312a24c0a0',
-          'address' => '10.10.0.7',
-          'port' => 4222
-        },
-        'redis' => {
-          'address' => '127.0.0.1', 'port' => 25255, 'password' => 'R3d!S',
-          'loglevel' => 'info',
-        },
-        'director' => {
-          'name' => 'vpc-bosh-idora',
-          'backend_port' => 25556,
-          'encryption' => false,
-          'max_tasks' => 500,
-          'max_threads' => 32,
-          'enable_snapshots' => true,
-          'db' => {
-            'adapter' => 'mysql2',
-            'user' => 'ub45391e00',
-            'password' => 'p4cd567d84d0e012e9258d2da30',
-            'host' => 'bosh.hamazonhws.com',
-            'port' => 3306,
-            'database' => 'bosh',
-            'connection_options' => {},
-          },
-          'auto_fix_stateful_nodes' => true,
-          'max_vm_create_tries' => 5,
+        'properties' => {
+            'ntp' => [
+                '0.north-america.pool.ntp.org',
+                '1.north-america.pool.ntp.org',
+            ],
+            'blobstore' => {
+                'address' => '10.10.0.7',
+                'port' => 25251,
+                'agent' => {'user' => 'agent', 'password' => '75d1605f59b60'},
+                'director' => {
+                    'user' => 'user',
+                    'password' => 'password'
+                },
+                'provider' => 'dav',
+            },
+            'nats' => {
+                'user' => 'nats',
+                'password' => '1a0312a24c0a0',
+                'address' => '10.10.0.7',
+                'port' => 4222
+            },
+            'redis' => {
+                'address' => '127.0.0.1', 'port' => 25255, 'password' => 'R3d!S',
+                'loglevel' => 'info',
+            },
+            'director' => {
+                'name' => 'vpc-bosh-idora',
+                'backend_port' => 25556,
+                'encryption' => false,
+                'max_tasks' => 500,
+                'max_threads' => 32,
+                'enable_snapshots' => true,
+                'db' => {
+                    'adapter' => 'mysql2',
+                    'user' => 'ub45391e00',
+                    'password' => 'p4cd567d84d0e012e9258d2da30',
+                    'host' => 'bosh.hamazonhws.com',
+                    'port' => 3306,
+                    'database' => 'bosh',
+                    'connection_options' => {},
+                },
+                'auto_fix_stateful_nodes' => true,
+                'max_vm_create_tries' => 5,
+            }
         }
-      }
     }
   end
 
@@ -61,7 +61,6 @@ describe 'director.yml.erb.erb' do
   end
 
   context 'vsphere' do
-
     before do
       deployment_manifest_fragment['properties']['vcenter'] = {
         'address' => 'vcenter.address',
@@ -73,7 +72,6 @@ describe 'director.yml.erb.erb' do
             'clusters' => ['cluster1']
           },
         ] }
-
     end
 
     context 'when vcenter.address begins with a bang and contains quotes' do
@@ -159,6 +157,175 @@ describe 'director.yml.erb.erb' do
         parsed = YAML.load(rendered_yaml)
         expect(parsed['cloud']['properties']['openstack']['connection_options']).to eq(
           { 'option1' => 'true', 'option2' => 'false' })
+      end
+    end
+  end
+
+  context 's3' do
+    before do
+      deployment_manifest_fragment['properties']['aws'] = {
+          'access_key_id' => 'key',
+          'secret_access_key' => 'secret',
+          'default_key_name' => 'default_key_name',
+          'default_security_groups' => 'default_security_groups',
+          'region' => 'region'
+      }
+
+      deployment_manifest_fragment['properties']['registry'] = {
+          'address' => 'aws-registry.example.com',
+          'http' => {
+              'port' => '1234',
+              'user' => 'aws.user',
+              'password' => 'aws.password'
+          }
+      }
+    end
+
+    context 'when the user specifies use_ssl, port, and host' do
+      before do
+        deployment_manifest_fragment['properties']['blobstore'] = {
+            'provider' => 's3',
+            'bucket_name' => 'mybucket',
+            'access_key_id' => 'key',
+            'secret_access_key' => 'secret',
+            'use_ssl' => false,
+            'port' => 5155,
+            'host' => 'myhost.hostland.edu'
+        }
+      end
+
+      it 'sets the blobstore fields appropriately' do
+        spec = deployment_manifest_fragment
+        rendered_yaml = ERB.new(erb_yaml).result(Bosh::Common::TemplateEvaluationContext.new(spec).get_binding)
+        parsed = YAML.load(rendered_yaml)
+
+        expect(parsed['blobstore']['options']).to eq({
+                                                         'bucket_name' => 'mybucket',
+                                                         'access_key_id' => 'key',
+                                                         'secret_access_key' => 'secret',
+                                                         'use_ssl' => false,
+                                                         'port' => 5155,
+                                                         'endpoint' => 'http://myhost.hostland.edu'
+                                                     })
+      end
+
+      it 'sets endpoint protocol appropriately when use_ssl is true' do
+        deployment_manifest_fragment['properties']['blobstore']['use_ssl'] = true
+        spec = deployment_manifest_fragment
+        rendered_yaml = ERB.new(erb_yaml).result(Bosh::Common::TemplateEvaluationContext.new(spec).get_binding)
+        parsed = YAML.load(rendered_yaml)
+
+        expect(parsed['blobstore']['options']).to eq({
+                                                         'bucket_name' => 'mybucket',
+                                                         'access_key_id' => 'key',
+                                                         'secret_access_key' => 'secret',
+                                                         'use_ssl' => true,
+                                                         'port' => 5155,
+                                                         'endpoint' => 'https://myhost.hostland.edu'
+                                                     })
+      end
+
+      describe 'the agent blobstore' do
+        it 'has the same config as the toplevel blobstore' do
+          spec = deployment_manifest_fragment
+          rendered_yaml = ERB.new(erb_yaml).result(Bosh::Common::TemplateEvaluationContext.new(spec).get_binding)
+          parsed = YAML.load(rendered_yaml)
+
+          expect(parsed['cloud']['properties']['agent']['blobstore']['options']).to eq({
+               'bucket_name' => 'mybucket',
+               'access_key_id' => 'key',
+               'secret_access_key' => 'secret',
+               'use_ssl' => false,
+               'port' => 5155,
+               'endpoint' => 'http://myhost.hostland.edu'
+           })
+        end
+
+        context 'when there are override values for the agent' do
+          before do
+            deployment_manifest_fragment['properties']['agent'] = {
+                'blobstore' => {
+                    'access_key_id' => 'agent-key',
+                    'secret_access_key' => 'agent-secret'
+                }
+            }
+          end
+
+          it 'uses the override values' do
+            spec = deployment_manifest_fragment
+            rendered_yaml = ERB.new(erb_yaml).result(Bosh::Common::TemplateEvaluationContext.new(spec).get_binding)
+            parsed = YAML.load(rendered_yaml)
+
+            expect(parsed['cloud']['properties']['agent']['blobstore']['options']).to eq({
+                 'bucket_name' => 'mybucket',
+                 'access_key_id' => 'agent-key',
+                 'secret_access_key' => 'agent-secret',
+                 'use_ssl' => false,
+                 'port' => 5155,
+                 'endpoint' => 'http://myhost.hostland.edu'
+             })
+          end
+        end
+      end
+    end
+
+    context 'when the user only specifies bucket, access, and secret' do
+      before do
+        deployment_manifest_fragment['properties']['blobstore'] = {
+            'provider' => 's3',
+            'bucket_name' => 'mybucket',
+            'access_key_id' => 'key',
+            'secret_access_key' => 'secret'
+        }
+      end
+
+      it 'sets the blobstore fields appropriately' do
+        spec = deployment_manifest_fragment
+        rendered_yaml = ERB.new(erb_yaml).result(Bosh::Common::TemplateEvaluationContext.new(spec).get_binding)
+        parsed = YAML.load(rendered_yaml)
+
+        expect(parsed['blobstore']['options']).to eq({
+                                                         'bucket_name' => 'mybucket',
+                                                         'access_key_id' => 'key',
+                                                         'secret_access_key' => 'secret',
+                                                     })
+      end
+
+      describe 'the agent blobstore' do
+        it 'has the same config as the toplevel blobstore' do
+          spec = deployment_manifest_fragment
+          rendered_yaml = ERB.new(erb_yaml).result(Bosh::Common::TemplateEvaluationContext.new(spec).get_binding)
+          parsed = YAML.load(rendered_yaml)
+
+          expect(parsed['cloud']['properties']['agent']['blobstore']['options']).to eq({
+                 'bucket_name' => 'mybucket',
+                 'access_key_id' => 'key',
+                 'secret_access_key' => 'secret',
+             })
+        end
+
+        context 'when there are override values for the agent' do
+          before do
+            deployment_manifest_fragment['properties']['agent'] = {
+                'blobstore' => {
+                    'access_key_id' => 'agent-key',
+                    'secret_access_key' => 'agent-secret'
+                }
+            }
+          end
+
+          it 'uses the override values' do
+            spec = deployment_manifest_fragment
+            rendered_yaml = ERB.new(erb_yaml).result(Bosh::Common::TemplateEvaluationContext.new(spec).get_binding)
+            parsed = YAML.load(rendered_yaml)
+
+            expect(parsed['cloud']['properties']['agent']['blobstore']['options']).to eq({
+                   'bucket_name' => 'mybucket',
+                   'access_key_id' => 'agent-key',
+                   'secret_access_key' => 'agent-secret',
+               })
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Here we add the ability to configure s3 blobstore client:

director: access_key_id, secret_access_key, bucket_name, use_ssl, port, host
agent: access_key_id, secret_access_key. (use director's configuration for other settings)
