### PR TITLE
Issue #573   associate public ip address support 

### DIFF
--- a/bosh_aws_cpi/README.md
+++ b/bosh_aws_cpi/README.md
@@ -107,3 +107,4 @@ This is a sample of how AWS specific properties are used in a BOSH deployment ma
         default_key_name: bosh
         default_security_groups: ["bosh"]
         ec2_private_key: /home/bosh/.ssh/bosh
+        associate_public_ip_address: true

--- a/bosh_aws_cpi/spec/spec_helper.rb
+++ b/bosh_aws_cpi/spec/spec_helper.rb
@@ -45,6 +45,13 @@ def make_cloud(options = nil)
   Bosh::AwsCloud::Cloud.new(options || mock_cloud_options)
 end
 
+def mock_security_groups(group_id="sg-baz-1234", group_name="baz")
+  sg1 = double(AWS::EC2::SecurityGroup, security_group_id: group_id)
+  allow(sg1).to receive(:id).and_return(group_id)
+  allow(sg1).to receive(:name).and_return(group_name)
+  [sg1]
+end
+
 def mock_registry(endpoint = 'http://registry:3333')
   registry = double('registry', :endpoint => endpoint)
   Bosh::Registry::Client.stub(:new).and_return(registry)

--- a/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require 'pry-debugger'
 
 describe Bosh::AwsCloud::InstanceManager do
   let(:registry) { double("registry", :endpoint => "http://...", :update_settings => nil) }

--- a/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require 'pry-debugger'
 
 describe Bosh::AwsCloud::InstanceManager do
   let(:registry) { double("registry", :endpoint => "http://...", :update_settings => nil) }
@@ -36,7 +37,21 @@ describe Bosh::AwsCloud::InstanceManager do
   describe "#create" do
     let(:availability_zone_selector) { double(Bosh::AwsCloud::AvailabilityZoneSelector, common_availability_zone: "us-east-1a") }
     let(:fake_aws_subnet) { double(AWS::EC2::Subnet).as_null_object }
-    let(:aws_instance_params) do
+    let(:aws_instance_params_vpc) do
+      {
+          count: 1,
+          image_id: "stemcell-id",
+          instance_type: "m1.small",
+          user_data: "{\"registry\":{\"endpoint\":\"http://...\"},\"dns\":{\"nameserver\":\"foo\"}}",
+          key_name: "bar",
+          security_group_ids: ["sg-baz-1234"],
+          subnet: fake_aws_subnet,
+          private_ip_address: "1.2.3.4",
+          availability_zone: "us-east-1a",
+          associate_public_ip_address: true
+      }
+    end
+    let(:aws_instance_params_no_vpc) do
       {
           count: 1,
           image_id: "stemcell-id",
@@ -56,8 +71,9 @@ describe Bosh::AwsCloud::InstanceManager do
     it "should ask AWS to create an instance in the given region, with parameters built up from the given arguments" do
       allow(region).to receive(:instances).and_return(aws_instances)
       allow(region).to receive(:subnets).and_return({"sub-123456" => fake_aws_subnet})
+      allow(region).to receive(:security_groups).and_return( mock_security_groups )
 
-      expect(aws_instances).to receive(:create).with(aws_instance_params).and_return(instance)
+      expect(aws_instances).to receive(:create).with(aws_instance_params_vpc).and_return(instance)
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_instance).with(instance: instance, state: :running)
 
       instance_manager = described_class.new(region, registry, availability_zone_selector)
@@ -87,11 +103,7 @@ describe Bosh::AwsCloud::InstanceManager do
       allow(region).to receive(:client).and_return(aws_client)
       allow(region).to receive(:subnets).and_return({"sub-123456" => fake_aws_subnet})
       allow(region).to receive(:instances).and_return( {'i-12345678' => instance } )
-
-      #need to translate security group names to security group ids
-      sg1 = double(AWS::EC2::SecurityGroup, security_group_id:"sg-baz-1234")
-      allow(sg1).to receive(:name).and_return("baz")
-      allow(region).to receive(:security_groups).and_return([sg1])
+      allow(region).to receive(:security_groups).and_return( mock_security_groups )
 
       agent_id = "agent-id"
       stemcell_id = "stemcell-id"
@@ -115,7 +127,7 @@ describe Bosh::AwsCloud::InstanceManager do
       resource_pool = {"spot_bid_price"=>0.15, "instance_type" => "m1.small", "key_name" => "bar"}
 
       #Should not recieve an ondemand instance create call
-      expect(aws_instances).to_not receive(:create).with(aws_instance_params)
+      expect(aws_instances).to_not receive(:create).with(aws_instance_params_no_vpc)
 
       #Should rather recieve a spot instance request
       expect(aws_client).to receive(:request_spot_instances) do |spot_request|
@@ -160,9 +172,10 @@ describe Bosh::AwsCloud::InstanceManager do
     it "should retry creating the VM when AWS::EC2::Errors::InvalidIPAddress::InUse raised" do
       allow(region).to receive(:instances).and_return(aws_instances)
       allow(region).to receive(:subnets).and_return({"sub-123456" => fake_aws_subnet})
+      allow(region).to receive(:security_groups).and_return( mock_security_groups )
 
-      expect(aws_instances).to receive(:create).with(aws_instance_params).and_raise(AWS::EC2::Errors::InvalidIPAddress::InUse)
-      expect(aws_instances).to receive(:create).with(aws_instance_params).and_return(instance)
+      expect(aws_instances).to receive(:create).with(aws_instance_params_vpc).and_raise(AWS::EC2::Errors::InvalidIPAddress::InUse)
+      expect(aws_instances).to receive(:create).with(aws_instance_params_vpc).and_return(instance)
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_instance).with(instance: instance, state: :running)
       
       instance_manager = described_class.new(region, registry, availability_zone_selector)


### PR DESCRIPTION
Issue #573 resolution

Added support for AssociatePublicIpAddress network parameter for manual networks.

AssociatePublicIpAddress can be explicitly described in deployment manifest (aws or resource pool props)
or assigned by convention (manual network without vip)