### PR TITLE
Adding additional properties to the stemcell for VMware hypervisor

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -132,7 +132,9 @@ module Bosh::OpenStackCloud
             }
 
             image_properties = {}
-            vanilla_options = ['name', 'version', 'os_type', 'os_distro', 'architecture', 'auto_disk_config']
+            vanilla_options = ['name', 'version', 'os_type', 'os_distro', 'architecture', 'auto_disk_config',
+                               'hw_vif_model', 'hypervisor_type', 'vmware_adaptertype', 'vmware_disktype',
+                               'vmware_linked_clone', 'vmware_ostype']
             vanilla_options.reject{ |o| cloud_properties[o].nil? }.each do |key|
               image_properties[key.to_sym] = cloud_properties[key]
             end


### PR DESCRIPTION
This change adds some additional properties that can be defined in the stemcell manifest that are used when using VMware as a hypervisor under OpenStack per the discussion at https://groups.google.com/a/cloudfoundry.org/forum/?fromgroups#!topic/bosh-dev/IOipFP3Z9Rg.

Aaron Huber
Intel Corporation
