### PR TITLE
Help please from aws_cpi/openstack_cpi binaries

### DIFF
--- a/bosh_aws_cpi/bin/aws_cpi
+++ b/bosh_aws_cpi/bin/aws_cpi
@@ -5,7 +5,13 @@ require 'bosh_aws_cpi'
 require 'bosh/cpi'
 require 'bosh/cpi/cli'
 
-cpi_config = YAML.load_file(ARGV.shift)
+manifest_path = ARGV.shift
+unless manifest_path && File.exists?(manifest_path)
+  $stderr.puts "USAGE: aws_cpi manifest.yml"
+  exit 1
+end
+
+cpi_config = YAML.load_file(manifest_path)
 
 cloud_config = OpenStruct.new(:logger => Logger.new(STDERR))
 

--- a/bosh_openstack_cpi/bin/openstack_cpi
+++ b/bosh_openstack_cpi/bin/openstack_cpi
@@ -5,7 +5,13 @@ require 'bosh_openstack_cpi'
 require 'bosh/cpi'
 require 'bosh/cpi/cli'
 
-cpi_config = YAML.load_file(ARGV.shift)
+manifest_path = ARGV.shift
+unless manifest_path && File.exists?(manifest_path)
+  $stderr.puts "USAGE: openstack_cpi manifest.yml"
+  exit 1
+end
+
+cpi_config = YAML.load_file(manifest_path)
 
 cloud_config = OpenStruct.new(:logger => Logger.new(STDERR))
 


### PR DESCRIPTION
The future of CPIs is for them to be executable binaries. But they don't seem like humans are supposed to use them. Could they please return user help/guidance?

```
$ aws_cpi 
/Users/drnic/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/psych.rb:464:in `initialize': no implicit conversion of nil into String (TypeError)
	from /Users/drnic/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/psych.rb:464:in `open'
	from /Users/drnic/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/psych.rb:464:in `load_file'
	from /Users/drnic/Projects/cloudfoundry/bosh/bosh_aws_cpi/bin/aws_cpi:8:in `<top (required)>'
	from /Users/drnic/.rvm/gems/ruby-2.1.5/bin/aws_cpi:23:in `load'
	from /Users/drnic/.rvm/gems/ruby-2.1.5/bin/aws_cpi:23:in `<main>'
	from /Users/drnic/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `eval'
	from /Users/drnic/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `<main>'

$ openstack_cpi 
/Users/drnic/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/psych.rb:464:in `initialize': no implicit conversion of nil into String (TypeError)
	from /Users/drnic/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/psych.rb:464:in `open'
	from /Users/drnic/.rvm/rubies/ruby-2.1.5/lib/ruby/2.1.0/psych.rb:464:in `load_file'
	from /Users/drnic/Projects/cloudfoundry/bosh/bosh_openstack_cpi/bin/openstack_cpi:8:in `<top (required)>'
	from /Users/drnic/.rvm/gems/ruby-2.1.5/bin/openstack_cpi:23:in `load'
	from /Users/drnic/.rvm/gems/ruby-2.1.5/bin/openstack_cpi:23:in `<main>'
	from /Users/drnic/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `eval'
	from /Users/drnic/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `<main>'
```
