### PR TITLE
Allow resource limits to be specified for Warden in the director config

### DIFF
--- a/bosh_warden_cpi/lib/cloud/warden/helpers.rb
+++ b/bosh_warden_cpi/lib/cloud/warden/helpers.rb
@@ -99,9 +99,23 @@ module Bosh::WardenCloud
         request.handle = handle
         request.privileged = true
         request.script = '/usr/sbin/runsvdir-start'
+        request.rlimits = resource_limits
         client.call(request)
       end
     end
 
+    def resource_limits
+      Warden::Protocol::ResourceLimits.new(
+        symbolize_keys(
+          @warden_properties.fetch('rlimits', {})
+        )
+      )
+    end
+
+    def symbolize_keys(hash_with_string_keys)
+      hash_with_string_keys.each_with_object({}) do |(key, value), result|
+        result[key.to_sym] = value
+      end
+    end
   end
 end

--- a/bosh_warden_cpi/spec/unit/helper_spec.rb
+++ b/bosh_warden_cpi/spec/unit/helper_spec.rb
@@ -86,10 +86,12 @@ describe Bosh::WardenCloud::Helpers do
 
   context 'start agent' do
     before :each do
+      @warden_properties = { 'rlimits' => { 'nofile' => 1111 } }
       allow(@warden_client).to receive(:call) do |req|
         res = req.create_response
         case req
           when Warden::Protocol::SpawnRequest
+            expect(req.rlimits).to eq(nofile: 1111)
             expect(req.script).to eq('/usr/sbin/runsvdir-start')
           else
             raise "#{req} not supported"


### PR DESCRIPTION
When using bosh-lite to run processes that need many open file descriptors (eg Cassandra, Jenkins etc.), the default 1024 limit is insufficient. This allows us to change these limits within the warden containers by adding them to the director.yml:

``` yml
---
name: Bosh Lite Director
# ...
cloud:
  plugin: warden
  properties:
    warden:
      unix_domain_socket: "/tmp/warden.sock"
      rlimits:
        nofiles: 10240
# ...
```

All options that can be specified within the rlimits property are defined in [Warden::Protocol::ResourceLimits](https://github.com/cloudfoundry/warden/blob/master/warden-protocol/lib/warden/protocol/pb/resource_limits.proto)
