### PR TITLE
When creating stemcell, proxy environment variable `https_proxy` wasn't ...

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
@@ -175,7 +175,7 @@ module Bosh::Stemcell
     end
 
     def proxy_settings_from_environment
-      keep = %w(HTTP_PROXY NO_PROXY)
+      keep = %w(HTTP_PROXY HTTPS_PROXY NO_PROXY)
 
       environment.select { |k| keep.include?(k.upcase) }
     end

--- a/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
@@ -246,7 +246,7 @@ module Bosh::Stemcell
     end
 
     describe '#command_env' do
-      context 'when the environment does not have HTTP_PROXY or NO_PROXY variables' do
+      context 'when the environment does not have HTTP_PROXY, HTTPS_PROXY or NO_PROXY variables' do
         it 'includes no variables' do
           expect(subject.command_env).to eq('env ')
         end
@@ -277,6 +277,36 @@ module Bosh::Stemcell
 
         it 'includes those variables' do
           expect(subject.command_env).to eq("env http_proxy='some_proxy' no_proxy='no_proxy'")
+        end
+      end
+
+      context 'when the environment has HTTP_PROXY, HTTPS_PROXY and NO_PROXY variables' do
+        let(:env) do
+          {
+            'HTTP_PROXY' => 'some_proxy',
+            'HTTPS_PROXY' => 'some_proxy',
+            'NO_PROXY' => 'no_proxy',
+            'SOME_PROXY' => 'other_proxy',
+          }
+        end
+
+        it 'includes those variables' do
+          expect(subject.command_env).to eq("env HTTP_PROXY='some_proxy' HTTPS_PROXY='some_proxy' NO_PROXY='no_proxy'")
+        end
+      end
+      
+      context 'when the environment has http_proxy, https_proxy and no_proxy variables' do
+        let(:env) do
+          {
+            'http_proxy' => 'some_proxy',
+            'https_proxy' => 'some_proxy',
+            'no_proxy' => 'no_proxy',
+            'some_proxy' => 'other_proxy',
+          }
+        end
+
+        it 'includes those variables' do
+          expect(subject.command_env).to eq("env http_proxy='some_proxy' https_proxy='some_proxy' no_proxy='no_proxy'")
         end
       end
     end


### PR DESCRIPTION
...kept, cause download failure.

An error occurred while running the follow command.
stemcell:build_with_local_os_image[openstack,ubuntu,trusty,go,/tmp/ubuntu_base_image_trusty.tgz]

Error dispaly:

++ echo '# THIS FILE IS GENERATED; DO NOT EDIT OR COMMIT'
cd /mnt/stemcells/openstack/kvm/ubuntu/build/build/stages/aws_cli/assets
rm -rf s3cli
curl -L -o s3cli.tar.gz https://api.github.com/repos/pivotal-golang/s3cli/tarball/2c4a7f0ceef411532bb051e7ca55a490a565cf60
% Total % Received % Xferd Average Speed Time Time Time Current
Dload Upload Total Spent Left Speed
0 0 0 0 0 0 0 0 --:--:-- 0:02:08 --:--:-- 0curl: (7) couldn't
connect to host
rake aborted!
Failed: 'sudo env http_proxy='http://z00XXXXXX:XXXXXX@10.xx.xx.xxx:8080' no_proxy='172.0.0.1,localhost'
...
