### PR TITLE
stemcell_builder: set infrastructure to vsphere for vcloud stemcell

### DIFF
--- a/stemcell_builder/stages/system_parameters/apply.sh
+++ b/stemcell_builder/stages/system_parameters/apply.sh
@@ -7,5 +7,11 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
+# set the infrastructure for the agent to "vsphere" when building the vcloud stemcell
+if [ "${stemcell_infrastructure}" == "vcloud" ]
+then
+  stemcell_infrastructure=vsphere
+fi
+
 echo -n $stemcell_infrastructure > $chroot/var/vcap/bosh/etc/infrastructure
 echo -n $stemcell_operating_system > $chroot/var/vcap/bosh/etc/operating_system


### PR DESCRIPTION
The go agent does not have a "vcloud" infrastructure defined so currently the agent fails to start in the vcloud stemcell. This change makes the agent use the "vsphere" infrastructure code when running in the vcloud stemcell.
