### PR TITLE
Remove error generating redundant statement from firstboot script

### DIFF
--- a/stemcell_builder/stages/base_ubuntu_firstboot/assets/root/firstboot.sh
+++ b/stemcell_builder/stages/base_ubuntu_firstboot/assets/root/firstboot.sh
@@ -5,14 +5,8 @@
 > /etc/resolv.conf
 rm /etc/ssh/ssh_host*key*
 
-DISTRIB_CODENAME=$(lsb_release --codename | cut -f2)
-if [ $DISTRIB_CODENAME == "trusty" ]; then
-  ifdown -a --no-loopback
-  ifup -a --no-loopback
-else
-  ifdown -a --exclude=lo
-  ifup -a --exclude=lo
-fi
+ifdown -a --exclude=lo
+ifup -a --exclude=lo
 
 dpkg-reconfigure -fnoninteractive -pcritical openssh-server
 dpkg-reconfigure -fnoninteractive sysstat


### PR DESCRIPTION
I've noticed that the firstboot script was causing an error during startup:

```
/root/firstboot.sh: 9: [: trusty: unexpected operator
```

The reason for it is that we're using /bin/sh as the shell, but using '==' as the string comparison, which isn't supported - this fails on both lucid as well as trusty. 

The consequence of the failure is that, regardless of the value in $DISTRIB_CODENAME, the else codepath is followed, and both lucid AND trusty support specifying "--exclude=dev" during ifup/ifdown statements.

Therefore, removing the redundant bits.
