### PR TITLE
Copy out the stemcell packages list and add it to stemcell tgz

### DIFF
--- a/bosh-dev/lib/bosh/dev/tasks/stemcell.rake
+++ b/bosh-dev/lib/bosh/dev/tasks/stemcell.rake
@@ -124,6 +124,9 @@ namespace :stemcell do
 
     sh(environment.stemcell_rspec_command)
 
+    stemcell_tgz_workdir = Dir.mktmpdir('stemcell_tgz')
+    sh(environment.stemcell_tgz_rspec_command(stemcell_tgz_workdir))
+
     mkdir_p('tmp')
     cp(environment.stemcell_file, 'tmp')
   end

--- a/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/build_environment.rb
@@ -51,6 +51,16 @@ module Bosh::Stemcell
       ].join(' ')
     end
 
+    def stemcell_tgz_rspec_command(workdir)
+      [
+        "cd #{STEMCELL_SPECS_DIR};",
+        "STEMCELL_TGZ=#{stemcell_file}",
+        "STEMCELL_TGZ_WORKDIR=#{workdir}",
+        'bundle exec rspec -fd',
+        "spec/stemcell_tgz/#{operating_system_spec_name}_spec.rb",
+      ].join(' ')
+    end
+
     def build_path
       File.join(build_root, 'build')
     end

--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -48,7 +48,15 @@ module Bosh::Stemcell
         warden_stages
       end
     end
-
+    
+    def aws_stages
+      if operating_system.instance_of?(OperatingSystem::Centos)
+        centos_aws_stages
+      else
+        default_aws_stages
+      end
+    end
+    
     def openstack_stages
       if operating_system.instance_of?(OperatingSystem::Centos)
         centos_openstack_stages
@@ -102,7 +110,6 @@ module Bosh::Stemcell
         :base_ubuntu_build_essential,
         :base_ubuntu_packages,
         :base_ssh,
-        :bosh_dpkg_list,
         :bosh_sysstat,
         :bosh_sysctl,
         :system_kernel,
@@ -171,7 +178,7 @@ module Bosh::Stemcell
       ]
     end
 
-    def aws_stages
+    def centos_aws_stages
       [
         # Misc
         :system_aws_network,
@@ -186,6 +193,28 @@ module Bosh::Stemcell
         :image_install_grub,
         :image_aws_update_grub,
         :image_aws_prepare_stemcell,
+        # Final stemcell
+        :stemcell,
+      ]
+    end
+
+    def default_aws_stages
+      [
+        # Misc
+        :system_aws_network,
+        :system_aws_modules,
+        :system_parameters,
+        # Finalisation
+        :bosh_clean,
+        :bosh_harden,
+        :bosh_harden_ssh,
+        # Image/bootloader
+        :image_create,
+        :image_install_grub,
+        :image_aws_update_grub,
+        :image_aws_prepare_stemcell,
+        # Package list
+        :bosh_dpkg_list,
         # Final stemcell
         :stemcell,
       ]
@@ -208,6 +237,8 @@ module Bosh::Stemcell
         :image_install_grub,
         :image_openstack_qcow2,
         :image_openstack_prepare_stemcell,
+        # Package list
+        :bosh_dpkg_list,
         # Final stemcell
         :stemcell_openstack,
       ]
@@ -228,6 +259,8 @@ module Bosh::Stemcell
         :image_ovf_vmx,
         :image_ovf_generate,
         :image_ovf_prepare_stemcell,
+        # Package list
+        :bosh_dpkg_list,
         # Final stemcell
         :stemcell,
       ]
@@ -248,6 +281,8 @@ module Bosh::Stemcell
         :image_ovf_vmx,
         :image_ovf_generate,
         :image_ovf_prepare_stemcell,
+        # Package list
+        :bosh_dpkg_list,
         # Final stemcell
         :stemcell
       ]

--- a/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/build_environment_spec.rb
@@ -215,6 +215,40 @@ module Bosh::Stemcell
       end
     end
 
