### PR TITLE
Allow openstack configurations that have a single storage AZ but multiple compute AZ's

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,7 @@ bundle exec rake spec:system:micro[openstack,kvm,ubuntu,trusty,manual,go]
 * `BOSH_OPENSTACK_REGISTRY_PORT` - (Optional) Local port on which to serve the microBOSH registry service
 * `BOSH_OPENSTACK_CONNECTION_TIMEOUT` - (Optional) HTTP connection timeout (in seconds) for talking to the OpenStack API
 * `BOSH_OPENSTACK_STATE_TIMEOUT` - (Optional) Timeout (in seconds) to wait for OpenStack resources to reach the desired state
+* `BOSH_OPENSTACK_IGNORE_SERVER_AZ` - (Optional) Ignore the servers availability zone when creating disks. Commonly used with storage systems like Ceph.
 * `BOSH_OPENSTACK_BAT_DEPLOYMENT_SPEC` Path to the BAT deployment spec YAML (input to the BATs deployment manifest erb template)
     * See [the `bat` README](bat/README.md#bat_deployment_spec) for BAT deployment spec examples.
       The director uuid and stemcell properties will be auto-populated by the rake task.

--- a/bosh_openstack_cpi/USAGE.md
+++ b/bosh_openstack_cpi/USAGE.md
@@ -34,6 +34,8 @@ The registry options are passed to the Openstack CPI by the BOSH director based 
   default OpenStack ssh key name to assign to created virtual machines
 * `default_security_group` (required)
   default OpenStack security group to assign to created virtual machines
+* `ignore_server_availability_zone` (optional)
+  When creating a disk, do not use the availability zone of the server, fall back to Openstacks default. Commonly used if Ceph is used for block storage. Defaults to false.
 
 ### Registry options
 

--- a/bosh_openstack_cpi/spec/integration/lifecycle_spec.rb
+++ b/bosh_openstack_cpi/spec/integration/lifecycle_spec.rb
@@ -16,6 +16,7 @@ describe Bosh::OpenStackCloud::Cloud do
     @disable_snapshots = get_config(:disable_snapshots, 'BOSH_OPENSTACK_DISABLE_SNAPSHOTS', false)
     @default_key_name  = get_config(:default_key_name, 'BOSH_OPENSTACK_DEFAULT_KEY_NAME', 'jenkins')
     @config_drive      = get_config(:config_drive, 'BOSH_OPENSTACK_CONFIG_DRIVE', 'cdrom')
+    @ignore_server_az  = get_config(:ignore_server_az, 'BOSH_OPENSTACK_IGNORE_SERVER_AZ', 'false')
 
     # some environments may not have this set, and it isn't strictly necessary so don't raise if it isn't set
     @region             = get_config(:region, 'BOSH_OPENSTACK_REGION', nil)
@@ -42,6 +43,7 @@ describe Bosh::OpenStackCloud::Cloud do
           'type' => boot_volume_type
         },
         'config_drive' => config_drive,
+        'ignore_server_availability_zone' => ignore_server_az,
       },
       'registry' => {
         'endpoint' => 'fake',

--- a/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
@@ -503,6 +503,17 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
       cloud.select_availability_zone(nil, "foobar-1a").should == "foobar-1a"
     end
 
+    it "should select the resource pool availability_zone when we are ignoring the disks zone" do
+      cloud_options = mock_cloud_options
+      cloud_options['properties']['openstack']['boot_from_volume'] = true
+      cloud_options['properties']['openstack']['ignore_server_availability_zone'] = true
+
+      cloud = mock_cloud(cloud_options["properties"]) do |openstack|
+        openstack.volumes.stub(:get).and_return(volume("foo"), volume("foo"))
+      end
+      cloud.select_availability_zone(%w[cid1 cid2], "foobar-1a").should == "foobar-1a"
+    end
+
     it "should select the zone from a list of disks" do
       cloud = mock_cloud do |openstack|
         openstack.volumes.stub(:get).and_return(volume("foo"), volume("foo"))

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -387,6 +387,9 @@ properties:
     default: 5
   openstack.config_drive:
     description: Config drive device (cdrom or disk) to use as metadata service on OpenStack (optional, nil by default)
+  openstack.ignore_server_availability_zone:
+    description: When creating disks do not use the servers AZ, default to openstack default
+    default: false
   vcenter.address:
     description: Address of vCenter server used by vsphere cpi
   vcenter.user:

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -290,6 +290,9 @@ cloud:
         type: <%= boot_volume_type %>
         <% end %>
       <% end %>
+      <% if_p("openstack.ignore_server_availability_zone") do |ignore_server_availability_zone| %>
+      ignore_server_availability_zone: <%= ignore_server_availability_zone %>
+      <% end %>
       default_key_name: <%= default_key_name %>
       default_security_groups: <%= default_security_groups %>
       wait_resource_poll_interval: <%= wait_resource_poll_interval %>


### PR DESCRIPTION
We are utilizing Ceph for our openstack storage and this is being presented as a single AZ from cinder, but we will have multiple AZ's for compute.

As of v1.2776 a bug was fixed that was actually permitting this behaviour, the bug did not pass the servers AZ to the compute api when creating disks. I agree that this should have been fixed, this PR is to explicitly allow storage and compute AZ's not to match by ignoring the AZ of the server and allowing openstack to fall back to the default zone for cinder.

In the public cloud world having this mismatch makes no sense (AZ == datacenter usually and we do not want vm's using storage in a different DC). With openstack in a private datacenter, the types of configuration will vary more, and systems like Ceph manage the availability of volumes on our behalf rather than relying on openstack az's being presented.