### PR TITLE
Check for user and password also in DAV blobstores

### DIFF
--- a/bosh_cli/lib/cli/release.rb
+++ b/bosh_cli/lib/cli/release.rb
@@ -73,6 +73,7 @@ module Bosh::Cli
       has_legacy_secret? ||
         has_blobstore_secrets?(bs, "atmos", "secret") ||
         has_blobstore_secrets?(bs, "simple", "user", "password") ||
+        has_blobstore_secrets?(bs, "dav", "user", "password") ||
         has_blobstore_secrets?(bs, "swift", "rackspace") ||
         has_blobstore_secrets?(bs, "swift", "hp") ||
         has_blobstore_secrets?(bs, "swift", "openstack") ||


### PR DESCRIPTION
According to the list in https://github.com/cloudfoundry/bosh/blob/f91fce17854855fb242e8cc24f1d777703f24260/blobstore_client/lib/blobstore_client/client.rb#L4 DAV is a valid option for a blobstore client