### PR TITLE
Allow atmos unsupported versions

### DIFF
--- a/blobstore_client/lib/blobstore_client/atmos_blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client/atmos_blobstore_client.rb
@@ -19,6 +19,10 @@ module Bosh
         }
         @tag = @options[:tag]
 
+        if @options[:unsupported]
+          @atmos_options[:unsupported] = @options[:unsupported]
+        end
+
         # Add proxy if ENV has the variable
         proxy = case URI.parse(@atmos_options[:url] || '').scheme
                   when 'https'

--- a/blobstore_client/spec/unit/atmos_blobstore_client_spec.rb
+++ b/blobstore_client/spec/unit/atmos_blobstore_client_spec.rb
@@ -42,6 +42,17 @@ module Bosh::Blobstore
         expect(HTTPClient).to receive(:new)
         client
       end
+
+      it 'initializes with unsupported' do
+        options[:unsupported] = true
+        expect(Atmos::Store).to receive(:new).with(options)
+        client.atmos_server
+      end
+
+      it 'initializes without unsupported' do
+        expect(Atmos::Store).to receive(:new).with(options)
+        client.atmos_server
+      end
     end
 
     describe '#exists?' do


### PR DESCRIPTION
When I'm trying to connect to our atmos blobstore I get the following error:

```
Bosh::Blobstore::BlobstoreError: Failed to create object, underlying error: 
#<Atmos::Exceptions::NotImplementedException: 
This library does not support Atmos version 2.1.5.0.  
Supported versions: ["1.2.7", "1.3.4", "1.4.0", "1.4.1", "1.4.2", "2.0.1"].  
To silence this, pass :unsupported => true when instantiating.
```

Since the blobstore-client already uses the latest version of [ruby-atmos-pure](the https://rubygems.org/gems/ruby-atmos-pure) gem the only option was to use the `:unsupported => true`.
