### PR TITLE
Enable SRM on vsphere by replacing the workflow of reading settings from cdrom with reading from attached independent disk

### DIFF
--- a/bosh-dev/lib/bosh/dev/vsphere/micro_bosh_deployment_manifest.rb
+++ b/bosh-dev/lib/bosh/dev/vsphere/micro_bosh_deployment_manifest.rb
@@ -12,6 +12,7 @@ module Bosh::Dev::VSphere
       @filename = 'micro_bosh.yml'
     end
 
+    # rubocop:disable MethodLength
     def to_h
       { 'name' => 'microbosh-vsphere-jenkins',
         'network' =>
@@ -43,6 +44,7 @@ module Bosh::Dev::VSphere
                           'persistent_datastore_pattern' =>
                             env['BOSH_VSPHERE_VCENTER_UBOSH_DATASTORE_PATTERN'],
                           'allow_mixed_datastores' => true,
+                          'srm' => env['BOSH_VSPHERE_VCENTER_SRM'].nil? ? false : env['BOSH_VSPHERE_VCENTER_SRM'] == 'true',
                           'clusters' =>
                             [{ env['BOSH_VSPHERE_VCENTER_CLUSTER'] =>
                                  { 'resource_pool' =>
@@ -63,12 +65,14 @@ module Bosh::Dev::VSphere
                          'persistent_datastore_pattern' =>
                            env['BOSH_VSPHERE_VCENTER_DATASTORE_PATTERN'],
                          'allow_mixed_datastores' => true,
+                         'srm' => env['BOSH_VSPHERE_VCENTER_SRM'].nil? ? false : env['BOSH_VSPHERE_VCENTER_SRM'] == 'true',
                          'clusters' =>
                            [{ env['BOSH_VSPHERE_VCENTER_CLUSTER'] =>
                                 { 'resource_pool' =>
                                     env['BOSH_VSPHERE_VCENTER_RESOURCE_POOL']
                                 } }] }] } } } }
     end
+    # rubocop:enable MethodLength
 
     private
 

--- a/bosh-dev/spec/bosh/dev/vsphere/micro_bosh_deployment_manifest_spec.rb
+++ b/bosh-dev/spec/bosh/dev/vsphere/micro_bosh_deployment_manifest_spec.rb
@@ -52,6 +52,7 @@ cloud:
             datastore_pattern: vcenter_ubosh_datastore_pattern
             persistent_datastore_pattern: vcenter_ubosh_datastore_pattern
             allow_mixed_datastores: true
+            srm: false
             clusters:
               - vcenter_cluster:
                   resource_pool: vcenter_rp
@@ -69,6 +70,7 @@ apply_spec:
           datastore_pattern: vcenter_datastore_pattern
           persistent_datastore_pattern: vcenter_datastore_pattern
           allow_mixed_datastores: true
+          srm: false
           clusters:
             - vcenter_cluster:
                 resource_pool: vcenter_rp

