### PR TITLE
Director can ignore UUID

### DIFF
--- a/bosh-director/lib/bosh/director/api/controllers/info_controller.rb
+++ b/bosh-director/lib/bosh/director/api/controllers/info_controller.rb
@@ -7,6 +7,7 @@ module Bosh::Director
         status = {
           'name' => Config.name,
           'uuid' => Config.uuid,
+          'ignores_uuid' => Config.ignores_uuid,
           'version' => "#{VERSION} (#{Config.revision})",
           'user' => @user,
           'cpi' => Config.cloud_type,

--- a/bosh-director/lib/bosh/director/config.rb
+++ b/bosh-director/lib/bosh/director/config.rb
@@ -30,6 +30,7 @@ module Bosh::Director
         :revision,
         :task_checkpoint_interval,
         :uuid,
+        :ignores_uuid,
         :current_job,
         :encryption,
         :fix_stateful_nodes,
@@ -124,6 +125,7 @@ module Bosh::Director
 
         @uuid = override_uuid || Bosh::Director::Models::DirectorAttribute.find_or_create_uuid(@logger)
         @logger.info("Director UUID: #{@uuid}")
+        @ignores_uuid = config.fetch('deployment', {}).fetch('ignores_uuid', false)
 
         @encryption = config['encryption']
         @fix_stateful_nodes = config.fetch('scan_and_fix', {})

--- a/bosh-director/spec/assets/test-director-config.yml
+++ b/bosh-director/spec/assets/test-director-config.yml
@@ -10,6 +10,9 @@ redis:
   port: 63790
   password:
 
+deployment:
+  ignores_uuid: true
+
 dir: /tmp/boshdir
 db:
   adapter: sqlite

--- a/bosh-director/spec/unit/api/controllers/info_controller_spec.rb
+++ b/bosh-director/spec/unit/api/controllers/info_controller_spec.rb
@@ -65,6 +65,7 @@ module Bosh::Director
           'name' => 'Test Director',
           'version' => "#{VERSION} (#{Config.revision})",
           'uuid' => Config.uuid,
+          'ignores_uuid' => true,
           'user' => 'admin',
           'cpi' => 'dummy',
           'features' => {

--- a/bosh-director/spec/unit/config_spec.rb
+++ b/bosh-director/spec/unit/config_spec.rb
@@ -88,4 +88,21 @@ describe Bosh::Director::Config do
       expect(described_class.cpi_task_log).to eq('fake-cpi-log')
     end
   end
+
+  describe '#ignores_uuid' do
+    it 'returns whether or not the director cares about the uuid in manifests' do
+      config = described_class.load_hash(test_config)
+      described_class.configure(config.hash)
+
+      expect(described_class.ignores_uuid).to eq(true)
+    end
+
+    it 'returns false if the value is not set' do
+      test_config.fetch('deployment').delete('ignores_uuid')
+      config = described_class.load_hash(test_config)
+      described_class.configure(config.hash)
+
+      expect(described_class.ignores_uuid).to eq(false)
+    end
+  end
 end

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -81,6 +81,9 @@ properties:
   director.max_vm_create_tries:
     description: Max retries when creating VMs
     default: 5
+  director.ignores_uuid:
+    description: Is this director lenient about the manifests that are deployed to it?
+    default: false
 
   redis.address:
     description: Address of the redis server

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -60,6 +60,9 @@ scheduled_jobs:
     schedule: <%= backup_schedule %>
   <% end %>
 
+deployment:
+  ignores_uuid: <%= p('director.ignores_uuid') %>
+
 scan_and_fix:
   auto_fix_stateful_nodes: <%= p('director.auto_fix_stateful_nodes') %>
 <% if_p('dns.db.adapter', 'dns.db.user', 'dns.db.password', 'dns.db.host',


### PR DESCRIPTION
Okay, so.

The director UUID feature of BOSH is pretty useful and I'm sure it has saved many deployments from being damaged by deploying the incorrect manifest. Unfortunately, it's also the most infuriating and tedious feature. This [piece of brilliance](https://github.com/concourse/concourse/blob/d203e2fab285e97630176c94374896e725967c5a/manifests/bosh-lite.yml#L4) has just gone too far.

There was a brief feature introduced a while back that allowed you to specify `uuid: ignore` in your manifest but this left production directors open to mistakes. If instead it's the director's responsibility to say whether or not its identity can be ignored. This way it can be ignored in BOSH-lite environments but left on in any important environments.
## Director
- [x] Add configuration option to director
- [x] Return configuration value in `/info`
- [x] Add option to director BOSH job
## CLI
- [ ] Don't error if deploying to a relaxed director
- [ ] Make sure that everything still works with mismatched director and cli versions

This PR isn't finished yet. I'd welcome any feedback that anyone has on this so far.
