### PR TITLE
[microbosh] fall back to configured network.ip [fixes #558]

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/aws.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager/aws.rb
@@ -121,14 +121,15 @@ module Bosh::Deployer
             raise RuntimeError, 'Failed to discover elastic public ip address' unless ip
           else
             ip = instance.public_ip_address
-            raise RuntimeError, 'Failed to discover public ip address' unless ip
           end
 
-          logger.info("discovered bosh ip=#{ip}")
-          ip
-        else
-          config.client_services_ip
+          if ip
+            logger.info("discovered bosh ip=#{ip}")
+            return ip
+          end
         end
+        logger.info("using configured ip=#{config.client_services_ip}")
+        config.client_services_ip
       end
     end
   end

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/instance_manager/aws_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/instance_manager/aws_spec.rb
@@ -108,10 +108,9 @@ module Bosh::Deployer
             end
 
             context 'when public ip is not set' do
-              it 'raises RuntimeError error' do
+              it 'return client_services_ip' do
                 allow(instance).to receive(:public_ip_address).and_return(nil)
-                expect { aws.send(method) }.to raise_error(
-                  RuntimeError, /Failed to discover public ip address/)
+                expect(aws.send(method)).to eq('fake-client-services-ip')
               end
             end
           end


### PR DESCRIPTION
The following micro_bosh.yml snippet previously failed unnecessarily:

```
network:
 type: manual
 ip: 10.15.212.70
 cloud_properties:
   subnet: subnet-0420752c
```

Now, the network.ip will be used as the client_services_ip.

The following is output in the logs:

```
using configured ip=10.15.212.70
```
