### PR TITLE
Adding changes to OpenStack CPI for volume type.

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -40,6 +40,7 @@ module Bosh::OpenStackCloud
       @stemcell_public_visibility = @openstack_properties["stemcell_public_visibility"]
       @wait_resource_poll_interval = @openstack_properties["wait_resource_poll_interval"]
       @boot_from_volume = @openstack_properties["boot_from_volume"]
+      @boot_volume_type = @openstack_properties["boot_volume_type"]
 
       unless @openstack_properties['auth_url'].match(/\/tokens$/)
         @openstack_properties['auth_url'] = @openstack_properties['auth_url'] + '/tokens'
@@ -85,12 +86,12 @@ module Bosh::OpenStackCloud
 
       volume_params = {
         :provider => "OpenStack",
-        :openstack_auth_url => @openstack_properties["auth_url"],
-        :openstack_username => @openstack_properties["username"],
-        :openstack_api_key => @openstack_properties["api_key"],
-        :openstack_tenant => @openstack_properties["tenant"],
+        :openstack_auth_url => @openstack_properties['auth_url'],
+        :openstack_username => @openstack_properties['username'],
+        :openstack_api_key => @openstack_properties['api_key'],
+        :openstack_tenant => @openstack_properties['tenant'],
         :openstack_region => @openstack_properties['region'],
-        :openstack_endpoint_type => @openstack_properties["endpoint_type"],
+        :openstack_endpoint_type => @openstack_properties['endpoint_type'],
         :connection_options => @openstack_properties['connection_options'].merge(extra_connection_options)
       }
       begin
@@ -245,14 +246,6 @@ module Bosh::OpenStackCloud
         cloud_error("Key-pair `#{keyname}' not found") if keypair.nil?
         @logger.debug("Using key-pair: `#{keypair.name}' (#{keypair.fingerprint})")
 
