### PR TITLE
Based upon discussion around PR #592, remove file injection entirely.

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -268,6 +268,7 @@ module Bosh::OpenStackCloud
                                                    :delete_on_termination => "1",
                                                    :device_name => "/dev/vda"
                                                  }]
+        end
 
         @logger.debug("Using boot parms: `#{server_params.inspect}'")
         server = with_openstack { @openstack.servers.create(server_params) }

--- a/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
@@ -42,6 +42,7 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
                                          :volume_id => volume_id,
                                          :delete_on_termination => "1",
                                          :device_name => "/dev/vda" }]
+    end
 
     params
   end


### PR DESCRIPTION
Backends like rbd do not support injection and emit an error at VM creation
if CONF.libvirt_inject_partition isn't set to -2 (which silently ignores
the personality parameter).

user-data field can provide the necessary bootstrap data when
personality isn't available, so no functionality loss is present.
