### PR TITLE
Only delete buckets from current region

### DIFF
--- a/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/destroyer.rb
+++ b/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/destroyer.rb
@@ -57,7 +57,11 @@ module Bosh::Aws
 
     def delete_all_s3
       s3 = Bosh::Aws::S3.new(@credentials)
+
       bucket_names = s3.bucket_names
+      region = @credentials["region"]
+
+      bucket_names.reject! { |b| s3.bucket_location(b) != region } # skip buckets not part of current region
 
       unless bucket_names.empty?
         @ui.say("THIS IS A VERY DESTRUCTIVE OPERATION AND IT CANNOT BE UNDONE!\n".make_red)

--- a/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/ec2.rb
+++ b/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/ec2.rb
@@ -3,14 +3,14 @@ module Bosh
     class EC2
 
       NAT_AMI_ID = {
-        'us-east-1' => 'ami-f619c29f',      # ami-vpc-nat-1.1.0-beta
-        'us-west-1' => 'ami-3bcc9e7e',      # ami-vpc-nat-1.0.0-beta
-        'us-west-2' => 'ami-52ff7262',      # ami-vpc-nat-1.0.0-beta
-        'eu-west-1' => 'ami-e5e2d991',      # ami-vpc-nat-1.1.0-beta
-        'ap-southeast-1' => 'ami-02eb9350', # ami-vpc-nat-1.0.0-beta
-        'ap-northeast-1' => 'ami-14d86d15', # ami-vpc-nat-1.0.0-beta
-        'ap-southeast-2' => 'ami-ab990e91', # ami-vpc-nat-1.0.0-beta
-        'sa-east-1' => 'ami-0039e61d',      # ami-vpc-nat-1.0.0-beta
+        "us-east-1"=>"ami-4f9fee26",
+        "us-west-1"=>"ami-7850793d",
+        "us-west-2"=>"ami-6d29b85d",
+        "eu-west-1"=>"ami-ed352799",
+        "ap-southeast-1"=>"ami-780a432a",
+        "ap-northeast-1"=>"ami-5f840e5e",
+        "ap-southeast-2"=>"ami-0154c73b",
+        "sa-east-1"=>"ami-7660c56b"
       }
 
       attr_reader :elastic_ips

--- a/bosh_cli_plugin_aws/migrations/20130529212130_create_more_unique_s3_buckets.rb
+++ b/bosh_cli_plugin_aws/migrations/20130529212130_create_more_unique_s3_buckets.rb
@@ -19,7 +19,7 @@ class CreateMoreUniqueS3Buckets < Bosh::Aws::Migration
 
     buckets.each_key do |bucket|
       say "creating bucket #{bucket}"
-      s3.create_bucket(bucket)
+      s3.create_bucket(bucket) unless s3.bucket_exists?(bucket)
     end
 
     buckets.each_pair do |new_bucket, old_bucket|


### PR DESCRIPTION
Despite S3 buckets not being associated to a region, they totally are! If you try and delete a bucket associated to a region whilst your S3 creds are pointing to another, errors occur!