+    describe '#stemcell_tgz_rspec_command' do
+      context 'when operation system has version' do
+        before { allow(operating_system).to receive(:version).and_return('fake-version') }
+
+        it 'returns the correct command' do
+          expected_rspec_command = [
+            "cd #{stemcell_specs_dir};",
+            "STEMCELL_TGZ=#{File.join(work_path, 'fake-stemcell.tgz')}",
+            'STEMCELL_TGZ_WORKDIR=/tmp/fakeworkdir',
+            'bundle exec rspec -fd',
+            "spec/stemcell_tgz/#{operating_system.name}_#{operating_system.version}_spec.rb",
+          ].join(' ')
+
+          expect(subject.stemcell_tgz_rspec_command('/tmp/fakeworkdir')).to eq(expected_rspec_command)
+        end
+      end
+
+      context 'when operation system does not have version' do
+        before { allow(operating_system).to receive(:version).and_return(nil) }
+
+        it 'returns the correct command' do
+          expected_rspec_command = [
+            "cd #{stemcell_specs_dir};",
+            "STEMCELL_TGZ=#{File.join(work_path, 'fake-stemcell.tgz')}",
+            'STEMCELL_TGZ_WORKDIR=/tmp/fakeworkdir',
+            'bundle exec rspec -fd',
+            "spec/stemcell_tgz/#{operating_system.name}_spec.rb",
+          ].join(' ')
+
+          expect(subject.stemcell_tgz_rspec_command('/tmp/fakeworkdir')).to eq(expected_rspec_command)
+        end
+      end
+    end
+
     describe '#build_path' do
       it 'returns the build path' do
         expect(subject.build_path).to eq(build_path)

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -29,7 +29,6 @@ module Bosh::Stemcell
               :base_ubuntu_build_essential,
               :base_ubuntu_packages,
               :base_ssh,
-              :bosh_dpkg_list,
               :bosh_sysstat,
               :bosh_sysctl,
               :system_kernel,
@@ -89,36 +88,49 @@ module Bosh::Stemcell
     describe '#infrastructure_stages' do
       context 'when using AWS' do
         let(:infrastructure) { Infrastructure.for('aws') }
-
-        let(:aws_infrastructure_stages) {
-          [
-            :system_aws_network,
-            :system_aws_modules,
-            :system_parameters,
-            :bosh_clean,
-            :bosh_harden,
-            :bosh_harden_ssh,
-            :image_create,
-            :image_install_grub,
-            :image_aws_update_grub,
-            :image_aws_prepare_stemcell,
-            :stemcell
-          ]
-        }
-
+ 
         context 'when the operating system is CentOS' do
           let(:operating_system) { OperatingSystem.for('centos') }
 
-          it 'returns the correct stages' do
-            expect(stage_collection.infrastructure_stages).to eq(aws_infrastructure_stages)
+          it 'has the correct stages' do
+            expect(stage_collection.infrastructure_stages).to eq(
+              [
+                :system_aws_network,
+                :system_aws_modules,
+                :system_parameters,
+                :bosh_clean,
+                :bosh_harden,
+                :bosh_harden_ssh,
+                :image_create,
+                :image_install_grub,
+                :image_aws_update_grub,
+                :image_aws_prepare_stemcell,
+                :stemcell
+              ]
+            )
           end
         end
 
         context 'when the operating system is Ubuntu' do
           let(:operating_system) { OperatingSystem.for('ubuntu') }
 
-          it 'returns the correct stages' do
-            expect(stage_collection.infrastructure_stages).to eq(aws_infrastructure_stages)
+          it 'has the correct stages' do
+            expect(stage_collection.infrastructure_stages).to eq(
+              [
+                :system_aws_network,
+                :system_aws_modules,
+                :system_parameters,
+                :bosh_clean,
+                :bosh_harden,
+                :bosh_harden_ssh,
+                :image_create,
+                :image_install_grub,
+                :image_aws_update_grub,
+                :image_aws_prepare_stemcell,
+                :bosh_dpkg_list,
+                :stemcell
+              ]
+            )
           end
 
         end
@@ -167,6 +179,7 @@ module Bosh::Stemcell
                 :image_install_grub,
                 :image_openstack_qcow2,
                 :image_openstack_prepare_stemcell,
+                :bosh_dpkg_list,
                 :stemcell_openstack
               ]
             )
@@ -215,6 +228,7 @@ module Bosh::Stemcell
                 :image_ovf_vmx,
                 :image_ovf_generate,
                 :image_ovf_prepare_stemcell,
+                :bosh_dpkg_list,
                 :stemcell
               ]
             )
@@ -241,6 +255,7 @@ module Bosh::Stemcell
                 :image_ovf_vmx,
                 :image_ovf_generate,
                 :image_ovf_prepare_stemcell,
+                :bosh_dpkg_list,
                 :stemcell
               ]
             )

