### PR TITLE
prevent param expansion to exit script if DB not set

### DIFF
--- a/gocd/bosh/tests/integration/job.sh
+++ b/gocd/bosh/tests/integration/job.sh
@@ -23,6 +23,6 @@ chruby $RUBY_VERSION
 
 bundle install --local --without development
 
-echo "DB: ${DB:?'<default>'}"
+echo `echo "DB: ${DB:?'<default>'}"`
 echo "Installing Go & Running integration tests..."
 bundle exec rake --trace go spec:integration


### PR DESCRIPTION
Current code causes script to exit if optional DB env var is not exported. It's because of:

```
${parameter:?word}
    If parameter is null or unset, the expansion of word (or a message to that effect if word 
is not present) is written to the standard error and the shell, if it is not interactive, exits. 
Otherwise, the value of parameter is substituted.
```

Putting an echo around it prevents this.
