### PR TITLE
Remove -u option

### DIFF
--- a/bosh-dev/lib/bosh/dev/stemcell_vm.rb
+++ b/bosh-dev/lib/bosh/dev/stemcell_vm.rb
@@ -6,7 +6,7 @@ module Bosh::Dev
 
     def run(cmd)
       run_cmd = <<-BASH
-        set -eu
+        set -e
 
         pushd bosh-stemcell
         vagrant ssh -c "bash -l -c '#{cmd}'" #{vm_name}
@@ -41,7 +41,7 @@ module Bosh::Dev
 
     def vagrant_destroy_cmd
       <<-BASH
-        set -eu
+        set -e
 
         pushd bosh-stemcell
         vagrant destroy #{vm_name} --force

--- a/bosh-dev/spec/bosh/dev/stemcell_vm_spec.rb
+++ b/bosh-dev/spec/bosh/dev/stemcell_vm_spec.rb
@@ -35,7 +35,7 @@ module Bosh::Dev
             expect(cmd).to eq('bash')
             expect(opt).to eq('-c')
             expect(strip_heredoc(actual_cmd)).to include(strip_heredoc(<<-BASH))
-              set -eu
+              set -e
 
               pushd bosh-stemcell
               vagrant ssh -c "bash -l -c 'echo hello'" #{vm_name}
@@ -52,7 +52,7 @@ module Bosh::Dev
             expect(cmd).to eq('bash')
             expect(opt).to eq('-c')
             expect(strip_heredoc(actual_cmd)).to include(strip_heredoc(<<-BASH))
-              set -eu
+              set -e
 
               pushd bosh-stemcell
               vagrant destroy remote --force


### PR DESCRIPTION
The -u option causes an error when running on gocd
