### PR TITLE
Enable the bosh_micro_enabled parameter

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/builder_options.rb
@@ -69,7 +69,6 @@ module Bosh::Stemcell
 
     def bosh_micro_options
       {
-        'bosh_micro_enabled' => 'yes',
         'bosh_micro_package_compiler_path' => File.join(source_root, 'bosh-release'),
         'bosh_micro_manifest_yml_path' => File.join(source_root, 'release', 'micro', "#{infrastructure.name}.yml"),
         'bosh_micro_release_tgz_path' => bosh_micro_release_tgz_path,

--- a/bosh-stemcell/spec/bosh/stemcell/builder_options_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/builder_options_spec.rb
@@ -99,7 +99,6 @@ module Bosh::Stemcell
               File.join(expected_source_root, 'go/src/github.com/cloudfoundry/bosh-agent')
             )
             expect(result['image_create_disk_size']).to eq(default_disk_size)
-            expect(result['bosh_micro_enabled']).to eq('yes')
             expect(result['bosh_micro_package_compiler_path']).to eq(
               File.join(expected_source_root, 'bosh-release'))
             expect(result['bosh_micro_manifest_yml_path']).to eq(expected_release_micro_manifest_path)

--- a/stemcell_builder/stages/bosh_micro_go/apply.sh
+++ b/stemcell_builder/stages/bosh_micro_go/apply.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+#
+# Copyright (c) 2009-2012 VMware, Inc.
 
 set -e
 set -x
@@ -7,18 +9,25 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
-mkdir -p $chroot/$bosh_dir/src/micro_bosh/bosh-release
-if [ -z "${agent_gem_src_url:-}" ]; then
-  cp -rvH $assets_dir/gems $chroot/$bosh_dir/src/micro_bosh/bosh-release/gems
-fi
-
-cp -rH $bosh_micro_manifest_yml_path $chroot/$bosh_dir/src/micro_bosh/release.yml
-cp -rH $bosh_micro_release_tgz_path $chroot/$bosh_dir/src/micro_bosh/release.tgz
-cp $dir/assets/configure_micro_bosh.sh $chroot/$bosh_dir/src/micro_bosh/configure_micro_bosh.sh
-
-run_in_bosh_chroot $chroot "$bosh_dir/src/micro_bosh/configure_micro_bosh.sh ${stemcell_infrastructure} ${agent_gem_src_url:-}"
-
 # Copy the generated apply spec to stemcell directory
 mkdir -p $work/stemcell
-# agent expects a json file on disk, microbosh deployer expects a yaml file (fortunately json is yaml)
-cp $chroot/$bosh_app_dir/micro/apply_spec.json $work/stemcell/apply_spec.yml
+
+# Ensure that the data directory has the proper permissions
+mkdir -p $chroot/var/vcap/data
+
+if [ ${bosh_micro_enabled} == "yes" ]
+then
+  mkdir -p $chroot/$bosh_dir/src/micro_bosh/bosh-release
+  if [ -z "${agent_gem_src_url:-}" ]; then
+    cp -rH $assets_dir/gems $chroot/$bosh_dir/src/micro_bosh/bosh-release/gems
+  fi
+
+  cp -rH $bosh_micro_manifest_yml_path $chroot/$bosh_dir/src/micro_bosh/release.yml
+  cp -rH $bosh_micro_release_tgz_path $chroot/$bosh_dir/src/micro_bosh/release.tgz
+  cp $dir/assets/configure_micro_bosh.sh $chroot/$bosh_dir/src/micro_bosh/configure_micro_bosh.sh
+
+  run_in_bosh_chroot $chroot "$bosh_dir/src/micro_bosh/configure_micro_bosh.sh ${stemcell_infrastructure} ${agent_gem_src_url:-}"
+
+  # agent expects a json file on disk, microbosh deployer expects a yaml file (fortunately json is yaml)
+  cp $chroot/$bosh_app_dir/micro/apply_spec.json $work/stemcell/apply_spec.yml
+fi

--- a/stemcell_builder/stages/bosh_micro_go/config.sh
+++ b/stemcell_builder/stages/bosh_micro_go/config.sh
@@ -8,7 +8,14 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_config.bash
 
-if [ ${bosh_micro_enabled:-no} == "yes" ]
+if [ -z "${bosh_micro_enabled:-}" ]
+then
+  bosh_micro_enabled=yes
+fi
+
+persist_value bosh_micro_enabled
+
+if [ ${bosh_micro_enabled} == "yes" ]
 then
   persist_dir bosh_micro_package_compiler_path
   persist_file bosh_micro_manifest_yml_path
@@ -19,7 +26,7 @@ fi
 
 if [ -z "${agent_gem_src_url:-}" ]; then
   mkdir -p $assets_dir/gems
-  cp -rvH $bosh_release_src_dir/bosh-release/* $assets_dir/gems
+  cp -rH $bosh_release_src_dir/bosh-release/* $assets_dir/gems
 else
   persist_value agent_gem_src_url
 fi


### PR DESCRIPTION
Currently, 'bosh_micro_enabled' is hardcoded to 'yes' in `builder_options.rb`, so the setting in `settings.bash` is useless. This parameter is used to control if the stemcell includes the micro-bosh package or not when building stemcell. It will reduce ~100 mb size if excluding the micro-bosh package from stemcell.

In this modification, we removed the hardcode in `builder_options.rb`, and re-organized the code of `apply.sh`, `config.sh` according to the 'bosh_micro_enabled' setting value. Then, the default value is kept 'yes' and user can control the stemcell to include micro-bosh package or not through the 'bosh_micro_enabled' setting in `settings.bash`.