### PR TITLE
Enable the proxy configuration to support user/password

### DIFF
--- a/bosh-dev/lib/bosh/dev/download_adapter.rb
+++ b/bosh-dev/lib/bosh/dev/download_adapter.rb
@@ -19,7 +19,7 @@ module Bosh::Dev
     def download_file(uri, write_path)
       proxy = ENV['http_proxy'] ? URI.parse(ENV['http_proxy']) : NullUri.new
 
-      Net::HTTP.start(uri.host, uri.port, proxy.host, proxy.port) do |http|
+      Net::HTTP.start(uri.host, uri.port, proxy.host, proxy.port, proxy.user, proxy.password) do |http|
         http.request_get(uri.request_uri) do |response|
           raise "remote file '#{uri}' not found" if response.kind_of? Net::HTTPNotFound
           write_response(response, write_path)

--- a/bosh-dev/spec/bosh/dev/download_adapter_spec.rb
+++ b/bosh-dev/spec/bosh/dev/download_adapter_spec.rb
@@ -71,6 +71,16 @@ module Bosh::Dev
           subject.download(uri, write_path)
         end
       end
+
+      context 'when a proxy is available and contains the user and password' do
+        before { stub_const('ENV', 'http_proxy' => 'http://user:password@proxy.example.com:1234') }
+
+        it 'uses the proxy' do
+          net_http_mock = class_double('Net::HTTP').as_stubbed_const
+          net_http_mock.should_receive(:start).with('a.sample.uri', 80, 'proxy.example.com', 1234, 'user', 'password')
+          subject.download(uri, write_path)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When we use BOSH behind an enterprise proxy server, we need to configure the user/password for proxy. But currently BOSH doesn't consider this scenario. This patch fixes the problem.
