### PR TITLE
Set content-type while creating blobs on s3

### DIFF
--- a/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
@@ -144,7 +144,7 @@ module Bosh
         s3_object = get_object_from_s3(oid)
         raise BlobstoreError, "object id #{oid} is already in use" if s3_object.exists?
         File.open(path, 'r') do |temp_file|
-          s3_object.write(temp_file)
+          s3_object.write(temp_file, content_type: "application/octet-stream")
         end
       end
 

--- a/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
+++ b/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
@@ -221,6 +221,26 @@ module Bosh::Blobstore
           }.to raise_error(BlobstoreError, 'unsupported action')
         end
       end
+
+      context 'with non existing blob' do
+        let(:blob) { instance_double('AWS::S3::S3Object', exists?: false) }
+        let(:options) do
+          {
+            bucket_name: 'test',
+            access_key_id: 'KEY',
+            secret_access_key: 'SECRET',
+          }
+        end
+
+        before do
+          allow(client).to receive(:get_object_from_s3).and_return(blob)          
+        end
+
+        it 'uses a proper content-type' do
+          expect(blob).to receive(:write).with(File, content_type: "application/octet-stream")
+          client.create('foobar', 'foobar')
+        end
+      end
     end
 
     describe '#get' do


### PR DESCRIPTION
this fixes an issue where atmos (when accessed over s3 api).
experiences an server error on blob download due to the content-type being a space.
