### PR TITLE
Update default mysql engine to 5.5.40a for AWS RDS

### DIFF
--- a/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/rds.rb
+++ b/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/rds.rb
@@ -8,7 +8,7 @@ module Bosh
           :db_instance_class => "db.m1.small",
           :engine => "mysql",
           :multi_az => true,
-          :engine_version => "5.5.31"
+          :engine_version => "5.5.40a"
       }
       DEFAULT_RDS_PROTOCOL = :tcp
       DEFAULT_MYSQL_PORT = 3306


### PR DESCRIPTION
The old MySQL engine version (5.5.31) seems to no longer be available as an
option for RDS.  Updated default version to 5.5.40a which is the only 5.5
version that is currently supported in RDS.