### PR TITLE
Retry AWS API throttling

### DIFF
--- a/bosh_aws_cpi/lib/cloud/aws/instance.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/instance.rb
@@ -92,7 +92,10 @@ module Bosh::AwsCloud
     def remove_from_load_balancers
       @elb.load_balancers.each do |load_balancer|
         begin
-          load_balancer.instances.deregister(@aws_instance)
+          Bosh::Common.retryable(on: [AWS::ELB::Errors::Throttling], tries: 20) do
+            load_balancer.instances.deregister(@aws_instance)
+            true
+          end
         rescue AWS::ELB::Errors::InvalidInstance
           # ignore this, as it just means it wasn't registered
         end

--- a/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -79,8 +79,8 @@ module Bosh::AwsCloud
         # address is in use - it can happen when the director recreates a VM and AWS
         # is too slow to update its state when we have released the IP address and want to
         # realocate it again.
-        errors = [AWS::EC2::Errors::InvalidIPAddress::InUse]
-        Bosh::Common.retryable(sleep: instance_create_wait_time, tries: 10, on: errors) do |tries, error|
+        errors = [AWS::EC2::Errors::InvalidIPAddress::InUse, AWS::EC2::Errors::RequestLimitExceeded]
+        Bosh::Common.retryable(sleep: instance_create_wait_time, tries: 20, on: errors) do |tries, error|
           @logger.info("Launching on demand instance...")
           @logger.warn("IP address was in use: #{error}") if tries > 0
           @region.instances.create(instance_params)

--- a/bosh_aws_cpi/spec/unit/instance_spec.rb
+++ b/bosh_aws_cpi/spec/unit/instance_spec.rb
@@ -142,5 +142,15 @@ describe Bosh::AwsCloud::Instance do
         instance.remove_from_load_balancers
       }.to_not raise_error
     end
+
+    it 'retries if the deregistration is rate limited' do
+      expect(lb1_instances).to receive(:deregister).and_raise(AWS::ELB::Errors::Throttling)
+      expect(lb1_instances).to receive(:deregister).and_return(nil)
+      allow(lb2_instances).to receive(:deregister)
+
+      expect {
+        instance.remove_from_load_balancers
+      }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
When AWS throttles your requests, retry them until they work. We addressed VM creation and ELB deregistration since those are the cases we've had issues with.