### PR TITLE
Run NATS.connect on EM thread

### DIFF
--- a/bosh-director/bin/bosh-director-worker
+++ b/bosh-director/bin/bosh-director-worker
@@ -67,8 +67,14 @@ rescue Resque::NoQueueError
 end
 
 Resque.after_fork do
-  EM.error_handler { |e| puts "Error raised during event loop: #{e.message}" }
-  Thread.new { EM.run }
+  EM.error_handler { |e| puts "Error raised during event loop: #{e.inspect}, backtrace: #{e.backtrace}" }
+  Thread.new do
+    EM.run do
+      # connect to NATS on EM thread
+      # EM::connect will throw unbound errors if run from a different thread.
+      Bosh::Director::Config.nats
+    end
+  end
 end
 
 Resque::Failure.backend = Resque::Failure::Backtrace

--- a/bosh-director/lib/bosh/director/config.rb
+++ b/bosh-director/lib/bosh/director/config.rb
@@ -229,6 +229,7 @@ module Bosh::Director
       def nats
         @lock.synchronize do
           if @nats.nil?
+            raise 'Failed to connect to NATS, need to be on EM thread' unless EM.reactor_thread?
             @nats = NATS.connect(:uri => @nats_uri, :autostart => false)
           end
         end

--- a/bosh-director/spec/unit/config_spec.rb
+++ b/bosh-director/spec/unit/config_spec.rb
@@ -88,4 +88,37 @@ describe Bosh::Director::Config do
       expect(described_class.cpi_task_log).to eq('fake-cpi-log')
     end
   end
+
+  describe '#nats' do
+    before do
+      config = described_class.load_hash(test_config)
+      described_class.configure(config.hash)
+    end
+
+    context 'when on reactor thread' do
+      it 'connects to nats' do
+        expect(NATS).to receive(:connect)
+        EM.run do
+          expect {
+            described_class.nats
+          }.to_not raise_error
+          EM.stop
+        end
+      end
+    end
+
+    context 'when not on reactor thread' do
+      before do
+        Thread.new { EM.run }
+      end
+
+      after { EM.stop }
+
+      it 'raises an error' do
+        expect {
+          expect(described_class.nats)
+        }.to raise_error /need to be on EM thread/
+      end
+    end
+  end
 end


### PR DESCRIPTION
I was able to reproduce the issue running:

```
while bundle exec rspec spec/integration/cli_vms_spec.rb:6; do echo ok; done
```

Roughly once in 10 times the compilation will be stuck since EM thread was dying.

Adding more logs to NATS revealed that NATS was sending EM.connect which was resulting in ConnectionNotBound error.

```
sending command CONNECT {"verbose":false,"pedantic":false}
Error raised during event loop: #<EventMachine::ConnectionNotBound: unknown connection: 1>
```

Every time it was the same error.

Based on this suggestion [1] I moved NATS.connect to run on EM thread. As suggested here [2] it was added to EM#run. The test is now running for 4+ hours and it never failed. 
- Verify that current thread is reactor thread when connecting to NATS.
- This is only an issue in worker and not in director since Thin processes requests on EM thread.

[1] https://github.com/eventmachine/eventmachine/wiki/FAQ#does-em-work-with-other-ruby-threads-running
[2] https://github.com/eventmachine/eventmachine/blob/master/lib/eventmachine.rb#L98
