### PR TITLE
Disable network_reconfiguration bat test for vcloud

### DIFF
--- a/bat/lib/bat/stemcell.rb
+++ b/bat/lib/bat/stemcell.rb
@@ -35,7 +35,7 @@ module Bat
     end
 
     def supports_network_reconfiguration?
-      !(name =~ /vsphere/ && (name =~ /centos/ || name !~ /go_agent/))
+      !((name =~ /vsphere/ || name =~ /vcloud/) && (name =~ /centos/ || name !~ /go_agent/))
     end
 
     def ==(other)

--- a/bat/spec/bat/stemcell_spec.rb
+++ b/bat/spec/bat/stemcell_spec.rb
@@ -78,17 +78,21 @@ describe Bat::Stemcell do
 
       # Ruby agent does not support prepare_configure_networks/configure_networks
       'bosh-vsphere-esxi-ubuntu' => false,
+      'bosh-vcloud-esxi-ubuntu' => false,
 
       # Centos currently does not include open-vm-tools
       'bosh-vsphere-esxi-centos' => false,
+      'bosh-vcloud-esxi-centos' => false,
 
       # Go agent
       'bosh-custom-xen-ubuntu-go_agent' => true,
       'bosh-custom-xen-centos-go_agent' => true,
       'bosh-vsphere-esxi-ubuntu-go_agent' => true,
+      'bosh-vcloud-esxi-ubuntu-go_agent' => true,
 
       # Centos currently does not include open-vm-tools
       'bosh-vsphere-esxi-centos-go_agent' => false,
+      'bosh-vcloud-esxi-centos-go_agent' => false,
 
     }.each do |stemcell_name, expected|
       it "returns #{expected} for #{stemcell_name}" do


### PR DESCRIPTION
vcloud does not support any additional features as compared to vsphere. this spec is breaking the vcloud BAT runs.
