### PR TITLE
Added shmmax to postgres control script.

### DIFF
--- a/release/jobs/postgres/templates/postgres_ctl.erb
+++ b/release/jobs/postgres/templates/postgres_ctl.erb
@@ -25,6 +25,8 @@ case "$1" in
     mkdir -p $DATA_DIR
     chown -R vcap:vcap $DATA_DIR
 
+    sysctl -w "kernel.shmmax=284934144"
+
     # We cannot kill the following conditional
     # because initdb is very picky about looking at an empty dir
     if [ ! -f $DATA_DIR/postgresql.conf ]; then


### PR DESCRIPTION
Postgres was unable to allocate enough memory for mapping. Added sysctl to change memory before postgres starts.

Signed-off-by: Jason Smith jasmith@pivotallabs.com
