### PR TITLE
Enable ssl configuration for EC2 endpoints

### DIFF
--- a/bosh-registry/lib/bosh/registry/instance_manager/aws.rb
+++ b/bosh-registry/lib/bosh/registry/instance_manager/aws.rb
@@ -21,6 +21,15 @@ module Bosh::Registry
           :ec2_endpoint => "ec2.#{@aws_properties['region']}.amazonaws.com",
           :logger => @logger
         }
+        # configure optional parameters
+        %w(
+          ssl_verify_peer
+          ssl_ca_file
+          ssl_ca_path
+        ).each do |k|
+          @aws_options[k.to_sym] = @aws_properties[k] unless @aws_properties[k].nil?
+        end
+
         @ec2 = AWS::EC2.new(@aws_options)
       end
 

--- a/bosh-registry/spec/unit/bosh/registry/aws/config_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/aws/config_spec.rb
@@ -54,6 +54,20 @@ describe Bosh::Registry::InstanceManager do
       }.to raise_error(Bosh::Registry::ConfigError, /Invalid AWS configuration parameters/)
     end
 
+    it "passes optional parameters to EC2" do
+      @config["cloud"]["aws"]["ssl_verify_peer"] = false
+      @config["cloud"]["aws"]["ssl_ca_file"] = '/custom/cert/ca-certificates'
+      @config["cloud"]["aws"]["ssl_ca_path"] = '/custom/cert/'
+
+      instance_double('AWS::EC2')
+      expect(AWS::EC2).to receive(:new) do |config|
+        config[:ssl_verify_peer].should be false
+        config[:ssl_ca_file].should eq('/custom/cert/ca-certificates')
+        config[:ssl_ca_path].should eq('/custom/cert/')
+      end
+      Bosh::Registry.configure(@config)
+    end
+
   end
 
 end

--- a/bosh_aws_cpi/lib/cloud/aws/cloud.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/cloud.rb
@@ -527,8 +527,11 @@ module Bosh::AwsCloud
         http_read_timeout
         http_wire_trace
         proxy_uri
+        ssl_verify_peer
+        ssl_ca_file
+        ssl_ca_path
       ).each do |k|
-        aws_params[k.to_sym] = aws_properties[k] if aws_properties[k]
+        aws_params[k.to_sym] = aws_properties[k] unless aws_properties[k].nil?
       end
 
       # AWS Ruby SDK is threadsafe but Ruby autoload isn't,

--- a/bosh_aws_cpi/spec/unit/cloud_spec.rb
+++ b/bosh_aws_cpi/spec/unit/cloud_spec.rb
@@ -66,6 +66,7 @@ describe Bosh::AwsCloud::Cloud do
       it 'default value is used for http properties' do
         expect(AWS.config.http_read_timeout).to eq(60)
         expect(AWS.config.http_wire_trace).to be false
+        expect(AWS.config.ssl_verify_peer).to be true
       end
     end
 
@@ -79,7 +80,10 @@ describe Bosh::AwsCloud::Cloud do
                 'region' => 'fake-region',
                 'default_key_name' => 'sesame',
                 'http_read_timeout' => 300,
