### PR TITLE
clean bundler env before calling out to bosh-registry

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/deployer/registry.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/registry.rb
@@ -30,7 +30,9 @@ module Bosh::Deployer
 
       cmd = "bosh-registry -c #{@registry_config.path}"
 
-      @registry_pid = Process.spawn(cmd)
+      Bundler.with_clean_env {
+        @registry_pid = Process.spawn(cmd)
+      }
 
       watch_for_crash(cmd)
       wait_for_listen


### PR DESCRIPTION
This was discovered to be necessary when using non-standard ruby/bundler locations and invoking `bosh micro deploy`.
