### PR TITLE
errands do not appear in "bosh tasks recent" as user activities

### DIFF
--- a/bosh-director/lib/bosh/director/api/controllers/tasks_controller.rb
+++ b/bosh-director/lib/bosh/director/api/controllers/tasks_controller.rb
@@ -30,6 +30,7 @@ module Bosh::Director
           create_snapshot
           delete_snapshot
           snapshot_deployment
+          run_errand
         ])
         end
 


### PR DESCRIPTION
I'd like `bosh run errands` tasks to appear in `bosh tasks recent` please; rather than in the system-only `bosh tasks recent --no-filter` list.