--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -209,6 +209,7 @@ module Bosh::Stemcell
       [
         :system_open_vm_tools,
         :system_vsphere_cdrom,
+        :system_vdiskmanager,
         # Misc
         :system_parameters,
         # Finalisation

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -102,6 +102,7 @@ module Bosh::Stemcell
       [
         :system_open_vm_tools,
         :system_vsphere_cdrom,
+        :system_vdiskmanager,
         :system_parameters,
         :bosh_clean,
         :bosh_harden,

--- a/bosh_agent/lib/bosh_agent/infrastructure/vsphere/settings.rb
+++ b/bosh_agent/lib/bosh_agent/infrastructure/vsphere/settings.rb
@@ -10,29 +10,30 @@ module Bosh::Agent
       base_dir = Bosh::Agent::Config.base_dir
       @logger = Bosh::Agent::Config.logger
       @cdrom_retry_wait = DEFAULT_CDROM_RETRY_WAIT
-      @cdrom_settings_mount_point = File.join(base_dir, 'bosh', 'settings')
+      @settings_mount_point = File.join(base_dir, 'bosh', 'settings')
       @cdrom_device = nil
     end
 
-    def cdrom_device
-      unless @cdrom_device
-        # only do this when not already done
-        cd_drive = File.read("/proc/sys/dev/cdrom/info").slice(/drive name:\s*\S*/).slice(/\S*\z/)
-        @cdrom_device = "/dev/#{cd_drive.strip}"
+    def load_settings
+      begin
+        @logger.info("Checking cdrom")
+        check_cdrom
+      rescue Bosh::Agent::LoadSettingsError
+        @logger.info("Loading settings from vmdk")
+        load_vmdk_settings
+      else
+        @logger.info("Loading settings from cdrom #{cdrom_device}")
+        load_cdrom_settings
       end
-      @cdrom_device
     end
 
-    def load_settings
-      load_cdrom_settings
-    end
+    private
 
     def load_cdrom_settings
-      check_cdrom
-      create_cdrom_settings_mount_point
+      create_settings_mount_point
       mount_cdrom
 
-      env_file = File.join(@cdrom_settings_mount_point, 'env')
+      env_file = File.join(@settings_mount_point, 'env')
 
       begin
         settings_json = File.read(env_file)
@@ -44,6 +45,15 @@ module Bosh::Agent
         eject_cdrom
       end
       @settings
+    end
+
+    def cdrom_device
+      unless @cdrom_device
+        # only do this when not already done
+        cd_drive = File.read("/proc/sys/dev/cdrom/info").slice(/drive name:\s*\S*/).slice(/\S*\z/)
+        @cdrom_device = "/dev/#{cd_drive.strip}"
+      end
+      @cdrom_device
     end
 
     def check_cdrom
@@ -116,24 +126,61 @@ module Bosh::Agent
       File.read(cdrom_device, 1)
     end
 
-    def create_cdrom_settings_mount_point
-      FileUtils.mkdir_p(@cdrom_settings_mount_point)
-      FileUtils.chmod(0700, @cdrom_settings_mount_point)
+    def create_settings_mount_point
+      FileUtils.mkdir_p(@settings_mount_point)
+      FileUtils.chmod(0700, @settings_mount_point)
+      @logger.info("Settings mount point #@settings_mount_point is created")
     end
 
     def mount_cdrom
-      result = Bosh::Exec.sh "mount #{cdrom_device} #@cdrom_settings_mount_point 2>&1"
+      result = Bosh::Exec.sh "mount #{cdrom_device} #@settings_mount_point 2>&1"
       raise Bosh::Agent::LoadSettingsError,
-        "Failed to mount settings on #@cdrom_settings_mount_point: #{result.output}" if result.failed?
+        "Failed to mount settings on #@settings_mount_point: #{result.output}" if result.failed?
     end
 
     def umount_cdrom
-      Bosh::Exec.sh "umount #@cdrom_settings_mount_point 2>&1"
+      Bosh::Exec.sh "umount #@settings_mount_point 2>&1"
     end
 
     def eject_cdrom
       Bosh::Exec.sh "eject #{cdrom_device}"
     end
 
+    def load_vmdk_settings
+      create_settings_mount_point
+      mount_vmdk_disk
+
+      env_file = File.join(@settings_mount_point, 'env')
+
+      begin
+        settings_json = File.read(env_file)
+        @settings = Yajl::Parser.new.parse(settings_json)
+      rescue Exception => ex
+        fail Bosh::Agent::LoadSettingsError,
+             "Failed to read/write env/settings.json: #{ex}"
+      ensure
+        remove_vmdk_disk
+      end
+      @settings
+    end
+
+    def mount_vmdk_disk
+      vmdk_disk_line = (`blkid /dev/sd* 2>&1`)
+                        .split(/\r?\n/)
+                        .find { |s| s.include? 'LABEL="CDROM" TYPE="iso9660"' }
+      fail Bosh::Agent::LoadSettingsError,
+           'Unable to find disk of LABEL="CDROM" TYPE="iso9660"' if vmdk_disk_line.nil?
+
+      @logger.info("vmdk_disk_line: #{vmdk_disk_line}")
+      vmdk_disk = vmdk_disk_line.match(/(?<disk>\/dev\/sd\w+):/)[:disk]
+      result = Bosh::Exec.sh "mount #{vmdk_disk} #@settings_mount_point 2>&1"
+      fail Bosh::Agent::LoadSettingsError,
+           "Failed to mount settings on #@settings_mount_point: #{result.output}" if result.failed?
+    end
+
+    def remove_vmdk_disk
+      Bosh::Exec.sh "umount #@settings_mount_point 2>&1"
+      FileUtils.rm_rf(@settings_mount_point)
+    end
   end
 end

--- a/bosh_agent/spec/unit/infrastructure/vsphere/settings_spec.rb
+++ b/bosh_agent/spec/unit/infrastructure/vsphere/settings_spec.rb
@@ -9,114 +9,200 @@ describe Bosh::Agent::Infrastructure::Vsphere::Settings do
   subject(:settings) do
     Bosh::Agent::Infrastructure::Vsphere::Settings.new
   end
-  
-  before do
-    @proc_contents = <<-eos
+
+  context 'load settings from cdrom' do
+    before do
+      @proc_contents = <<-eos
 CD-ROM information, Id: cdrom.c 3.20 2003/12/17
 
-drive name:		sr0
-drive speed:		24
-drive # of slots:	1
-Can close tray:		1
-Can open tray:		1
-Can lock tray:		1
-Can change speed:	1
-Can select disk:	0
-Can read multisession:	1
-Can read MCN:		1
-Reports media changed:	1
-Can play audio:		1
-Can write CD-R:		1
-Can write CD-RW:	1
-Can read DVD:		1
-Can write DVD-R:	1
-Can write DVD-RAM:	1
-Can read MRW:		1
-Can write MRW:		1
-Can write RAM:		1
-eos
-    
-    settings.cdrom_retry_wait = 0.1
+drive name: sr0
+drive speed: 24
+drive # of slots: 1
+Can close tray: 1
+Can open tray: 1
+Can lock tray: 1
+Can change speed: 1
+Can select disk: 0
+Can read multisession: 1
+Can read MCN: 1
+Reports media changed: 1
+Can play audio: 1
+Can write CD-R: 1
+Can write CD-RW: 1
+Can read DVD: 1
+Can write DVD-R: 1
+Can write DVD-RAM: 1
+Can read MRW: 1
+Can write MRW: 1
+Can write RAM: 1
+      eos
 
-    settings.stub(:mount_cdrom)
-    settings.stub(:umount_cdrom)
-    settings.stub(:eject_cdrom)
-    settings.stub(:udevadm_settle)
-    settings.stub(:read_cdrom_byte)
+      settings.cdrom_retry_wait = 0.1
 
-    settings.read_cdrom_byte
-  end
+      settings.stub(:mount_cdrom)
+      settings.stub(:umount_cdrom)
+      settings.stub(:eject_cdrom)
+      settings.stub(:udevadm_settle)
+      settings.stub(:read_cdrom_byte)
 
-  it "should parse the /proc/sys/dev/cdrom/info with newline correctly" do
-    File.should_receive(:read).with('/proc/sys/dev/cdrom/info').and_return(@proc_contents)
-    settings.cdrom_device.should eq "/dev/sr0"
-  end
+      settings.send(:read_cdrom_byte)
+    end
 
-  it "should invoke commandline for /proc/sys/dev/cdrom/info just once" do
-    File.should_receive(:read).with('/proc/sys/dev/cdrom/info').and_return(@proc_contents)
-    settings.cdrom_device.should eq "/dev/sr0"
-    settings.cdrom_device.should eq "/dev/sr0"
-  end
-
-  it 'should load settings' do
-    cdrom_dir = File.join(base_dir, 'bosh', 'settings')
-    env = File.join(cdrom_dir, 'env')
-
-    FileUtils.mkdir_p(cdrom_dir)
-    File.open(env, 'w') { |f| f.write(settings_json) }
-
-    settings.load_settings.should == Yajl::Parser.new.parse(settings_json)
-  end
-
-  it "should fail when there is no cdrom" do
-    settings.stub(:read_cdrom_byte).and_raise(Errno::ENOMEDIUM)
-    lambda {
+    it "should parse the /proc/sys/dev/cdrom/info with newline correctly" do
       File.should_receive(:read).with('/proc/sys/dev/cdrom/info').and_return(@proc_contents)
-      settings.check_cdrom
-    }.should raise_error(Bosh::Agent::LoadSettingsError)
-  end
+      settings.send(:cdrom_device).should eq "/dev/sr0"
+    end
 
-  it "should fail when cdrom is busy" do
-    settings.stub(:read_cdrom_byte).and_raise(Errno::EBUSY)
-    lambda {
+    it "should invoke commandline for /proc/sys/dev/cdrom/info just once" do
       File.should_receive(:read).with('/proc/sys/dev/cdrom/info').and_return(@proc_contents)
-      settings.check_cdrom
-    }.should raise_error(Bosh::Agent::LoadSettingsError)
+      settings.send(:cdrom_device).should eq "/dev/sr0"
+      settings.send(:cdrom_device).should eq "/dev/sr0"
+    end
+
+    it 'should load settings' do
+      cdrom_dir = File.join(base_dir, 'bosh', 'settings')
+      env = File.join(cdrom_dir, 'env')
+      File
+        .should_receive(:read)
+        .with('/proc/sys/dev/cdrom/info')
+        .ordered
+        .once
+        .and_return(@proc_contents)
+      File
+        .should_receive(:read)
+        .with(env)
+        .ordered
+        .once
+        .and_return(settings_json)
+
+      settings.load_settings.should == Yajl::Parser.new.parse(settings_json)
+    end
+
+    it "should fail when there is no cdrom" do
+      settings.stub(:read_cdrom_byte).and_raise(Errno::ENOMEDIUM)
+      lambda {
+        File.should_receive(:read).with('/proc/sys/dev/cdrom/info').and_return(@proc_contents)
+        settings.send(:check_cdrom)
+      }.should raise_error(Bosh::Agent::LoadSettingsError)
+    end
+
+    it "should fail when cdrom is busy" do
+      settings.stub(:read_cdrom_byte).and_raise(Errno::EBUSY)
+      lambda {
+        File.should_receive(:read).with('/proc/sys/dev/cdrom/info').and_return(@proc_contents)
+        settings.send(:check_cdrom)
+      }.should raise_error(Bosh::Agent::LoadSettingsError)
+    end
+
+    it 'should return nil when asked for network settings' do
+      Bosh::Agent::Config.setup('infrastructure_name' => 'dummy')
+      properties = Bosh::Agent::Config.infrastructure.get_network_settings("test", {})
+      properties.should be_nil
+    end
+
+    describe '#check_cdrom' do
+      context 'when udev settle returns 0' do
+        before do
+          settings.stub(:udevadm_settle)
+        end
+
+        it 'succeeds' do
+          expect {
+            settings.send(:check_cdrom)
+          }.not_to raise_error
+        end
+      end
+
+      context 'when udev settle returns 1' do
+        before do
+          settings.stub(:udevadm_settle).and_raise(Bosh::Exec::Error.new(1, '/sbin/udevadm settle'))
+        end
+
+        it 'wraps the error so Bosh::Agent::Settings can deal with it appropriately' do
+          expect {
+            settings.send(:check_cdrom)
+          }.to raise_error(Bosh::Agent::LoadSettingsError)
+        end
+      end
+    end
   end
 
-  it 'should return nil when asked for network settings' do
-    Bosh::Agent::Config.setup('infrastructure_name' => 'dummy')
-    properties = Bosh::Agent::Config.infrastructure.get_network_settings("test", {})
-    properties.should be_nil
+  context 'load settings from vmdk disk' do
+    before do
+      proc_contents = <<-eos
+drive name:
+drive speed:
+drive # of slots:
+Can close tray:
+Can open tray:
+Can lock tray:
+Can change speed:
+Can select disk:
+Can read multisession:
+Can read MCN:
+Reports media changed:
+Can play audio:
+Can write CD-R:
+Can write CD-RW:
+Can read DVD:
+Can write DVD-R:
+Can write DVD-RAM:
+Can read MRW:
+Can write MRW:
+Can write RAM:
+      eos
+      subject
+        .should_receive(:check_cdrom)
+        .and_raise Bosh::Agent::LoadSettingsError
+
+      settings.stub(:mount_vmdk_disk)
+      settings.stub(:create_settings_mount_point)
+      settings.stub(:remove_vmdk_disk)
+    end
+
+    it 'should load settings' do
+      settings_mount_point = File.join(base_dir, 'bosh', 'settings')
+      env = File.join(settings_mount_point, 'env')
+      File
+        .should_receive(:read)
+        .with(env)
+        .and_return(settings_json)
+
+      settings.load_settings.should == Yajl::Parser.new.parse(settings_json)
+    end
+
+    it 'raises LoadSettingsError when it fails to read settings file' do
+      settings_mount_point = File.join(base_dir, 'bosh', 'settings')
+      env = File.join(settings_mount_point, 'env')
+      File
+        .should_receive(:read)
+        .with(env)
+        .and_raise Errno::ENOENT, 'No such file or directory'
+      expect { settings.load_settings }
+        .to raise_exception Bosh::Agent::LoadSettingsError
+    end
+
+    it 'raises LoadSettingsError when it fails to parse settings file' do
+      settings_mount_point = File.join(base_dir, 'bosh', 'settings')
+      env = File.join(settings_mount_point, 'env')
+      File
+        .should_receive(:read)
+        .with(env)
+        .and_return(settings_json)
+      Yajl::Parser
+        .any_instance
+        .should_receive(:parse)
+        .with(settings_json)
+        .and_raise 'Fail to parse json'
+
+      expect { settings.load_settings }
+        .to raise_exception Bosh::Agent::LoadSettingsError
+    end
   end
+
+  private
 
   def settings_json
     %q[{"vm":{"name":"vm-273a202e-eedf-4475-a4a1-66c6d2628742","id":"vm-51290"},"disks":{"ephemeral":1,"persistent":{"250":2},"system":0},"mbus":"nats://user:pass@11.0.0.11:4222","networks":{"network_a":{"netmask":"255.255.248.0","mac":"00:50:56:89:17:70","ip":"172.30.40.115","default":["gateway","dns"],"gateway":"172.30.40.1","dns":["172.30.22.153","172.30.22.154"],"cloud_properties":{"name":"VLAN440"}}},"blobstore":{"provider":"simple","options":{"password":"Ag3Nt","user":"agent","endpoint":"http://172.30.40.11:25250"}},"ntp":["ntp01.las01.emcatmos.com","ntp02.las01.emcatmos.com"],"agent_id":"a26efbe5-4845-44a0-9323-b8e36191a2c8"}]
-  end
-
-  describe '#check_cdrom' do
-    context 'when udev settle returns 0' do
-      before do
-        settings.stub(:udevadm_settle)
-      end
-
-      it 'succeeds' do
-        expect {
-          settings.check_cdrom
-        }.not_to raise_error
-      end
-    end
-
-    context 'when udev settle returns 1' do
-      before do
-        settings.stub(:udevadm_settle).and_raise(Bosh::Exec::Error.new(1, '/sbin/udevadm settle'))
-      end
-
-      it 'wraps the error so Bosh::Agent::Settings can deal with it appropriately' do
-        expect {
-          settings.check_cdrom
-        }.to raise_error(Bosh::Agent::LoadSettingsError)
-      end
-    end
   end
 end

--- a/bosh_vsphere_cpi/lib/cloud/vsphere/agent_env.rb
+++ b/bosh_vsphere_cpi/lib/cloud/vsphere/agent_env.rb
@@ -3,9 +3,12 @@ module VSphereCloud
     include VimSdk
     include RetryBlock
 
-    def initialize(client, file_provider)
+    def initialize(cpi, client, file_provider, config, logger)
+      @cpi = cpi
       @client = client
       @file_provider = file_provider
+      @config = config
+      @logger = logger
     end
 
     def get_current_env(location)
@@ -14,12 +17,27 @@ module VSphereCloud
     end
 
     def set_env(vm, location, env)
-      env_json = JSON.dump(env)
+      if @config.datacenter_srm
+        set_vmdk_content(vm, location, env)
+      else
+        set_cdrom_content(vm, location, env)
+      end
+    end
 
-      connect_cdrom(vm, false)
-      @file_provider.upload_file(location[:datacenter], location[:datastore], "#{location[:vm]}/env.json", env_json)
-      @file_provider.upload_file(location[:datacenter], location[:datastore], "#{location[:vm]}/env.iso", generate_env_iso(env_json))
-      connect_cdrom(vm, true)
+    def configure_vm_cdrom(cluster, datastore, name, vm, devices)
+      if @config.datacenter_srm
+        @file_provider.upload_file(cluster.datacenter.name, datastore.name, "#{name}/env.vmdk", '')
+        return
+      end
+
+      # Configure the ENV CDROM
+      @file_provider.upload_file(cluster.datacenter.name, datastore.name, "#{name}/env.iso", '')
+      config = Vim::Vm::ConfigSpec.new
+      config.device_change = []
+      file_name = "[#{datastore.name}] #{name}/env.iso"
+      cdrom_change = configure_env_cdrom(datastore.mob, devices, file_name)
+      config.device_change << cdrom_change
+      @client.reconfig_vm(vm, config)
     end
 
     def configure_env_cdrom(datastore, devices, file_name)
@@ -40,6 +58,16 @@ module VSphereCloud
     end
 
     private
+
+    def set_cdrom_content(vm, location, env)
+      @logger.info('Setting env from cdrom')
+      env_json = JSON.dump(env)
+
+      connect_cdrom(vm, false)
+      @file_provider.upload_file(location[:datacenter], location[:datastore], "#{location[:vm]}/env.json", env_json)
+      @file_provider.upload_file(location[:datacenter], location[:datastore], "#{location[:vm]}/env.iso", generate_env_iso(env_json))
+      connect_cdrom(vm, true)
+    end
 
     def connect_cdrom(vm, connected = true)
       devices = @client.get_property(vm, Vim::VirtualMachine, 'config.hardware.device', ensure_all: true)
@@ -74,8 +102,23 @@ module VSphereCloud
       programs.first
     end
 
+    def find_bin(bin_path, bin)
+      exe = File.join(bin_path, bin)
+      return exe if File.exists?(exe)
+      ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+        exe = File.join(path, bin)
+        return exe if File.exists?(exe)
+      end
+
+      fail "Unable to find #{bin} in either #{bin_path} or system PATH"
+    end
+
     def genisoimage
       @genisoimage ||= which(%w{genisoimage mkisofs})
+    end
+
+    def qemu_img
+      @qemu_img ||= which(['qemu-img'])
     end
 
     def create_edit_device_spec(device)
@@ -84,5 +127,82 @@ module VSphereCloud
       device_config_spec.operation = Vim::Vm::Device::VirtualDeviceSpec::Operation::EDIT
       device_config_spec
     end
+
+    def generate_vmdk_iso(env)
+      path = Dir.mktmpdir
+      env_path = File.join(path, 'env')
+      iso_path = File.join(path, 'env.iso')
+      File.open(env_path, 'w') { |f| f.write(env) }
+
+      # HACK: Write a dummy file to make iso file exceed 1 MB
+      # Because SRM needs at least 1 MB to replicate a disk
+      File.open(File.join(path, 'env_dummy'), 'w') do |f|
+        193000.times do |i|
+          f.write(i)
+        end
+      end
+
+      output = `#{genisoimage} -o #{iso_path} #{env_path}* 2>&1`
+      raise "#{$?.exitstatus} -#{output}" if $?.exitstatus != 0
+      path
+    end
+
+    def upload_vmdk_file(location, local_vmdk_file_dir)
+      @file_provider.upload_file(location[:datacenter],
+                                 location[:datastore],
+                                 "#{location[:vm]}/env.vmdk",
+                                 File.open(File.join(local_vmdk_file_dir, 'env.vmdk'), 'r') { |f| f.read })
+
+      @file_provider.upload_file(location[:datacenter],
+                                 location[:datastore],
+                                 "#{location[:vm]}/env-flat.vmdk",
+                                 File.open(File.join(local_vmdk_file_dir, 'env-flat.vmdk'), 'r') { |f| f.read })
+    end
+
+    def convert_iso_to_vmdk(tmp_dir)
+      iso_file = File.join(tmp_dir, 'env.iso')
+      fail "ISO file #{iso_file} does not exist!" if !File.exists?(iso_file)
+      output = `#{qemu_img} convert -O vmdk #{iso_file} #{File.join(tmp_dir, 'env_source.vmdk')} 2>&1`
+      fail "#{$?.exitstatus} -#{output}" if $?.exitstatus != 0
+    end
+
+    def convert_vmdk_to_esx_type(tmp_dir)
+      env_source_vmdk = File.join(tmp_dir, 'env_source.vmdk')
+      fail "ENV source vmdk file #{env_source_vmdk} does not exist!" if !File.exists?(env_source_vmdk)
+      target_vmdk_file = File.join(tmp_dir, 'env.vmdk')
+      [target_vmdk_file, File.join(tmp_dir, 'env-flat.vmdk')].each do |f|
+        File.delete(f) if File.exists?(f)
+      end
+
+      module_dir = (`ls -d /lib/modules/3.*-virtual | tail -1`).strip
+      vdiskmanager = find_bin("#{module_dir}/vdiskmanager/bin", 'vmware-vdiskmanager')
+      output = `#{vdiskmanager} -r #{env_source_vmdk} -t 4 #{target_vmdk_file} 2>&1`
+      fail "#{$?.exitstatus} -#{output}" if $?.exitstatus != 0
+    end
+
+    def set_vmdk_content(vm, location, env)
+      @logger.info('Setting env from vmdk')
+      env_json = JSON.dump(env)
+
+      vmdk_path = "[#{location[:datastore]}] #{location[:vm]}/env.vmdk"
+      @cpi.detach_independent_disk(vm, vmdk_path, location)
+
+      @file_provider.upload_file(location[:datacenter],
+                                 location[:datastore],
+                                 "#{location[:vm]}/env.json", env_json)
+
+      local_vmdk_file_dir = generate_vmdk_iso(env_json)
+      begin
+        convert_iso_to_vmdk(local_vmdk_file_dir)
+        convert_vmdk_to_esx_type(local_vmdk_file_dir)
+
+        upload_vmdk_file(location, local_vmdk_file_dir)
+      ensure
+        FileUtils.remove_entry_secure local_vmdk_file_dir
+      end
+
+      @cpi.attach_independent_disk(vm, vmdk_path, location, 3)
+    end
+
   end
 end

--- a/bosh_vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/bosh_vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -122,6 +122,10 @@ module VSphereCloud
       !!vcenter_datacenter['allow_mixed_datastores']
     end
 
+    def datacenter_srm
+      !!vcenter_datacenter['srm']
+    end
+
     def datacenter_use_sub_folder
       datacenter_clusters.any? { |_, cluster| cluster.resource_pool } ||
         !!vcenter_datacenter['use_sub_folder']
@@ -165,6 +169,7 @@ module VSphereCloud
                                                'datastore_pattern' => String,
                                                'persistent_datastore_pattern' => String,
                                                optional('allow_mixed_datastores') => bool,
+                                               optional('srm') => bool,
                                                'clusters' => [enum(String,
                                                                    dict(String, { 'resource_pool' => String }))]
                                              }]

