### PR TITLE
open temp file as binary to suppress LF->CRLF conversion on Windows

### DIFF
--- a/bosh_cli/lib/cli/versions/version_file_resolver.rb
+++ b/bosh_cli/lib/cli/versions/version_file_resolver.rb
@@ -27,7 +27,7 @@ module Bosh::Cli::Versions
 
       tmp_file_path = File.join(@tmpdir, "bosh-tmp-file-#{SecureRandom.uuid}")
       begin
-        File.open(tmp_file_path, 'w') do |tmp_file|
+        File.open(tmp_file_path, 'wb') do |tmp_file|
           @blobstore.get(blobstore_id, tmp_file, sha1: sha1)
         end
 


### PR DESCRIPTION
This command on Windows currently fails:
`bosh --no-color upload release releases/cf-177.yml`

with error:

`uaa (e95f22b7838e41bde03de3e10ffc5dddbfdfbd9a) FOUND REMOTE
Downloading package uaa (e95f22b7838e41bde03de3e10ffc5dddbfdfbd9a) from blobstore (id=d9c58bd8-6581-4727-8f2d-3a187e99c8e5)...
Blobstore error: sha1 mismatch expected=0ddf3ca5aafba07afee7b9d25d9451347738ef35 actual=67dd8b8e568eeb790acaa123bb6bdcc891ad1c46`

because the file during download is saved using a Ruby API that defaults to a mode that performs LF->CRLF conversion on Windows. With this patch the conversion is suppressed and the command completes successfully.
