### PR TITLE
blobstores and solo installations should have a persistent disk.

### DIFF
--- a/release/examples/bosh-aws-dns.yml
+++ b/release/examples/bosh-aws-dns.yml
@@ -101,6 +101,7 @@ jobs:
     template: blobstore
     instances: 1
     resource_pool: small
+    persistent_disk: 51200
     networks:
       - name: default
         default: [dns, gateway]

--- a/release/examples/bosh-aws-solo.yml
+++ b/release/examples/bosh-aws-solo.yml
@@ -61,6 +61,7 @@ jobs:
     - health_monitor
     instances: 1
     resource_pool: medium
+    persistent_disk: 51200
     networks:
       - name: default
         default: [dns, gateway]

--- a/release/examples/bosh-aws-vip.yml
+++ b/release/examples/bosh-aws-vip.yml
@@ -110,6 +110,7 @@ jobs:
     template: blobstore
     instances: 1
     resource_pool: small
+    persistent_disk: 51200
     networks:
       - name: default
         default: [dns, gateway]

--- a/release/examples/bosh-openstack-dynamic.yml
+++ b/release/examples/bosh-openstack-dynamic.yml
@@ -78,6 +78,7 @@ jobs:
     template: blobstore
     instances: 1
     resource_pool: common
+    persistent_disk: 51200
     networks:
       - name: default
         default: [dns, gateway]

--- a/release/examples/bosh-openstack-manual.yml
+++ b/release/examples/bosh-openstack-manual.yml
@@ -92,6 +92,7 @@ jobs:
     template: blobstore
     instances: 1
     resource_pool: common
+    persistent_disk: 51200
     networks:
       - name: default
         default: [dns, gateway]

--- a/release/examples/bosh-openstack-solo.yml
+++ b/release/examples/bosh-openstack-solo.yml
@@ -61,6 +61,7 @@ jobs:
     - health_monitor
     instances: 1
     resource_pool: medium
+    persistent_disk: 51200
     networks:
       - name: default
         default: [dns, gateway]


### PR DESCRIPTION
To not loose the blobstores (and db on solo installations), these
jobs should use a persistent disk.

People will use these examples as a starting point and once they will
update for example a stemcell, they will suddently loose all the blobs
if they haven't configured a persistent disk for these jobs. So we
should provide a sane example.