--- a/bosh_vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
+++ b/bosh_vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
@@ -43,6 +43,10 @@ module VSphereCloud
         @config.datacenter_allow_mixed_datastores
       end
 
+      def srm
+        @config.datacenter_srm
+      end
+
       def inspect
         "<Datacenter: #{mob} / #{name}>"
       end

--- a/bosh_vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/bosh_vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -77,18 +77,10 @@ module VSphereCloud
       vm = @client.wait_for_task(task)
 
       begin
-        @file_provider.upload_file(cluster.datacenter.name, datastore.name, "#{name}/env.iso", '')
-
         vm_properties = @client.get_properties(vm, VimSdk::Vim::VirtualMachine, ['config.hardware.device'], ensure_all: true)
         devices = vm_properties['config.hardware.device']
 
-        # Configure the ENV CDROM
-        config = VimSdk::Vim::Vm::ConfigSpec.new
-        config.device_change = []
-        file_name = "[#{datastore.name}] #{name}/env.iso"
-        cdrom_change = @agent_env.configure_env_cdrom(datastore.mob, devices, file_name)
-        config.device_change << cdrom_change
-        @client.reconfig_vm(vm, config)
+        @agent_env.configure_vm_cdrom(cluster, datastore, name, vm, devices)
 
         network_env = @cpi.generate_network_env(devices, networks, dvs_index)
         disk_env = @cpi.generate_disk_env(system_disk, ephemeral_disk_config.device)

