### PR TITLE
Expose the Openstack CPI wait_resource poll interval as a config item

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -37,11 +37,7 @@ module Bosh::OpenStackCloud
       @default_security_groups = @openstack_properties["default_security_groups"]
       @state_timeout = @openstack_properties["state_timeout"]
       @stemcell_public_visibility = @openstack_properties["stemcell_public_visibility"]
-
-      # If the wait_resource sleep time is overridden in the Openstack BOSH manifest properties
-      if @openstack_properties["wait_resource_poll_interval"]
       @wait_resource_poll_interval = @openstack_properties["wait_resource_poll_interval"]
-      end
 
       unless @openstack_properties["auth_url"].match(/\/tokens$/)
         @openstack_properties["auth_url"] = @openstack_properties["auth_url"] + "/tokens"

--- a/bosh_openstack_cpi/lib/cloud/openstack/helpers.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/helpers.rb
@@ -119,8 +119,7 @@ module Bosh::OpenStackCloud
 
         break if target_state.include?(state)
 
-        # Enforcing the original defaults, sleep time is 1 if wait_resource_poll_interval was not set as
-        sleep(@wait_resource_poll_interval || 1)
+        sleep(@wait_resource_poll_interval)
         
       end
 

--- a/bosh_openstack_cpi/spec/spec_helper.rb
+++ b/bosh_openstack_cpi/spec/spec_helper.rb
@@ -32,7 +32,8 @@ def mock_cloud_options
       'api_key' => 'nova',
       'tenant' => 'admin',
       'region' => 'RegionOne',
-      'state_timeout' => 0.1
+      'state_timeout' => 0.1,
+      'wait_resource_poll_interval' => 3
     },
     'registry' => {
       'endpoint' => 'localhost:42288',

--- a/bosh_openstack_cpi/spec/unit/helpers_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/helpers_spec.rb
@@ -10,6 +10,7 @@ describe Bosh::OpenStackCloud::Helpers do
   end
 
   describe "wait_resource" do
+
     it "should time out" do
       resource = double("resource")
       resource.stub(:id).and_return("foobar")
@@ -98,6 +99,12 @@ describe Bosh::OpenStackCloud::Helpers do
 
       @cloud.wait_resource(resource, :deleted, :status, true)
     end
+
+    it "should receive a value for sleep" do
+      @cloud.instance_variable_defined?("@wait_resource_poll_interval").should eq(true)
+      @cloud.instance_variable_get("@wait_resource_poll_interval").should eq(3)
+    end 
+
   end
 
   describe "with_openstack" do

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -289,7 +289,8 @@ properties:
   openstack.default_security_groups:
     description: Default OpenStack security groups to use when spinning up new vms
   openstack.wait_resource_poll_interval:
-    description: Changes the delay (in seconds) between each status check to the OpenStack API when creating new resources. (Optional)
+    description: Changes the delay (in seconds) between each status check to OpenStack when creating a resource
+    default: 1
   vcenter.address:
     description: Address of vCenter server used by vsphere cpi
   vcenter.user:

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -178,11 +178,11 @@ cloud:
 <% end %>
 <% if_p('openstack.auth_url', 'openstack.username', 'openstack.api_key',
         'openstack.tenant', 'openstack.default_key_name',
-        'openstack.default_security_groups', 'registry.address',
+        'openstack.default_security_groups','openstack.wait_resource_poll_interval', 'registry.address',
         'registry.http.port', 'registry.http.user',
         'registry.http.password') do |auth_url, username, api_key,
                                                 tenant, default_key_name,
-                                                default_security_groups, reg_address,
+                                                default_security_groups, wait_resource_poll_interval, reg_address,
                                                 reg_port, reg_user,
                                                 reg_password| %>
   plugin: openstack <% plugin = "openstack" %>
@@ -204,14 +204,12 @@ cloud:
       <% if_p("openstack.stemcell_public_visibility") do |stemcell_public_visibility| %>
       stemcell_public_visibility: <%= stemcell_public_visibility %>
       <% end %>
-      <% if_p("openstack.wait_resource_poll_interval") do |wait_resource_poll_interval| %>
-      wait_resource_poll_interval: <%= wait_resource_poll_interval %>
-      <% end %>
       <% if_p('openstack.connection_options') do |connection_options| %>
       connection_options: <%= JSON.generate(connection_options) %>
       <% end %>
       default_key_name: <%= default_key_name %>
       default_security_groups: <%= default_security_groups %>
+      wait_resource_poll_interval: <%= wait_resource_poll_interval %>
     registry:
       endpoint: http://<%= reg_address %>:<%= reg_port %>
       user: <%= reg_user %>

--- a/release/spec/director.yml.erb.erb_spec.rb
+++ b/release/spec/director.yml.erb.erb_spec.rb
@@ -131,7 +131,8 @@ describe 'director.yml.erb.erb' do
         'api_key' => 'api_key',
         'tenant' => 'tenant',
         'default_key_name' => 'default_key_name',
-        'default_security_groups' => 'default_security_groups'
+        'default_security_groups' => 'default_security_groups',
+        'wait_resource_poll_interval' => 'wait_resource_poll_interval'
       }
       deployment_manifest_fragment['properties']['registry'] = {
         'address' => 'address',


### PR DESCRIPTION
Default 1 second sleep time on resource creation in the Openstack CPI could cause load/performance issues with some OpenStack installations. Making this configurable seems like a better option that enforcing a new default.

Change will keep the existing default if option is not set.

https://groups.google.com/a/cloudfoundry.org/forum/#!topic/bosh-dev/Q8_oZd9shJ8
