### PR TITLE
Default NTP configuration.

### DIFF
--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -277,8 +277,10 @@ properties:
     description: Rackspace Cloud Files Region (optional, dfw or ord)
 
   ntp:
-    description: List of ntp server IPs
-    default: []
+    description: List of ntp server IPs. Defaults to North American NTP servers. Edit for your region.
+    default:
+      - 0.north-america.pool.ntp.org
+      - 1.north-america.pool.ntp.org
 
   # Cpi
   external_cpi.enabled:


### PR DESCRIPTION
It is better to have some time syncing than none at all.

We spent many hours debugging the cloudcontroller worker being slow to pick up new jobs. It turned out the worker & the api jobs had skewed by over a minute.

We think it is better for BOSH to have default NTP settings than to have no NTP settings at all.

Created with @teancom
