### PR TITLE
fix use-vip for openstack

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -279,6 +279,10 @@ module Bosh::OpenStackCloud
         server = with_openstack { @openstack.servers.create(server_params) }
 
         @logger.info("Creating new server `#{server.id}'...")
+
+        @logger.info("Configuring network for server `#{server.id}'...")
+        network_configurator.configure(@openstack, server)
+
         begin
           wait_resource(server, :active, :state)
         rescue Bosh::Clouds::CloudError => e
@@ -288,9 +292,6 @@ module Bosh::OpenStackCloud
 
           raise Bosh::Clouds::VMCreationFailed.new(true)
         end
-
-        @logger.info("Configuring network for server `#{server.id}'...")
-        network_configurator.configure(@openstack, server)
 
         @logger.info("Updating settings for server `#{server.id}'...")
         settings = initial_agent_settings(server_name, agent_id, network_spec, environment,


### PR DESCRIPTION
This PR suggest that you change the location of the configuration.

I use openstack(icehouse) with neutron.
But I can't deploy to use "vip" by floating-ip with neutron.
I was success if it change the location of the network configuration.
