### PR TITLE
Update default mysql engine to 5.5.40a for AWS RDS

### DIFF
--- a/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/rds.rb
+++ b/bosh_cli_plugin_aws/lib/bosh_cli_plugin_aws/rds.rb
@@ -8,7 +8,7 @@ module Bosh
           :db_instance_class => "db.m1.small",
           :engine => "mysql",
           :multi_az => true,
-          :engine_version => "5.5.31"
+          :engine_version => "5.5.40a"
       }
       DEFAULT_RDS_PROTOCOL = :tcp
       DEFAULT_MYSQL_PORT = 3306

--- a/bosh_cli_plugin_aws/spec/unit/rds_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/rds_spec.rb
@@ -155,7 +155,7 @@ describe Bosh::Aws::RDS do
         options[:allocated_storage].should == 5
         options[:db_instance_class].should == "db.m1.small"
         options[:engine].should == "mysql"
-        options[:engine_version].should == "5.5.31"
+        options[:engine_version].should == "5.5.40a"
         options[:db_parameter_group_name].should == "utf8"
         options[:master_username].should be_kind_of(String)
         options[:master_username].length.should be >= 8
@@ -183,7 +183,7 @@ describe Bosh::Aws::RDS do
         options[:allocated_storage].should == 16
         options[:db_instance_class].should == "db.m1.small"
         options[:engine].should == "mysql"
-        options[:engine_version].should == "5.5.31"
+        options[:engine_version].should == "5.5.40a"
         options[:master_username].should be_kind_of(String)
         options[:master_username].length.should be >= 8
         options[:master_user_password].should == "swordfish"


### PR DESCRIPTION
The old MySQL engine version (5.5.31) seems to no longer be available as an
option for RDS.  Updated default version to 5.5.40a.