### PR TITLE
Update spec

### DIFF
--- a/release/jobs/blobstore/spec
+++ b/release/jobs/blobstore/spec
@@ -27,3 +27,6 @@ properties:
     description: Username agents must use to access blobstore via HTTP Basic
   blobstore.agent.password:
     description: Password agents must use to access blobstore via HTTP Basic
+  blobstore.max_upload_size:
+    description: Maximum release size that is allowed
+    default: 1G


### PR DESCRIPTION
adding default value for blobstore.max_upload_size