--- a/bosh-stemcell/spec/stemcell_tgz/centos_spec.rb
+++ b/bosh-stemcell/spec/stemcell_tgz/centos_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'CentOS stemcell.tgz', stemcell_tgz: true do
+  
+end

--- a/bosh-stemcell/spec/stemcell_tgz/ubuntu_lucid_spec.rb
+++ b/bosh-stemcell/spec/stemcell_tgz/ubuntu_lucid_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'Ubuntu Lucid stemcell.tgz', stemcell_tgz: true do
+  
+  context 'installed by bosh_dpkg_list stage' do
+    describe file("#{ENV['STEMCELL_TGZ_WORKDIR']}/stemcell_dpkg_l.txt") do
+      it { should be_file }
+      it { should contain 'Status=Not/Inst/Cfg-files/Unpacked/Failed-cfg/Half-inst/trig-aWait/Trig-pend' }
+      it { should contain 'ubuntu-minimal' }
+    end
+  end
+  
+end

--- a/bosh-stemcell/spec/stemcell_tgz/ubuntu_trusty_spec.rb
+++ b/bosh-stemcell/spec/stemcell_tgz/ubuntu_trusty_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'Ubuntu 14.04 stemcell.tgz', stemcell_tgz: true do
+  
+  context 'installed by bosh_dpkg_list stage' do
+    describe file("#{ENV['STEMCELL_TGZ_WORKDIR']}/stemcell_dpkg_l.txt") do
+      it { should be_file }
+      it { should contain 'Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend' }
+      it { should contain 'ubuntu-minimal' }
+    end
+  end
+  
+end

--- a/bosh-stemcell/spec/support/stemcell_tgz.rb
+++ b/bosh-stemcell/spec/support/stemcell_tgz.rb
@@ -1,0 +1,18 @@
+require 'rspec/core/formatters/console_codes'
+
+RSpec.configure do |config|
+  if ENV['STEMCELL_TGZ'] && ENV['STEMCELL_TGZ_WORKDIR']
+    config.before(:all) do
+      Bosh::Core::Shell.new.run("sudo tar xf #{ENV['STEMCELL_TGZ']} -C #{ENV['STEMCELL_TGZ_WORKDIR']}")
+    end
+
+    config.after(:all) do
+      FileUtils.rm_rf(ENV['STEMCELL_TGZ_WORKDIR']) if ENV['STEMCELL_TGZ'] && ENV['STEMCELL_TGZ_WORKDIR']
+    end
+  else
+    warning = 'All STEMCELL_TGZ tests are being skipped.'\
+              ' ENV["STEMCELL_TGZ"] and ENV["STEMCELL_TGZ_WORKDIR"] must be set to test stemcell tgz file'
+    puts RSpec::Core::Formatters::ConsoleCodes.wrap(warning, :yellow)
+    config.filter_run_excluding stemcell_tgz: true
+  end
+end


### PR DESCRIPTION
This PR corresponds to following ticket and add corresponding tests:
- BOSH should copy out the stemcell packages list and add it to the repo
  (https://www.pivotaltracker.com/n/projects/956238/stories/83337650)

Changes:
- Moved 'bosh_dpkg_list' stage (which creates packages list file from 
  Ubuntu env) to later stage, so that the file (dpkg_list.txt) can be copied into stemcell tgz file.
- Added unit tests which check created stemcell's tgz files.
- Modified unit tests for modified classes (stage_collection.rb, build_environment.rb)
	
Note:
- Initially I thought the rspec execution (called in stemcell.rake) should be like below:
  `STEMCELL_TGZ=<tgz-file> bundle exec rspec -fd <specfile>_spec.rb`
and temporary directory should be created and deleted in the global hook (config.before(:all) and config.after(:all) in 'bosh-stemcell/spec/support/stemcell_tgz.rb').
However, I didn't find the best way to pass the variable (the path of the temporarydirectory created in global hook) from global hook to each spec file.
Therefore in this implementation, the path is created in stemcell.rake file and pass the path to global hook/spec files by using environment variable (STEMCELL_TGZ_WORKDIR).
So the rspec execution (called in stemcell.rake) is like below:
  `STEMCELL_TGZ=<tgz-file> STEMCELL_TGZ_WORKDIR=<tmpdir>  bundle exec rspec -fd <specfile>_spec.rb`
Any comment to improve this is appreciated.
- The 'bosh_dpkg_list' stage works for Ubuntu only. Corresponding stage for CentOS has not been added.