--- a/bosh_vsphere_cpi/spec/integration/lifecycle_spec.rb
+++ b/bosh_vsphere_cpi/spec/integration/lifecycle_spec.rb
@@ -16,6 +16,7 @@ describe VSphereCloud::Cloud do
     @template_folder              = ENV.fetch('BOSH_VSPHERE_CPI_TEMPLATE_FOLDER', 'ACCEPTANCE_BOSH_Templates')
     @disk_path                    = ENV.fetch('BOSH_VSPHERE_CPI_DISK_PATH', 'ACCEPTANCE_BOSH_Disks')
     @datastore_pattern            = ENV.fetch('BOSH_VSPHERE_CPI_DATASTORE_PATTERN', 'jalapeno')
+    @srm                          = ENV['BOSH_VSPHERE_VCENTER_SRM'].nil? ? false : ENV['BOSH_VSPHERE_VCENTER_SRM'] == 'true'
     @persistent_datastore_pattern = ENV.fetch('BOSH_VSPHERE_CPI_PERSISTENT_DATASTORE_PATTERN', 'jalapeno')
     @cluster                      = ENV.fetch('BOSH_VSPHERE_CPI_CLUSTER', 'BOSH_CL')
     @resource_pool_name           = ENV.fetch('BOSH_VSPHERE_CPI_RESOURCE_POOL', 'ACCEPTANCE_RP')
@@ -40,6 +41,7 @@ describe VSphereCloud::Cloud do
           'datastore_pattern' => @datastore_pattern,
           'persistent_datastore_pattern' => @persistent_datastore_pattern,
           'allow_mixed_datastores' => true,
