### PR TITLE
[WIP] Enable using SSD backed AWS EBS persistent disks

### DIFF
--- a/bosh_aws_cpi/lib/cloud/aws/cloud.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/cloud.rb
@@ -166,9 +166,12 @@ module Bosh::AwsCloud
       with_thread_name("create_disk(#{size}, #{instance_id})") do
         validate_disk_size(size)
 
+        volume_type = "gp2" #hardcode usage of SSD backed EBS instances, until a way to configure volume_type this is completed
+
         # if the disk is created for an instance, use the same availability zone as they must match
         volume = @ec2.volumes.create(:size => (size / 1024.0).ceil,
-                                     :availability_zone => @az_selector.select_availability_zone(instance_id))
+                                     :availability_zone => @az_selector.select_availability_zone(instance_id),
+                                     :volume_type => volume_type)
 
         logger.info("Creating volume '#{volume.id}'")
         ResourceWait.for_volume(volume: volume, state: :available)


### PR DESCRIPTION
## This PR is currently a work in progress

This PR enables the usage of SSD backed AWS EBS persistent disks.

It is a stop gap that you can choose to patch your BOSH director with in order to use [SSD EBS disks on AWS](https://groups.google.com/a/cloudfoundry.org/forum/#!topic/bosh-dev/CjIHzo43i_I) until the work related to the [disk pools](https://groups.google.com/a/cloudfoundry.org/forum/#!topic/bosh-dev/wuzsVvpzuS0) is completed.

It is unlikely it will every make sense to merge this PR
