### PR TITLE
Add workstation setup to Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,27 @@ Follow these steps to make a contribution to any of our open source repositories
 
         git config --global user.name "Firstname Lastname"
         git config --global user.email "your_email@example.com"
+       
+## Set up a workstation for development
+We assume you can install packages (brew, apt-get, or equivalent). We include Mac examples here, replace with your package manager of choice.
+
+Bring homebrew index up-to-date:
+* `brew update`
+
+Get mysql libraries (needed by the mysql2 gem):
+* `brew install mysql`
+
+Get postgresql libraries (needed by the pg gem):
+* `brew install postgresql`
+
+Install pg gem manually by specifying your architecture:
+* `(sudo) env ARCHFLAGS="-arch x86_64" gem install pg -v '0.15.1'`
+ 
+Get redis:
+* `brew install redis`
+
+Get Golang:
+* `brew install go`
 
 ## General Workflow
 


### PR DESCRIPTION
Running `bundle` leads to some cases where gems can't be installed due to missing dependencies for their native extensions. Specifically installing the pg gem proves more difficult than necessary if you install postgresql using brew, as it does't fix the architecture to `x86_64`. Furthermore, redis and golang are needed for running the tests with `bundle exec rake`.