-        if @boot_from_volume
-          boot_vol_size = flavor.disk * 1024
-
-          boot_vol_id = create_boot_disk(boot_vol_size, stemcell_id)
-          cloud_error("Failed to create boot volume.") if boot_vol_id.nil?
-          @logger.debug("Using boot volume: `#{boot_vol_id}'")
-        end
-
         use_config_drive = @openstack_properties.fetch("use_config_drive", false)
 
         server_params = {
@@ -270,6 +263,12 @@ module Bosh::OpenStackCloud
         server_params[:availability_zone] = availability_zone if availability_zone
 
         if @boot_from_volume
+          boot_vol_size = flavor.disk * 1024
+
+          boot_vol_id = create_boot_disk(boot_vol_size, stemcell_id, availability_zone, @boot_volume_type)
+          cloud_error("Failed to create boot volume.") if boot_vol_id.nil?
+          @logger.debug("Using boot volume: `#{boot_vol_id}'")
+
           server_params[:block_device_mapping] = [{
                                                    :volume_size => "",
                                                    :volume_id => boot_vol_id,
@@ -387,16 +386,20 @@ module Bosh::OpenStackCloud
     #   this disk will be attached to
     # @return [String] OpenStack volume UUID
     def create_disk(size, cloud_properties, server_id = nil)
-      with_thread_name("create_disk(#{size}, #{server_id})") do
+      with_thread_name("create_disk(#{size}, #{cloud_properties}, #{server_id})") do
         raise ArgumentError, 'Disk size needs to be an integer' unless size.kind_of?(Integer)
         cloud_error('Minimum disk size is 1 GiB') if (size < 1024)
         cloud_error('Maximum disk size is 1 TiB') if (size > 1024 * 1000)
 
         volume_params = {
-          :name => "volume-#{generate_unique_name}",
-          :description => '',
+          :display_name => "volume-#{generate_unique_name}",
+          :display_description => '',
           :size => (size / 1024.0).ceil
         }
+
+        if cloud_properties.has_key?('type')
+          volume_params[:volume_type] = cloud_properties['type']
+        end
 
         if server_id
           server = with_openstack { @openstack.servers.get(server_id) }
@@ -406,12 +409,12 @@ module Bosh::OpenStackCloud
         end
 
         @logger.info('Creating new volume...')
-        volume = with_openstack { @openstack.volumes.create(volume_params) }
+        new_volume = with_openstack { @volume.volumes.create(volume_params) }
 
-        @logger.info("Creating new volume `#{volume.id}'...")
-        wait_resource(volume, :available)
+        @logger.info("Creating new volume `#{new_volume.id}'...")
+        wait_resource(new_volume, :available)
 
-        volume.id.to_s
+        new_volume.id.to_s
       end
     end
 
@@ -421,9 +424,11 @@ module Bosh::OpenStackCloud
     # @param [Integer] size disk size in MiB
     # @param [String] stemcell_id OpenStack image UUID that will be used to
     #   populate the boot volume
+    # @param [optional, String] availability_zone to be passed to the volume API
+    # @param [optional, String] volume_type to be passed to the volume API
     # @return [String] OpenStack volume UUID
-    def create_boot_disk(size, stemcell_id)
-      with_thread_name("create_boot_disk(#{size}, #{stemcell_id})") do
+    def create_boot_disk(size, stemcell_id, availability_zone = nil, volume_type = nil)
+      with_thread_name("create_boot_disk(#{size}, #{stemcell_id}, #{availability_zone}, #{volume_type})") do
         raise ArgumentError, "Disk size needs to be an integer" unless size.kind_of?(Integer)
         cloud_error("Minimum disk size is 1 GiB") if (size < 1024)
         cloud_error("Maximum disk size is 1 TiB") if (size > 1024 * 1000)
@@ -433,6 +438,9 @@ module Bosh::OpenStackCloud
           :size => (size / 1024.0).ceil,
           :imageRef => stemcell_id
         }
+
+        volume_params[:availability_zone] = availability_zone if availability_zone
+        volume_params[:volume_type] = volume_type if volume_type
 
         @logger.info("Creating new boot volume...")
         boot_volume = with_openstack { @volume.volumes.create(volume_params) }

--- a/bosh_openstack_cpi/spec/unit/cloud_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/cloud_spec.rb
@@ -26,6 +26,7 @@ describe Bosh::OpenStackCloud::Cloud do
         :openstack_username => 'admin',
         :openstack_api_key => 'nova',
         :openstack_tenant => 'admin',
+        :openstack_region => 'RegionOne',
         :openstack_endpoint_type => nil,
         :connection_options => merged_connection_options,
       }

--- a/bosh_openstack_cpi/spec/unit/create_disk_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/create_disk_spec.rb
@@ -8,8 +8,8 @@ describe Bosh::OpenStackCloud::Cloud do
   it "creates an OpenStack volume" do
     unique_name = SecureRandom.uuid
     disk_params = {
-      :name => "volume-#{unique_name}",
-      :description => "",
+      :display_name => "volume-#{unique_name}",
+      :display_description => "",
       :size => 2
     }
     volume = double("volume", :id => "v-foobar")
@@ -23,6 +23,27 @@ describe Bosh::OpenStackCloud::Cloud do
     cloud.should_receive(:wait_resource).with(volume, :available)
 
     cloud.create_disk(2048, {}).should == "v-foobar"
+  end
+
+  it "creates an OpenStack volume with a volume_type" do
+    unique_name = SecureRandom.uuid
+    disk_params = {
+      :display_name => "volume-#{unique_name}",
+      :display_description => "",
+      :size => 2,
+      :volume_type => "foo"
+    }
+    volume = double("volume", :id => "v-foobar")
+
+    cloud = mock_cloud do |openstack|
+      openstack.volumes.should_receive(:create).
+        with(disk_params).and_return(volume)
+    end
+
+    cloud.should_receive(:generate_unique_name).and_return(unique_name)
+    cloud.should_receive(:wait_resource).with(volume, :available)
+
+    cloud.create_disk(2048, {"type" => "foo"}).should == "v-foobar"
   end
 
   it "creates an OpenStack boot volume" do
@@ -46,11 +67,55 @@ describe Bosh::OpenStackCloud::Cloud do
     cloud.create_boot_disk(2048, stemcell_id).should == "v-foobar"
   end
 
+  it "creates an OpenStack boot volume with an availability_zone" do
+    unique_name = SecureRandom.uuid
+    stemcell_id = SecureRandom.uuid
+    disk_params = {
+      :display_name => "volume-#{unique_name}",
+      :size => 2,
+      :imageRef => stemcell_id,
+      :availability_zone => "foobar-land"
+    }
+    boot_volume = double("volume", :id => "v-foobar")
+
+    cloud = mock_cloud do |openstack|
+      openstack.volumes.should_receive(:create).
+        with(disk_params).and_return(boot_volume)
+    end
+
+    cloud.should_receive(:generate_unique_name).and_return(unique_name)
+    cloud.should_receive(:wait_resource).with(boot_volume, :available)
+
+    cloud.create_boot_disk(2048, stemcell_id, "foobar-land").should == "v-foobar"
+  end
+
+  it "creates an OpenStack boot volume with a volume_type" do
+    unique_name = SecureRandom.uuid
+    stemcell_id = SecureRandom.uuid
+    disk_params = {
+      :display_name => "volume-#{unique_name}",
+      :size => 2,
+      :imageRef => stemcell_id,
+      :volume_type => "foo"
+    }
+    boot_volume = double("volume", :id => "v-foobar")
+
+    cloud = mock_cloud do |openstack|
+      openstack.volumes.should_receive(:create).
+        with(disk_params).and_return(boot_volume)
+    end
+
+    cloud.should_receive(:generate_unique_name).and_return(unique_name)
+    cloud.should_receive(:wait_resource).with(boot_volume, :available)
+
+    cloud.create_boot_disk(2048, stemcell_id, nil, "foo").should == "v-foobar"
+  end
+
   it "rounds up disk size" do
     unique_name = SecureRandom.uuid
     disk_params = {
-      :name => "volume-#{unique_name}",
-      :description => "",
+      :display_name => "volume-#{unique_name}",
+      :display_description => "",
       :size => 3
     }
     volume = double("volume", :id => "v-foobar")
@@ -79,8 +144,8 @@ describe Bosh::OpenStackCloud::Cloud do
   it "puts disk in the same AZ as a server" do
     unique_name = SecureRandom.uuid
     disk_params = {
-      :name => "volume-#{unique_name}",
-      :description => "",
+      :display_name => "volume-#{unique_name}",
+      :display_description => "",
       :size => 1,
       :availability_zone => "foobar-land"
     }

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -341,6 +341,8 @@ properties:
   openstack.boot_from_volume:
     description: Boot from volume
     default: false
+  openstack.boot_volume_type:
+    description: Volume type for the boot volume (optional)
   openstack.stemcell_public_visibility:
     description: Set public visibility for stemcells (optional, false by default)
     default: false

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -262,6 +262,9 @@ cloud:
       <% if_p("openstack.boot_from_volume") do |boot_from_volume| %>
       boot_from_volume: <%= boot_from_volume %>
       <% end %>
+      <% if_p("openstack.boot_volume_type") do |boot_volume_type| %>
+      boot_volume_type: <%= boot_volume_type %>
+      <% end %>
       default_key_name: <%= default_key_name %>
       default_security_groups: <%= default_security_groups %>
       wait_resource_poll_interval: <%= wait_resource_poll_interval %>


### PR DESCRIPTION
Adding the following functionality to the OpenStack CPI:
- Switched from the compute to the volume API for persistent disk creation
  - Creating volumes from the compute API is deprecated in OpenStack
  - The volume API adds support for availability zones and volume type
- Adding availability zone support to the boot_from_volume functionality
- Added support for the new cloud_properties to set the volume_type from disk pool configuration