-                'http_wire_trace' => true
+                'http_wire_trace' => true,
+                'ssl_verify_peer' => false,
+                'ssl_ca_file' => '/custom/cert/ca-certificates',
+                'ssl_ca_path' => '/custom/cert/'
             },
             'registry' => {
                 'user' => 'abuser',
@@ -97,6 +101,9 @@ describe Bosh::AwsCloud::Cloud do
       it 'passes optional properties to AWS SDK' do
         expect(AWS.config.http_read_timeout).to eq(300)
         expect(AWS.config.http_wire_trace).to be true
+        expect(AWS.config.ssl_verify_peer).to be false
+        expect(AWS.config.ssl_ca_file).to eq('/custom/cert/ca-certificates')
+        expect(AWS.config.ssl_ca_path).to eq('/custom/cert/')
       end
     end
 

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -342,6 +342,12 @@ properties:
   aws.http_wire_trace:
     description: When true aws cpi will log all wire traces
     default: false
+  aws.ssl_ca_file:
+    description: The path to a CA cert bundle in PEM format
+  aws.ssl_ca_path:
+    description: The path the a CA cert directory
+  aws.ssl_verify_peer:
+    description: When true the HTTP handler validate server certificates for HTTPS requests
   aws.stemcell.kernel_id:
     description: AWS kernel id used by aws cpi
   openstack.auth_url:

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -232,6 +232,15 @@ cloud:
       <% if_p('aws.http_wire_trace') do |http_wire_trace| %>
       http_wire_trace: <%= http_wire_trace %>
       <% end %>
+      <% if_p('aws.ssl_ca_file') do |ssl_ca_file| %>
+      ssl_ca_file: <%= ssl_ca_file %>
+      <% end %>
+      <% if_p('aws.ssl_ca_path') do |ssl_ca_path| %>
+      ssl_ca_path: <%= ssl_ca_path %>
+      <% end %>
+      <% if_p('aws.ssl_verify_peer') do |ssl_verify_peer| %>
+      ssl_verify_peer: <%= ssl_verify_peer %>
+      <% end %>
     registry:
       endpoint: http://<%= reg_address %>:<%= reg_port %>
       user: <%= reg_user %>

--- a/release/jobs/registry/spec
+++ b/release/jobs/registry/spec
@@ -57,6 +57,12 @@ properties:
   aws.max_retries:
     description: Max number of retries to connect to AWS
     default: 2
+  aws.ssl_ca_file:
+    description: The path to a CA cert bundle in PEM format
+  aws.ssl_ca_path:
+    description: The path the a CA cert directory
+  aws.ssl_verify_peer:
+    description: When true the HTTP handler validate server certificates for HTTPS requests
 
   # For OpenStack
   openstack.auth_url:

--- a/release/jobs/registry/templates/registry.yml.erb
+++ b/release/jobs/registry/templates/registry.yml.erb
@@ -32,6 +32,15 @@ cloud:
     <% if_p('aws.max_retries') do |max_retries| %>
     max_retries: <%= max_retries %>
     <% end %>
+    <% if_p('aws.ssl_ca_file') do |ssl_ca_file| %>
+    ssl_ca_file: <%= ssl_ca_file %>
+    <% end %>
+    <% if_p('aws.ssl_ca_path') do |ssl_ca_path| %>
+    ssl_ca_path: <%= ssl_ca_path %>
+    <% end %>
+    <% if_p('aws.ssl_verify_peer') do |ssl_verify_peer| %>
+    ssl_verify_peer: <%= ssl_verify_peer %>
+    <% end %>
 <% end %>
 <% if_p('openstack.auth_url', 'openstack.username', 'openstack.api_key', 'openstack.tenant') do |auth_url, username, api_key, tenant| %>
   plugin: openstack <% plugin = 'openstack' %>

--- a/release/spec/director.yml.erb.erb_spec.rb
+++ b/release/spec/director.yml.erb.erb_spec.rb
@@ -227,7 +227,10 @@ describe 'director.yml.erb.erb' do
           'elb_endpoint' => 'some_elb_endpoint',
           'max_retries' => 3,
           'http_read_timeout' => 300,
-          'http_wire_trace' => true
+          'http_wire_trace' => true,
+          'ssl_verify_peer' => false,
+          'ssl_ca_file' => '/custom/cert/ca-certificates',
+          'ssl_ca_path' => '/custom/cert/'
       }
       deployment_manifest_fragment['properties']['registry'] = {
           'address' => 'address',
@@ -256,7 +259,10 @@ describe 'director.yml.erb.erb' do
         'elb_endpoint' => 'some_elb_endpoint',
         'max_retries' => 3,
         'http_read_timeout' => 300,
-        'http_wire_trace' => true
+        'http_wire_trace' => true,
+        'ssl_verify_peer' => false,
+        'ssl_ca_file' => '/custom/cert/ca-certificates',
+        'ssl_ca_path' => '/custom/cert/'
       })
     end
   end

--- a/release/spec/registry.yml.erb_spec.rb
+++ b/release/spec/registry.yml.erb_spec.rb
@@ -43,7 +43,10 @@ describe 'registry.yml.erb' do
         'region' => 'region',
         'ec2_endpoint' => 'some_ec2_endpoint',
         'elb_endpoint' => 'some_elb_endpoint',
-        'max_retries' => 10
+        'max_retries' => 10,
+        'ssl_verify_peer' => false,
+        'ssl_ca_file' => '/custom/cert/ca-certificates',
+        'ssl_ca_path' => '/custom/cert/'
       }
     end
 
@@ -60,7 +63,10 @@ describe 'registry.yml.erb' do
         'region' => 'region',
         'ec2_endpoint' => 'some_ec2_endpoint',
         'elb_endpoint' => 'some_elb_endpoint',
-        'max_retries' => 10
+        'max_retries' => 10,
+        'ssl_verify_peer' => false,
+        'ssl_ca_file' => '/custom/cert/ca-certificates',
+        'ssl_ca_path' => '/custom/cert/'
       })
     end
   end


### PR DESCRIPTION
Allow the following optional parameters to be passed to the AWS SDK from the bosh-director and the bosh-registry:
  ssl_verify_peer
  ssl_ca_file
  ssl_ca_path

This enables the CA certificates configuration for AWS compatible but non-amazon end-points.
