### PR TITLE
Make download_adapter aware of no_proxy environment setting

### DIFF
--- a/bosh-dev/lib/bosh/dev/download_adapter.rb
+++ b/bosh-dev/lib/bosh/dev/download_adapter.rb
@@ -19,6 +19,11 @@ module Bosh::Dev
     def download_file(uri, write_path)
       proxy = ENV['http_proxy'] ? URI.parse(ENV['http_proxy']) : NullUri.new
 
+      # disable use of proxy when URI domain is in no_proxy
+      if uri_matches_noproxy?(uri)
+        proxy.host = nil
+      end
+
       Net::HTTP.start(uri.host, uri.port, proxy.host, proxy.port, proxy.user, proxy.password) do |http|
         http.request_get(uri.request_uri) do |response|
           raise "remote file '#{uri}' not found" if response.kind_of? Net::HTTPNotFound
@@ -33,6 +38,26 @@ module Bosh::Dev
           file.write(chunk)
         end
       end
+    end
+
+    def uri_matches_noproxy?(uri)
+      no_proxy = get_noproxy
+      no_proxy.each do |no_proxy_domain|
+        # remove leading dot if there is one in the no_proxy_domain
+        no_proxy_domain.sub(/^\./,'')
+        if uri.host.end_with?(no_proxy_domain)
+          return true
+        end
+      end
+      false
+    end
+
+    def get_noproxy
+      noproxy = ENV['no_proxy']
+
+      return [] unless noproxy
+
+      noproxy.split(',')
     end
 
     NullUri = Struct.new(:host, :port, :user, :password)

--- a/bosh-dev/spec/bosh/dev/download_adapter_spec.rb
+++ b/bosh-dev/spec/bosh/dev/download_adapter_spec.rb
@@ -81,6 +81,26 @@ module Bosh::Dev
           subject.download(uri, write_path)
         end
       end
+
+      context 'when a proxy is available and the URL matches the noproxy list' do
+        before { stub_const('ENV', 'http_proxy' => 'http://proxy.example.com:1234', 'no_proxy' => 'some.domain,sample.uri,someother.domain')}
+
+        it 'does not use the proxy' do
+          net_http_mock = class_double('Net::HTTP').as_stubbed_const
+          expect(net_http_mock).to receive(:start).with('a.sample.uri', 80, nil, 1234, nil, nil)
+          subject.download(uri, write_path)
+        end
+      end
+
+      context 'when a proxy is available and the URL matches the noproxy list, even if specified with leading .' do
+        before { stub_const('ENV', 'http_proxy' => 'http://proxy.example.com:1234', 'no_proxy' => 'some.domain,.sample.uri')}
+
+        it 'does not use the proxy' do
+          net_http_mock = class_double('Net::HTTP').as_stubbed_const
+          expect(net_http_mock).to receive(:start).with('a.sample.uri', 80, nil, 1234, nil, nil)
+          subject.download(uri, write_path)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If you have a http_proxy set but the URL you download from is matching your no_proxy list, set the proxy.host to nil. There is some fiddling around with the entries in the no_proxy list, as in most cases we have domains in there, starting with a leading '.'
