### PR TITLE
GET /stemcells "deployments" key returns names instead of rubbish

### DIFF
--- a/bosh-director/lib/bosh/director/api/controllers/stemcells_controller.rb
+++ b/bosh-director/lib/bosh/director/api/controllers/stemcells_controller.rb
@@ -16,11 +16,12 @@ module Bosh::Director
 
       get '/stemcells' do
         stemcells = Models::Stemcell.order_by(:name.asc).map do |stemcell|
+          deployment_names = stemcell.deployments && stemcell.deployments.map(&:name)
           {
             'name' => stemcell.name,
             'version' => stemcell.version,
             'cid' => stemcell.cid,
-            'deployments' => stemcell.deployments
+            'deployments' => deployment_names
           }
         end
         json_encode(stemcells)


### PR DESCRIPTION
Previously the "deployments" value of the response was an internal Ruby
construct; and not any useful JSON value.

Now the "deployments" value is a list of the deployment names that are using
each stemcell.
