### PR TITLE
added 'rb' to open stemcell in binary to suppress CR/LF conversion on Win

### DIFF
--- a/bosh_cli/lib/cli/stemcell.rb
+++ b/bosh_cli/lib/cli/stemcell.rb
@@ -23,7 +23,7 @@ module Bosh::Cli
       tar = nil
       step("Read tarball",
            "Cannot read tarball #{@stemcell_file}", :fatal) do
-        tgz = Zlib::GzipReader.new(File.open(@stemcell_file))
+        tgz = Zlib::GzipReader.new(File.open(@stemcell_file,'rb'))
         tar = Minitar.open(tgz)
         !!tar
       end


### PR DESCRIPTION
stemcell.rb fails to read tgz'ed stemcell on Windows because it uses Ruby's File.open which defaults to CRLF conversion. This fix adds a 'rb' flag (read binary mode) to suppress the conversion.

Before this patch:

Verifying stemcell...
File exists and readable
Verifying tarball...
Read tarball                                                 D:/Programs/Ruby193/lib/ruby/gems/1.9.1/gems/bosh_cli-1.2549.0/lib/
e': invalid bit length repeat (Zlib::DataError)
        from D:/Programs/Ruby193/lib/ruby/gems/1.9.1/gems/bosh_cli-1.2549.0/lib/cli/stemcell.rb:26:in `new'
        from D:/Programs/Ruby193/lib/ruby/gems/1.9.1/gems/bosh_cli-1.2549.0/lib/cli/stemcell.rb:26:in`block in perform_validation

After:

Verifying stemcell...
File exists and readable                                     [0m[32mOK[0m
Verifying tarball...
Read tarball                                                 [0m[32mOK[0m
Manifest exists                                              [0m[32mOK[0m
Stemcell image file                                          [0m[32mOK[0m
Stemcell properties                                          [0m[32mOK[0m
## Stemcell info
