### PR TITLE
Aws spot lifecycle tests

### DIFF
--- a/bosh_aws_cpi/spec/integration/lifecycle_spec.rb
+++ b/bosh_aws_cpi/spec/integration/lifecycle_spec.rb
@@ -236,7 +236,7 @@ describe Bosh::AwsCloud::Cloud do
     end
   end
 
-  describe 'spot' do
+  describe 'spot' do 
     
     context 'without existing disks' do
       


### PR DESCRIPTION
[@calebamiles asks](https://github.com/cloudfoundry/bosh/pull/585#issuecomment-45359345):

> Additionally, since the spot instance creation fundamentally changes how a VM is created, would it be possible for you to add an additional test (in a separate PR) to the AWS lifecycle tests to reflect the additional functionality?

This PR adds:
-  simple AWS Spot lifecycle integration test
