### PR TITLE
Add VPC support

### DIFF
--- a/bosh-stemcell/README.md
+++ b/bosh-stemcell/README.md
@@ -19,10 +19,23 @@ Tools for creating stemcells
 
 From a fresh copy of the bosh repo:
 
+If you use AWS EC2-Classic environment, run:
+
     export BOSH_AWS_ACCESS_KEY_ID=YOUR-AWS-ACCESS-KEY
     export BOSH_AWS_SECRET_ACCESS_KEY=YOUR-AWS-SECRET-KEY
     cd bosh-stemcell
     vagrant up remote --provider=aws
+
+If you use AWS VPC environment, run:
+
+    export BOSH_AWS_ACCESS_KEY_ID=YOUR-AWS-ACCESS-KEY
+    export BOSH_AWS_SECRET_ACCESS_KEY=YOUR-AWS-SECRET-KEY
+    export BOSH_AWS_SECURITY_GROUP=YOUR-AWS-SECURITY-GROUP-ID
+    export BOSH_AWS_SUBNET_ID=YOUR-AWS-SUBNET-ID
+    cd bosh-stemcell
+    vagrant up remote --provider=aws
+
+(Note: BOSH\_AWS\_SECURITY\_GROUP should be security group id, instead of name "bosh-stemcell")
 
 ## Updating source code on stemcell building VM
 

--- a/bosh-stemcell/Vagrantfile
+++ b/bosh-stemcell/Vagrantfile
@@ -30,7 +30,13 @@ Vagrant.configure('2') do |config|
       aws.access_key_id = env.fetch('BOSH_AWS_ACCESS_KEY_ID')
       aws.secret_access_key = env.fetch('BOSH_AWS_SECRET_ACCESS_KEY')
       aws.keypair_name = 'bosh'
-      aws.security_groups = ['bosh-stemcell']
+      if env['BOSH_AWS_SUBNET_ID']
+        aws.associate_public_ip = true
+        aws.subnet_id = env.fetch('BOSH_AWS_SUBNET_ID')
+        aws.security_groups = [env.fetch('BOSH_AWS_SECURITY_GROUP')]
+      else
+        aws.security_groups = ['bosh-stemcell']
+      end
       aws.tags = { 'Name' => vm_box }
 
       override.ssh.username = 'ubuntu'


### PR DESCRIPTION
Current Vagrantfile for stemcell building VM is written for EC2-Classic environment.
However, those who created AWS account after March 2013 can't use EC2-Classic environment (they can use EC2-VPC environment only).
This PR is to add EC2-VPC support to Vagrantfile for stemcell building VM.