### PR TITLE
add --force-local option to tar cmd so Windows paths like D:/boshrelease...

### DIFF
--- a/bosh_cli/lib/cli/release_tarball.rb
+++ b/bosh_cli/lib/cli/release_tarball.rb
@@ -15,8 +15,10 @@ module Bosh::Cli
 
     # Unpacks tarball to @unpack_dir, returns true if succeeded, false if failed
     def unpack
+      #--force-local ensures Windows paths are not misinterpreted as
+      # remote files due to the colon
       return @unpacked unless @unpacked.nil?
-      `tar -C #{@unpack_dir} -xzf #{@tarball_path} 2>&1`
+      `tar --force-local -C #{@unpack_dir} -xzf #{@tarball_path} 2>&1`
       @unpacked = $?.exitstatus == 0
     end
 
@@ -204,7 +206,9 @@ module Bosh::Cli
 
           job_tmp_dir = Dir.mktmpdir
           FileUtils.mkdir_p(job_tmp_dir)
-          `tar -C #{job_tmp_dir} -xzf #{job_file} 2>&1`
+          #--force-local ensures Windows paths are not misinterpreted as
+          # remote files due to the colon
+          `tar --force-local -C #{job_tmp_dir} -xzf #{job_file} 2>&1`
           job_extracted = $?.exitstatus == 0
 
           step("Extract job '#{name}'", "Cannot extract job '#{name}'") do


### PR DESCRIPTION
This change is to make `bosh upload release boshrelease-cf-176.tgz` work on Windows.

Currently:

```
D:\bosh-lite>bosh --no-color upload release boshrelease-cf-176.tgz
Verifying release...
validation.rb: about to perform_validation
release_tarball.rb: allow_sparse: true
File exists and readable                                     OK
Extract tarball                                              FAILED
```

Debugging uncovered that BOSH uses the tar command to extract the archive, resulting in the following arguments on Windows:
`tar -C C:/Users/DiesK/AppData/Local/Temp/d20140808... -xzf D:/bosh-lite/boshrelease-cf-176.tgz`

tar interprets "D:/blah" as a remote file due to the colon. The '--force-local' option makes it interpret as if the "archive file is local even if it has a colon". After this change, this command completes fine on Windows.
