### PR TITLE
Adding volume_type configuration for Micro BOSH

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager.rb
@@ -280,12 +280,10 @@ module Bosh::Deployer
       step 'Create disk' do
         size = config.resources['persistent_disk']
 
-        volume_type = config.resources['persistent_type']
-
-        if volume_type.nil?
-          cloud_properties = {}
+        if config.resources.has_key?('persistent_disk_cloud_properties')
+          cloud_properties = config.resources['persistent_disk_cloud_properties']
         else
-          cloud_properties = { 'type' => volume_type }
+          cloud_properties = {}
         end
 
         state.disk_cid = cloud.create_disk(size, cloud_properties, state.vm_cid)


### PR DESCRIPTION
Adding the ability to set a new "persistent_type" property in the Micro BOSH manifest in order to specify the volume type for the persistent disk.  This gets passed to the create_disk function in the CPI in the same way that the new disk_pool functionality uses, via the cloud_properties parameter.

Micro BOSH manifest would look as follows:

```
resources:
  persistent_disk: 20480
  persistent_type: gp2
  cloud_properties:
    instance_type: flavor
    availability_zone: az1
```

If the new property is not specified than no value is passed to the create_disk function as before.

Aaron Huber
Intel Corporation
