### PR TITLE
validate_db_connection

### DIFF
--- a/bosh-director/lib/bosh/director/config.rb
+++ b/bosh-director/lib/bosh/director/config.rb
@@ -175,6 +175,8 @@ module Bosh::Director
         db_config = db_config.merge(connection_options)
 
         db = Sequel.connect(db_config)
+	 db.extention :connection_validator
+	 db.pool.connection_validation_timeout = connection_options['connection_validation_timeout']
         if logger
           db.logger = logger
           db.sql_log_level = :debug

--- a/bosh-director/lib/bosh/director/config.rb
+++ b/bosh-director/lib/bosh/director/config.rb
@@ -175,8 +175,8 @@ module Bosh::Director
         db_config = db_config.merge(connection_options)
 
         db = Sequel.connect(db_config)
-	 db.extention :connection_validator
-	 db.pool.connection_validation_timeout = connection_options['connection_validation_timeout']
+        db.extension :connection_validator
+        db.pool.connection_validation_timeout = connection_options['connection_validation_timeout']
         if logger
           db.logger = logger
           db.sql_log_level = :debug

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -135,6 +135,7 @@ properties:
     default:
       max_connections: 32
       pool_timeout: 10
+      connection_validation_timeout: 3600
 
   # DNS
   dns.address:
@@ -163,6 +164,7 @@ properties:
     default:
       max_connections: 32
       pool_timeout: 10
+      connection_validation_timeout: 3600
 
   # Blobstore
   blobstore.provider:


### PR DESCRIPTION
Abstract : To validate the db connection because once the director-worker is spawned by the monit , if there is a connection break on postgres DB side then this thread gives a Error i.e not able to connect PG error and no worker Job is processed (create release , delete release).

Solution: Using connection validator extension from sequel , if there is a persistent connection then all things are fine but if connection breaks this extension will validate the connection and worker will process the job.

By default the timeout is 3600 ( 1 hour ) but can reduce in cases where either firewall or other network issues we are loosing connections to database.

Below is error trace:

 INFO  DirectorWorker : got: (Job{normal} | Bosh::Director::Jobs::DeleteRelease | [10, "pgpool", {"version"=>nil}])
 INFO  DirectorWorker : Running before_fork hooks with [(Job{normal} | Bosh::Director::Jobs::DeleteRelease | [10, "pgpool", {"version"=>nil}])]
 INFO  DirectorWorker : Running after_fork hooks with [(Job{normal} | Bosh::Director::Jobs::DeleteRelease | [10, "pgpool", {"version"=>nil}])]
 INFO  DirectorWorker : (Job{normal} | Bosh::Director::Jobs::DeleteRelease | [10, "pgpool", {"version"=>nil}]) failed: #<Sequel::DatabaseDisconnectError: PG::Error: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
>
 INFO  DirectorWorker : /var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:145:in `exec'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:145:in `block in execute_query'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/database/logging.rb:37:in `log_yield'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:145:in `execute_query'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:132:in `block in execute'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:111:in `check_disconnect_errors'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:132:in `execute'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:413:in `_execute'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:242:in `block (2 levels) in execute'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:425:in `check_database_errors'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:242:in `block in execute'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/database/connecting.rb:236:in `block in synchronize'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/connection_pool/threaded.rb:104:in `hold'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/database/connecting.rb:236:in `synchronize'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:242:in `execute'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/dataset/actions.rb:801:in `execute'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/adapters/postgres.rb:525:in `fetch_rows'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/model/base.rb:798:in `primary_key_lookup'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/sequel-3.43.0/lib/sequel/model/base.rb:117:in `[]'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/bosh-director-1.2780.0/lib/bosh/director/api/task_manager.rb:11:in `find_task'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/bosh-director-1.2780.0/lib/bosh/director/job_runner.rb:21:in `initialize'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/bosh-director-1.2780.0/lib/bosh/director/jobs/base_job.rb:10:in `new'
/var/vcap/packages/director/gem_home/ruby/2.1.0/gems/bosh-director-1.2780.0/lib/bosh/director/jobs/base_job.rb:10:in `perform'