### PR TITLE
rspec fails on bosh_cli_plugin_micro/spec/unit/bosh/deployer/deployer_renderer_spec.rb

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/deployer/deployer_renderer.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/deployer_renderer.rb
@@ -17,7 +17,7 @@ module Bosh::Deployer
 
     def update(state, task)
       event = {
-        'time'     => Time.now,
+        'time'     => Time.now.to_s,
         'stage'    => @stage,
         'task'     => task,
         'tags'     => [],


### PR DESCRIPTION
rspec fails on bosh_cli_plugin_micro/spec/unit/bosh/deployer/deployer_renderer_spec.rb:26

  1) Bosh::Deployer::DeployerRenderer#update adds an event to the event log for the given task and state
     Failure/Error: expect(JSON.parse(@actual_json)).to include({
       expected {"time"=>"2014-04-23T10:23:40+02:00", "stage"=>nil, "task"=>"fake-task", "tags"=>[], "index"=>1, "total"=>nil, "state"=>"fake_state", "progress"=>0} to include {"time"=>"2014-04-23 10:23:40 +0200", "task"=>"fake-task", "tags"=>[], "state"=>"fake_state"}

i.e the implementation and the test used different time formats. Not sure which of them does it right - I chose to add a 'to_s' in the implementation, as shown in the diff.
