### PR TITLE
Remove processing deployment manifest message

### DIFF
--- a/bosh_cli/lib/cli/deployment_helper.rb
+++ b/bosh_cli/lib/cli/deployment_helper.rb
@@ -8,8 +8,6 @@ module Bosh::Cli
         err("Cannot find deployment manifest in `#{manifest_filename}'")
       end
 
-      header('Processing deployment manifest')
-
       manifest = load_yaml_file(manifest_filename)
       manifest_yaml = File.read(manifest_filename)
 


### PR DESCRIPTION
This message appears 3 times when running bosh ssh and isn't informative,
so let's get rid of it and reduce the visual noise

Signed-off-by: Haydon Ryan hryan@pivotallabs.com
