### PR TITLE
Use ec2_endpoint from the manifest in bosh-registry

### DIFF
--- a/bosh-registry/lib/bosh/registry/instance_manager/aws.rb
+++ b/bosh-registry/lib/bosh/registry/instance_manager/aws.rb
@@ -18,7 +18,7 @@ module Bosh::Registry
           :access_key_id => @aws_properties["access_key_id"],
           :secret_access_key => @aws_properties["secret_access_key"],
           :max_retries => @aws_properties["max_retries"] || AWS_MAX_RETRIES,
-          :ec2_endpoint => "ec2.#{@aws_properties['region']}.amazonaws.com",
+          :ec2_endpoint => @aws_properties['ec2_endpoint'] || "ec2.#{@aws_properties['region']}.amazonaws.com",
           :logger => @logger
         }
         @ec2 = AWS::EC2.new(@aws_options)

--- a/bosh-registry/spec/unit/bosh/registry/aws/config_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/aws/config_spec.rb
@@ -54,6 +54,23 @@ describe Bosh::Registry::InstanceManager do
       }.to raise_error(Bosh::Registry::ConfigError, /Invalid AWS configuration parameters/)
     end
 
+    it "uses default ec2_endpoint if none specified" do
+      instance_double('AWS::EC2')
+      expect(AWS::EC2).to receive(:new) do |config|
+        config[:ec2_endpoint].should eq("ec2.#{@config['cloud']['aws']['region']}.amazonaws.com")
+      end
+      Bosh::Registry.configure(@config)
+    end
+
+    it "uses specified ec2_endpoint" do
+      @config["cloud"]["aws"]["ec2_endpoint"] = "ec2endpoint.websites.com"
+      instance_double('AWS::EC2')
+      expect(AWS::EC2).to receive(:new) do |config|
+        config[:ec2_endpoint].should eq("ec2endpoint.websites.com")
+      end
+      Bosh::Registry.configure(@config)
+    end
+
   end
 
 end


### PR DESCRIPTION
The registry currently passes an (almost) hardcoded ec2_endpoint to the aws sdk, although the ec2_endpoint can be configured via the manifest.
This patch takes the configured value instead.
