### PR TITLE
propagate proxy settings to VM, docker container and test run if set

### DIFF
--- a/bosh-dev/lib/bosh/dev/tasks/spec.rake
+++ b/bosh-dev/lib/bosh/dev/tasks/spec.rake
@@ -37,7 +37,7 @@ namespace :spec do
     def run_in_parallel(test_path, options={})
       count = " -n #{options[:count]}" unless options[:count].to_s.empty?
       group = " --only-group #{options[:group]}" unless options[:group].to_s.empty?
-      command = "bundle exec parallel_test '#{test_path}'#{count}#{group} --group-by filesize --type rspec"
+      command = "https_proxy= http_proxy= bundle exec parallel_test '#{test_path}'#{count}#{group} --group-by filesize --type rspec"
       puts command
       abort unless system(command)
     end

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -7,14 +7,20 @@ This module is a set of scripts to run the BOSH unit and integration tests in li
 
 To run tests locally, follow these steps...
 
-1. (Mac OS only) Bring up the VM
+1. (If running in VM) Bring up the VM
     
     ```
+    # if behind a proxy, set http_proxy, https_proxy and no_proxy first
+    export http_proxy=http://user:pwd@myproxy.example.com:8080
+    export https_proxy=http://user:pwd@myproxy.example.com:8080
+    export no_proxy=localhost
     cd gocd/docker
     vagrant up --provider virtualbox
+    # if behind a proxy, reload to propagate settings to docker in VM
+    vagrant reload
     ```
 
-2. (Mac OS only) SSH into the VM
+2. (If running in VM) SSH into the VM
     
     ```
     vagrant ssh
@@ -52,7 +58,7 @@ To run tests locally, follow these steps...
     gocd/bosh/run-in-container.sh /opt/bosh/gocd/bosh/tests/integration/job.sh
     ```
 
-6. (Mac OS only) Destroy the VM
+6. (If running in VM) Destroy the VM
     
     ```
     vagrant destroy bosh-docker-builder --force

--- a/gocd/bosh/run-in-container.sh
+++ b/gocd/bosh/run-in-container.sh
@@ -22,6 +22,9 @@ docker run \
   -e DB \
   -e CODECLIMATE_REPO_TOKEN \
   -e COVERAGE \
+  -e http_proxy=$http_proxy \
+  -e https_proxy=$https_proxy \
+  -e no_proxy=$no_proxy \
   $DOCKER_IMAGE \
   $@ \
   &

--- a/gocd/docker/Vagrantfile
+++ b/gocd/docker/Vagrantfile
@@ -13,5 +13,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # mount bosh dir for testing
   config.vm.synced_folder('../../', '/opt/bosh', owner: 'root', group: 'root')
 
+  if Vagrant.has_plugin?("vagrant-proxyconf")
+    if ENV["http_proxy"]
+      config.proxy.http        = ENV["http_proxy"]
+      config.apt_proxy.http    = ENV["http_proxy"]
+    end
+    if ENV["https_proxy"]
+      config.proxy.https        = ENV["https_proxy"]
+      config.apt_proxy.https    = ENV["https_proxy"]
+    end
+    if ENV["no_proxy"]
+      config.proxy.no_proxy     = ENV["no_proxy"]
+    end
+  end
+
   config.vm.provision('docker')
 end


### PR DESCRIPTION
- By setting http_proxy in the host, vagrant can download the box but fails to download & install docker. Hence the change to Vagrantfile.
- See here why the vagrant reload is required: https://github.com/tmatilai/vagrant-proxyconf/issues/97.
- Finally, proxy settings need to be propagated into the VM for `curl https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz` to succeed. no_proxy is required for tests to connect to bosh on localhost.