+          'srm' => @srm,
           'clusters' => [{
               @cluster => { 'resource_pool' => @resource_pool_name },
             },

--- a/bosh_vsphere_cpi/spec/unit/cloud/vsphere/agent_env_spec.rb
+++ b/bosh_vsphere_cpi/spec/unit/cloud/vsphere/agent_env_spec.rb
@@ -5,10 +5,13 @@ module VSphereCloud
   describe AgentEnv do
     include FakeFS::SpecHelpers
 
-    subject(:agent_env) { described_class.new(client, file_provider) }
+    subject(:agent_env) { described_class.new(cpi, client, file_provider, config, logger) }
 
+    let(:cpi) { instance_double('VSphereCloud::Cloud') }
     let(:client) { instance_double('VSphereCloud::Client') }
     let(:file_provider) { double('VSphereCloud::FileProvider') }
+    let(:config) { instance_double('VSphereCloud::Config') }
+    let(:logger) { instance_double('Logger', info: nil, debug: nil) }
 
     let(:location) do
       {
@@ -40,112 +43,77 @@ module VSphereCloud
 
       let(:env) { ['fake-json'] }
 
-      let(:cdrom_connectable) { double(:connectable, connected: true) }
-      let(:cdrom) { instance_double('VimSdk::Vim::Vm::Device::VirtualCdrom', connectable: cdrom_connectable) }
-      before do
-        allow(cdrom).to receive(:kind_of?).with(VimSdk::Vim::Vm::Device::VirtualCdrom).and_return(true)
-        allow(client).to receive(:get_property).with(
-          vm, VimSdk::Vim::VirtualMachine, 'config.hardware.device', ensure_all: true
-        ).and_return([cdrom])
-      end
-
-      def it_disconnects_cdrom
-        expect(cdrom_connectable).to receive(:connected=).with(false) do
-          allow(cdrom_connectable).to receive(:connected).and_return(false)
-        end.ordered
-        expect(device_config_spec).to receive(:device=).with(cdrom).ordered
-        expect(device_config_spec).to receive(:operation=).with(VimSdk::Vim::Vm::Device::VirtualDeviceSpec::Operation::EDIT).ordered
-        expect(config_spec).to receive(:device_change=).with([device_config_spec]).ordered
-        expect(client).to receive(:reconfig_vm).with(vm, config_spec)
-      end
-
       def it_uploads_environment_json(code = 204)
         expect(file_provider).to receive(:upload_file).with(
-          'fake-datacenter-name 1',
-          'fake-datastore-name 1',
-          'fake-vm-name/env.json',
-          '["fake-json"]'
-        ).and_return(double(:response, code: code))
+                                   'fake-datacenter-name 1',
+                                   'fake-datastore-name 1',
+                                   'fake-vm-name/env.json',
+                                   '["fake-json"]'
+                                 ).and_return(double(:response, code: code))
       end
 
-      def it_generates_environment_iso(options = {})
-        iso_generator = options.fetch(:iso_generator, 'genisoimage')
-        exit_status = options.fetch(:exit_status, 0)
-
-        allow(Dir).to receive(:mktmpdir) do |&blk|
-          FileUtils.mkdir_p('/some/tmp/dir')
-          blk.call('/some/tmp/dir')
-        end
-
-        expect(agent_env).to receive(:`).with("#{iso_generator} -o /some/tmp/dir/env.iso /some/tmp/dir/env 2>&1") do
-          expect(File.read('/some/tmp/dir/env')).to eq('["fake-json"]')
-          File.open('/some/tmp/dir/env.iso', 'w') { |f| f.write('iso contents') }
-          allow($?).to receive(:exitstatus).and_return(exit_status)
-        end
-      end
-
-      def it_uploads_environment_iso
-        expect(file_provider).to receive(:upload_file).with(
-          'fake-datacenter-name 1',
-          'fake-datastore-name 1',
-          'fake-vm-name/env.iso',
-          'iso contents',
-        ).and_return(double(:response, code: 204))
-      end
-
-      def it_connects_cdrom
-        expect(cdrom_connectable).to receive(:connected=).with(true) do
-          allow(cdrom_connectable).to receive(:connected).and_return(true)
-        end
-        expect(device_config_spec).to receive(:device=).with(cdrom).ordered
-        expect(device_config_spec).to receive(:operation=).with(VimSdk::Vim::Vm::Device::VirtualDeviceSpec::Operation::EDIT).ordered
-        expect(config_spec).to receive(:device_change=).with([device_config_spec]).ordered
-        expect(client).to receive(:reconfig_vm).with(vm, config_spec)
-      end
-
-      it 'disconnects cdrom, uploads envrionment json, uploads environment iso and connectes cdrom' do
-        it_disconnects_cdrom.ordered
-
-        it_uploads_environment_json.ordered
-
-        it_generates_environment_iso.ordered
-
-        it_uploads_environment_iso.ordered
-
-        it_connects_cdrom.ordered
-
-        agent_env.set_env(vm, location, env)
-      end
-
-      context 'when cdrom is disconnected' do
-        before { allow(cdrom_connectable).to receive(:connected).and_return(false) }
-
-        it 'does not disconnect cdrom' do
-          it_uploads_environment_json.ordered
-
-          it_generates_environment_iso(iso_generator: 'genisoimage').ordered
-
-          it_uploads_environment_iso.ordered
-
-          it_connects_cdrom.ordered
-
-          agent_env.set_env(vm, location, env)
-        end
-      end
-
-      context 'when genisoimage is found' do
+      context 'SRM feature is not enabled' do
+        let(:cdrom_connectable) { double(:connectable, connected: true) }
+        let(:cdrom) { instance_double('VimSdk::Vim::Vm::Device::VirtualCdrom', connectable: cdrom_connectable) }
         before do
-          stub_const('ENV', {'PATH' => '/bin'})
-          allow(File).to receive(:exists?).and_call_original
-          allow(File).to receive(:exists?).with('/bin/genisoimage').and_return(true)
+          allow(config).to receive(:datacenter_srm).and_return(false)
+          allow(cdrom).to receive(:kind_of?).with(VimSdk::Vim::Vm::Device::VirtualCdrom).and_return(true)
+          allow(client).to receive(:get_property).with(
+                             vm, VimSdk::Vim::VirtualMachine, 'config.hardware.device', ensure_all: true
+                           ).and_return([cdrom])
         end
 
-        it 'uses genisoimage' do
+        def it_disconnects_cdrom
+          expect(cdrom_connectable).to receive(:connected=).with(false) do
+            allow(cdrom_connectable).to receive(:connected).and_return(false)
+          end.ordered
+          expect(device_config_spec).to receive(:device=).with(cdrom).ordered
+          expect(device_config_spec).to receive(:operation=).with(VimSdk::Vim::Vm::Device::VirtualDeviceSpec::Operation::EDIT).ordered
+          expect(config_spec).to receive(:device_change=).with([device_config_spec]).ordered
+          expect(client).to receive(:reconfig_vm).with(vm, config_spec)
+        end
+
+        def it_generates_environment_iso(options = {})
+          iso_generator = options.fetch(:iso_generator, 'genisoimage')
+          exit_status = options.fetch(:exit_status, 0)
+
+          allow(Dir).to receive(:mktmpdir) do |&blk|
+            FileUtils.mkdir_p('/some/tmp/dir')
+            blk.call('/some/tmp/dir')
+          end
+
+          expect(agent_env).to receive(:`).with("#{iso_generator} -o /some/tmp/dir/env.iso /some/tmp/dir/env 2>&1") do
+            expect(File.read('/some/tmp/dir/env')).to eq('["fake-json"]')
+            File.open('/some/tmp/dir/env.iso', 'w') { |f| f.write('iso contents') }
+            allow($?).to receive(:exitstatus).and_return(exit_status)
+          end
+        end
+
+        def it_uploads_environment_iso
+          expect(file_provider).to receive(:upload_file).with(
+                                     'fake-datacenter-name 1',
+                                     'fake-datastore-name 1',
+                                     'fake-vm-name/env.iso',
+                                     'iso contents',
+                                   ).and_return(double(:response, code: 204))
+        end
+
+        def it_connects_cdrom
+          expect(cdrom_connectable).to receive(:connected=).with(true) do
+            allow(cdrom_connectable).to receive(:connected).and_return(true)
+          end
+          expect(device_config_spec).to receive(:device=).with(cdrom).ordered
+          expect(device_config_spec).to receive(:operation=).with(VimSdk::Vim::Vm::Device::VirtualDeviceSpec::Operation::EDIT).ordered
+          expect(config_spec).to receive(:device_change=).with([device_config_spec]).ordered
+          expect(client).to receive(:reconfig_vm).with(vm, config_spec)
+        end
+
+        it 'disconnects cdrom, uploads envrionment json, uploads environment iso and connectes cdrom' do
           it_disconnects_cdrom.ordered
 
           it_uploads_environment_json.ordered
 
-          it_generates_environment_iso(iso_generator: '/bin/genisoimage').ordered
+          it_generates_environment_iso.ordered
 
           it_uploads_environment_iso.ordered
 
@@ -153,53 +121,158 @@ module VSphereCloud
 
           agent_env.set_env(vm, location, env)
         end
+
+        context 'when cdrom is disconnected' do
+          before { allow(cdrom_connectable).to receive(:connected).and_return(false) }
+
+          it 'does not disconnect cdrom' do
+            it_uploads_environment_json.ordered
+
+            it_generates_environment_iso(iso_generator: 'genisoimage').ordered
+
+            it_uploads_environment_iso.ordered
+
+            it_connects_cdrom.ordered
+
+            agent_env.set_env(vm, location, env)
+          end
+        end
+
+        context 'when genisoimage is found' do
+          before do
+            stub_const('ENV', {'PATH' => '/bin'})
+            allow(File).to receive(:exists?).and_call_original
+            allow(File).to receive(:exists?).with('/bin/genisoimage').and_return(true)
+          end
+
+          it 'uses genisoimage' do
+            it_disconnects_cdrom.ordered
+
+            it_uploads_environment_json.ordered
+
+            it_generates_environment_iso(iso_generator: '/bin/genisoimage').ordered
+
+            it_uploads_environment_iso.ordered
+
+            it_connects_cdrom.ordered
+
+            agent_env.set_env(vm, location, env)
+          end
+        end
+
+        context 'when genisoimage is not found' do
+          before do
+            stub_const('ENV', {'PATH' => '/bin'})
+            allow(File).to receive(:exists?).and_call_original
+            allow(File).to receive(:exists?).with('/bin/mkisofs').and_return(true)
+          end
+
+          it 'uses mkisofs' do
+            it_disconnects_cdrom.ordered
+
+            it_uploads_environment_json.ordered
+
+            it_generates_environment_iso(iso_generator: '/bin/mkisofs').ordered
+
+            it_uploads_environment_iso.ordered
+
+            it_connects_cdrom.ordered
+
+            agent_env.set_env(vm, location, env)
+          end
+        end
+
+        context 'when uploading environment file fails' do
+          before { it_uploads_environment_json(500) }
+
+          it 'retries and raises an error' do
+            it_disconnects_cdrom.ordered
+
+            expect {
+              agent_env.set_env(vm, location, env)
+            }.to raise_error
+          end
+        end
+
+        context 'when generating iso image fails' do
+          before { it_generates_environment_iso(exit_status: 1) }
+
+          it 'raises an error' do
+            it_disconnects_cdrom.ordered
+
+            it_uploads_environment_json.ordered
+
+            expect {
+              agent_env.set_env(vm, location, env)
+            }.to raise_error
+          end
+        end
       end
 
-      context 'when genisoimage is not found' do
+      context 'SRM feature is enabled' do
         before do
-          stub_const('ENV', {'PATH' => '/bin'})
-          allow(File).to receive(:exists?).and_call_original
-          allow(File).to receive(:exists?).with('/bin/mkisofs').and_return(true)
+          allow(config).to receive(:datacenter_srm).and_return(true)
         end
 
-        it 'uses mkisofs' do
-          it_disconnects_cdrom.ordered
+        it 'detaches independent disk, uploads envrionment json, uploads environment vmdk and attaches independent disk' do
+          expect(cpi).to receive(:detach_independent_disk).with(vm, '[fake-datastore-name 1] fake-vm-name/env.vmdk', location)
 
           it_uploads_environment_json.ordered
 
-          it_generates_environment_iso(iso_generator: '/bin/mkisofs').ordered
+          expect(agent_env).to receive(:generate_vmdk_iso).with('["fake-json"]').and_return('local_vmdk_file_dir')
+          expect(agent_env).to receive(:convert_iso_to_vmdk).with('local_vmdk_file_dir')
+          expect(agent_env).to receive(:convert_vmdk_to_esx_type).with('local_vmdk_file_dir')
+          expect(agent_env).to receive(:upload_vmdk_file).with(location, 'local_vmdk_file_dir')
+          FakeFS::FileUtils.should_receive(:remove_entry_secure).with('local_vmdk_file_dir')
 
-          it_uploads_environment_iso.ordered
-
-          it_connects_cdrom.ordered
+          expect(cpi).to receive(:attach_independent_disk).with(vm, '[fake-datastore-name 1] fake-vm-name/env.vmdk', location, 3)
 
           agent_env.set_env(vm, location, env)
         end
       end
+    end
 
-      context 'when uploading environment file fails' do
-        before { it_uploads_environment_json(500) }
+    describe '#configure_vm_cdrom' do
+      let(:datacenter) { double('fake datacenter', name: 'fake_datacenter') }
+      let(:cluster) { double('fake cluster', datacenter: datacenter) }
+      let(:datastore) { instance_double('VSphereCloud::Resources::Datastore', name: 'fake-datastore-name', mob: double('mob')) }
+      let(:vm) { instance_double('VimSdk::Vim::VirtualMachine') }
+      let(:name) { 'fake-vm-name' }
+      let(:devices) { double('face devices') }
 
-        it 'retries and raises an error' do
-          it_disconnects_cdrom.ordered
+      context 'SRM feature is not enabled' do
+        before do
+          allow(config).to receive(:datacenter_srm).and_return(false)
+        end
 
-          expect {
-            agent_env.set_env(vm, location, env)
-          }.to raise_error
+        it 'configures the ENV CDROM' do
+          expect(file_provider).to receive(:upload_file).with(
+                                     'fake_datacenter',
+                                     'fake-datastore-name',
+                                     'fake-vm-name/env.iso',
+                                     '',
+                                   ).and_return(double(:response, code: 204))
+          expect(agent_env).to receive(:configure_env_cdrom)
+          expect(client).to receive(:reconfig_vm)
+          agent_env.configure_vm_cdrom(cluster, datastore, name, vm, devices)
         end
       end
 
-      context 'when generating iso image fails' do
-        before { it_generates_environment_iso(exit_status: 1) }
+      context 'SRM feature is enabled' do
+        before do
+          allow(config).to receive(:datacenter_srm).and_return(true)
+        end
 
-        it 'raises an error' do
-          it_disconnects_cdrom.ordered
-
-          it_uploads_environment_json.ordered
-
-          expect {
-            agent_env.set_env(vm, location, env)
-          }.to raise_error
+        it 'uploads empty file env.vmdk only and does not configures the ENV CDROM' do
+          expect(file_provider).to receive(:upload_file).with(
+                                     'fake_datacenter',
+                                     'fake-datastore-name',
+                                     'fake-vm-name/env.vmdk',
+                                     '',
+                                   ).and_return(double(:response, code: 204))
+          agent_env.should_not_receive(:configure_env_cdrom)
+          client.should_not_receive(:reconfig_vm)
+          agent_env.configure_vm_cdrom(cluster, datastore, name, vm, devices)
         end
       end
     end

--- a/bosh_vsphere_cpi/spec/unit/cloud/vsphere/agent_env_spec.rb
+++ b/bosh_vsphere_cpi/spec/unit/cloud/vsphere/agent_env_spec.rb
@@ -219,11 +219,11 @@ module VSphereCloud
 
           it_uploads_environment_json.ordered
 
-          expect(agent_env).to receive(:generate_vmdk_iso).with('["fake-json"]').and_return('local_vmdk_file_dir')
-          expect(agent_env).to receive(:convert_iso_to_vmdk).with('local_vmdk_file_dir')
-          expect(agent_env).to receive(:convert_vmdk_to_esx_type).with('local_vmdk_file_dir')
-          expect(agent_env).to receive(:upload_vmdk_file).with(location, 'local_vmdk_file_dir')
-          FakeFS::FileUtils.should_receive(:remove_entry_secure).with('local_vmdk_file_dir')
+          expect(agent_env).to receive(:generate_vmdk_iso).with('["fake-json"]').and_return('/local_vmdk_file_dir/env.iso')
+          expect(agent_env).to receive(:convert_iso_to_vmdk).with('/local_vmdk_file_dir')
+          expect(agent_env).to receive(:convert_vmdk_to_esx_type).with('/local_vmdk_file_dir')
+          expect(agent_env).to receive(:upload_vmdk_file).with(location, '/local_vmdk_file_dir')
+          FakeFS::FileUtils.should_receive(:remove_entry_secure).with('/local_vmdk_file_dir')
 
           expect(cpi).to receive(:attach_independent_disk).with(vm, '[fake-datastore-name 1] fake-vm-name/env.vmdk', location, 3)
 

--- a/go_agent/src/bosh/infrastructure/vsphere_infrastructure.go
+++ b/go_agent/src/bosh/infrastructure/vsphere_infrastructure.go
@@ -42,7 +42,11 @@ func (inf vsphereInfrastructure) GetSettings() (boshsettings.Settings, error) {
 
 	contents, err := inf.platform.GetFileContentsFromCDROM("env")
 	if err != nil {
-		return settings, bosherr.WrapError(err, "Reading contents from CDROM")
+		contents, err = inf.platform.GetFileContentsFromVMDK("env")
+	}
+
+	if err != nil {
+		return settings, bosherr.WrapError(err, "Reading contents from CDROM or VMDK")
 	}
 
 	inf.logger.Debug("disks", "Got CDrom data %v", string(contents))

--- a/go_agent/src/bosh/platform/dummy_platform.go
+++ b/go_agent/src/bosh/platform/dummy_platform.go
@@ -151,6 +151,10 @@ func (p dummyPlatform) GetFileContentsFromCDROM(filePath string) (contents []byt
 	return
 }
 
+func (p dummyPlatform) GetFileContentsFromVMDK(filePath string) (contents []byte, err error) {
+	return
+}
+
 func (p dummyPlatform) MigratePersistentDisk(fromMountPoint, toMountPoint string) (err error) {
 	return
 }

--- a/go_agent/src/bosh/platform/fakes/fake_platform.go
+++ b/go_agent/src/bosh/platform/fakes/fake_platform.go
@@ -68,6 +68,8 @@ type FakePlatform struct {
 
 	GetFileContentsFromCDROMPath     string
 	GetFileContentsFromCDROMContents []byte
+	GetFileContentsFromVMDKPath      string
+	GetFileContentsFromVMDKContents  []byte
 
 	NormalizeDiskPathCalled   bool
 	NormalizeDiskPathPath     string
@@ -240,6 +242,12 @@ func (p *FakePlatform) NormalizeDiskPath(devicePath string) (realPath string, fo
 func (p *FakePlatform) GetFileContentsFromCDROM(path string) (contents []byte, err error) {
 	p.GetFileContentsFromCDROMPath = path
 	contents = p.GetFileContentsFromCDROMContents
+	return
+}
+
+func (p *FakePlatform) GetFileContentsFromVMDK(path string) (contents []byte, err error) {
+	p.GetFileContentsFromVMDKPath = path
+	contents = p.GetFileContentsFromVMDKContents
 	return
 }
 

--- a/go_agent/src/bosh/platform/linux_platform.go
+++ b/go_agent/src/bosh/platform/linux_platform.go
@@ -19,6 +19,7 @@ import (
 	boshnet "bosh/platform/net"
 	boshstats "bosh/platform/stats"
 	boshvitals "bosh/platform/vitals"
+	boshvmdkutil "bosh/platform/vmdkutil"
 	boshsettings "bosh/settings"
 	boshdir "bosh/settings/directories"
 	boshdirs "bosh/settings/directories"
@@ -47,6 +48,7 @@ type linux struct {
 	dirProvider        boshdirs.DirectoriesProvider
 	vitalsService      boshvitals.Service
 	cdutil             boshcd.CdUtil
+	vmdkutil           boshvmdkutil.VmdkUtil
 	diskManager        boshdisk.Manager
 	netManager         boshnet.NetManager
 	diskScanDuration   time.Duration
@@ -64,6 +66,7 @@ func NewLinuxPlatform(
 	dirProvider boshdirs.DirectoriesProvider,
 	vitalsService boshvitals.Service,
 	cdutil boshcd.CdUtil,
+	vmdkutil boshvmdkutil.VmdkUtil,
 	diskManager boshdisk.Manager,
 	netManager boshnet.NetManager,
 	diskScanDuration time.Duration,
@@ -79,6 +82,7 @@ func NewLinuxPlatform(
 		dirProvider:      dirProvider,
 		vitalsService:    vitalsService,
 		cdutil:           cdutil,
+		vmdkutil:         vmdkutil,
 		diskManager:      diskManager,
 		netManager:       netManager,
 		diskScanDuration: diskScanDuration,
@@ -114,6 +118,10 @@ func (p linux) GetVitalsService() (service boshvitals.Service) {
 
 func (p linux) GetFileContentsFromCDROM(fileName string) (contents []byte, err error) {
 	return p.cdutil.GetFileContents(fileName)
+}
+
+func (p linux) GetFileContentsFromVMDK(fileName string) (contents []byte, err error) {
+	return p.vmdkutil.GetFileContents(fileName)
 }
 
 func (p linux) GetDevicePathResolver() (devicePathResolver boshdpresolv.DevicePathResolver) {

--- a/go_agent/src/bosh/platform/linux_platform_test.go
+++ b/go_agent/src/bosh/platform/linux_platform_test.go
@@ -19,6 +19,8 @@ import (
 	fakenet "bosh/platform/net/fakes"
 	fakestats "bosh/platform/stats/fakes"
 	boshvitals "bosh/platform/vitals"
+	"bosh/platform/vmdk"
+	fakevmdk "bosh/platform/vmdkutil/fakes"
 	boshsettings "bosh/settings"
 	boshdirs "bosh/settings/directories"
 	fakesys "bosh/system/fakes"
@@ -34,6 +36,7 @@ var _ = Describe("LinuxPlatform", func() {
 		devicePathResolver *fakedpresolv.FakeDevicePathResolver
 		platform           Platform
 		cdutil             *fakecd.FakeCdUtil
+		vmdkutil           *fakevmdk.FakeVmdkUtil
 		compressor         boshcmd.Compressor
 		copier             boshcmd.Copier
 		vitalsService      boshvitals.Service
@@ -781,6 +784,17 @@ fake-base-path/data/sys/log/*.log fake-base-path/data/sys/log/*/*.log fake-base-
 			contents, err := platform.GetFileContentsFromCDROM(filename)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cdutil.GetFileContentsFilename).To(Equal(filename))
+			Expect(contents).To(Equal(cdutil.GetFileContentsContents))
+		})
+	})
+
+	Describe("GetFileContentsFromVMDK", func() {
+		It("delegates to vmdkutil", func() {
+			vmdkutil.GetFileContentsContents = []byte("fake-contents")
+			filename := "fake-env"
+			contents, err := platform.GetFileContentsFromVMDK(filename)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmdkutil.GetFileContentsFilename).To(Equal(filename))
 			Expect(contents).To(Equal(cdutil.GetFileContentsContents))
 		})
 	})

--- a/go_agent/src/bosh/platform/platform_interface.go
+++ b/go_agent/src/bosh/platform/platform_interface.go
@@ -49,6 +49,7 @@ type Platform interface {
 	IsPersistentDiskMounted(path string) (result bool, err error)
 
 	GetFileContentsFromCDROM(filePath string) (contents []byte, err error)
+	GetFileContentsFromVMDK(filePath string) (contents []byte, err error)
 
 	GetDefaultNetwork() (boshsettings.Network, error)
 

--- a/go_agent/src/bosh/platform/provider.go
+++ b/go_agent/src/bosh/platform/provider.go
@@ -13,6 +13,8 @@ import (
 	boshnet "bosh/platform/net"
 	boshstats "bosh/platform/stats"
 	boshvitals "bosh/platform/vitals"
+	boshvmdk "bosh/platform/vmdk"
+	boshvmdktuil "bosh/platform/vmdkutil"
 	boshdirs "bosh/settings/directories"
 	boshsys "bosh/system"
 )
@@ -33,7 +35,9 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.DirectoriesProvider
 
 	udev := boshudev.NewConcreteUdevDevice(runner)
 	linuxCdrom := boshcdrom.NewLinuxCdrom("/dev/sr0", udev, runner)
+	linuxVmdk := boshvmdk.NewLinuxVmdk(runner, logger)
 	linuxCdutil := boshcd.NewCdUtil(dirProvider.SettingsDir(), fs, linuxCdrom)
+	linuxVmdkutil := boshvmdktuil.NewVmdkUtil(dirProvider.SettingsDir(), fs, linuxVmdk)
 
 	compressor := boshcmd.NewTarballCompressor(runner, fs)
 	copier := boshcmd.NewCpCopier(runner, fs, logger)
@@ -59,6 +63,7 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.DirectoriesProvider
 		dirProvider,
 		vitalsService,
 		linuxCdutil,
+		linuxVmdkutil,
 		linuxDiskManager,
 		centosNetManager,
 		500*time.Millisecond,
@@ -75,6 +80,7 @@ func NewProvider(logger boshlog.Logger, dirProvider boshdirs.DirectoriesProvider
 		dirProvider,
 		vitalsService,
 		linuxCdutil,
+		linuxVmdkutil,
 		linuxDiskManager,
 		ubuntuNetManager,
 		500*time.Millisecond,

--- a/go_agent/src/bosh/platform/vmdk/fakes/fake_vmdk.go
+++ b/go_agent/src/bosh/platform/vmdk/fakes/fake_vmdk.go
@@ -1,0 +1,69 @@
+package fakes
+
+import (
+	"errors"
+	"path/filepath"
+
+	fakesys "bosh/system/fakes"
+)
+
+type FakeVmdk struct {
+	MountError   error
+	UnmountError error
+
+	MediaAvailable    bool
+	Fs                *fakesys.FakeFileSystem
+	MediaFilePath     string
+	MediaFileContents string
+
+	MountMountPath string
+	Mounted        bool
+}
+
+func NewFakeVmdk(fs *fakesys.FakeFileSystem, filepath, contents string) *FakeVmdk {
+	return &FakeVmdk{
+		Fs:                fs,
+		MediaFilePath:     filepath,
+		MediaFileContents: contents,
+	}
+}
+
+func (vmdk *FakeVmdk) Mount(mountPath string) error {
+	switch {
+	case !vmdk.MediaAvailable:
+		return errors.New("media not available")
+	case vmdk.Mounted:
+		return errors.New("already mounted")
+	case vmdk.MountError != nil:
+		return vmdk.MountError
+	}
+
+	vmdk.MountMountPath = mountPath
+
+	err := vmdk.Fs.WriteFileString(filepath.Join(mountPath, vmdk.MediaFilePath), vmdk.MediaFileContents)
+	if err != nil {
+		return err
+	}
+
+	vmdk.Mounted = true
+
+	return nil
+}
+
+func (vmdk *FakeVmdk) Unmount() error {
+	switch {
+	case !vmdk.Mounted:
+		return errors.New("device not mounted")
+	case vmdk.UnmountError != nil:
+		return vmdk.UnmountError
+	}
+
+	err := vmdk.Fs.RemoveAll(filepath.Join(vmdk.MountMountPath, vmdk.MediaFilePath))
+	if err != nil {
+		return err
+	}
+
+	vmdk.Mounted = false
+
+	return nil
+}

--- a/go_agent/src/bosh/platform/vmdk/linux_vmdk.go
+++ b/go_agent/src/bosh/platform/vmdk/linux_vmdk.go
@@ -1,0 +1,72 @@
+package vmdk
+
+import (
+	"regexp"
+	"strings"
+
+	bosherr "bosh/errors"
+	boshlog "bosh/logger"
+	boshsys "bosh/system"
+)
+
+const vmdkLogTag = "vmdk"
+
+type LinuxVmdk struct {
+	runner boshsys.CmdRunner
+	logger boshlog.Logger
+}
+
+func NewLinuxVmdk(runner boshsys.CmdRunner, logger boshlog.Logger) (vmdk LinuxVmdk) {
+	vmdk = LinuxVmdk{
+		runner: runner,
+		logger: logger,
+	}
+	return
+}
+
+func (vmdk LinuxVmdk) getDevicePath() (devicePath string, err error) {
+	cmdOut, _, _, err := vmdk.runner.RunCommand("blkid")
+	if err != nil {
+		vmdk.logger.Error(vmdkLogTag, "Error of command blkid: %s", err.Error())
+		return
+	}
+
+	regex, _ := regexp.Compile("(\\/dev\\/sd\\w+):")
+	for _, line := range strings.Split(cmdOut, "\n") {
+		if strings.Contains(line, "LABEL=\"CDROM\" TYPE=\"iso9660\"") {
+			matched_line := regex.FindString(line)
+			devicePath = matched_line[0 : len(matched_line)-1]
+			return
+		}
+	}
+
+	vmdk.logger.Error(vmdkLogTag, "Unable to find disk of LABEL=\"CDROM\" TYPE=\"iso9660\"")
+	err = bosherr.WrapError(err, "Getting VMDK Device Path: Unable to find disk of LABEL=\"CDROM\" TYPE=\"iso9660\"")
+	return
+}
+
+func (vmdk LinuxVmdk) Mount(mountPath string) (err error) {
+	devicePath, err := vmdk.getDevicePath()
+	if err != nil {
+		return
+	}
+
+	_, stderr, _, err := vmdk.runner.RunCommand("mount", devicePath, mountPath)
+	if err != nil {
+		err = bosherr.WrapError(err, "Mounting VMDK: %s", stderr)
+	}
+	return
+}
+
+func (vmdk LinuxVmdk) Unmount() (err error) {
+	devicePath, err := vmdk.getDevicePath()
+	if err != nil {
+		return
+	}
+
+	_, stderr, _, err := vmdk.runner.RunCommand("umount", devicePath)
+	if err != nil {
+		err = bosherr.WrapError(err, "Unmounting VMDK: %s", stderr)
+	}
+	return
+}

--- a/go_agent/src/bosh/platform/vmdk/linux_vmdk_test.go
+++ b/go_agent/src/bosh/platform/vmdk/linux_vmdk_test.go
@@ -1,0 +1,98 @@
+package vmdk_test
+
+import (
+	boshlog "bosh/logger"
+	. "bosh/platform/vmdk"
+	fakesys "bosh/system/fakes"
+	"errors"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LinuxVmdk", func() {
+	var (
+		runner *fakesys.FakeCmdRunner
+		vmdk   Vmdk
+	)
+
+	BeforeEach(func() {
+		runner = fakesys.NewFakeCmdRunner()
+		logger = boshlog.NewLogger(boshlog.LevelNone)
+	})
+
+	JustBeforeEach(func() {
+		vmdk = NewLinuxVmdk(runner, logger)
+	})
+
+	Describe("Mount", func() {
+		var (
+			mountResults fakesys.FakeCmdResult
+		)
+
+		BeforeEach(func() {
+			mountResults = fakesys.FakeCmdResult{}
+		})
+
+		JustBeforeEach(func() {
+			runner.AddCmdResult("blkid", "/dev/sda1: UUID=\"ac647c11-a380-47c6-8830-a0edf9091fc8\" TYPE=\"ext4\"\n/dev/sdb1: UUID=\"1461ff24-ec2b-4ac7-a9dd-5a6140c5593e\" TYPE=\"swap\"\n/dev/sdc: LABEL=\"CDROM\" TYPE=\"iso9660\"")
+			runner.AddCmdResult("mount /dev/sdc /fake/settings/path", mountResults)
+		})
+
+		It("runs the mount command", func() {
+			err := vmdk.Mount("/fake/settings/path")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runner.RunCommands).To(Equal([][]string{{"mount", "/dev/sdc", "/fake/settings/path"}}))
+		})
+
+		Context("when mount command errors", func() {
+			BeforeEach(func() {
+				mountResults = fakesys.FakeCmdResult{
+					Stderr: "failed to mount",
+					Error:  errors.New("exit 1"),
+				}
+			})
+
+			It("wraps the error", func() {
+				err := vmdk.Mount("/fake/settings/path")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Mounting VMDK: failed to mount: exit 1"))
+			})
+		})
+	})
+
+	Describe("Unmount", func() {
+		var (
+			umountResults fakesys.FakeCmdResult
+		)
+
+		BeforeEach(func() {
+			umountResults = fakesys.FakeCmdResult{}
+		})
+
+		JustBeforeEach(func() {
+			runner.AddCmdResult("blkid", "/dev/sda1: UUID=\"ac647c11-a380-47c6-8830-a0edf9091fc8\" TYPE=\"ext4\"\n/dev/sdb1: UUID=\"1461ff24-ec2b-4ac7-a9dd-5a6140c5593e\" TYPE=\"swap\"\n/dev/sdc: LABEL=\"CDROM\" TYPE=\"iso9660\"")
+			runner.AddCmdResult("umount /dev/sdc", umountResults)
+		})
+
+		It("runs the umount command", func() {
+			err := vmdk.Unmount()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runner.RunCommands).To(Equal([][]string{{"umount", "/dev/sdc"}}))
+		})
+
+		Context("when umount command errors", func() {
+			BeforeEach(func() {
+				umountResults = fakesys.FakeCmdResult{
+					Stderr: "failed to umount",
+					Error:  errors.New("exit 1"),
+				}
+			})
+
+			It("wraps the error", func() {
+				err := vmdk.Unmount()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Unmounting VMDK: failed to umount: exit 1"))
+			})
+		})
+	})
+})

--- a/go_agent/src/bosh/platform/vmdk/vmdk_interface.go
+++ b/go_agent/src/bosh/platform/vmdk/vmdk_interface.go
@@ -1,0 +1,6 @@
+package vmdk
+
+type Vmdk interface {
+	Mount(mountPath string) (err error)
+	Unmount() (err error)
+}

--- a/go_agent/src/bosh/platform/vmdk/vmdk_suite_test.go
+++ b/go_agent/src/bosh/platform/vmdk/vmdk_suite_test.go
@@ -1,0 +1,13 @@
+package vmdk_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestVmdk(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Vmdk Suite")
+}

--- a/go_agent/src/bosh/platform/vmdkutil/fakes/fake_vmdkutil.go
+++ b/go_agent/src/bosh/platform/vmdkutil/fakes/fake_vmdkutil.go
@@ -1,0 +1,19 @@
+package fakes
+
+type FakeVmdkUtil struct {
+	GetFileContentsFilename string
+	GetFileContentsError    error
+	GetFileContentsContents []byte
+}
+
+func NewFakeVmdkUtil() (util *FakeVmdkUtil) {
+	util = &FakeVmdkUtil{}
+	return
+}
+
+func (util *FakeVmdkUtil) GetFileContents(fileName string) (contents []byte, err error) {
+	util.GetFileContentsFilename = fileName
+	contents = util.GetFileContentsContents
+	err = util.GetFileContentsError
+	return
+}

--- a/go_agent/src/bosh/platform/vmdkutil/vmdkutil.go
+++ b/go_agent/src/bosh/platform/vmdkutil/vmdkutil.go
@@ -1,0 +1,57 @@
+package vmdkutil
+
+import (
+	bosherr "bosh/errors"
+	boshsys "bosh/system"
+
+	boshvmdk "bosh/platform/vmdk"
+	"os"
+	"path/filepath"
+)
+
+type concreteVmdkUtil struct {
+	settingsMountPath string
+	fs                boshsys.FileSystem
+	vmdk              boshvmdk.Vmdk
+}
+
+func NewVmdkUtil(settingsMountPath string, fs boshsys.FileSystem, vmdk boshvmdk.Vmdk) (util VmdkUtil) {
+	util = concreteVmdkUtil{
+		settingsMountPath: settingsMountPath,
+		fs:                fs,
+		vmdk:              vmdk,
+	}
+	return
+}
+
+func (util concreteVmdkUtil) GetFileContents(fileName string) (contents []byte, err error) {
+	err = util.fs.MkdirAll(util.settingsMountPath, os.FileMode(0700))
+	if err != nil {
+		err = bosherr.WrapError(err, "Creating VMDK mount point")
+		return
+	}
+
+	err = util.vmdk.Mount(util.settingsMountPath)
+	if err != nil {
+		err = bosherr.WrapError(err, "Mounting VMDK")
+		return
+	}
+
+	settingsPath := filepath.Join(util.settingsMountPath, fileName)
+	stringContents, err := util.fs.ReadFile(settingsPath)
+	if err != nil {
+		err = bosherr.WrapError(err, "Reading from VMDK")
+		return
+	}
+
+	err = util.vmdk.Unmount()
+	if err != nil {
+		err = bosherr.WrapError(err, "Unmounting VMDK")
+		return
+	}
+
+	util.fs.RemoveAll(util.settingsMountPath)
+	contents = []byte(stringContents)
+
+	return
+}

--- a/go_agent/src/bosh/platform/vmdkutil/vmdkutil_interface.go
+++ b/go_agent/src/bosh/platform/vmdkutil/vmdkutil_interface.go
@@ -1,0 +1,5 @@
+package vmdkutil
+
+type VmdkUtil interface {
+	GetFileContents(fileName string) (contents []byte, err error)
+}

--- a/go_agent/src/bosh/platform/vmdkutil/vmdkutil_suite_test.go
+++ b/go_agent/src/bosh/platform/vmdkutil/vmdkutil_suite_test.go
@@ -1,0 +1,13 @@
+package vmdkutil_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestVmdkutil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Vmdkutil Suite")
+}

--- a/go_agent/src/bosh/platform/vmdkutil/vmdkutil_test.go
+++ b/go_agent/src/bosh/platform/vmdkutil/vmdkutil_test.go
@@ -1,0 +1,39 @@
+package vmdkutil_test
+
+import (
+	fakevmdk "bosh/platform/vmdk/fakes"
+	. "bosh/platform/vmdkutil"
+	fakesys "bosh/system/fakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Vmdkutil", func() {
+	var (
+		fs       *fakesys.FakeFileSystem
+		vmdk     *fakevmdk.FakeVmdk
+		vmdkutil VmdkUtil
+	)
+
+	BeforeEach(func() {
+		fs = fakesys.NewFakeFileSystem()
+		vmdk = fakevmdk.NewFakeVmdk(fs, "env", "fake env contents")
+	})
+
+	JustBeforeEach(func() {
+		vmdkutil = NewVmdkUtil("/fake/settings/dir", fs, vmdk)
+	})
+
+	It("gets file contents from VMDK", func() {
+		contents, err := vmdkutil.GetFileContents("env")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(vmdk.Mounted).To(Equal(false))
+		Expect(vmdk.MediaAvailable).To(Equal(false))
+		Expect(fs.FileExists("/fake/settings/dir")).To(Equal(true))
+		Expect(vmdk.MountMountPath).To(Equal("/fake/settings/dir"))
+
+		Expect(contents).To(Equal([]byte("fake env contents")))
+	})
+
+})

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -254,6 +254,7 @@ cloud:
             datastore_pattern: <%= dc['datastore_pattern'] %>
             persistent_datastore_pattern: <%= dc['persistent_datastore_pattern'] %>
             allow_mixed_datastores: <%= dc.fetch('allow_mixed_datastores', true) %>
+            srm: <%= dc.fetch('srm', false) %>
             clusters:
               <% dc['clusters'].each do |cluster| %>
                 <% case cluster

--- a/stemcell_builder/stages/system_vdiskmanager/apply.sh
+++ b/stemcell_builder/stages/system_vdiskmanager/apply.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2009-2012 VMware, Inc.
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+source $base_dir/lib/prelude_bosh.bash
+
+# Install qemu-img
+pkg_mgr install "qemu"
+
+mkdir -p $chroot/tmp
+cp $assets_dir/vdiskmanager.tar $chroot/tmp
+cp $assets_dir/vdiskmanager-install.sh $chroot/tmp
+
+run_in_chroot $chroot "
+/tmp/vdiskmanager-install.sh
+"

--- a/stemcell_builder/stages/system_vdiskmanager/assets/vdiskmanager-install.sh
+++ b/stemcell_builder/stages/system_vdiskmanager/assets/vdiskmanager-install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+cd /tmp
+tar -xvf vdiskmanager.tar
+
+module_dir=`ls -d /lib/modules/3.*-virtual | tail -1`
+install_dir="${module_dir}/vdiskmanager"
+perl vmware-vix-disklib-distrib/vmware-install.pl "$install_dir"


### PR DESCRIPTION
We run three steps to create the vmdk file as follows. Then use the created vmdk file to upload and attach to VM as independent disk.

           Convert a file with content, such as environment settings, to an iso file
                        Tool: genisoimage (ref: http://linux.die.net/man/1/genisoimage)
                        Command: `genisoimage -o #{iso_file_path} #{original_file_path}`

           Convert the iso file to one vmdk file
                        Tool: qemu-img (To install, run `sudo apt-get install qemu`)
                        Command: `qemu-img convert -O vmdk #{iso_file} #{env.vmdk}`

           Convert the vmdk file to esx type vmdk files (one descriptor file, i.e. env.vmdk and one content file, i.e. env-flat.vmdk)
                        Tools: vmware-vdiskmanager (VMware Virtual Disk Manager, ref: http://www.vmware.com/pdf/VirtualDiskManager.pdf)
                        Command: `vmware-vdiskmanager -r #{original_vmdk_file} -t 4 #{new_vmdk_file}`
Note:
You need to install qemu and vdiskmanager and make sure vdiskmanager is in your system path
Instruction on how to install vdiskmanager:
Download vdiskmanager.tar from link https://github.com/vchs/bosh/blob/wip_remove_iso_f1/stemcell_builder/stages/system_vdiskmanager/assets/vdiskmanager.tar
Then run the following commands:
tar -xvf vdiskmanager.tar
module_dir=`ls -d /lib/modules/3.*-virtual | tail -1`
install_dir="${module_dir}/vdiskmanager"
perl vmware-vix-disklib-distrib/vmware-install.pl "$install_dir"