### PR TITLE
Remove rspec deprecation warnings

### DIFF
--- a/bosh-dev/spec/bosh/dev/artifacts_downloader_spec.rb
+++ b/bosh-dev/spec/bosh/dev/artifacts_downloader_spec.rb
@@ -14,8 +14,8 @@ module Bosh::Dev
         expected_remote_uri = URI('http://bosh-ci-pipeline.s3.amazonaws.com/fake-build-number/release/bosh-fake-build-number.tgz')
         expected_local_path = 'fake-output-dir/bosh-fake-build-number.tgz'
 
-        download_adapter
-          .should_receive(:download)
+        expect(download_adapter)
+          .to receive(:download)
           .with(expected_remote_uri, expected_local_path)
           .and_return('returned-path')
 
@@ -57,8 +57,8 @@ module Bosh::Dev
         expected_remote_uri = URI('http://bosh-ci-pipeline.s3.amazonaws.com/fake-build-number/bosh-stemcell/fake-infrastructure-name/light-bosh-stemcell-fake-build-number-fake-stemcell-name-fake-disk-format.tgz')
         expected_local_path = "fake-output-dir/#{stemcell.name}"
 
-        download_adapter
-          .should_receive(:download)
+        expect(download_adapter)
+          .to receive(:download)
           .with(expected_remote_uri, expected_local_path)
           .and_return('returned-path')
 

--- a/bosh-dev/spec/bosh/dev/automated_deploy_spec.rb
+++ b/bosh-dev/spec/bosh/dev/automated_deploy_spec.rb
@@ -38,7 +38,7 @@ module Bosh::Dev
       let(:bosh_cli_session) { instance_double('Bosh::Dev::BoshCliSession') }
 
       before do
-        Bosh::Dev::DirectorClient.stub(:new).with(
+        allow(Bosh::Dev::DirectorClient).to receive(:new).with(
           bosh_target,
           'fake-username',
           'fake-password',

--- a/bosh-dev/spec/bosh/dev/aws/deployment_account_spec.rb
+++ b/bosh-dev/spec/bosh/dev/aws/deployment_account_spec.rb
@@ -20,34 +20,34 @@ module Bosh::Dev::Aws
       )
     end
 
-    before { Bosh::Core::Shell.stub(new: shell) }
+    before { allow(Bosh::Core::Shell).to receive_messages(new: shell) }
     let(:shell) { instance_double('Bosh::Core::Shell') }
 
     describe '#initialize' do
-      before { shell.stub(:run).with('. /tmp/deployments-repo/fake-env/bosh_environment && echo $BOSH_USER').and_return("fake-username\n") }
-      before { shell.stub(:run).with('. /tmp/deployments-repo/fake-env/bosh_environment && echo $BOSH_PASSWORD').and_return("fake-password\n") }
+      before { allow(shell).to receive(:run).with('. /tmp/deployments-repo/fake-env/bosh_environment && echo $BOSH_USER').and_return("fake-username\n") }
+      before { allow(shell).to receive(:run).with('. /tmp/deployments-repo/fake-env/bosh_environment && echo $BOSH_PASSWORD').and_return("fake-password\n") }
 
       its(:manifest_path) { should eq('/tmp/deployments-repo/fake-env/deployments/fake-deployment-name/manifest.yml') }
       its(:bosh_user)     { should eq('fake-username') }
       its(:bosh_password) { should eq('fake-password') }
 
       it 'clones a deployment repository for the deployment\'s manifest & bosh_environment' do
-        deployments_repository.should_receive(:clone_or_update!)
+        expect(deployments_repository).to receive(:clone_or_update!)
         account
       end
     end
 
     describe '#prepare' do
       it 'runs AWS migrations and pushes changes to deployments repo' do
-        shell.should_receive(:run).with('. /tmp/deployments-repo/fake-env/bosh_environment && bosh aws create --trace')
-        deployments_repository.should_receive(:push)
+        expect(shell).to receive(:run).with('. /tmp/deployments-repo/fake-env/bosh_environment && bosh aws create --trace')
+        expect(deployments_repository).to receive(:push)
         account.prepare
       end
     end
 
     describe '#save' do
       it 'pushes changes to deployments repo' do
-        deployments_repository.should_receive(:update_and_push)
+        expect(deployments_repository).to receive(:update_and_push)
         account.save
       end
     end

--- a/bosh-dev/spec/bosh/dev/aws/deployments_repository_spec.rb
+++ b/bosh-dev/spec/bosh/dev/aws/deployments_repository_spec.rb
@@ -9,7 +9,7 @@ module Bosh::Dev
     let(:env) { { 'BOSH_JENKINS_DEPLOYMENTS_REPO' => 'fake_BOSH_JENKINS_DEPLOYMENTS_REPO' } }
     let(:options) { {} }
 
-    before { Bosh::Core::Shell.stub(new: shell) }
+    before { allow(Bosh::Core::Shell).to receive_messages(new: shell) }
     let(:shell) { instance_double('Bosh::Core::Shell', run: 'FAKE_SHELL_OUTPUT') }
 
     let(:git_repo_updater) { instance_double('Bosh::Dev::GitRepoUpdater') }
@@ -44,14 +44,14 @@ module Bosh::Dev
           before { FileUtils.mkdir_p(File.join(subject.path, '.git')) }
 
           it 'updates the repo at "#path"' do
-            shell.should_receive(:run).with('git clean -fd && git pull')
+            expect(shell).to receive(:run).with('git clean -fd && git pull')
             subject.clone_or_update!
           end
         end
 
         context 'when the directory does not contain a .git subdirectory' do
           it 'clones the repo into "#path"'do
-            shell.should_receive(:run).with('git clone --depth=1 fake_BOSH_JENKINS_DEPLOYMENTS_REPO /tmp/deployments')
+            expect(shell).to receive(:run).with('git clone --depth=1 fake_BOSH_JENKINS_DEPLOYMENTS_REPO /tmp/deployments')
             subject.clone_or_update!
           end
         end
@@ -59,7 +59,7 @@ module Bosh::Dev
 
       context 'when the directory does NOT exist' do
         it 'clones the repo into "#path"'do
-          shell.should_receive(:run).with('git clone --depth=1 fake_BOSH_JENKINS_DEPLOYMENTS_REPO /tmp/deployments')
+          expect(shell).to receive(:run).with('git clone --depth=1 fake_BOSH_JENKINS_DEPLOYMENTS_REPO /tmp/deployments')
 
           expect {
             subject.clone_or_update!
@@ -70,27 +70,27 @@ module Bosh::Dev
 
     describe '#push' do
       it 'commit and pushes the current state of the directory' do
-        git_repo_updater.should_receive(:update_directory).with('/tmp/deployments', kind_of(String))
+        expect(git_repo_updater).to receive(:update_directory).with('/tmp/deployments', kind_of(String))
         subject.push
       end
     end
 
     describe '#update_and_push' do
-      before { Bosh::Dev::GitRepoUpdater.stub(:new).and_return(git_repo_updater) }
+      before { allow(Bosh::Dev::GitRepoUpdater).to receive(:new).and_return(git_repo_updater) }
       let(:git_repo_updater) { instance_double('Bosh::Dev::GitRepoUpdater') }
 
       before { FileUtils.mkdir_p(subject.path) }
 
       it 'updates repo by pulling in new changes, commits and pushes the current state of the directory' do
-        shell.should_receive(:run).with('git clean -fd && git pull').ordered
-        git_repo_updater.should_receive(:update_directory).with('/tmp/deployments', kind_of(String)).ordered
+        expect(shell).to receive(:run).with('git clean -fd && git pull').ordered
+        expect(git_repo_updater).to receive(:update_directory).with('/tmp/deployments', kind_of(String)).ordered
         subject.update_and_push
       end
 
       it 'does not commit and push if pulling in new changes fails due to merge conflicts' do
         error = Exception.new('fake-pull-exception')
-        shell.should_receive(:run).with('git clean -fd && git pull').and_raise(error)
-        git_repo_updater.should_not_receive(:update_directory)
+        expect(shell).to receive(:run).with('git clean -fd && git pull').and_raise(error)
+        expect(git_repo_updater).not_to receive(:update_directory)
 
         expect {
           subject.update_and_push

--- a/bosh-dev/spec/bosh/dev/aws/micro_bosh_deployment_cleaner_spec.rb
+++ b/bosh-dev/spec/bosh/dev/aws/micro_bosh_deployment_cleaner_spec.rb
@@ -16,11 +16,11 @@ module Bosh::Dev::Aws
         )
       end
 
-      before { AWS::EC2.stub(new: ec2) }
+      before { allow(AWS::EC2).to receive_messages(new: ec2) }
       let(:ec2) { instance_double('AWS::EC2', instances: []) }
 
       it 'connects to ec2 with credentials from manifest' do
-        AWS::EC2.should_receive(:new).with(
+        expect(AWS::EC2).to receive(:new).with(
           access_key_id: 'fake-access-key-id',
           secret_access_key: 'fake-secret-access-key',
         ).and_return(ec2)
@@ -32,24 +32,24 @@ module Bosh::Dev::Aws
         it 'terminates vms that have specific microbosh tag name and are not already terminated' do
           instance_with_non_matching =
             instance_double('AWS::EC2::Instance', tags: { 'director' => 'non-matching-tag-value' })
-          instance_with_non_matching.stub(:status).and_return(:running, :terminated)
-          instance_with_non_matching.should_not_receive(:terminate)
+          allow(instance_with_non_matching).to receive(:status).and_return(:running, :terminated)
+          expect(instance_with_non_matching).not_to receive(:terminate)
 
           instance_with_matching =
             instance_double('AWS::EC2::Instance', tags: { 'director' => 'fake-director-name' })
-          instance_with_matching.stub(:status).and_return(:running, :terminated)
-          instance_with_matching.should_receive(:terminate)
+          allow(instance_with_matching).to receive(:status).and_return(:running, :terminated)
+          expect(instance_with_matching).to receive(:terminate)
 
           microbosh_instance =
             instance_double('AWS::EC2::Instance', tags: { 'Name' => 'fake-director-name' })
-          microbosh_instance.stub(:status).and_return(:running, :terminated)
-          microbosh_instance.should_receive(:terminate)
+          allow(microbosh_instance).to receive(:status).and_return(:running, :terminated)
+          expect(microbosh_instance).to receive(:terminate)
 
           terminated_instance_with_matching =
             instance_double('AWS::EC2::Instance', tags: { 'director' => 'fake-director-name' }, status: :terminated)
-          terminated_instance_with_matching.should_not_receive(:terminate)
+          expect(terminated_instance_with_matching).not_to receive(:terminate)
 
-          ec2.stub(instances: [
+          allow(ec2).to receive_messages(instances: [
             instance_with_non_matching,
             instance_with_matching,
             microbosh_instance,
@@ -64,30 +64,30 @@ module Bosh::Dev::Aws
           matching_tags = { 'director' => 'fake-director-name' }
           instance1 = instance_double('AWS::EC2::Instance', tags: matching_tags, terminate: nil)
           instance2 = instance_double('AWS::EC2::Instance', tags: matching_tags, terminate: nil)
-          ec2.stub(instances: [instance1, instance2])
+          allow(ec2).to receive_messages(instances: [instance1, instance2])
 
           retryable = instance_double('Bosh::Retryable')
-          Bosh::Retryable.stub(new: retryable)
+          allow(Bosh::Retryable).to receive_messages(new: retryable)
 
-          retryable.should_receive(:retryer) do |&blk|
-            instance1.stub(status: :terminated)
-            instance2.stub(status: :shutting_down)
-            blk.call.should be(false)
+          expect(retryable).to receive(:retryer) do |&blk|
+            allow(instance1).to receive_messages(status: :terminated)
+            allow(instance2).to receive_messages(status: :shutting_down)
+            expect(blk.call).to be(false)
 
-            instance1.stub(status: :terminated)
-            instance2.stub(status: :terminated)
-            blk.call.should be(true)
+            allow(instance1).to receive_messages(status: :terminated)
+            allow(instance2).to receive_messages(status: :terminated)
+            expect(blk.call).to be(true)
           end
 
-          instance1.stub(status: :running)
-          instance2.stub(status: :running)
+          allow(instance1).to receive_messages(status: :running)
+          allow(instance2).to receive_messages(status: :running)
           micro_bosh_deployment_cleaner.clean
         end
       end
 
       context 'when matching instances are not found' do
         it 'finishes without waiting for anything' do
-          ec2.stub(instances: [])
+          allow(ec2).to receive_messages(instances: [])
           micro_bosh_deployment_cleaner.clean
         end
       end

--- a/bosh-dev/spec/bosh/dev/aws/micro_bosh_deployment_manifest_spec.rb
+++ b/bosh-dev/spec/bosh/dev/aws/micro_bosh_deployment_manifest_spec.rb
@@ -6,7 +6,7 @@ module Bosh::Dev::Aws
     subject { described_class.new(env, 'manual') }
     let(:env) { {} }
 
-    before { Receipts.stub(new: receipts) }
+    before { allow(Receipts).to receive_messages(new: receipts) }
     let(:receipts) do
       instance_double(
         'Bosh::Dev::Aws::Receipts',
@@ -15,7 +15,7 @@ module Bosh::Dev::Aws
       )
     end
 
-    before { Bosh::Aws::MicroboshManifest.stub(new: manifest) }
+    before { allow(Bosh::Aws::MicroboshManifest).to receive_messages(new: manifest) }
     let(:manifest) do
       instance_double(
         'Bosh::Aws::MicroboshManifest',
@@ -26,11 +26,11 @@ module Bosh::Dev::Aws
       )
     end
 
-    before { YAML.stub(load_file: {}) }
+    before { allow(YAML).to receive_messages(load_file: {}) }
 
-    its(:director_name) { should == 'micro-fake-name' }
-    its(:access_key_id) { should == 'fake-access-key-id' }
-    its(:secret_access_key) { should == 'fake-secret-access-key' }
+    its(:director_name) { should eq('micro-fake-name') }
+    its(:access_key_id) { should eq('fake-access-key-id') }
+    its(:secret_access_key) { should eq('fake-secret-access-key') }
 
     it 'requires the net type to match the manifest' do
       allow(manifest).to receive(:network_type).and_return('dynamic')
@@ -40,14 +40,14 @@ module Bosh::Dev::Aws
 
     describe '#write' do
       before do
-        File.stub(:write)
-        manifest.stub(file_name: 'fake-file-name', to_yaml: 'manifest-yaml')
+        allow(File).to receive(:write)
+        allow(manifest).to receive_messages(file_name: 'fake-file-name', to_yaml: 'manifest-yaml')
       end
 
       it 'loads manifest based on proper receipts' do
-        YAML.should_receive(:load_file).with('fake_vpc_outfile_path').and_return('vpc-receipt' => true)
-        YAML.should_receive(:load_file).with('fake_route53_outfile_path').and_return('route53-receipt' => true)
-        Bosh::Aws::MicroboshManifest.should_receive(:new).with(
+        expect(YAML).to receive(:load_file).with('fake_vpc_outfile_path').and_return('vpc-receipt' => true)
+        expect(YAML).to receive(:load_file).with('fake_route53_outfile_path').and_return('route53-receipt' => true)
+        expect(Bosh::Aws::MicroboshManifest).to receive(:new).with(
           { 'vpc-receipt' => true },
           { 'route53-receipt' => true },
           { hm_director_user: 'admin', hm_director_password: 'admin' },
@@ -56,7 +56,7 @@ module Bosh::Dev::Aws
       end
 
       it 'writes generated microbosh manfifest ' do
-        File.should_receive(:write).with('fake-file-name', 'manifest-yaml')
+        expect(File).to receive(:write).with('fake-file-name', 'manifest-yaml')
         subject.write
       end
     end

--- a/bosh-dev/spec/bosh/dev/aws/receipts_spec.rb
+++ b/bosh-dev/spec/bosh/dev/aws/receipts_spec.rb
@@ -19,7 +19,7 @@ module Bosh::Dev::Aws
       its(:vpc_outfile_path) { should eq('/fake/deployments/path/fake_BOSH_VPC_SUBDOMAIN/aws_vpc_receipt.yml') }
 
       it 'clones or updates the aws deployments repository' do
-        deployments_repository.should_receive(:clone_or_update!)
+        expect(deployments_repository).to receive(:clone_or_update!)
         subject.vpc_outfile_path
       end
     end
@@ -28,7 +28,7 @@ module Bosh::Dev::Aws
       its(:route53_outfile_path) { should eq('/fake/deployments/path/fake_BOSH_VPC_SUBDOMAIN/aws_route53_receipt.yml') }
 
       it 'clones or updates the aws deployments repository' do
-        deployments_repository.should_receive(:clone_or_update!)
+        expect(deployments_repository).to receive(:clone_or_update!)
         subject.route53_outfile_path
       end
     end

--- a/bosh-dev/spec/bosh/dev/aws/runner_builder_spec.rb
+++ b/bosh-dev/spec/bosh/dev/aws/runner_builder_spec.rb
@@ -12,45 +12,45 @@ module Bosh::Dev::Aws
         )
 
         director_address = instance_double('Bosh::Dev::Bat::DirectorAddress')
-        Bosh::Dev::Bat::DirectorAddress
-          .should_receive(:resolved_from_env)
+        expect(Bosh::Dev::Bat::DirectorAddress)
+          .to receive(:resolved_from_env)
           .with(ENV, 'BOSH_VPC_SUBDOMAIN')
           .and_return(director_address)
 
         bosh_cli_session = instance_double('Bosh::Dev::BoshCliSession')
-        Bosh::Dev::BoshCliSession
-          .should_receive(:default)
+        expect(Bosh::Dev::BoshCliSession)
+          .to receive(:default)
           .and_return(bosh_cli_session)
 
         stemcell_archive = instance_double(
           'Bosh::Stemcell::Archive',
           version: 'stemcell-archive-version',
         )
-        Bosh::Stemcell::Archive
-          .should_receive(:new)
+        expect(Bosh::Stemcell::Archive)
+          .to receive(:new)
           .with('stemcell-path')
           .and_return(stemcell_archive)
 
         microbosh_deployment_manifest = instance_double('Bosh::Dev::Aws::MicroBoshDeploymentManifest')
-        Bosh::Dev::Aws::MicroBoshDeploymentManifest
-          .should_receive(:new)
+        expect(Bosh::Dev::Aws::MicroBoshDeploymentManifest)
+          .to receive(:new)
           .with(ENV, 'net-type')
           .and_return(microbosh_deployment_manifest)
 
         microbosh_deployment_cleaner = instance_double('Bosh::Dev::Aws::MicroBoshDeploymentCleaner')
-        Bosh::Dev::Aws::MicroBoshDeploymentCleaner
-          .should_receive(:new)
+        expect(Bosh::Dev::Aws::MicroBoshDeploymentCleaner)
+          .to receive(:new)
           .with(microbosh_deployment_manifest)
           .and_return(microbosh_deployment_cleaner)
 
         bat_deployment_manifest = instance_double('Bosh::Dev::Aws::BatDeploymentManifest')
-        Bosh::Dev::Aws::BatDeploymentManifest
-          .should_receive(:new)
+        expect(Bosh::Dev::Aws::BatDeploymentManifest)
+          .to receive(:new)
           .with(ENV, 'net-type', bosh_cli_session, stemcell_archive)
           .and_return(bat_deployment_manifest)
 
         runner = instance_double('Bosh::Dev::Bat::Runner')
-        Bosh::Dev::Bat::Runner.should_receive(:new).with(
+        expect(Bosh::Dev::Bat::Runner).to receive(:new).with(
           ENV,
           artifacts,
           director_address,

--- a/bosh-dev/spec/bosh/dev/bat/artifacts_spec.rb
+++ b/bosh-dev/spec/bosh/dev/bat/artifacts_spec.rb
@@ -7,7 +7,7 @@ module Bosh::Dev::Bat
     let(:path) { '/fake/artifacts/path' }
     let(:stemcell) { instance_double('Bosh::Stemcell::Stemcell', name: 'fake-stemcell-name') }
 
-    its(:micro_bosh_deployment_name) { should == 'microbosh' }
+    its(:micro_bosh_deployment_name) { should eq('microbosh') }
     its(:micro_bosh_deployment_dir)  { should eq("#{path}/microbosh") }
 
     describe '#stemcell_path' do
@@ -17,15 +17,15 @@ module Bosh::Dev::Bat
     end
 
     describe '#prepare_directories' do
-      before { FileUtils.stub(rm_rf: nil, mkdir_p: nil) }
+      before { allow(FileUtils).to receive_messages(rm_rf: nil, mkdir_p: nil) }
 
       it 'removes the artifacts dir' do
-        FileUtils.should_receive(:rm_rf).with(subject.path)
+        expect(FileUtils).to receive(:rm_rf).with(subject.path)
         subject.prepare_directories
       end
 
       it 'creates the microbosh depolyments dir (which is contained within artifacts dir)' do
-        FileUtils.should_receive(:mkdir_p).with(subject.micro_bosh_deployment_dir)
+        expect(FileUtils).to receive(:mkdir_p).with(subject.micro_bosh_deployment_dir)
         subject.prepare_directories
       end
     end

--- a/bosh-dev/spec/bosh/dev/bat/director_address_spec.rb
+++ b/bosh-dev/spec/bosh/dev/bat/director_address_spec.rb
@@ -13,8 +13,8 @@ module Bosh::Dev::Bat
 
     describe '.resolved_from_env' do
       it 'fetches address from env and resolves it via DNS' do
-        Resolv
-          .should_receive(:getaddress)
+        expect(Resolv)
+          .to receive(:getaddress)
           .with('micro.subdomain-from-env.cf-app.com')
           .and_return('resolved-ip')
 

--- a/bosh-dev/spec/bosh/dev/bat/director_uuid_spec.rb
+++ b/bosh-dev/spec/bosh/dev/bat/director_uuid_spec.rb
@@ -9,7 +9,7 @@ module Bosh::Dev::Bat
       let(:cli_session) { instance_double('Bosh::Dev::BoshCliSession') }
 
       context 'when we are able to extract uuid' do
-        before { cli_session.stub(:run_bosh).with('status --uuid').and_return(<<-OUTPUT) }
+        before { allow(cli_session).to receive(:run_bosh).with('status --uuid').and_return(<<-OUTPUT) }
 39be73f2-103a-4968-9645-9cd6406aedce
         OUTPUT
 
@@ -19,7 +19,7 @@ module Bosh::Dev::Bat
       end
 
       context 'when we are not able to obtain a uuid' do
-        before { cli_session.stub(:run_bosh).with('status --uuid') { Bosh::Core::Shell.new.run('false') } }
+        before { allow(cli_session).to receive(:run_bosh).with('status --uuid') { Bosh::Core::Shell.new.run('false') } }
 
         it 'raises an error' do
           expect {

--- a/bosh-dev/spec/bosh/dev/bat/runner_spec.rb
+++ b/bosh-dev/spec/bosh/dev/bat/runner_spec.rb
@@ -54,10 +54,10 @@ module Bosh::Dev::Bat
     let(:bat_deployment_manifest) { double('bat-deployment-manifest', net_type: 'net-type', write: nil) }
 
     describe '#deploy_bats_microbosh' do
-      before { subject.stub(:run_bats) }
+      before { allow(subject).to receive(:run_bats) }
 
       it 'generates a micro manifest' do
-        microbosh_deployment_manifest.should_receive(:write) do
+        expect(microbosh_deployment_manifest).to receive(:write) do
           FileUtils.touch(File.join(Dir.pwd, 'FAKE_MICROBOSH_MANIFEST'))
         end
         subject.deploy_bats_microbosh
@@ -65,30 +65,30 @@ module Bosh::Dev::Bat
       end
 
       it 'cleans any previous deployments out' do
-        microbosh_deployment_cleaner.should_receive(:clean)
+        expect(microbosh_deployment_cleaner).to receive(:clean)
         subject.deploy_bats_microbosh
       end
 
       it 'targets the micro' do
-        bosh_cli_session.should_receive(:run_bosh).with(
+        expect(bosh_cli_session).to receive(:run_bosh).with(
           'micro deployment fake_micro_bosh_deployment_name')
         subject.deploy_bats_microbosh
       end
 
       it 'deploys the micro' do
-        bosh_cli_session.should_receive(:run_bosh).with(
+        expect(bosh_cli_session).to receive(:run_bosh).with(
           'micro deploy fake_bosh_stemcell_path')
         subject.deploy_bats_microbosh
       end
 
       it 'logs in to the micro' do
-        bosh_cli_session.should_receive(:run_bosh).with('login admin admin')
+        expect(bosh_cli_session).to receive(:run_bosh).with('login admin admin')
         subject.deploy_bats_microbosh
       end
     end
 
     describe '#run_bats' do
-      before { Rake::Task.stub(:[]).with('bat').and_return(bat_rake_task) }
+      before { allow(Rake::Task).to receive(:[]).with('bat').and_return(bat_rake_task) }
       let(:bat_rake_task) { double("Rake::Task['bat']", invoke: nil) }
 
       describe 'targetting the micro' do
@@ -131,7 +131,7 @@ module Bosh::Dev::Bat
       end
 
       it 'generates a bat manifest' do
-        bat_deployment_manifest.should_receive(:write) do
+        expect(bat_deployment_manifest).to receive(:write) do
           FileUtils.touch(File.join(Dir.pwd, 'FAKE_BAT_MANIFEST'))
         end
         subject.run_bats
@@ -162,7 +162,7 @@ module Bosh::Dev::Bat
       end
 
       it 'invokes the "bat" rake task' do
-        bat_rake_task.should_receive(:invoke)
+        expect(bat_rake_task).to receive(:invoke)
         subject.run_bats
       end
     end

--- a/bosh-dev/spec/bosh/dev/bat_helper_spec.rb
+++ b/bosh-dev/spec/bosh/dev/bat_helper_spec.rb
@@ -71,14 +71,14 @@ module Bosh::Dev
       end
 
       before do
-        described_class
-        .should_receive(:runner_builder_for_infrastructure_name)
+        expect(described_class)
+        .to receive(:runner_builder_for_infrastructure_name)
         .with('infrastructure-name')
         .and_return(bat_runner_builder)
       end
 
       it 'returns bat helper configured with rake arguments' do
-        Build.should_receive(:candidate).and_return(build)
+        expect(Build).to receive(:candidate).and_return(build)
 
         expect(Bosh::Stemcell::Definition).to receive(:for)
           .with(
@@ -93,8 +93,8 @@ module Bosh::Dev
         expect(Bosh::Stemcell::Stemcell).to receive(:new).and_return(stemcell)
 
         bat_helper = instance_double('Bosh::Dev::BatHelper')
-        described_class
-          .should_receive(:new)
+        expect(described_class)
+          .to receive(:new)
           .with(bat_runner_builder, instance_of(Bosh::Dev::Bat::Artifacts), build, networking_type, stemcell)
           .and_return(bat_helper)
 
@@ -187,12 +187,12 @@ module Bosh::Dev
       it 'uses bats runner to run bats without deploying microbosh ' +
          '(assumption is user already has microbosh)' do
         bat_runner = instance_double('Bosh::Dev::Bat::Runner')
-        bat_runner_builder
-          .should_receive(:build)
+        expect(bat_runner_builder)
+          .to receive(:build)
           .with(artifacts, networking_type)
           .and_return(bat_runner)
 
-        bat_runner.should_receive(:run_bats)
+        expect(bat_runner).to receive(:run_bats)
         subject.run_bats
       end
     end

--- a/bosh-dev/spec/bosh/dev/bosh_cli_session_spec.rb
+++ b/bosh-dev/spec/bosh/dev/bosh_cli_session_spec.rb
@@ -9,39 +9,39 @@ module Bosh::Dev
       let(:bosh_cmd) { instance_double('Bosh::Dev::PathBoshCmd', cmd: 'fake-bosh-bin', env: bosh_cmd_env) }
       let(:bosh_cmd_env) { { 'fake-env' => 'fake-env-value' } }
 
-      before { Bosh::Core::Shell.stub(:new).and_return(shell) }
+      before { allow(Bosh::Core::Shell).to receive(:new).and_return(shell) }
       let(:shell) { instance_double('Bosh::Core::Shell') }
 
-      before { subject.stub(:puts) }
+      before { allow(subject).to receive(:puts) }
 
-      before { Tempfile.stub(:new).with('bosh_config').and_return(tempfile) }
+      before { allow(Tempfile).to receive(:new).with('bosh_config').and_return(tempfile) }
       let(:tempfile) { instance_double('Tempfile', path: 'fake-tmp/bosh_config') }
 
       it 'runs the specified bosh command' do
         expected_cmd = "fake-bosh-bin -v -n -P 10 --config 'fake-tmp/bosh_config' fake-cmd"
         output       = double('cmd-output')
-        shell.should_receive(:run).with(expected_cmd, env: bosh_cmd_env).and_return(output)
+        expect(shell).to receive(:run).with(expected_cmd, env: bosh_cmd_env).and_return(output)
         expect(subject.run_bosh('fake-cmd', fake: 'options')).to eq(output)
       end
 
       context 'when bosh fails with a RuntimeError and retrying' do
         full_cmd = "fake-bosh-bin -v -n -P 10 --config 'fake-tmp/bosh_config' fake-cmd"
 
-        before { retryable.stub(:sleep) }
+        before { allow(retryable).to receive(:sleep) }
         let(:retryable) { Bosh::Retryable.new(tries: 2, on: [RuntimeError]) }
         let(:error)     { RuntimeError.new('eror-message') }
 
         context 'when command finally succeeds on the third time' do
           it 'retries same command given number of times' do
-            shell.should_receive(:run).with(full_cmd, env: bosh_cmd_env).ordered.and_raise(error)
-            shell.should_receive(:run).with(full_cmd, env: bosh_cmd_env).ordered.and_return('cmd-output')
+            expect(shell).to receive(:run).with(full_cmd, env: bosh_cmd_env).ordered.and_raise(error)
+            expect(shell).to receive(:run).with(full_cmd, env: bosh_cmd_env).ordered.and_return('cmd-output')
             expect(subject.run_bosh('fake-cmd', retryable: retryable)).to eq('cmd-output')
           end
         end
 
         context 'when command still raises an error on the third time' do
           it 'retries and eventually raises an error' do
-            shell.should_receive(:run).with(full_cmd, env: bosh_cmd_env).ordered.exactly(2).times.and_raise(error)
+            expect(shell).to receive(:run).with(full_cmd, env: bosh_cmd_env).ordered.exactly(2).times.and_raise(error)
             expect {
               subject.run_bosh('fake-cmd', retryable: retryable)
             }.to raise_error(error)
@@ -51,12 +51,12 @@ module Bosh::Dev
 
       context 'when bosh fails and debugging failures' do
         before do
-          shell.stub(:run) { |cmd, _| raise 'fake-cmd broke' if cmd =~ /fake-cmd/ }
+          allow(shell).to receive(:run) { |cmd, _| raise 'fake-cmd broke' if cmd =~ /fake-cmd/ }
         end
 
         it 'debugs the last task' do
           expect_cmd = "fake-bosh-bin -v -n -P 10 --config 'fake-tmp/bosh_config' task last --debug"
-          shell.should_receive(:run).with(expect_cmd, last_number: 100, env: bosh_cmd_env).and_return('cmd-output')
+          expect(shell).to receive(:run).with(expect_cmd, last_number: 100, env: bosh_cmd_env).and_return('cmd-output')
 
           expect {
             subject.run_bosh('fake-cmd', debug_on_fail: true)
@@ -64,10 +64,10 @@ module Bosh::Dev
         end
 
         context 'and it also fails debugging the original failure' do
-          before { shell.stub(:run).and_raise }
+          before { allow(shell).to receive(:run).and_raise }
 
           it "doesn't debug again" do
-            shell.should_receive(:run).twice
+            expect(shell).to receive(:run).twice
 
             expect {
               subject.run_bosh('fake-cmd', debug_on_fail: true)
@@ -103,7 +103,7 @@ module Bosh::Dev
 
     include FakeFS::SpecHelpers
 
-    before { Bosh::Core::Shell.stub(:new).and_return(shell) }
+    before { allow(Bosh::Core::Shell).to receive(:new).and_return(shell) }
     let(:shell) { instance_double('Bosh::Core::Shell', run: nil) }
     before { allow(Bundler).to receive(:ruby_scope).and_return('fake-bundler-ruby-scope') }
 

--- a/bosh-dev/spec/bosh/dev/bosh_release_publisher_spec.rb
+++ b/bosh-dev/spec/bosh/dev/bosh_release_publisher_spec.rb
@@ -7,34 +7,34 @@ describe Bosh::Dev::BoshReleasePublisher do
 
   describe '.setup_for' do
     it 'instantiates a publisher with the given build and upload/download adapters' do
-      Bosh::Dev::UploadAdapter.stub(:new).with(no_args).and_return(upload_adapter)
+      allow(Bosh::Dev::UploadAdapter).to receive(:new).with(no_args).and_return(upload_adapter)
 
       publisher = double
-      described_class.should_receive(:new).with(candidate_build, upload_adapter).and_return(publisher)
-      described_class.setup_for(candidate_build).should eq(publisher)
+      expect(described_class).to receive(:new).with(candidate_build, upload_adapter).and_return(publisher)
+      expect(described_class.setup_for(candidate_build)).to eq(publisher)
     end
   end
 
   describe '#publish' do
     it 'uploads the build and then stages the changes' do
-      Bosh::Dev::Build.stub(candidate: candidate_build)
+      allow(Bosh::Dev::Build).to receive_messages(candidate: candidate_build)
       publisher = described_class.new(candidate_build, upload_adapter)
 
       release = double('bosh release')
-      Bosh::Dev::BoshRelease.stub(:build).with(no_args).and_return(release)
+      allow(Bosh::Dev::BoshRelease).to receive(:build).with(no_args).and_return(release)
       release_changes = instance_double('Bosh::Dev::ReleaseChangeStager')
 
       pwd = double('pwd')
-      Dir.stub(:pwd).with(no_args).and_return(pwd)
+      allow(Dir).to receive(:pwd).with(no_args).and_return(pwd)
 
-      Bosh::Dev::ReleaseChangeStager.should_receive(:new).with(
+      expect(Bosh::Dev::ReleaseChangeStager).to receive(:new).with(
         pwd,
         candidate_build.number,
         upload_adapter,
       ).and_return(release_changes)
 
-      candidate_build.should_receive(:upload_release).ordered.with(release)
-      release_changes.should_receive(:stage).ordered.with(no_args)
+      expect(candidate_build).to receive(:upload_release).ordered.with(release)
+      expect(release_changes).to receive(:stage).ordered.with(no_args)
 
       publisher.publish
     end

--- a/bosh-dev/spec/bosh/dev/bosh_release_spec.rb
+++ b/bosh-dev/spec/bosh/dev/bosh_release_spec.rb
@@ -11,21 +11,21 @@ module Bosh::Dev
 
     describe '#final_tarball_path' do
       it 'return path to created bosh final release' do
-        release_creator
-          .should_receive(:create_final)
+        expect(release_creator)
+          .to receive(:create_final)
           .with(no_args)
           .and_return('fake-final-tarball-path')
-        subject.final_tarball_path.should == 'fake-final-tarball-path'
+        expect(subject.final_tarball_path).to eq('fake-final-tarball-path')
       end
     end
 
     describe '#dev_tarball_path' do
       it 'return path to created bosh dev release' do
-        release_creator
-          .should_receive(:create_dev)
+        expect(release_creator)
+          .to receive(:create_dev)
           .with(no_args)
           .and_return('fake-dev-tarball-path')
-        subject.dev_tarball_path.should == 'fake-dev-tarball-path'
+        expect(subject.dev_tarball_path).to eq('fake-dev-tarball-path')
       end
     end
   end

--- a/bosh-dev/spec/bosh/dev/data_dog_formatter_spec.rb
+++ b/bosh-dev/spec/bosh/dev/data_dog_formatter_spec.rb
@@ -13,10 +13,10 @@ module Bosh::Dev
         })
     end
 
-    it { DataDogFormatter.should < RSpec::Core::Formatters::BaseFormatter }
+    it { expect(DataDogFormatter).to be < RSpec::Core::Formatters::BaseFormatter }
 
     it 'should reported to DataDog when an example passes' do
-      sender.should_receive(:report_on).with(example)
+      expect(sender).to receive(:report_on).with(example)
       formatter.example_passed(example)
     end
   end

--- a/bosh-dev/spec/bosh/dev/data_dog_reporter_spec.rb
+++ b/bosh-dev/spec/bosh/dev/data_dog_reporter_spec.rb
@@ -14,12 +14,12 @@ module Bosh::Dev
     end
 
     before do
-      ENV.stub(:fetch).with('BAT_INFRASTRUCTURE').and_return('vsphere')
-      subject.stub(:puts)
+      allow(ENV).to receive(:fetch).with('BAT_INFRASTRUCTURE').and_return('vsphere')
+      allow(subject).to receive(:puts)
     end
 
     it 'should send a message to DataDog when an example passes' do
-      data_dog_client.should_receive(:emit_point).with('ci.bosh.bat.duration', 3.14, tags: %w[infrastructure:vsphere example:foo-bar-baz])
+      expect(data_dog_client).to receive(:emit_point).with('ci.bosh.bat.duration', 3.14, tags: %w[infrastructure:vsphere example:foo-bar-baz])
       sender.report_on(example)
     end
   end

--- a/bosh-dev/spec/bosh/dev/director_client_spec.rb
+++ b/bosh-dev/spec/bosh/dev/director_client_spec.rb
@@ -16,9 +16,9 @@ module Bosh::Dev
     let(:bosh_cli_session) { instance_double('Bosh::Dev::BoshCliSession', run_bosh: nil) }
 
     before do
-      class_double('Bosh::Cli::Client::Director')
-        .as_stubbed_const
-        .stub(:new)
+      allow(class_double('Bosh::Cli::Client::Director')
+        .as_stubbed_const)
+        .to receive(:new)
         .with('bosh.example.com', 'fake_username', 'fake_password')
         .and_return(director_handle)
     end
@@ -34,30 +34,30 @@ module Bosh::Dev
         })
       end
 
-      before { director_handle.stub(:list_stemcells) { [] } }
+      before { allow(director_handle).to receive(:list_stemcells) { [] } }
 
       it 'uploads the stemcell with the cli' do
-        bosh_cli_session.should_receive(:run_bosh).
+        expect(bosh_cli_session).to receive(:run_bosh).
           with('upload stemcell /path/to/fake-stemcell-008.tgz', debug_on_fail: true)
         director_client.upload_stemcell(stemcell_archive)
       end
 
       it 'always re-targets and logs in first' do
         target_retryable = double('target-retryable')
-        Bosh::Retryable.stub(:new).with(tries: 3, on: [RuntimeError]).and_return(target_retryable)
+        allow(Bosh::Retryable).to receive(:new).with(tries: 3, on: [RuntimeError]).and_return(target_retryable)
 
-        bosh_cli_session.should_receive(:run_bosh).with('target bosh.example.com', retryable: target_retryable).ordered
-        bosh_cli_session.should_receive(:run_bosh).with('login fake_username fake_password').ordered
-        bosh_cli_session.should_receive(:run_bosh).with(/upload stemcell/, debug_on_fail: true).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('target bosh.example.com', retryable: target_retryable).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('login fake_username fake_password').ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with(/upload stemcell/, debug_on_fail: true).ordered
 
         director_client.upload_stemcell(stemcell_archive)
       end
 
       context 'when the stemcell being uploaded exists on the director' do
-        before { director_handle.stub(:list_stemcells).and_return([{ 'name' => 'fake-stemcell', 'version' => '008' }]) }
+        before { allow(director_handle).to receive(:list_stemcells).and_return([{ 'name' => 'fake-stemcell', 'version' => '008' }]) }
 
         it 'does not re-upload it' do
-          bosh_cli_session.should_not_receive(:run_bosh).with(/upload stemcell/, debug_on_fail: true)
+          expect(bosh_cli_session).not_to receive(:run_bosh).with(/upload stemcell/, debug_on_fail: true)
           director_client.upload_stemcell(stemcell_archive)
         end
       end
@@ -65,18 +65,18 @@ module Bosh::Dev
 
     describe '#upload_release' do
       it 'uploads the release using the cli, skipping if the release already exists' do
-        bosh_cli_session.should_receive(:run_bosh).
+        expect(bosh_cli_session).to receive(:run_bosh).
           with('upload release /path/to/fake-release.tgz --skip-if-exists', debug_on_fail: true)
         director_client.upload_release('/path/to/fake-release.tgz')
       end
 
       it 'always re-targets and logs in first' do
         target_retryable = double('target-retryable')
-        Bosh::Retryable.stub(:new).with(tries: 3, on: [RuntimeError]).and_return(target_retryable)
+        allow(Bosh::Retryable).to receive(:new).with(tries: 3, on: [RuntimeError]).and_return(target_retryable)
 
-        bosh_cli_session.should_receive(:run_bosh).with('target bosh.example.com', retryable: target_retryable).ordered
-        bosh_cli_session.should_receive(:run_bosh).with('login fake_username fake_password').ordered
-        bosh_cli_session.should_receive(:run_bosh).with(/upload release/, debug_on_fail: true).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('target bosh.example.com', retryable: target_retryable).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('login fake_username fake_password').ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with(/upload release/, debug_on_fail: true).ordered
 
         director_client.upload_release('/path/to/fake-release.tgz')
       end
@@ -125,22 +125,22 @@ EOF
       end
 
       it 'sets the deployment and then runs a deploy using the cli' do
-        bosh_cli_session.should_receive(:run_bosh).with('deployment /path/to/fake-manifest.yml').ordered
-        bosh_cli_session.should_receive(:run_bosh).with('deploy', debug_on_fail: true).ordered
-        bosh_cli_session.should_receive(:run_bosh).with('deployments').ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('deployment /path/to/fake-manifest.yml').ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('deploy', debug_on_fail: true).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('deployments').ordered
 
         director_client.deploy(manifest_path)
       end
 
       it 'always re-targets and logs in first' do
         target_retryable = double('target-retryable')
-        Bosh::Retryable.stub(:new).with(tries: 3, on: [RuntimeError]).and_return(target_retryable)
+        allow(Bosh::Retryable).to receive(:new).with(tries: 3, on: [RuntimeError]).and_return(target_retryable)
 
-        bosh_cli_session.should_receive(:run_bosh).with('target bosh.example.com', retryable: target_retryable).ordered
-        bosh_cli_session.should_receive(:run_bosh).with('login fake_username fake_password').ordered
-        bosh_cli_session.should_receive(:run_bosh).with(/deployment/).ordered
-        bosh_cli_session.should_receive(:run_bosh).with(/deploy/, debug_on_fail: true).ordered
-        bosh_cli_session.should_receive(:run_bosh).with('deployments').ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('target bosh.example.com', retryable: target_retryable).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('login fake_username fake_password').ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with(/deployment/).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with(/deploy/, debug_on_fail: true).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('deployments').ordered
 
         director_client.deploy(manifest_path)
       end
@@ -148,17 +148,17 @@ EOF
 
     describe '#clean_up' do
       it 'cleans up resources on the director' do
-        bosh_cli_session.should_receive(:run_bosh).with('cleanup', debug_on_fail: true)
+        expect(bosh_cli_session).to receive(:run_bosh).with('cleanup', debug_on_fail: true)
         director_client.clean_up
       end
 
       it 'always re-targets and logs in first' do
         target_retryable = double('target-retryable')
-        Bosh::Retryable.stub(:new).with(tries: 3, on: [RuntimeError]).and_return(target_retryable)
+        allow(Bosh::Retryable).to receive(:new).with(tries: 3, on: [RuntimeError]).and_return(target_retryable)
 
-        bosh_cli_session.should_receive(:run_bosh).with('target bosh.example.com', retryable: target_retryable).ordered
-        bosh_cli_session.should_receive(:run_bosh).with('login fake_username fake_password').ordered
-        bosh_cli_session.should_receive(:run_bosh).with(/cleanup/, debug_on_fail: true).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('target bosh.example.com', retryable: target_retryable).ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with('login fake_username fake_password').ordered
+        expect(bosh_cli_session).to receive(:run_bosh).with(/cleanup/, debug_on_fail: true).ordered
 
         director_client.clean_up
       end

--- a/bosh-dev/spec/bosh/dev/emitable_example_spec.rb
+++ b/bosh-dev/spec/bosh/dev/emitable_example_spec.rb
@@ -4,7 +4,7 @@ require 'bosh/dev/emitable_example'
 module Bosh::Dev
   describe EmitableExample do
     subject do
-      ENV.stub(:fetch).with('BAT_INFRASTRUCTURE').and_return('openstack')
+      allow(ENV).to receive(:fetch).with('BAT_INFRASTRUCTURE').and_return('openstack')
       EmitableExample.new(example)
     end
 

--- a/bosh-dev/spec/bosh/dev/gem_component_spec.rb
+++ b/bosh-dev/spec/bosh/dev/gem_component_spec.rb
@@ -14,7 +14,7 @@ module Bosh::Dev
     before do
       stub_const('Bosh::Dev::GemComponent::ROOT', root)
 
-      Rake::FileUtilsExt.stub(:sh)
+      allow(Rake::FileUtilsExt).to receive(:sh)
     end
 
     after do
@@ -27,12 +27,12 @@ module Bosh::Dev
       include FakeFS::SpecHelpers
 
       before do
-        File.stub(read: '1.5.0.pre.3') # old version
-        File.stub(:open)
+        allow(File).to receive_messages(read: '1.5.0.pre.3') # old version
+        allow(File).to receive(:open)
       end
 
       it 'shells out to build the gem' do
-        Rake::FileUtilsExt.should_receive(:sh).with('cd fake-component && ' +
+        expect(Rake::FileUtilsExt).to receive(:sh).with('cd fake-component && ' +
                                                     'gem build fake-component.gemspec && ' +
                                                     'mv fake-component-1.1234.0.gem fake-destination-dir')
 

--- a/bosh-dev/spec/bosh/dev/gems_generator_spec.rb
+++ b/bosh-dev/spec/bosh/dev/gems_generator_spec.rb
@@ -8,28 +8,28 @@ module Bosh::Dev
       subject { described_class.new(build) }
       let(:build) { instance_double('Bosh::Dev::Build', number: 456, upload_gems: nil) }
 
-      before { GemComponents.stub(new: gem_components) }
+      before { allow(GemComponents).to receive_messages(new: gem_components) }
       let(:gem_components) { instance_double('Bosh::Dev::GemComponents', build_release_gems: nil) }
 
       before do
-        Rake::FileUtilsExt.stub(:sh)
-        Dir.stub(:chdir).and_yield
+        allow(Rake::FileUtilsExt).to receive(:sh)
+        allow(Dir).to receive(:chdir).and_yield
       end
 
       it 'builds all bosh gems' do
-        gem_components.should_receive(:build_release_gems)
+        expect(gem_components).to receive(:build_release_gems)
         subject.generate_and_upload
       end
 
       it 'builds gem server index' do
-        Dir.should_receive(:chdir).with('pkg').and_yield
-        Bundler.should_receive(:with_clean_env).and_yield
-        Rake::FileUtilsExt.should_receive(:sh).with('gem', 'generate_index', '.')
+        expect(Dir).to receive(:chdir).with('pkg').and_yield
+        expect(Bundler).to receive(:with_clean_env).and_yield
+        expect(Rake::FileUtilsExt).to receive(:sh).with('gem', 'generate_index', '.')
         subject.generate_and_upload
       end
 
       it 'uploads all bosh gems' do
-        build.should_receive(:upload_gems).with('.', 'gems')
+        expect(build).to receive(:upload_gems).with('.', 'gems')
         subject.generate_and_upload
       end
     end

--- a/bosh-dev/spec/bosh/dev/git_tagger_spec.rb
+++ b/bosh-dev/spec/bosh/dev/git_tagger_spec.rb
@@ -75,7 +75,7 @@ module Bosh::Dev
           end
 
           it 'does not execute any git commands' do
-            Open3.should_not_receive(:capture3)
+            expect(Open3).not_to receive(:capture3)
             expect { git_tagger.tag_and_push(sha, build_number) }.to raise_error
           end
         end

--- a/bosh-dev/spec/bosh/dev/micro_client_spec.rb
+++ b/bosh-dev/spec/bosh/dev/micro_client_spec.rb
@@ -24,13 +24,13 @@ module Bosh::Dev
           path: '/path/to/fake-stemcell-008.tgz',
         )
 
-        bosh_cli_session.should_receive(:run_bosh).
+        expect(bosh_cli_session).to receive(:run_bosh).
           with('micro deployment /path/to/fake-manifest.yml').
           ordered
 
         deploy_pwd = nil
 
-        bosh_cli_session.should_receive(:run_bosh).
+        expect(bosh_cli_session).to receive(:run_bosh).
           with('micro deploy /path/to/fake-stemcell-008.tgz --update-if-exists').
           ordered { deploy_pwd = Dir.pwd }
 

--- a/bosh-dev/spec/bosh/dev/release_creator_spec.rb
+++ b/bosh-dev/spec/bosh/dev/release_creator_spec.rb
@@ -21,7 +21,7 @@ module Bosh::Dev
 
       it 'is inside release directory when creating final release' do
         old_current_dir = Dir.pwd
-        cli_session.stub(:run_bosh).with(/create release/) do
+        allow(cli_session).to receive(:run_bosh).with(/create release/) do
           @current_dir = Dir.pwd
           create_release_output
         end
@@ -30,13 +30,13 @@ module Bosh::Dev
       end
 
       it 'creates a dev release then creates a new final release tarball' do
-        cli_session
-          .should_receive(:run_bosh)
+        expect(cli_session)
+          .to receive(:run_bosh)
           .with('create release --force')
           .ordered
 
-        cli_session
-          .should_receive(:run_bosh)
+        expect(cli_session)
+          .to receive(:run_bosh)
           .with('create release --force --final --with-tarball')
           .ordered
           .and_return(create_release_output)
@@ -57,7 +57,7 @@ module Bosh::Dev
 
       it 'is inside release directory when creating final release' do
         old_current_dir = Dir.pwd
-        cli_session.stub(:run_bosh).with(/create release/) do
+        allow(cli_session).to receive(:run_bosh).with(/create release/) do
           @current_dir = Dir.pwd
           create_release_output
         end
@@ -66,8 +66,8 @@ module Bosh::Dev
       end
 
       it 'creates a dev release then creates a new final release tarball' do
-        cli_session
-          .should_receive(:run_bosh)
+        expect(cli_session)
+          .to receive(:run_bosh)
           .with('create release --force --with-tarball')
           .and_return(create_release_output)
 

--- a/bosh-dev/spec/bosh/dev/sandbox/mysql_spec.rb
+++ b/bosh-dev/spec/bosh/dev/sandbox/mysql_spec.rb
@@ -8,7 +8,7 @@ module Bosh::Dev::Sandbox
 
     describe '#create_db' do
       it 'creates a database' do
-        runner.should_receive(:run).with(
+        expect(runner).to receive(:run).with(
           %Q{mysql --user=root --password=password -e 'create database `fake_db_name`;' > /dev/null 2>&1})
         mysql.create_db
       end
@@ -16,7 +16,7 @@ module Bosh::Dev::Sandbox
 
     describe '#drop_db' do
       it 'drops a database' do
-        runner.should_receive(:run).with(
+        expect(runner).to receive(:run).with(
           %Q{mysql --user=root --password=password -e 'drop database `fake_db_name`;' > /dev/null 2>&1})
         mysql.drop_db
       end

--- a/bosh-dev/spec/bosh/dev/sandbox/postgresql_spec.rb
+++ b/bosh-dev/spec/bosh/dev/sandbox/postgresql_spec.rb
@@ -8,7 +8,7 @@ module Bosh::Dev::Sandbox
 
     describe '#create_db' do
       it 'creates a database' do
-        runner.should_receive(:run).with(
+        expect(runner).to receive(:run).with(
           %Q{psql -U postgres -c 'create database "fake_db_name";' > /dev/null 2>&1})
         postgresql.create_db
       end
@@ -16,7 +16,7 @@ module Bosh::Dev::Sandbox
 
     describe '#drop_db' do
       it 'drops a database' do
-        runner.should_receive(:run).with(
+        expect(runner).to receive(:run).with(
           %Q{psql -U postgres -c 'drop database "fake_db_name";' > /dev/null 2>&1})
         postgresql.drop_db
       end

--- a/bosh-dev/spec/bosh/dev/sandbox/socket_connector_spec.rb
+++ b/bosh-dev/spec/bosh/dev/sandbox/socket_connector_spec.rb
@@ -7,13 +7,13 @@ module Bosh::Dev::Sandbox
 
     describe '#try_to_connect' do
       context 'when connecting fails after some time' do
-        before { Timeout.stub(:timeout).and_raise(error) }
+        before { allow(Timeout).to receive(:timeout).and_raise(error) }
         let(:error) { Timeout::Error.new }
 
         it 'sleeps after each failed attempt then raises' do
-          Timeout.should_receive(:timeout).ordered
-          socket_connector.should_receive(:sleep).with(0.2).ordered
-          Timeout.should_receive(:timeout).ordered
+          expect(Timeout).to receive(:timeout).ordered
+          expect(socket_connector).to receive(:sleep).with(0.2).ordered
+          expect(Timeout).to receive(:timeout).ordered
 
           expect {
             socket_connector.try_to_connect(2)
@@ -21,8 +21,8 @@ module Bosh::Dev::Sandbox
         end
 
         it 'defaults to 40 attempts before raising' do
-          Timeout.should_receive(:timeout).exactly(40).times
-          socket_connector.should_receive(:sleep).exactly(39).times
+          expect(Timeout).to receive(:timeout).exactly(40).times
+          expect(socket_connector).to receive(:sleep).exactly(39).times
 
           expect {
             socket_connector.try_to_connect
@@ -30,7 +30,7 @@ module Bosh::Dev::Sandbox
         end
 
         it 'logs name, error and other misc information if error raised' do
-          socket_connector.stub(:sleep)
+          allow(socket_connector).to receive(:sleep)
 
           expect(logger).to receive(:error).at_least(1).with(
             /Failed to connect to fake-name: .*Timeout::Error.*fake-host.*fake-port/)

--- a/bosh-dev/spec/bosh/dev/shipit_lifecycle_spec.rb
+++ b/bosh-dev/spec/bosh/dev/shipit_lifecycle_spec.rb
@@ -4,13 +4,13 @@ require 'bosh/dev/shipit_lifecycle'
 
 module Bosh::Dev
   describe ShipitLifecycle do
-    before { Bosh::Core::Shell.stub(:new).and_return(shell) }
+    before { allow(Bosh::Core::Shell).to receive(:new).and_return(shell) }
     let(:shell) { instance_double('Bosh::Core::Shell') }
 
     before do
       repo_path = '/home/user/bosh'
-      Rugged::Repository.stub(:discover).with('.').and_return(repo_path)
-      Rugged::Repository.stub(:new).with(repo_path).and_return(repository)
+      allow(Rugged::Repository).to receive(:discover).with('.').and_return(repo_path)
+      allow(Rugged::Repository).to receive(:new).with(repo_path).and_return(repository)
     end
 
     let(:repository)     { instance_double('Rugged::Repository', head: head_reference) }
@@ -18,26 +18,26 @@ module Bosh::Dev
 
     describe '#pull' do
       it 'pulls the current branch from origin' do
-        shell.should_receive(:run).with('git pull --rebase origin this-branch', output_command: true)
+        expect(shell).to receive(:run).with('git pull --rebase origin this-branch', output_command: true)
         subject.pull
       end
     end
 
     describe '#push' do
       context 'when current branch is not master' do
-        before { head_reference.stub(name: 'refs/heads/not-master') }
+        before { allow(head_reference).to receive_messages(name: 'refs/heads/not-master') }
 
         it 'pushes the current branch to origin' do
-          shell.should_receive(:run).with('git push origin not-master', output_command: true)
+          expect(shell).to receive(:run).with('git push origin not-master', output_command: true)
           subject.push
         end
       end
 
       context 'when current branch is master' do
-        before { head_reference.stub(name: 'refs/heads/master') }
+        before { allow(head_reference).to receive_messages(name: 'refs/heads/master') }
 
         it 'does not push to the branch' do
-          shell.should_not_receive(:run)
+          expect(shell).not_to receive(:run)
           expect { subject.push }.to raise_error
         end
 

--- a/bosh-dev/spec/bosh/dev/tasks/migrations_specs.rb
+++ b/bosh-dev/spec/bosh/dev/tasks/migrations_specs.rb
@@ -21,11 +21,11 @@ describe 'migrations:aws:new' do
     Rake.application.rake_require(task_path, [root], loaded_files_excluding_current_rake_file)
 
     Rake::Task.define_task(:environment)
-    Time.stub(:new).and_return(timestamp)
+    allow(Time).to receive(:new).and_return(timestamp)
 
     @tempdir = Dir.mktmpdir
-    Bosh::Aws::MigrationHelper.stub(:aws_migration_directory).and_return(@tempdir)
-    Bosh::Aws::MigrationHelper.stub(:aws_spec_migration_directory).and_return(@tempdir)
+    allow(Bosh::Aws::MigrationHelper).to receive(:aws_migration_directory).and_return(@tempdir)
+    allow(Bosh::Aws::MigrationHelper).to receive(:aws_spec_migration_directory).and_return(@tempdir)
   end
 
   after do
@@ -39,8 +39,8 @@ describe 'migrations:aws:new' do
   it 'generates migration from the template with the correct timestamped filename' do
     subject.invoke(name)
 
-    File.exists?("#{@tempdir}/#{timestamp_string}_#{name}.rb").should be(true)
-    File.read("#{@tempdir}/#{timestamp_string}_#{name}.rb").should == <<-H
+    expect(File.exists?("#{@tempdir}/#{timestamp_string}_#{name}.rb")).to be(true)
+    expect(File.read("#{@tempdir}/#{timestamp_string}_#{name}.rb")).to eq <<-H
 class CoolMigration < Bosh::Aws::Migration
   def execute
 
@@ -52,8 +52,8 @@ end
   it 'generates the spec template for the migration' do
     subject.invoke(name)
 
-    File.exists?("#{@tempdir}/#{timestamp_string}_#{name}_spec.rb").should be(true)
-    File.read("#{@tempdir}/#{timestamp_string}_#{name}_spec.rb").should == <<-H
+    expect(File.exists?("#{@tempdir}/#{timestamp_string}_#{name}_spec.rb")).to be(true)
+    expect(File.read("#{@tempdir}/#{timestamp_string}_#{name}_spec.rb")).to eq <<-H
 require 'spec_helper'
 require '#{timestamp_string}_#{name}'
 

--- a/bosh-dev/spec/bosh/dev/upload_adapter_spec.rb
+++ b/bosh-dev/spec/bosh/dev/upload_adapter_spec.rb
@@ -17,7 +17,7 @@ module Bosh::Dev
     before do
       Fog.mock!
       Fog::Mock.reset
-      ENV.stub(to_hash: {
+      allow(ENV).to receive_messages(to_hash: {
         'BOSH_AWS_ACCESS_KEY_ID' => aws_access_key_id,
         'BOSH_AWS_SECRET_ACCESS_KEY' => aws_secret_access_key,
       })

--- a/bosh-dev/spec/bosh/dev/uri_provider_spec.rb
+++ b/bosh-dev/spec/bosh/dev/uri_provider_spec.rb
@@ -4,30 +4,30 @@ require 'bosh/dev/uri_provider'
 describe Bosh::Dev::UriProvider do
   describe '.pipeline_uri' do
     it 'returns a http uri object relative to the Bosh pipeline base URI' do
-      Bosh::Dev::UriProvider.pipeline_uri('foo/bar', 'baz.bat').should == URI('http://bosh-ci-pipeline.s3.amazonaws.com/foo/bar/baz.bat')
+      expect(Bosh::Dev::UriProvider.pipeline_uri('foo/bar', 'baz.bat')).to eq(URI('http://bosh-ci-pipeline.s3.amazonaws.com/foo/bar/baz.bat'))
     end
   end
 
   describe '.pipeline_s3_path' do
     it 'returns a s3 uri string relative to the Bosh pipeline bucket' do
-      Bosh::Dev::UriProvider.pipeline_s3_path('foo/bar', 'baz.bat').should == 's3://bosh-ci-pipeline/foo/bar/baz.bat'
+      expect(Bosh::Dev::UriProvider.pipeline_s3_path('foo/bar', 'baz.bat')).to eq('s3://bosh-ci-pipeline/foo/bar/baz.bat')
     end
   end
 
   describe '.artifacts_uri' do
     it 'returns a uri object relative to the Bosh artifacts base URI' do
-      Bosh::Dev::UriProvider.artifacts_uri('foo/bar', 'baz.bat').should == URI('http://bosh-jenkins-artifacts.s3.amazonaws.com/foo/bar/baz.bat')
+      expect(Bosh::Dev::UriProvider.artifacts_uri('foo/bar', 'baz.bat')).to eq(URI('http://bosh-jenkins-artifacts.s3.amazonaws.com/foo/bar/baz.bat'))
     end
   end
 
   describe '.artifacts_s3_path' do
     it 'returns a uri object relative to the Bosh artifacts base URI' do
-      Bosh::Dev::UriProvider.artifacts_s3_path('foo/bar', 'baz.bat').should == 's3://bosh-jenkins-artifacts/foo/bar/baz.bat'
+      expect(Bosh::Dev::UriProvider.artifacts_s3_path('foo/bar', 'baz.bat')).to eq('s3://bosh-jenkins-artifacts/foo/bar/baz.bat')
     end
 
     context 'when given path has leading slash' do
       it 'does not double up on the slash' do
-        Bosh::Dev::UriProvider.artifacts_s3_path('/foo/bar', 'baz.bat').should == 's3://bosh-jenkins-artifacts/foo/bar/baz.bat'
+        expect(Bosh::Dev::UriProvider.artifacts_s3_path('/foo/bar', 'baz.bat')).to eq('s3://bosh-jenkins-artifacts/foo/bar/baz.bat')
       end
     end
   end
@@ -35,13 +35,13 @@ describe Bosh::Dev::UriProvider do
   describe '.release_patches_uri' do
     context 'when a remote directory path is provided' do
       it 'returns a uri object relative to the Bosh release patches base URI' do
-        Bosh::Dev::UriProvider.release_patches_uri('foo/bar', 'baz.bat').should == URI('http://bosh-jenkins-release-patches.s3.amazonaws.com/foo/bar/baz.bat')
+        expect(Bosh::Dev::UriProvider.release_patches_uri('foo/bar', 'baz.bat')).to eq(URI('http://bosh-jenkins-release-patches.s3.amazonaws.com/foo/bar/baz.bat'))
       end
     end
 
     context 'when the remote directory path is empty' do
       it 'returns a uri object relative to the Bosh release patches base URI' do
-        Bosh::Dev::UriProvider.release_patches_uri('', 'baz.bat').should == URI('http://bosh-jenkins-release-patches.s3.amazonaws.com/baz.bat')
+        expect(Bosh::Dev::UriProvider.release_patches_uri('', 'baz.bat')).to eq(URI('http://bosh-jenkins-release-patches.s3.amazonaws.com/baz.bat'))
       end
     end
   end

--- a/bosh-dev/spec/bosh/dev/vcloud/deployment_account_spec.rb
+++ b/bosh-dev/spec/bosh/dev/vcloud/deployment_account_spec.rb
@@ -47,7 +47,7 @@ module Bosh::Dev::VCloud
 
     describe '#save' do
       it 'pushes changes to deployments repo' do
-        deployments_repository.should_receive(:update_and_push)
+        expect(deployments_repository).to receive(:update_and_push)
         account.save
       end
     end

--- a/bosh-dev/spec/bosh/dev/vcloud/runner_builder_spec.rb
+++ b/bosh-dev/spec/bosh/dev/vcloud/runner_builder_spec.rb
@@ -12,49 +12,49 @@ module Bosh::Dev::VCloud
         )
 
         director_address = instance_double('Bosh::Dev::Bat::DirectorAddress')
-        Bosh::Dev::Bat::DirectorAddress
-          .should_receive(:from_env)
+        expect(Bosh::Dev::Bat::DirectorAddress)
+          .to receive(:from_env)
           .with(ENV, 'BOSH_VCLOUD_MICROBOSH_IP')
           .and_return(director_address)
 
         bosh_cli_session = instance_double('Bosh::Dev::BoshCliSession')
-        Bosh::Dev::BoshCliSession
-          .should_receive(:new)
+        expect(Bosh::Dev::BoshCliSession)
+          .to receive(:new)
           .and_return(bosh_cli_session)
 
         stemcell_archive = instance_double(
           'Bosh::Stemcell::Archive',
           version: 'stemcell-archive-version',
         )
-        Bosh::Stemcell::Archive
-          .should_receive(:new)
+        expect(Bosh::Stemcell::Archive)
+          .to receive(:new)
           .with('stemcell-path')
           .and_return(stemcell_archive)
 
         microbosh_deployment_manifest = instance_double('Bosh::Dev::VCloud::MicroBoshDeploymentManifest')
-        Bosh::Dev::VCloud::MicroBoshDeploymentManifest
-          .should_receive(:new).with(ENV)
+        expect(Bosh::Dev::VCloud::MicroBoshDeploymentManifest)
+          .to receive(:new).with(ENV)
           .and_return(microbosh_deployment_manifest)
 
         microbosh_deployment_cleaner = instance_double('Bosh::Dev::VCloud::MicroBoshDeploymentCleaner')
-        Bosh::Dev::VCloud::MicroBoshDeploymentCleaner
-          .should_receive(:new).with(ENV, microbosh_deployment_manifest)
+        expect(Bosh::Dev::VCloud::MicroBoshDeploymentCleaner)
+          .to receive(:new).with(ENV, microbosh_deployment_manifest)
           .and_return(microbosh_deployment_cleaner)
 
         director_uuid = instance_double('Bosh::Dev::Bat::DirectorUuid')
-        Bosh::Dev::Bat::DirectorUuid
-          .should_receive(:new)
+        expect(Bosh::Dev::Bat::DirectorUuid)
+          .to receive(:new)
           .with(bosh_cli_session)
           .and_return(director_uuid)
 
         bat_deployment_manifest = instance_double('Bosh::Dev::VCloud::BatDeploymentManifest')
-        Bosh::Dev::VCloud::BatDeploymentManifest
-          .should_receive(:new)
+        expect(Bosh::Dev::VCloud::BatDeploymentManifest)
+          .to receive(:new)
           .with(ENV, 'net-type', director_uuid, stemcell_archive)
           .and_return(bat_deployment_manifest)
 
         runner = instance_double('Bosh::Dev::Bat::Runner')
-        Bosh::Dev::Bat::Runner.should_receive(:new).with(
+        expect(Bosh::Dev::Bat::Runner).to receive(:new).with(
           ENV,
           artifacts,
           director_address,

--- a/bosh-dev/spec/bosh/dev/vm_command/build_and_publish_stemcell_command_spec.rb
+++ b/bosh-dev/spec/bosh/dev/vm_command/build_and_publish_stemcell_command_spec.rb
@@ -55,8 +55,8 @@ module Bosh::Dev
         before { env['UBUNTU_ISO'] = 'fake-UBUNTU_ISO' }
 
         it 'includes the UBUNTU_ISO export' do
-          subject.to_s.should_not match(/bundle.*(?=export)/m)
-          subject.to_s.should match(/export UBUNTU_ISO='fake-UBUNTU_ISO'/)
+          expect(subject.to_s).not_to match(/bundle.*(?=export)/m)
+          expect(subject.to_s).to match(/export UBUNTU_ISO='fake-UBUNTU_ISO'/)
         end
       end
     end

--- a/bosh-dev/spec/bosh/dev/vsphere/deployment_account_spec.rb
+++ b/bosh-dev/spec/bosh/dev/vsphere/deployment_account_spec.rb
@@ -47,7 +47,7 @@ module Bosh::Dev::VSphere
 
     describe '#save' do
       it 'pushes changes to deployments repo' do
-        deployments_repository.should_receive(:update_and_push)
+        expect(deployments_repository).to receive(:update_and_push)
         account.save
       end
     end

--- a/bosh-dev/spec/bosh/dev/writable_manifest_spec.rb
+++ b/bosh-dev/spec/bosh/dev/writable_manifest_spec.rb
@@ -17,7 +17,7 @@ module Bosh::Dev
       it 'writes it to disk as yaml' do
         expect { manifest.write }.to change { File.exist?('foo.yml') }.to(true)
 
-        File.read('foo.yml').should eq("---\nfoo: bar\n")
+        expect(File.read('foo.yml')).to eq("---\nfoo: bar\n")
       end
     end
   end

--- a/bosh-director-core/spec/bosh/director/core/tar_gzipper_spec.rb
+++ b/bosh-director-core/spec/bosh/director/core/tar_gzipper_spec.rb
@@ -29,11 +29,11 @@ module Bosh::Director::Core
 
     context 'when copy first feature is enabled' do
       it 'copies the files to a temp directory before archiving' do
-        Dir.stub(:mktmpdir).and_yield('/tempthing')
-        FileUtils.should_receive(:cp_r).with(%w(/foo/baz /foo/bar), '/tempthing/')
-        Pathname.stub(:new).and_return(instance_double('Pathname', exist?: true, absolute?: true))
+        allow(Dir).to receive(:mktmpdir).and_yield('/tempthing')
+        expect(FileUtils).to receive(:cp_r).with(%w(/foo/baz /foo/bar), '/tempthing/')
+        allow(Pathname).to receive(:new).and_return(instance_double('Pathname', exist?: true, absolute?: true))
 
-        Open3.should_receive(:capture3)
+        expect(Open3).to receive(:capture3)
         .with(*%w(tar -C /tempthing -czf /tmp/backup.tgz baz bar))
         .and_return(success_retval)
 
@@ -78,7 +78,7 @@ module Bosh::Director::Core
     end
 
     it 'raises if it fails to tar' do
-      Open3.stub(:capture3).and_return(errored_retval)
+      allow(Open3).to receive(:capture3).and_return(errored_retval)
       expect {
         subject.compress(base_dir, sources, dest)
       }.to raise_error(RuntimeError,

--- a/bosh-director-core/spec/bosh/director/core/templates/compressed_rendered_job_templates_spec.rb
+++ b/bosh-director-core/spec/bosh/director/core/templates/compressed_rendered_job_templates_spec.rb
@@ -19,10 +19,10 @@ module Bosh::Director::Core::Templates
 
       before { allow(Dir).to receive(:mktmpdir).and_yield('/tmp/path/for/non-compressed/templates') }
 
-      before { RenderedTemplatesWriter.stub(new: writer) }
+      before { allow(RenderedTemplatesWriter).to receive_messages(new: writer) }
       let(:writer) { instance_double('Bosh::Director::Core::Templates::RenderedTemplatesWriter') }
 
-      before { Bosh::Director::Core::TarGzipper.stub(new: tar_gzipper) }
+      before { allow(Bosh::Director::Core::TarGzipper).to receive_messages(new: tar_gzipper) }
       let(:tar_gzipper) { instance_double('Bosh::Director::Core::TarGzipper') }
 
       it 'writes rendered templates to disk and then compresses them' do

--- a/bosh-director-core/spec/bosh/director/core/templates/job_instance_renderer_spec.rb
+++ b/bosh-director-core/spec/bosh/director/core/templates/job_instance_renderer_spec.rb
@@ -37,11 +37,11 @@ module Bosh::Director::Core::Templates
         let(:expected_rendered_templates) { [double('rendered template')] }
 
         before do
-          job_template_renderer.stub(:render).with(spec).and_return(expected_rendered_templates[0])
+          allow(job_template_renderer).to receive(:render).with(spec).and_return(expected_rendered_templates[0])
         end
 
         it 'returns the rendered template for the given instance' do
-          job_template_loader.stub(:process).with(templates[0]).and_return(job_template_renderer)
+          allow(job_template_loader).to receive(:process).with(templates[0]).and_return(job_template_renderer)
 
           job_instance_renderer.render(spec)
           expect(RenderedJobInstance).to have_received(:new).with(expected_rendered_templates)
@@ -68,11 +68,11 @@ module Bosh::Director::Core::Templates
         let(:job_template_renderer2) { instance_double('Bosh::Director::Core::Templates::JobTemplateRenderer') }
 
         before do
-          job_template_loader.stub(:process).with(templates[0]).and_return(job_template_renderer)
-          job_template_loader.stub(:process).with(templates[1]).and_return(job_template_renderer2)
+          allow(job_template_loader).to receive(:process).with(templates[0]).and_return(job_template_renderer)
+          allow(job_template_loader).to receive(:process).with(templates[1]).and_return(job_template_renderer2)
 
-          job_template_renderer.stub(:render).with(spec).and_return(expected_rendered_templates[0])
-          job_template_renderer2.stub(:render).with(spec).and_return(expected_rendered_templates[1])
+          allow(job_template_renderer).to receive(:render).with(spec).and_return(expected_rendered_templates[0])
+          allow(job_template_renderer2).to receive(:render).with(spec).and_return(expected_rendered_templates[1])
         end
 
         it 'returns the rendered templates for an instance' do

--- a/bosh-director-core/spec/bosh/director/core/templates/rendered_job_instance_spec.rb
+++ b/bosh-director-core/spec/bosh/director/core/templates/rendered_job_instance_spec.rb
@@ -96,7 +96,7 @@ module Bosh::Director::Core::Templates
 
       before { allow(blobstore).to receive(:create).and_return('fake-blobstore-id') }
 
-      before { Tempfile.stub(:new).and_return(temp_file) }
+      before { allow(Tempfile).to receive(:new).and_return(temp_file) }
       let(:temp_file) { instance_double('Tempfile', path: '/temp/archive/path.tgz', close!: nil) }
 
       it 'compresses the provided RenderedJobTemplate objects' do

--- a/bosh-director-core/spec/bosh/director/core/templates/rendered_job_template_spec.rb
+++ b/bosh-director-core/spec/bosh/director/core/templates/rendered_job_template_spec.rb
@@ -22,7 +22,7 @@ module Bosh::Director::Core::Templates
 
       it 'caculates the sha1 of the rendered erb content and returns hexdigest' do
         fake_digester = double('digester')
-        Digest::SHA1.stub(new: fake_digester)
+        allow(Digest::SHA1).to receive_messages(new: fake_digester)
         expect(fake_digester).to receive(:<<).with('monit file').ordered
         expect(fake_digester).to receive(:<<).with('rendered bar erb').ordered
         expect(fake_digester).to receive(:<<).with('rendered foo erb').ordered

--- a/bosh-registry/spec/unit/bosh/registry/api_controller_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/api_controller_spec.rb
@@ -16,12 +16,12 @@ describe Bosh::Registry::ApiController do
   end
 
   def expect_json_response(response, status, body)
-    response.status.should == status
-    Yajl::Parser.parse(response.body).should == body
+    expect(response.status).to eq(status)
+    expect(Yajl::Parser.parse(response.body)).to eq(body)
   end
 
   it "returns settings for given instance (IP check)" do
-    @instance_manager.should_receive(:read_settings).
+    expect(@instance_manager).to receive(:read_settings).
       with("foo", "127.0.0.1").and_return("bar")
 
     @session.get("/instances/foo/settings")
@@ -31,7 +31,7 @@ describe Bosh::Registry::ApiController do
   end
 
   it "returns settings (authorized user, no IP check)" do
-    @instance_manager.should_receive(:read_settings).
+    expect(@instance_manager).to receive(:read_settings).
       with("foo", nil).and_return("bar")
 
     @session.basic_authorize("admin", "admin")
@@ -46,7 +46,7 @@ describe Bosh::Registry::ApiController do
     expect_json_response(@session.last_response, 401,
                          { "status" => "access_denied" })
 
-    @instance_manager.should_receive(:update_settings).
+    expect(@instance_manager).to receive(:update_settings).
       with("foo", "bar").and_return(true)
 
     @session.basic_authorize("admin", "admin")
@@ -62,7 +62,7 @@ describe Bosh::Registry::ApiController do
       expect_json_response(@session.last_response, 401,
                            { "status" => "access_denied" })
 
-      @instance_manager.should_receive(:delete_settings).
+      expect(@instance_manager).to receive(:delete_settings).
         with("foo").and_return(true)
 
       @session.basic_authorize("admin", "admin")
@@ -73,7 +73,7 @@ describe Bosh::Registry::ApiController do
     end
 
     it "doesn't error when an instance isn't found" do
-      @instance_manager.should_receive(:delete_settings).
+      expect(@instance_manager).to receive(:delete_settings).
         with("foo").and_raise Bosh::Registry::InstanceNotFound
 
       @session.basic_authorize("admin", "admin")

--- a/bosh-registry/spec/unit/bosh/registry/aws/config_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/aws/config_spec.rb
@@ -61,9 +61,9 @@ describe Bosh::Registry::InstanceManager do
 
       instance_double('AWS::EC2')
       expect(AWS::EC2).to receive(:new) do |config|
-        config[:ssl_verify_peer].should be false
-        config[:ssl_ca_file].should eq('/custom/cert/ca-certificates')
-        config[:ssl_ca_path].should eq('/custom/cert/')
+        expect(config[:ssl_verify_peer]).to be false
+        expect(config[:ssl_ca_file]).to eq('/custom/cert/ca-certificates')
+        expect(config[:ssl_ca_path]).to eq('/custom/cert/')
       end
       Bosh::Registry.configure(@config)
     end
@@ -71,7 +71,7 @@ describe Bosh::Registry::InstanceManager do
     it "uses default ec2_endpoint if none specified" do
       instance_double('AWS::EC2')
       expect(AWS::EC2).to receive(:new) do |config|
-        config[:ec2_endpoint].should eq("ec2.#{@config['cloud']['aws']['region']}.amazonaws.com")
+        expect(config[:ec2_endpoint]).to eq("ec2.#{@config['cloud']['aws']['region']}.amazonaws.com")
       end
       Bosh::Registry.configure(@config)
     end
@@ -80,7 +80,7 @@ describe Bosh::Registry::InstanceManager do
       @config["cloud"]["aws"]["ec2_endpoint"] = "ec2endpoint.websites.com"
       instance_double('AWS::EC2')
       expect(AWS::EC2).to receive(:new) do |config|
-        config[:ec2_endpoint].should eq("ec2endpoint.websites.com")
+        expect(config[:ec2_endpoint]).to eq("ec2endpoint.websites.com")
       end
       Bosh::Registry.configure(@config)
     end

--- a/bosh-registry/spec/unit/bosh/registry/aws/instance_manager_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/aws/instance_manager_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Bosh::Registry::InstanceManager do
   before(:each) do
     @ec2 = double("ec2")
-    AWS::EC2.stub(:new).and_return(@ec2)
+    allow(AWS::EC2).to receive(:new).and_return(@ec2)
   end
 
   let(:manager) do
@@ -30,28 +30,28 @@ describe Bosh::Registry::InstanceManager do
     instance = double("instance")
     if eip
       elastic_ip = double("elastic_ip", :public_ip => eip)
-      instance.should_receive(:has_elastic_ip?).and_return(true)
-      instance.should_receive(:elastic_ip).and_return(elastic_ip)
+      expect(instance).to receive(:has_elastic_ip?).and_return(true)
+      expect(instance).to receive(:elastic_ip).and_return(elastic_ip)
     else
-      instance.should_receive(:has_elastic_ip?).and_return(false)
+      expect(instance).to receive(:has_elastic_ip?).and_return(false)
     end
-    @ec2.should_receive(:instances).and_return(instances)
-    instances.should_receive(:[]).with("foo").and_return(instance)
-    instance.should_receive(:private_ip_address).and_return(public_ip)
-    instance.should_receive(:public_ip_address).and_return(private_ip)
+    expect(@ec2).to receive(:instances).and_return(instances)
+    expect(instances).to receive(:[]).with("foo").and_return(instance)
+    expect(instance).to receive(:private_ip_address).and_return(public_ip)
+    expect(instance).to receive(:public_ip_address).and_return(private_ip)
   end
 
   describe "reading settings" do
     it "returns settings after verifying IP address" do
       create_instance(:instance_id => "foo", :settings => "bar")
       actual_ip_is("10.0.0.1", "10.0.1.1")
-      manager.read_settings("foo", "10.0.0.1").should == "bar"
+      expect(manager.read_settings("foo", "10.0.0.1")).to eq("bar")
     end
 
     it "returns settings after verifying elastic IP address" do
       create_instance(:instance_id => "foo", :settings => "bar")
       actual_ip_is("10.0.0.1", "10.0.1.1", "10.0.3.1")
-      manager.read_settings("foo", "10.0.3.1").should == "bar"
+      expect(manager.read_settings("foo", "10.0.3.1")).to eq("bar")
     end
 
     it "raises an error if IP cannot be verified" do

--- a/bosh-registry/spec/unit/bosh/registry/config_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/config_spec.rb
@@ -58,25 +58,25 @@ describe Bosh::Registry do
 
       logger = Bosh::Registry.logger
 
-      logger.should be_kind_of(Logger)
-      logger.level.should == Logger::DEBUG
+      expect(logger).to be_kind_of(Logger)
+      expect(logger.level).to eq(Logger::DEBUG)
 
-      Bosh::Registry.http_port.should == 25777
-      Bosh::Registry.http_user.should == "admin"
-      Bosh::Registry.http_password.should == "admin"
+      expect(Bosh::Registry.http_port).to eq(25777)
+      expect(Bosh::Registry.http_user).to eq("admin")
+      expect(Bosh::Registry.http_password).to eq("admin")
 
       db = Bosh::Registry.db
-      db.should be_kind_of(Sequel::SQLite::Database)
-      db.opts[:database].should == "/:memory:"
-      db.opts[:max_connections].should == 433
-      db.opts[:pool_timeout].should == 227
+      expect(db).to be_kind_of(Sequel::SQLite::Database)
+      expect(db.opts[:database]).to eq("/:memory:")
+      expect(db.opts[:max_connections]).to eq(433)
+      expect(db.opts[:pool_timeout]).to eq(227)
 
       im = Bosh::Registry.instance_manager
-      im.should be_kind_of(Bosh::Registry::InstanceManager::Aws)
+      expect(im).to be_kind_of(Bosh::Registry::InstanceManager::Aws)
     end
 
     it "reads provided configuration file and sets singletons for OpenStack" do
-      Fog::Compute.stub(:new)
+      allow(Fog::Compute).to receive(:new)
 
       config = valid_config
       config["cloud"] = {
@@ -93,21 +93,21 @@ describe Bosh::Registry do
 
       logger = Bosh::Registry.logger
 
-      logger.should be_kind_of(Logger)
-      logger.level.should == Logger::DEBUG
+      expect(logger).to be_kind_of(Logger)
+      expect(logger.level).to eq(Logger::DEBUG)
 
-      Bosh::Registry.http_port.should == 25777
-      Bosh::Registry.http_user.should == "admin"
-      Bosh::Registry.http_password.should == "admin"
+      expect(Bosh::Registry.http_port).to eq(25777)
+      expect(Bosh::Registry.http_user).to eq("admin")
+      expect(Bosh::Registry.http_password).to eq("admin")
 
       db = Bosh::Registry.db
-      db.should be_kind_of(Sequel::SQLite::Database)
-      db.opts[:database].should == "/:memory:"
-      db.opts[:max_connections].should == 433
-      db.opts[:pool_timeout].should == 227
+      expect(db).to be_kind_of(Sequel::SQLite::Database)
+      expect(db.opts[:database]).to eq("/:memory:")
+      expect(db.opts[:max_connections]).to eq(433)
+      expect(db.opts[:pool_timeout]).to eq(227)
 
       im = Bosh::Registry.instance_manager
-      im.should be_kind_of(Bosh::Registry::InstanceManager::Openstack)
+      expect(im).to be_kind_of(Bosh::Registry::InstanceManager::Openstack)
     end
 
   end
@@ -126,7 +126,7 @@ describe Bosh::Registry do
     let(:database_connection) { double('Database Connection').as_null_object }
 
     before do
-      Sequel.stub(:connect).and_return(database_connection)
+      allow(Sequel).to receive(:connect).and_return(database_connection)
     end
 
     it "configures a new database connection" do
@@ -138,35 +138,35 @@ describe Bosh::Registry do
           'adapter' => 'sqlite',
           'max_connections' => 32
       }
-      Sequel.should_receive(:connect).with(expected_options).and_return(database_connection)
+      expect(Sequel).to receive(:connect).with(expected_options).and_return(database_connection)
       described_class.connect_db(database_options)
     end
 
     it "ignores empty and nil options" do
-      Sequel.should_receive(:connect).with('baz' => 'baz').and_return(database_connection)
+      expect(Sequel).to receive(:connect).with('baz' => 'baz').and_return(database_connection)
       described_class.connect_db('foo' => nil, 'bar' => '', 'baz' => 'baz')
     end
 
     context "when logger is available" do
       before do
-        described_class.stub(:logger).and_return(double('Fake Logger'))
+        allow(described_class).to receive(:logger).and_return(double('Fake Logger'))
       end
 
       it "sets the database logger" do
-        database_connection.should_receive(:logger=)
-        database_connection.should_receive(:sql_log_level=)
+        expect(database_connection).to receive(:logger=)
+        expect(database_connection).to receive(:sql_log_level=)
         described_class.connect_db(database_options)
       end
     end
 
     context "when logger is unavailable" do
       before do
-        described_class.stub(:logger).and_return(nil)
+        allow(described_class).to receive(:logger).and_return(nil)
       end
 
       it "does not sets the database logger" do
-        database_connection.should_not_receive(:logger=)
-        database_connection.should_not_receive(:sql_log_level=)
+        expect(database_connection).not_to receive(:logger=)
+        expect(database_connection).not_to receive(:sql_log_level=)
         described_class.connect_db(database_options)
       end
     end

--- a/bosh-registry/spec/unit/bosh/registry/instance_manager_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/instance_manager_spec.rb
@@ -14,7 +14,7 @@ describe Bosh::Registry::InstanceManager do
   describe "reading settings" do
     it "doesn't check remote IP if it's not provided" do
       create_instance(:instance_id => "foo", :settings => "bar")
-      manager.read_settings("foo").should == "bar"
+      expect(manager.read_settings("foo")).to eq("bar")
     end
 
     it "raises an error if instance not found" do
@@ -28,14 +28,14 @@ describe Bosh::Registry::InstanceManager do
   describe "updating settings" do
     it "updates settings (new instance)" do
       manager.update_settings("foo", "baz")
-      manager.read_settings("foo").should == "baz"
+      expect(manager.read_settings("foo")).to eq("baz")
     end
 
     it "updates settings (existing instance)" do
       create_instance(:instance_id => "foo", :settings => "bar")
-      manager.read_settings("foo").should == "bar"
+      expect(manager.read_settings("foo")).to eq("bar")
       manager.update_settings("foo", "baz")
-      manager.read_settings("foo").should == "baz"
+      expect(manager.read_settings("foo")).to eq("baz")
     end
   end
 

--- a/bosh-registry/spec/unit/bosh/registry/openstack/instance_manager_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/openstack/instance_manager_spec.rb
@@ -32,10 +32,10 @@ describe Bosh::Registry::InstanceManager do
     servers = double('servers')
     instance = double('instance')
 
-    compute.should_receive(:servers).and_return(servers)
-    servers.should_receive(:find).and_return(instance)
-    instance.should_receive(:private_ip_addresses).and_return([private_ip])
-    instance.should_receive(:floating_ip_addresses).and_return([floating_ip])
+    expect(compute).to receive(:servers).and_return(servers)
+    expect(servers).to receive(:find).and_return(instance)
+    expect(instance).to receive(:private_ip_addresses).and_return([private_ip])
+    expect(instance).to receive(:floating_ip_addresses).and_return([floating_ip])
   end
 
   describe :openstack do
@@ -53,7 +53,7 @@ describe Bosh::Registry::InstanceManager do
     }
 
     it 'should create a Fog::Compute connection' do
-      Fog::Compute.should_receive(:new).with(openstack_compute).and_return(compute)
+      expect(Fog::Compute).to receive(:new).with(openstack_compute).and_return(compute)
       expect(manager.openstack).to eql(compute)
     end
 
@@ -65,7 +65,7 @@ describe Bosh::Registry::InstanceManager do
       }
 
       it 'should add optional options to the Fog::Compute connection' do
-        Fog::Compute.should_receive(:new).with(openstack_compute).and_return(compute)
+        expect(Fog::Compute).to receive(:new).with(openstack_compute).and_return(compute)
         expect(manager.openstack).to eql(compute)
       end
     end
@@ -73,19 +73,19 @@ describe Bosh::Registry::InstanceManager do
 
   describe 'reading settings' do
     before(:each) do
-      Fog::Compute.stub(:new).and_return(compute)
+      allow(Fog::Compute).to receive(:new).and_return(compute)
     end
 
     it 'returns settings after verifying IP address' do
       create_instance(:instance_id => 'foo', :settings => 'bar')
       actual_ip_is('10.0.0.1', nil)
-      manager.read_settings('foo', '10.0.0.1').should == 'bar'
+      expect(manager.read_settings('foo', '10.0.0.1')).to eq('bar')
     end
 
     it 'returns settings after verifying floating IP address' do
       create_instance(:instance_id => 'foo', :settings => 'bar')
       actual_ip_is(nil, '10.0.1.1')
-      manager.read_settings('foo', '10.0.1.1').should == 'bar'
+      expect(manager.read_settings('foo', '10.0.1.1')).to eq('bar')
     end
 
     it 'raises an error if IP cannot be verified' do
@@ -100,16 +100,16 @@ describe Bosh::Registry::InstanceManager do
 
     it 'it should create a new fog connection if there is an Unauthorized error' do
       create_instance(:instance_id => 'foo', :settings => 'bar')
-      compute.should_receive(:servers).and_raise(Excon::Errors::Unauthorized, 'Unauthorized')
+      expect(compute).to receive(:servers).and_raise(Excon::Errors::Unauthorized, 'Unauthorized')
       actual_ip_is('10.0.0.1', nil)
-      manager.read_settings('foo', '10.0.0.1').should == 'bar'
+      expect(manager.read_settings('foo', '10.0.0.1')).to eq('bar')
     end
 
     it 'it should raise a ConnectionError if there is a persistent Unauthorized error' do
       create_instance(:instance_id => 'foo', :settings => 'bar')
-      compute.should_receive(:servers).twice.and_raise(Excon::Errors::Unauthorized, 'Unauthorized')
+      expect(compute).to receive(:servers).twice.and_raise(Excon::Errors::Unauthorized, 'Unauthorized')
       expect {
-        manager.read_settings('foo', '10.0.0.1').should == 'bar'
+        expect(manager.read_settings('foo', '10.0.0.1')).to eq('bar')
       }.to raise_error(Bosh::Registry::ConnectionError, 'Unable to connect to OpenStack API: Unauthorized') 
     end
   end

--- a/bosh-registry/spec/unit/bosh/registry/runner_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/runner_spec.rb
@@ -20,7 +20,7 @@ describe Bosh::Registry::Runner do
       config = { "key" => "value" }
       write_config(config_file.path, config)
 
-      Bosh::Registry.should_receive(:configure).with(config)
+      expect(Bosh::Registry).to receive(:configure).with(config)
       make_runner(config_file.path)
     end
 
@@ -44,7 +44,7 @@ describe Bosh::Registry::Runner do
       config_file = Tempfile.new("config")
       write_config(config_file.path, { "foo" => "bar" })
 
-      Psych.stub(:load_file).and_raise(SystemCallError.new("baz"))
+      allow(Psych).to receive(:load_file).and_raise(SystemCallError.new("baz"))
 
       expect {
         make_runner(config_file.path)
@@ -59,21 +59,21 @@ describe Bosh::Registry::Runner do
     end
 
     it "spins up/shuts down reactor and HTTP server" do
-      Bosh::Registry.stub(:configure)
+      allow(Bosh::Registry).to receive(:configure)
       Bosh::Registry.http_port = 25777
 
       runner = make_runner(@config_file)
       mock_thin = double("thin")
 
-      Thin::Server.should_receive(:new).
+      expect(Thin::Server).to receive(:new).
         with("0.0.0.0", 25777, :signals => false).
         and_return(mock_thin)
 
-      mock_thin.should_receive(:start!)
+      expect(mock_thin).to receive(:start!)
 
       runner.run
 
-      mock_thin.should_receive(:stop!)
+      expect(mock_thin).to receive(:stop!)
 
       runner.stop
     end

--- a/bosh-release/spec/unit/bosh/release/compiler_spec.rb
+++ b/bosh-release/spec/unit/bosh/release/compiler_spec.rb
@@ -34,22 +34,22 @@ describe Bosh::Release::Compiler do
 
     let(:test_agent) do
       agent = double(:agent)
-      agent.stub(:ping)
-      agent.stub(:run_task).and_return(result)
+      allow(agent).to receive(:ping)
+      allow(agent).to receive(:run_task).and_return(result)
       agent
     end
 
     let(:result) { {'result' => {'blobstore_id' => 'blah', 'sha1' => 'blah'}} }
 
     before do
-      Bosh::Agent::Client.should_receive(:create).and_return(test_agent)
+      expect(Bosh::Agent::Client).to receive(:create).and_return(test_agent)
     end
 
     it 'should compile packages according to the manifest' do
-      test_agent.stub(:run_task).with(:compile_package, kind_of(String), 'sha1',
+      allow(test_agent).to receive(:run_task).with(:compile_package, kind_of(String), 'sha1',
                                       /(ruby|nats|redis|libpq|postgres|blobstore|nginx|director|health_monitor)/,
                                       kind_of(String), kind_of(Hash)).and_return(result)
-      compiler.compile.should include('director')
+      expect(compiler.compile).to include('director')
     end
 
     it 'writes the apply spec as json if the json option is set' do
@@ -60,8 +60,8 @@ describe Bosh::Release::Compiler do
       contents = file.read
 
       apply_spec_hash = JSON.parse(contents)
-      apply_spec_hash["deployment"].should eq("micro")
-      compiler.apply_spec_json.should match(/json\z/)
+      expect(apply_spec_hash["deployment"]).to eq("micro")
+      expect(compiler.apply_spec_json).to match(/json\z/)
     end
 
     context 'when job uses job collocation' do
@@ -73,10 +73,10 @@ describe Bosh::Release::Compiler do
         spec = Psych.load_file(compiler.apply_spec)
 
         spec_jobs = spec['job']['templates']
-        spec_jobs.size.should eq(3)
-        spec_jobs[0]['name'].should eq('nats')
-        spec_jobs[1]['name'].should eq('redis')
-        spec_jobs[2]['name'].should eq('postgres')
+        expect(spec_jobs.size).to eq(3)
+        expect(spec_jobs[0]['name']).to eq('nats')
+        expect(spec_jobs[1]['name']).to eq('redis')
+        expect(spec_jobs[2]['name']).to eq('postgres')
       end
     end
 
@@ -84,20 +84,20 @@ describe Bosh::Release::Compiler do
       it 'should put only this job in apply spec' do
         compiler.compile
         spec =Psych.load_file(compiler.apply_spec)
-        spec['job']['templates'].size.should eq(1)
+        expect(spec['job']['templates'].size).to eq(1)
 
         micro_job_spec = spec['job']['templates'][0]
-        micro_job_spec['name'].should eq('micro')
-        micro_job_spec['version'].should eq('0.9-dev')
-        micro_job_spec['sha1'].should eq('ab62ca83016af6ddd5b24d535e339ee193bc7168')
-        micro_job_spec['blobstore_id'].should match(/[a-z\d-]/)
+        expect(micro_job_spec['name']).to eq('micro')
+        expect(micro_job_spec['version']).to eq('0.9-dev')
+        expect(micro_job_spec['sha1']).to eq('ab62ca83016af6ddd5b24d535e339ee193bc7168')
+        expect(micro_job_spec['blobstore_id']).to match(/[a-z\d-]/)
       end
     end
 
     it 'should call agent start after applying custom properties' do
-      test_agent.should_receive(:run_task).with(:stop)
-      test_agent.should_receive(:run_task).with(:apply, kind_of(Hash))
-      test_agent.should_receive(:run_task).with(:start)
+      expect(test_agent).to receive(:run_task).with(:stop)
+      expect(test_agent).to receive(:run_task).with(:apply, kind_of(Hash))
+      expect(test_agent).to receive(:run_task).with(:start)
       compiler.apply
     end
   end
@@ -106,16 +106,16 @@ describe Bosh::Release::Compiler do
     options[:job] = 'micro_aws'
     @compiler = Bosh::Release::Compiler.new(options)
     test_agent = double(:agent)
-    test_agent.stub(:ping)
+    allow(test_agent).to receive(:ping)
     digester = double('Digest::SHA1')
-    digester.stub(hexdigest: 'fake-sha1')
-    Digest::SHA1.stub(:file).and_return(digester)
+    allow(digester).to receive_messages(hexdigest: 'fake-sha1')
+    allow(Digest::SHA1).to receive(:file).and_return(digester)
     result = {'result' => {'blobstore_id' => 'blah', 'sha1' => 'blah'}}
-    test_agent.stub(:run_task).with(:compile_package, kind_of(String), 'fake-sha1',
+    allow(test_agent).to receive(:run_task).with(:compile_package, kind_of(String), 'fake-sha1',
                                     /(ruby|nats|redis|libpq|postgres|blobstore|nginx|director|health_monitor|aws_registry)/,
                                     kind_of(String), kind_of(Hash)).and_return(result)
-    Bosh::Agent::Client.should_receive(:create).and_return(test_agent)
-    @compiler.compile.should include('aws_registry')
+    expect(Bosh::Agent::Client).to receive(:create).and_return(test_agent)
+    expect(@compiler.compile).to include('aws_registry')
   end
 
   it 'should respect spec properties if job properties are empty' do
@@ -126,7 +126,7 @@ describe Bosh::Release::Compiler do
 
     @compiler = Bosh::Release::Compiler.new(options)
     @compiler.add_default_properties(spec_properties, job_properties)
-    spec_properties.should == spec_properties
+    expect(spec_properties).to eq(spec_properties)
   end
 
   it 'should add default job properties to spec properties' do
@@ -143,11 +143,11 @@ describe Bosh::Release::Compiler do
 
     @compiler = Bosh::Release::Compiler.new(options)
     @compiler.add_default_properties(spec_properties, job_properties)
-    spec_properties.should == {'foo' => {'bar1' => 'original',
+    expect(spec_properties).to eq({'foo' => {'bar1' => 'original',
                                          'bar2' => 'added'},
                                'bar' => {'vtrue' => true,
                                          'vfalse' => false}
-                              }
+                              })
   end
 
 end

--- a/bosh-template/spec/unit/bosh/template/evaluation_context_spec.rb
+++ b/bosh-template/spec/unit/bosh/template/evaluation_context_spec.rb
@@ -30,36 +30,36 @@ module Bosh
       end
 
       it 'unrolls properties into OpenStruct' do
-        eval_template('<%= properties.foo %>', @context).should == 'bar'
+        expect(eval_template('<%= properties.foo %>', @context)).to eq('bar')
       end
 
       it 'retains raw_properties' do
-        eval_template("<%= raw_properties['router']['token'] %>", @context).should == 'zbb'
+        expect(eval_template("<%= raw_properties['router']['token'] %>", @context)).to eq('zbb')
       end
 
       it 'supports looking up template index' do
-        eval_template('<%= spec.index %>', @context).should == '0'
+        expect(eval_template('<%= spec.index %>', @context)).to eq('0')
       end
 
       describe 'p' do
         it 'looks up properties' do
-          eval_template("<%= p('router.token') %>", @context).should == 'zbb'
-          eval_template("<%= p('vtrue') %>", @context).should == 'true'
-          eval_template("<%= p('vfalse') %>", @context).should == 'false'
+          expect(eval_template("<%= p('router.token') %>", @context)).to eq('zbb')
+          expect(eval_template("<%= p('vtrue') %>", @context)).to eq('true')
+          expect(eval_template("<%= p('vfalse') %>", @context)).to eq('false')
           expect {
             eval_template("<%= p('bar.baz') %>", @context)
           }.to raise_error(UnknownProperty, "Can't find property `[\"bar.baz\"]'")
-          eval_template("<%= p('bar.baz', 22) %>", @context).should == '22'
+          expect(eval_template("<%= p('bar.baz', 22) %>", @context)).to eq('22')
         end
 
         it 'supports hash properties' do
-          eval_template(<<-TMPL, @context).strip.should == 'zbb'
+          expect(eval_template(<<-TMPL, @context).strip).to eq('zbb')
         <%= p(%w(a b router c))['token'] %>
           TMPL
         end
 
         it 'chains property lookups' do
-          eval_template(<<-TMPL, @context).strip.should == 'zbb'
+          expect(eval_template(<<-TMPL, @context).strip).to eq('zbb')
         <%= p(%w(a b router.token c)) %>
           TMPL
 
@@ -70,18 +70,18 @@ module Bosh
           }.to raise_error(UnknownProperty,
                            "Can't find property `[\"a\", \"b\", \"c\"]'")
 
-          eval_template(<<-TMPL, @context).strip.should == '22'
+          expect(eval_template(<<-TMPL, @context).strip).to eq('22')
         <%= p(%w(a b c), 22) %>
           TMPL
         end
       end
 
       it "allows 'false' and 'nil' defaults for 'p' helper" do
-        eval_template(<<-TMPL, @context).strip.should == 'false'
+        expect(eval_template(<<-TMPL, @context).strip).to eq('false')
       <%= p(%w(a b c), false) %>
         TMPL
 
-        eval_template(<<-TMPL, @context).strip.should == ''
+        expect(eval_template(<<-TMPL, @context).strip).to eq('')
       <%= p(%w(a b c), nil) %>
         TMPL
       end
@@ -94,7 +94,7 @@ module Bosh
         <% end %>
           TMPL
 
-          eval_template(template, @context).strip.should == 'zbb'
+          expect(eval_template(template, @context).strip).to eq('zbb')
         end
 
         it 'works with two properties' do
@@ -104,7 +104,7 @@ module Bosh
         <% end %>
           TMPL
 
-          eval_template(template, @context).strip.should == 'zbb, bar'
+          expect(eval_template(template, @context).strip).to eq('zbb, bar')
         end
 
         it "does not call the block if a property can't be found" do
@@ -114,7 +114,7 @@ module Bosh
         <% end %>
           TMPL
 
-          eval_template(template, @context).strip.should == ''
+          expect(eval_template(template, @context).strip).to eq('')
         end
 
         describe '.else' do
@@ -127,7 +127,7 @@ module Bosh
           <% end %>
             TMPL
 
-            eval_template(template, @context).strip.should == 'zbb, bar'
+            expect(eval_template(template, @context).strip).to eq('zbb, bar')
           end
 
           it 'calls the else block if any of the properties are missing' do
@@ -139,7 +139,7 @@ module Bosh
           <% end %>
             TMPL
 
-            eval_template(template, @context).strip.should == 'visible text'
+            expect(eval_template(template, @context).strip).to eq('visible text')
           end
         end
 
@@ -155,7 +155,7 @@ module Bosh
           <% end %>
             TMPL
 
-            eval_template(template, @context).strip.should == 'zbb, bar'
+            expect(eval_template(template, @context).strip).to eq('zbb, bar')
           end
 
           it 'is called when if_p does not match' do
@@ -169,7 +169,7 @@ module Bosh
           <% end %>
             TMPL
 
-            eval_template(template, @context).strip.should == 'true'
+            expect(eval_template(template, @context).strip).to eq('true')
           end
 
           it "calls else when its conditions aren't met" do
@@ -183,7 +183,7 @@ module Bosh
           <% end %>
             TMPL
 
-            eval_template(template, @context).strip.should == 'totally going to get here'
+            expect(eval_template(template, @context).strip).to eq('totally going to get here')
           end
         end
       end

--- a/bosh-template/spec/unit/bosh/template/property_helper_spec.rb
+++ b/bosh-template/spec/unit/bosh/template/property_helper_spec.rb
@@ -14,36 +14,36 @@ module Bosh
         src = {'foo' => {'bar' => 'baz', 'secret' => 'zazzle'}}
 
         @helper.copy_property(dst, src, 'foo.bar')
-        dst.should == {'foo' => {'bar' => 'baz'}}
+        expect(dst).to eq({'foo' => {'bar' => 'baz'}})
 
         @helper.copy_property(dst, src, 'no.such.prop', 'default')
-        dst.should == {
+        expect(dst).to eq({
           'foo' => {'bar' => 'baz'},
           'no' => {
             'such' => {'prop' => 'default'}
           }
-        }
+        })
       end
 
       it 'should return the default value if the value not found in src' do
         dst = {}
         src = {}
         @helper.copy_property(dst, src, 'foo.bar', 'foobar')
-        dst.should == {'foo' => {'bar' => 'foobar'}}
+        expect(dst).to eq({'foo' => {'bar' => 'foobar'}})
       end
 
       it "should return the 'false' value when parsing a boolean false value" do
         dst = {}
         src = {'foo' => {'bar' => false}}
         @helper.copy_property(dst, src, 'foo.bar', true)
-        dst.should == {'foo' => {'bar' => false}}
+        expect(dst).to eq({'foo' => {'bar' => false}})
       end
 
       it 'should get a nil when value not found in src and no default value specified ' do
         dst = {}
         src = {}
         @helper.copy_property(dst, src, 'foo.bar')
-        dst.should == {'foo' => {'bar' => nil}}
+        expect(dst).to eq({'foo' => {'bar' => nil}})
       end
 
       it 'can lookup the property in a Hash using dot-syntax' do
@@ -52,9 +52,9 @@ module Bosh
           'router' => {'token' => 'foo'}
         }
 
-        @helper.lookup_property(properties, 'foo.bar').should == 'baz'
-        @helper.lookup_property(properties, 'router').should == {'token' => 'foo'}
-        @helper.lookup_property(properties, 'no.prop').should be_nil
+        expect(@helper.lookup_property(properties, 'foo.bar')).to eq('baz')
+        expect(@helper.lookup_property(properties, 'router')).to eq({'token' => 'foo'})
+        expect(@helper.lookup_property(properties, 'no.prop')).to be_nil
       end
     end
   end

--- a/bosh_aws_cpi/spec/integration/lifecycle_spec.rb
+++ b/bosh_aws_cpi/spec/integration/lifecycle_spec.rb
@@ -21,7 +21,7 @@ describe Bosh::AwsCloud::Cloud do
   let(:network_spec) { {} }
   let(:resource_pool) { { 'instance_type' => instance_type } }
 
-  before { Bosh::Registry::Client.stub(new: double('registry').as_null_object) }
+  before { allow(Bosh::Registry::Client).to receive_messages(new: double('registry').as_null_object) }
 
   # Use subject-bang because AWS SDK needs to be reconfigured
   # with a current test's logger before new AWS::EC2 object is created.
@@ -55,7 +55,7 @@ describe Bosh::AwsCloud::Cloud do
       double('delegate', task_checkpoint: nil, logger: Logger.new(STDOUT)))
   end
 
-  before { Bosh::Clouds::Config.stub(logger: logger) }
+  before { allow(Bosh::Clouds::Config).to receive_messages(logger: logger) }
   let(:logger) { Logger.new(STDERR) }
 
   before { @instance_id = nil }

--- a/bosh_aws_cpi/spec/spec_helper.rb
+++ b/bosh_aws_cpi/spec/spec_helper.rb
@@ -36,7 +36,7 @@ end
 
 def mock_registry(endpoint = 'http://registry:3333')
   registry = double('registry', :endpoint => endpoint)
-  Bosh::Registry::Client.stub(:new).and_return(registry)
+  allow(Bosh::Registry::Client).to receive(:new).and_return(registry)
   registry
 end
 

--- a/bosh_aws_cpi/spec/unit/aki_picker_spec.rb
+++ b/bosh_aws_cpi/spec/unit/aki_picker_spec.rb
@@ -15,13 +15,13 @@ describe Bosh::AwsCloud::AKIPicker do
   let(:picker) {Bosh::AwsCloud::AKIPicker.new(double("ec2"))}
 
   it "should pick the AKI with the highest version" do
-    picker.should_receive(:logger).and_return(logger)
-    picker.should_receive(:fetch_akis).and_return(akis)
-    picker.pick("x86_64", "/dev/sda1").should == "aki-b4aa75dd"
+    expect(picker).to receive(:logger).and_return(logger)
+    expect(picker).to receive(:fetch_akis).and_return(akis)
+    expect(picker.pick("x86_64", "/dev/sda1")).to eq("aki-b4aa75dd")
   end
 
   it "should raise an error when it can't pick an AKI" do
-    picker.should_receive(:fetch_akis).and_return(akis)
+    expect(picker).to receive(:fetch_akis).and_return(akis)
     expect {
       picker.pick("foo", "bar")
     }.to raise_error Bosh::Clouds::CloudError, "unable to find AKI"

--- a/bosh_aws_cpi/spec/unit/attach_disk_spec.rb
+++ b/bosh_aws_cpi/spec/unit/attach_disk_spec.rb
@@ -12,16 +12,16 @@ describe Bosh::AwsCloud::Cloud do
     attachment = double('attachment', :device => '/dev/sdf')
 
     cloud = mock_cloud do |ec2|
-      ec2.instances.should_receive(:[]).with('i-test').and_return(instance)
-      ec2.volumes.should_receive(:[]).with('v-foobar').and_return(volume)
+      expect(ec2.instances).to receive(:[]).with('i-test').and_return(instance)
+      expect(ec2.volumes).to receive(:[]).with('v-foobar').and_return(volume)
     end
 
-    volume.should_receive(:attach_to).
+    expect(volume).to receive(:attach_to).
       with(instance, '/dev/sdf').and_return(attachment)
 
-    instance.should_receive(:block_device_mappings).and_return({})
+    expect(instance).to receive(:block_device_mappings).and_return({})
 
-    Bosh::AwsCloud::ResourceWait.stub(:for_attachment).with(attachment: attachment, state: :attached)
+    allow(Bosh::AwsCloud::ResourceWait).to receive(:for_attachment).with(attachment: attachment, state: :attached)
 
     old_settings = { 'foo' => 'bar'}
     new_settings = {
@@ -33,11 +33,11 @@ describe Bosh::AwsCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).
+    expect(@registry).to receive(:read_settings).
       with('i-test').
       and_return(old_settings)
 
-    @registry.should_receive(:update_settings).with('i-test', new_settings)
+    expect(@registry).to receive(:update_settings).with('i-test', new_settings)
 
     cloud.attach_disk('i-test', 'v-foobar')
   end
@@ -48,17 +48,17 @@ describe Bosh::AwsCloud::Cloud do
     attachment = double('attachment', :device => '/dev/sdh')
 
     cloud = mock_cloud do |ec2|
-      ec2.instances.should_receive(:[]).with('i-test').and_return(instance)
-      ec2.volumes.should_receive(:[]).with('v-foobar').and_return(volume)
+      expect(ec2.instances).to receive(:[]).with('i-test').and_return(instance)
+      expect(ec2.volumes).to receive(:[]).with('v-foobar').and_return(volume)
     end
 
-    instance.should_receive(:block_device_mappings).
+    expect(instance).to receive(:block_device_mappings).
       and_return({ '/dev/sdf' => 'foo', '/dev/sdg' => 'bar'})
 
-    volume.should_receive(:attach_to).
+    expect(volume).to receive(:attach_to).
       with(instance, '/dev/sdh').and_return(attachment)
 
-    Bosh::AwsCloud::ResourceWait.stub(:for_attachment).with(attachment: attachment, state: :attached)
+    allow(Bosh::AwsCloud::ResourceWait).to receive(:for_attachment).with(attachment: attachment, state: :attached)
 
     old_settings = { 'foo' => 'bar'}
     new_settings = {
@@ -70,11 +70,11 @@ describe Bosh::AwsCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).
+    expect(@registry).to receive(:read_settings).
       with('i-test').
       and_return(old_settings)
 
-    @registry.should_receive(:update_settings).with('i-test', new_settings)
+    expect(@registry).to receive(:update_settings).with('i-test', new_settings)
 
     cloud.attach_disk('i-test', 'v-foobar')
   end
@@ -85,17 +85,17 @@ describe Bosh::AwsCloud::Cloud do
     attachment = double('attachment', :device => '/dev/sdh')
 
     cloud = mock_cloud do |ec2|
-      ec2.instances.should_receive(:[]).with('i-test').and_return(instance)
-      ec2.volumes.should_receive(:[]).with('v-foobar').and_return(volume)
+      expect(ec2.instances).to receive(:[]).with('i-test').and_return(instance)
+      expect(ec2.volumes).to receive(:[]).with('v-foobar').and_return(volume)
     end
 
-    instance.should_receive(:block_device_mappings).
+    expect(instance).to receive(:block_device_mappings).
       and_return({ '/dev/sdf' => 'foo', '/dev/sdg' => 'bar'})
 
-    volume.should_receive(:attach_to).
+    expect(volume).to receive(:attach_to).
       with(instance, '/dev/sdh').and_return(attachment)
 
-    Bosh::AwsCloud::ResourceWait.stub(:for_attachment).with(attachment: attachment, state: :attached)
+    allow(Bosh::AwsCloud::ResourceWait).to receive(:for_attachment).with(attachment: attachment, state: :attached)
 
     old_settings = { 'foo' => 'bar'}
     new_settings = {
@@ -107,11 +107,11 @@ describe Bosh::AwsCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).
+    expect(@registry).to receive(:read_settings).
       with('i-test').
       and_return(old_settings)
 
-    @registry.should_receive(:update_settings).with('i-test', new_settings)
+    expect(@registry).to receive(:update_settings).with('i-test', new_settings)
 
     cloud.attach_disk('i-test', 'v-foobar')
   end
@@ -121,8 +121,8 @@ describe Bosh::AwsCloud::Cloud do
     volume = double('volume', :id => 'v-foobar')
 
     cloud = mock_cloud do |ec2|
-      ec2.instances.should_receive(:[]).with('i-test').and_return(instance)
-      ec2.volumes.should_receive(:[]).with('v-foobar').and_return(volume)
+      expect(ec2.instances).to receive(:[]).with('i-test').and_return(instance)
+      expect(ec2.volumes).to receive(:[]).with('v-foobar').and_return(volume)
     end
 
     all_mappings = ('f'..'p').inject({}) do |hash, char|
@@ -130,7 +130,7 @@ describe Bosh::AwsCloud::Cloud do
       hash
     end
 
-    instance.should_receive(:block_device_mappings).
+    expect(instance).to receive(:block_device_mappings).
       and_return(all_mappings)
 
     expect {

--- a/bosh_aws_cpi/spec/unit/availability_zone_selector_spec.rb
+++ b/bosh_aws_cpi/spec/unit/availability_zone_selector_spec.rb
@@ -19,11 +19,11 @@ describe Bosh::AwsCloud::AvailabilityZoneSelector do
     end
 
     it 'should select the common availability zone' do
-      subject.common_availability_zone(%w(this_zone), 'this_zone', nil).should == 'this_zone'
+      expect(subject.common_availability_zone(%w(this_zone), 'this_zone', nil)).to eq('this_zone')
     end
 
     it 'should return the default when no availability zone is passed' do
-      subject.common_availability_zone([], nil, nil).should == 'default_zone'
+      expect(subject.common_availability_zone([], nil, nil)).to eq('default_zone')
     end
 
   end
@@ -32,15 +32,15 @@ describe Bosh::AwsCloud::AvailabilityZoneSelector do
     context 'with a default' do
       context 'with a instance id' do
         it 'should return the az of the instance' do
-          instances.stub(:[]).and_return(instance)
+          allow(instances).to receive(:[]).and_return(instance)
 
-          subject.select_availability_zone(instance).should == 'this_zone'
+          expect(subject.select_availability_zone(instance)).to eq('this_zone')
         end
       end
 
       context 'without a instance id' do
         it 'should return the default az' do
-          subject.select_availability_zone(nil).should == 'default_zone'
+          expect(subject.select_availability_zone(nil)).to eq('default_zone')
         end
       end
     end
@@ -50,16 +50,16 @@ describe Bosh::AwsCloud::AvailabilityZoneSelector do
 
       context 'with a instance id' do
         it 'should return the az of the instance' do
-          instances.stub(:[]).and_return(instance)
+          allow(instances).to receive(:[]).and_return(instance)
 
-          subject.select_availability_zone(instance).should == 'this_zone'
+          expect(subject.select_availability_zone(instance)).to eq('this_zone')
         end
       end
 
       context 'without a instance id' do
         it 'should return a random az' do
-          Random.stub(:rand => 0)
-          subject.select_availability_zone(nil).should == 'us-east-1a'
+          allow(Random).to receive_messages(:rand => 0)
+          expect(subject.select_availability_zone(nil)).to eq('us-east-1a')
         end
       end
     end

--- a/bosh_aws_cpi/spec/unit/configure_networks_spec.rb
+++ b/bosh_aws_cpi/spec/unit/configure_networks_spec.rb
@@ -18,14 +18,14 @@ describe Bosh::AwsCloud::Cloud do
                       :security_groups => [sec_grp])
 
     cloud = mock_cloud do |ec2|
-      ec2.instances.stub(:[]).
+      allow(ec2.instances).to receive(:[]).
           with("i-foobar").
           and_return(instance)
     end
 
-    lambda {
+    expect {
       cloud.configure_networks("i-foobar", combined_network_spec)
-    }.should raise_error Bosh::Clouds::NotSupported
+    }.to raise_error Bosh::Clouds::NotSupported
   end
 
   it "forces recreation when IP address differ" do
@@ -36,7 +36,7 @@ describe Bosh::AwsCloud::Cloud do
                       :private_ip_address => "10.10.10.1")
 
     cloud = mock_cloud do |ec2|
-      ec2.instances.stub(:[]).
+      allow(ec2.instances).to receive(:[]).
           with("i-foobar").
           and_return(instance)
     end
@@ -54,26 +54,26 @@ describe Bosh::AwsCloud::Cloud do
                       :id => "i-foobar",
                       :security_groups => [sec_grp],
                       :private_ip_address => "10.10.10.1")
-    Bosh::Clouds::Config.stub(:task_checkpoint)
+    allow(Bosh::Clouds::Config).to receive(:task_checkpoint)
 
     cloud = mock_cloud do |ec2|
-      ec2.instances.stub(:[]).
+      allow(ec2.instances).to receive(:[]).
           with("i-foobar").
           and_return(instance)
-      ec2.stub(:elastic_ips).
+      allow(ec2).to receive(:elastic_ips).
           and_return({"10.0.0.1" => "10.0.0.1"})
     end
 
     old_settings = {"foo" => "bar", "networks" => "baz"}
     new_settings = {"foo" => "bar", "networks" => combined_network_spec}
 
-    @registry.should_receive(:read_settings).
+    expect(@registry).to receive(:read_settings).
         with("i-foobar").
         and_return(old_settings)
 
-    @registry.should_receive(:update_settings).with("i-foobar", new_settings)
+    expect(@registry).to receive(:update_settings).with("i-foobar", new_settings)
 
-    instance.should_receive(:associate_elastic_ip).with("10.0.0.1")
+    expect(instance).to receive(:associate_elastic_ip).with("10.0.0.1")
 
     cloud.configure_networks("i-foobar", combined_network_spec)
   end
@@ -86,13 +86,13 @@ describe Bosh::AwsCloud::Cloud do
                       :private_ip_address => "10.10.10.1")
 
     cloud = mock_cloud do |ec2|
-      ec2.instances.stub(:[]).
+      allow(ec2.instances).to receive(:[]).
           with("i-foobar").
           and_return(instance)
     end
 
-    instance.should_receive(:elastic_ip).and_return("10.0.0.1")
-    instance.should_receive(:disassociate_elastic_ip)
+    expect(instance).to receive(:elastic_ip).and_return("10.0.0.1")
+    expect(instance).to receive(:disassociate_elastic_ip)
 
     old_settings = {"foo" => "bar", "networks" => combined_network_spec}
     new_settings = {
@@ -102,11 +102,11 @@ describe Bosh::AwsCloud::Cloud do
         }
     }
 
-    @registry.should_receive(:read_settings).
+    expect(@registry).to receive(:read_settings).
         with("i-foobar").
         and_return(old_settings)
 
-    @registry.should_receive(:update_settings).with("i-foobar", new_settings)
+    expect(@registry).to receive(:update_settings).with("i-foobar", new_settings)
 
     cloud.configure_networks("i-foobar", "net_a" => dynamic_network_spec)
   end
@@ -120,7 +120,7 @@ describe Bosh::AwsCloud::Cloud do
 
     it "checks that at least one dynamic or manual network is defined" do
       expect {
-        mock_cloud { |ec2| ec2.instances.stub(:[]).with("i-foobar").and_return(instance) }.
+        mock_cloud { |ec2| allow(ec2.instances).to receive(:[]).with("i-foobar").and_return(instance) }.
             configure_networks("i-foobar", "net_a" => vip_network_spec)
       }.to raise_error(Bosh::Clouds::CloudError,
                        "Exactly one dynamic or manual network must be defined")
@@ -128,7 +128,7 @@ describe Bosh::AwsCloud::Cloud do
 
     it "checks that at most one VIP network is defined" do
       expect {
-        mock_cloud { |ec2| ec2.instances.stub(:[]).with("i-foobar").and_return(instance) }.
+        mock_cloud { |ec2| allow(ec2.instances).to receive(:[]).with("i-foobar").and_return(instance) }.
             configure_networks("i-foobar",
                                "net_a" => vip_network_spec,
                                "net_b" => vip_network_spec)
@@ -137,9 +137,9 @@ describe Bosh::AwsCloud::Cloud do
     end
 
     it "checks that at most one dynamic or manual network is defined" do
-      instance.stub(:security_groups).and_return([double("security_group", name: "default")])
+      allow(instance).to receive(:security_groups).and_return([double("security_group", name: "default")])
       expect {
-        mock_cloud { |ec2| ec2.instances.stub(:[]).with("i-foobar").and_return(instance) }.
+        mock_cloud { |ec2| allow(ec2.instances).to receive(:[]).with("i-foobar").and_return(instance) }.
             configure_networks("i-foobar",
                                "net_a" => dynamic_network_spec,
                                "net_b" => dynamic_network_spec
@@ -150,7 +150,7 @@ describe Bosh::AwsCloud::Cloud do
 
     it "checks that the network types are either 'dynamic', 'manual', 'vip', or blank" do
       expect {
-        mock_cloud { |ec2| ec2.instances.stub(:[]).with("i-foobar").and_return(instance) }.
+        mock_cloud { |ec2| allow(ec2.instances).to receive(:[]).with("i-foobar").and_return(instance) }.
             configure_networks("i-foobar",
                                "net_a" => {
                                    "type" => "foo",

--- a/bosh_aws_cpi/spec/unit/create_disk_spec.rb
+++ b/bosh_aws_cpi/spec/unit/create_disk_spec.rb
@@ -9,17 +9,17 @@ describe Bosh::AwsCloud::Cloud do
   let(:instance) { double('instance', id: 'i-test', availability_zone: 'foobar-land') }
 
   before do
-    Bosh::AwsCloud::ResourceWait.stub(:for_volume).with(volume: volume, state: :available)
+    allow(Bosh::AwsCloud::ResourceWait).to receive(:for_volume).with(volume: volume, state: :available)
     @cloud = mock_cloud do |_ec2, region|
       @ec2 = _ec2
-      @ec2.volumes.stub(:create) { volume }
-      region.stub(:availability_zones => zones)
-      region.stub(instances: double('instances', :[] => instance))
+      allow(@ec2.volumes).to receive(:create) { volume }
+      allow(region).to receive_messages(:availability_zones => zones)
+      allow(region).to receive_messages(instances: double('instances', :[] => instance))
     end
   end
 
   it 'creates an EC2 volume' do
-    @cloud.create_disk(2048, {}).should == 'v-foobar'
+    expect(@cloud.create_disk(2048, {})).to eq('v-foobar')
     expect(@ec2.volumes).to have_received(:create) do |params|
       expect(params[:size]).to eq(2)
     end

--- a/bosh_aws_cpi/spec/unit/current_vm_id_spec.rb
+++ b/bosh_aws_cpi/spec/unit/current_vm_id_spec.rb
@@ -33,7 +33,7 @@ describe Bosh::AwsCloud::Cloud do
     it "should make a call to AWS and return the correct vm id" do
       stub_request(:get, "http://169.254.169.254/latest/meta-data/instance-id/")
         .to_return(:body => fake_instance_id)
-      cloud.current_vm_id.should == fake_instance_id
+      expect(cloud.current_vm_id).to eq(fake_instance_id)
     end
   end
 end

--- a/bosh_aws_cpi/spec/unit/delete_disk_spec.rb
+++ b/bosh_aws_cpi/spec/unit/delete_disk_spec.rb
@@ -6,36 +6,36 @@ describe Bosh::AwsCloud::Cloud do
   let(:volume) { double(AWS::EC2::Volume, id: 'v-foo') }
   let(:cloud) do
     mock_cloud do |ec2|
-      ec2.volumes.stub(:[]).with('v-foo').and_return(volume)
+      allow(ec2.volumes).to receive(:[]).with('v-foo').and_return(volume)
     end
   end
 
   before do
-    Bosh::AwsCloud::ResourceWait.stub(sleep_callback: 0)
+    allow(Bosh::AwsCloud::ResourceWait).to receive_messages(sleep_callback: 0)
   end
 
   it 'deletes an EC2 volume' do
-    Bosh::AwsCloud::ResourceWait.stub(for_volume: {volume: volume, state: :deleted})
+    allow(Bosh::AwsCloud::ResourceWait).to receive_messages(for_volume: {volume: volume, state: :deleted})
 
-    volume.should_receive(:delete)
+    expect(volume).to receive(:delete)
 
     cloud.delete_disk('v-foo')
   end
 
   it 'retries deleting the volume if it is in use' do
-    Bosh::AwsCloud::ResourceWait.stub(for_volume: {volume: volume, state: :deleted})
-    Bosh::Clouds::Config.stub(:task_checkpoint)
+    allow(Bosh::AwsCloud::ResourceWait).to receive_messages(for_volume: {volume: volume, state: :deleted})
+    allow(Bosh::Clouds::Config).to receive(:task_checkpoint)
 
-    volume.should_receive(:delete).once.ordered.and_raise(AWS::EC2::Errors::Client::VolumeInUse)
-    volume.should_receive(:delete).ordered
+    expect(volume).to receive(:delete).once.ordered.and_raise(AWS::EC2::Errors::Client::VolumeInUse)
+    expect(volume).to receive(:delete).ordered
 
     cloud.delete_disk('v-foo')
   end
 
   it 'raises an error if the volume remains in use after every deletion retry' do
-    Bosh::Clouds::Config.stub(:task_checkpoint)
+    allow(Bosh::Clouds::Config).to receive(:task_checkpoint)
 
-    volume.should_receive(:delete).exactly(10).times.and_raise(AWS::EC2::Errors::Client::VolumeInUse)
+    expect(volume).to receive(:delete).exactly(10).times.and_raise(AWS::EC2::Errors::Client::VolumeInUse)
 
     expect {
       cloud.delete_disk('v-foo')
@@ -46,12 +46,12 @@ describe Bosh::AwsCloud::Cloud do
     options = mock_cloud_options['properties']
     options['aws']['fast_path_delete'] = 'yes'
     cloud = mock_cloud(options) do |ec2|
-      ec2.volumes.stub(:[]).with('v-foo').and_return(volume)
+      allow(ec2.volumes).to receive(:[]).with('v-foo').and_return(volume)
     end
 
-    volume.should_receive(:delete)
-    volume.should_receive(:add_tag).with('Name', {value: 'to be deleted'})
-    Bosh::AwsCloud::ResourceWait.should_not_receive(:for_volume)
+    expect(volume).to receive(:delete)
+    expect(volume).to receive(:add_tag).with('Name', {value: 'to be deleted'})
+    expect(Bosh::AwsCloud::ResourceWait).not_to receive(:for_volume)
 
     cloud.delete_disk('v-foo')
   end

--- a/bosh_aws_cpi/spec/unit/delete_snapshot_spec.rb
+++ b/bosh_aws_cpi/spec/unit/delete_snapshot_spec.rb
@@ -7,20 +7,20 @@ describe Bosh::AwsCloud::Cloud do
     let(:cloud) {
       mock_cloud do |ec2|
         snapshots = double(AWS::EC2::SnapshotCollection, :[] => snapshot)
-        ec2.stub(snapshots: snapshots)
+        allow(ec2).to receive_messages(snapshots: snapshots)
       end
     }
 
     it 'should delete a snapshot' do
-      snapshot.should_receive(:status).and_return(:available)
-      snapshot.should_receive(:delete)
+      expect(snapshot).to receive(:status).and_return(:available)
+      expect(snapshot).to receive(:delete)
 
       cloud.delete_snapshot('snap-xxxxxxxx')
     end
 
     it 'should raise an error if the snapshot is in use' do
-      snapshot.should_receive(:status).and_return(:in_use)
-      snapshot.should_not_receive(:delete)
+      expect(snapshot).to receive(:status).and_return(:in_use)
+      expect(snapshot).not_to receive(:delete)
 
       expect {
         cloud.delete_snapshot('snap-xxxxxxxx')

--- a/bosh_aws_cpi/spec/unit/delete_stemcell_spec.rb
+++ b/bosh_aws_cpi/spec/unit/delete_stemcell_spec.rb
@@ -7,10 +7,10 @@ describe Bosh::AwsCloud::Cloud do
     stemcell = double(Bosh::AwsCloud::Stemcell)
 
     cloud = mock_cloud do |_, region|
-      Bosh::AwsCloud::StemcellFinder.stub(:find_by_region_and_id).with(region, 'ami-xxxxxxxx').and_return(stemcell)
+      allow(Bosh::AwsCloud::StemcellFinder).to receive(:find_by_region_and_id).with(region, 'ami-xxxxxxxx').and_return(stemcell)
     end
 
-    stemcell.should_receive(:delete)
+    expect(stemcell).to receive(:delete)
 
     cloud.delete_stemcell('ami-xxxxxxxx')
   end

--- a/bosh_aws_cpi/spec/unit/delete_vm_spec.rb
+++ b/bosh_aws_cpi/spec/unit/delete_vm_spec.rb
@@ -25,18 +25,18 @@ describe Bosh::AwsCloud::Cloud, "delete_vm" do
 
   it 'deletes an EC2 instance' do
     registry = double("registry")
-    Bosh::Registry::Client.stub(:new).and_return(registry)
+    allow(Bosh::Registry::Client).to receive(:new).and_return(registry)
 
     region = double("region")
-    AWS::EC2.stub(:new).and_return(double("ec2", regions: {"bar" => region}))
+    allow(AWS::EC2).to receive(:new).and_return(double("ec2", regions: {"bar" => region}))
 
     az_selector = double("availability zone selector")
-    Bosh::AwsCloud::AvailabilityZoneSelector.stub(:new).
+    allow(Bosh::AwsCloud::AvailabilityZoneSelector).to receive(:new).
       with(region, "foo").
       and_return(az_selector)
 
     instance_manager = instance_double('Bosh::AwsCloud::InstanceManager')
-    Bosh::AwsCloud::InstanceManager.stub(:new).
+    allow(Bosh::AwsCloud::InstanceManager).to receive(:new).
       with(region, registry, be_an_instance_of(AWS::ELB), az_selector, be_an_instance_of(Logger)).
       and_return(instance_manager)
 

--- a/bosh_aws_cpi/spec/unit/detach_disk_spec.rb
+++ b/bosh_aws_cpi/spec/unit/detach_disk_spec.rb
@@ -14,8 +14,8 @@ describe Bosh::AwsCloud::Cloud do
     attachment = double("attachment", :device => "/dev/sdf")
 
     cloud = mock_cloud do |ec2|
-      ec2.instances.should_receive(:[]).with("i-test").and_return(instance)
-      ec2.volumes.should_receive(:[]).with("v-foobar").and_return(volume)
+      expect(ec2.instances).to receive(:[]).with("i-test").and_return(instance)
+      expect(ec2.volumes).to receive(:[]).with("v-foobar").and_return(volume)
     end
 
     mappings = {
@@ -25,12 +25,12 @@ describe Bosh::AwsCloud::Cloud do
                          :volume => double("volume", :id => "v-deadbeef")),
     }
 
-    instance.should_receive(:block_device_mappings).and_return(mappings)
+    expect(instance).to receive(:block_device_mappings).and_return(mappings)
 
-    volume.should_receive(:detach_from).
+    expect(volume).to receive(:detach_from).
       with(instance, "/dev/sdf", force: false).and_return(attachment)
 
-    Bosh::AwsCloud::ResourceWait.stub(:for_attachment).with(attachment: attachment, state: :detached)
+    allow(Bosh::AwsCloud::ResourceWait).to receive(:for_attachment).with(attachment: attachment, state: :detached)
 
     old_settings = {
       "foo" => "bar",
@@ -51,11 +51,11 @@ describe Bosh::AwsCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).
+    expect(@registry).to receive(:read_settings).
       with("i-test").
       and_return(old_settings)
 
-    @registry.should_receive(:update_settings).with("i-test", new_settings)
+    expect(@registry).to receive(:update_settings).with("i-test", new_settings)
 
     cloud.detach_disk("i-test", "v-foobar")
   end

--- a/bosh_aws_cpi/spec/unit/get_disks_spec.rb
+++ b/bosh_aws_cpi/spec/unit/get_disks_spec.rb
@@ -9,8 +9,8 @@ describe Bosh::AwsCloud::Cloud do
 
     cloud = mock_cloud do |ec2, region|
       mock_instance = double("AWS Instance")
-      ec2.instances.should_receive(:[]).with(fake_instance_id).and_return(mock_instance)
-      mock_instance.should_receive(:block_devices).and_return([
+      expect(ec2.instances).to receive(:[]).with(fake_instance_id).and_return(mock_instance)
+      expect(mock_instance).to receive(:block_devices).and_return([
                                                              {
                                                                  :device_name => "/dev/sda2",
                                                                  :ebs => {
@@ -35,7 +35,7 @@ describe Bosh::AwsCloud::Cloud do
                                                          ])
     end
 
-    cloud.get_disks(fake_instance_id).should == ["vol-123", "vol-456"]
+    expect(cloud.get_disks(fake_instance_id)).to eq(["vol-123", "vol-456"])
   end
 
 end

--- a/bosh_aws_cpi/spec/unit/helpers_spec.rb
+++ b/bosh_aws_cpi/spec/unit/helpers_spec.rb
@@ -20,7 +20,7 @@ describe Bosh::AwsCloud::Helpers do
       end
 
       helpers_tester = HelpersTester.new
-      helpers_tester.extract_security_group_names(networks_spec).should =~ ["numero uno", "two to tango"]
+      expect(helpers_tester.extract_security_group_names(networks_spec)).to match_array(["numero uno", "two to tango"])
     end
   end
 end

--- a/bosh_aws_cpi/spec/unit/light_stemcell_spec.rb
+++ b/bosh_aws_cpi/spec/unit/light_stemcell_spec.rb
@@ -8,35 +8,35 @@ module Bosh::AwsCloud
 
     describe '#delete' do
       it 'does not delete the light stemcell' do
-        logger.stub(:info)
-        heavy_stemcell.should_not_receive(:delete)
+        allow(logger).to receive(:info)
+        expect(heavy_stemcell).not_to receive(:delete)
         light_stemcell.delete
       end
 
       it 'logs at INFO about the deletion' do
-        logger.should_receive(:info).with("NoOP: Deleting light stemcell 'fake-ami-id'")
+        expect(logger).to receive(:info).with("NoOP: Deleting light stemcell 'fake-ami-id'")
         light_stemcell.delete
       end
     end
 
     describe '#id' do
       it 'appends " light" to the id of heavy stemcell to distinguish the light stemcell from a heavy one' do
-        heavy_stemcell.should_receive(:id).and_return('ami-id')
-        light_stemcell.id.should eq('ami-id light')
+        expect(heavy_stemcell).to receive(:id).and_return('ami-id')
+        expect(light_stemcell.id).to eq('ami-id light')
       end
     end
 
     describe '#root_device_name' do
       it 'delegates the method to heavy stemcell' do
-        heavy_stemcell.should_receive(:root_device_name).and_return('THEROOOOT')
-        light_stemcell.root_device_name.should eq('THEROOOOT')
+        expect(heavy_stemcell).to receive(:root_device_name).and_return('THEROOOOT')
+        expect(light_stemcell.root_device_name).to eq('THEROOOOT')
       end
     end
 
     describe '#image_id' do
       it 'delegates the method to heavy stemcell' do
-        heavy_stemcell.should_receive(:image_id).and_return('ami-id')
-        light_stemcell.image_id.should eq('ami-id')
+        expect(heavy_stemcell).to receive(:image_id).and_return('ami-id')
+        expect(light_stemcell.image_id).to eq('ami-id')
       end
     end
   end

--- a/bosh_aws_cpi/spec/unit/manual_network_spec.rb
+++ b/bosh_aws_cpi/spec/unit/manual_network_spec.rb
@@ -15,6 +15,6 @@ describe Bosh::AwsCloud::ManualNetwork do
                     "mac"=>"00:50:56:ae:90:ab"}
     sn = Bosh::AwsCloud::ManualNetwork.new("default", network_spec)
 
-    sn.private_ip.should == "172.20.214.10"
+    expect(sn.private_ip).to eq("172.20.214.10")
   end
 end

--- a/bosh_aws_cpi/spec/unit/network_configurator_spec.rb
+++ b/bosh_aws_cpi/spec/unit/network_configurator_spec.rb
@@ -23,12 +23,12 @@ describe Bosh::AwsCloud::NetworkConfigurator do
   describe "#vpc?" do
     it "should be true for a manual network" do
       nc = Bosh::AwsCloud::NetworkConfigurator.new("network1" => manual)
-      nc.vpc?.should be(true)
+      expect(nc.vpc?).to be(true)
     end
 
     it "should be false for a dynamic network" do
       nc = Bosh::AwsCloud::NetworkConfigurator.new("network1" => dynamic)
-      nc.vpc?.should be(false)
+      expect(nc.vpc?).to be(false)
     end
 
   end
@@ -40,7 +40,7 @@ describe Bosh::AwsCloud::NetworkConfigurator do
       spec["network_a"]["ip"] = "10.0.0.1"
 
       nc = Bosh::AwsCloud::NetworkConfigurator.new(spec)
-      nc.private_ip.should == "10.0.0.1"
+      expect(nc.private_ip).to eq("10.0.0.1")
     end
 
     it "should extract private ip address from manual network when there's also vip network" do
@@ -51,7 +51,7 @@ describe Bosh::AwsCloud::NetworkConfigurator do
       spec["network_b"]["ip"] = "10.0.0.2"      
 
       nc = Bosh::AwsCloud::NetworkConfigurator.new(spec)
-      nc.private_ip.should == "10.0.0.2"
+      expect(nc.private_ip).to eq("10.0.0.2")
     end     
     
     it "should not extract private ip address for dynamic network" do
@@ -60,7 +60,7 @@ describe Bosh::AwsCloud::NetworkConfigurator do
       spec["network_a"]["ip"] = "10.0.0.1"
 
       nc = Bosh::AwsCloud::NetworkConfigurator.new(spec)
-      nc.private_ip.should be_nil
+      expect(nc.private_ip).to be_nil
     end     
   end
   
@@ -128,7 +128,7 @@ describe Bosh::AwsCloud::NetworkConfigurator do
           network_spec = {"network1" => dynamic, "network2" => vip}
           nc = Bosh::AwsCloud::NetworkConfigurator.new(network_spec)
 
-          nc.vip_network.should_receive(:configure).with(ec2, instance)
+          expect(nc.vip_network).to receive(:configure).with(ec2, instance)
 
           nc.configure(ec2, instance)
         end
@@ -137,7 +137,7 @@ describe Bosh::AwsCloud::NetworkConfigurator do
           network_spec = {"network1" => vip, "network2" => manual}
           nc = Bosh::AwsCloud::NetworkConfigurator.new(network_spec)
 
-          nc.vip_network.should_receive(:configure).with(ec2, instance)
+          expect(nc.vip_network).to receive(:configure).with(ec2, instance)
 
           nc.configure(ec2, instance)
         end
@@ -147,23 +147,23 @@ describe Bosh::AwsCloud::NetworkConfigurator do
       describe "without vip" do
         context "without associated elastic ip" do
           it "should configure dynamic network" do
-            instance.stub(:elastic_ip).and_return(nil)
+            allow(instance).to receive(:elastic_ip).and_return(nil)
 
             network_spec = {"network1" => dynamic}
             nc = Bosh::AwsCloud::NetworkConfigurator.new(network_spec)
 
-            nc.vip_network.should be_nil
+            expect(nc.vip_network).to be_nil
 
             nc.configure(ec2, instance)
           end
 
           it "should configure manual network" do
-            instance.stub(:elastic_ip).and_return(nil)
+            allow(instance).to receive(:elastic_ip).and_return(nil)
 
             network_spec = {"network1" => manual}
             nc = Bosh::AwsCloud::NetworkConfigurator.new(network_spec)
 
-            nc.vip_network.should be_nil
+            expect(nc.vip_network).to be_nil
 
             nc.configure(ec2, instance)
           end
@@ -171,14 +171,14 @@ describe Bosh::AwsCloud::NetworkConfigurator do
 
         context "with previously associated elastic ip" do
           it "should disassociate from the old elastic ip" do
-            instance.should_receive(:elastic_ip).and_return(double("elastic ip"))
-            instance.should_receive(:id).and_return("i-xxxxxxxx")
-            instance.should_receive(:disassociate_elastic_ip)
+            expect(instance).to receive(:elastic_ip).and_return(double("elastic ip"))
+            expect(instance).to receive(:id).and_return("i-xxxxxxxx")
+            expect(instance).to receive(:disassociate_elastic_ip)
 
             network_spec = {"network1" => dynamic}
             nc = Bosh::AwsCloud::NetworkConfigurator.new(network_spec)
 
-            nc.network.stub(:configure)
+            allow(nc.network).to receive(:configure)
 
             nc.configure(ec2, instance)
           end

--- a/bosh_aws_cpi/spec/unit/reboot_vm_spec.rb
+++ b/bosh_aws_cpi/spec/unit/reboot_vm_spec.rb
@@ -25,18 +25,18 @@ describe Bosh::AwsCloud::Cloud, "reboot_vm" do
 
   it 'deletes an EC2 instance' do
     registry = double("registry")
-    Bosh::Registry::Client.stub(:new).and_return(registry)
+    allow(Bosh::Registry::Client).to receive(:new).and_return(registry)
 
     region = double("region")
-    AWS::EC2.stub(:new).and_return(double("ec2", regions: {"bar" => region}))
+    allow(AWS::EC2).to receive(:new).and_return(double("ec2", regions: {"bar" => region}))
 
     az_selector = double("availability zone selector")
-    Bosh::AwsCloud::AvailabilityZoneSelector.stub(:new).
+    allow(Bosh::AwsCloud::AvailabilityZoneSelector).to receive(:new).
       with(region, "foo").
       and_return(az_selector)
 
     instance_manager = instance_double('Bosh::AwsCloud::InstanceManager')
-    Bosh::AwsCloud::InstanceManager.stub(:new).
+    allow(Bosh::AwsCloud::InstanceManager).to receive(:new).
       with(region, registry, be_an_instance_of(AWS::ELB), az_selector, be_an_instance_of(Logger)).
       and_return(instance_manager)
 

--- a/bosh_aws_cpi/spec/unit/resource_wait_spec.rb
+++ b/bosh_aws_cpi/spec/unit/resource_wait_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
 describe Bosh::AwsCloud::ResourceWait do
-  before { Kernel.stub(:sleep) }
-  before { described_class.stub(:task_checkpoint) }
+  before { allow(Kernel).to receive(:sleep) }
+  before { allow(described_class).to receive(:task_checkpoint) }
 
   describe '.for_instance' do
     let(:instance) { double(AWS::EC2::Instance, id: 'i-1234') }
 
     context 'deletion' do
       it 'should wait until the state is terminated' do
-        instance.should_receive(:status).and_return(:shutting_down)
-        instance.should_receive(:status).and_return(:shutting_down)
-        instance.should_receive(:status).and_return(:terminated)
+        expect(instance).to receive(:status).and_return(:shutting_down)
+        expect(instance).to receive(:status).and_return(:shutting_down)
+        expect(instance).to receive(:status).and_return(:terminated)
 
         described_class.for_instance(instance: instance, state: :terminated)
       end
@@ -20,9 +20,9 @@ describe Bosh::AwsCloud::ResourceWait do
     context 'creation' do
       context 'when EC2 fails to find an instance' do
         it 'should wait until the state is running' do
-          instance.should_receive(:status).and_raise(AWS::EC2::Errors::InvalidInstanceID::NotFound)
-          instance.should_receive(:status).and_return(:pending)
-          instance.should_receive(:status).and_return(:running)
+          expect(instance).to receive(:status).and_raise(AWS::EC2::Errors::InvalidInstanceID::NotFound)
+          expect(instance).to receive(:status).and_return(:pending)
+          expect(instance).to receive(:status).and_return(:running)
 
           described_class.for_instance(instance: instance, state: :running)
         end
@@ -30,9 +30,9 @@ describe Bosh::AwsCloud::ResourceWait do
 
       context 'when resource is not found' do
         it 'should wait until the state is running' do
-          instance.should_receive(:status).and_raise(AWS::Core::Resource::NotFound)
-          instance.should_receive(:status).and_return(:pending)
-          instance.should_receive(:status).and_return(:running)
+          expect(instance).to receive(:status).and_raise(AWS::Core::Resource::NotFound)
+          expect(instance).to receive(:status).and_return(:pending)
+          expect(instance).to receive(:status).and_return(:running)
 
           described_class.for_instance(instance: instance, state: :running)
         end
@@ -40,19 +40,19 @@ describe Bosh::AwsCloud::ResourceWait do
 
       context 'when resource status service is not available' do
         it 'should wait until the service is available and the state is running' do
-          instance.should_receive(:status).and_raise(
+          expect(instance).to receive(:status).and_raise(
             AWS::Errors::ServerError.new('The service is unavailable. Please try again shortly.'))
-          instance.should_receive(:status).and_return(:pending)
-          instance.should_receive(:status).and_return(:running)
+          expect(instance).to receive(:status).and_return(:pending)
+          expect(instance).to receive(:status).and_return(:running)
 
           described_class.for_instance(instance: instance, state: :running)
         end
       end
 
       it 'should fail if AWS terminates the instance' do
-        instance.should_receive(:status).and_return(:pending)
-        instance.should_receive(:status).and_return(:pending)
-        instance.should_receive(:status).and_return(:terminated)
+        expect(instance).to receive(:status).and_return(:pending)
+        expect(instance).to receive(:status).and_return(:pending)
+        expect(instance).to receive(:status).and_return(:terminated)
 
         expect {
           described_class.for_instance(instance: instance, state: :running)
@@ -68,15 +68,15 @@ describe Bosh::AwsCloud::ResourceWait do
 
     context 'attachment' do
       it 'should wait until the state is attached' do
-        attachment.should_receive(:status).and_return(:attaching)
-        attachment.should_receive(:status).and_return(:attached)
+        expect(attachment).to receive(:status).and_return(:attaching)
+        expect(attachment).to receive(:status).and_return(:attached)
 
         described_class.for_attachment(attachment: attachment, state: :attached)
       end
 
       it 'should retry when AWS::Core::Resource::NotFound is raised' do
-        attachment.should_receive(:status).and_raise(AWS::Core::Resource::NotFound)
-        attachment.should_receive(:status).and_return(:attached)
+        expect(attachment).to receive(:status).and_raise(AWS::Core::Resource::NotFound)
+        expect(attachment).to receive(:status).and_return(:attached)
 
         described_class.for_attachment(attachment: attachment, state: :attached)
       end
@@ -84,15 +84,15 @@ describe Bosh::AwsCloud::ResourceWait do
 
     context 'detachment' do
       it 'should wait until the state is detached' do
-        attachment.should_receive(:status).and_return(:detaching)
-        attachment.should_receive(:status).and_return(:detached)
+        expect(attachment).to receive(:status).and_return(:detaching)
+        expect(attachment).to receive(:status).and_return(:detached)
 
         described_class.for_attachment(attachment: attachment, state: :detached)
       end
 
       it 'should consider AWS::Core::Resource::NotFound to be detached' do
-        attachment.should_receive(:status).and_return(:detaching)
-        attachment.should_receive(:status).and_raise(AWS::Core::Resource::NotFound)
+        expect(attachment).to receive(:status).and_return(:detaching)
+        expect(attachment).to receive(:status).and_raise(AWS::Core::Resource::NotFound)
 
         described_class.for_attachment(attachment: attachment, state: :detached)
       end
@@ -104,15 +104,15 @@ describe Bosh::AwsCloud::ResourceWait do
 
     context 'creation' do
       it 'should wait until the state is available' do
-        volume.should_receive(:status).and_return(:creating)
-        volume.should_receive(:status).and_return(:available)
+        expect(volume).to receive(:status).and_return(:creating)
+        expect(volume).to receive(:status).and_return(:available)
 
         described_class.for_volume(volume: volume, state: :available)
       end
 
       it 'should raise an error on error state' do
-        volume.should_receive(:status).and_return(:creating)
-        volume.should_receive(:status).and_return(:error)
+        expect(volume).to receive(:status).and_return(:creating)
+        expect(volume).to receive(:status).and_return(:error)
 
         expect {
           described_class.for_volume(volume: volume, state: :available)
@@ -122,15 +122,15 @@ describe Bosh::AwsCloud::ResourceWait do
 
     context 'deletion' do
       it 'should wait until the state is deleted' do
-        volume.should_receive(:status).and_return(:deleting)
-        volume.should_receive(:status).and_return(:deleted)
+        expect(volume).to receive(:status).and_return(:deleting)
+        expect(volume).to receive(:status).and_return(:deleted)
 
         described_class.for_volume(volume: volume, state: :deleted)
       end
 
       it 'should consider InvalidVolume error to mean deleted' do
-        volume.should_receive(:status).and_return(:deleting)
-        volume.should_receive(:status).and_raise(AWS::EC2::Errors::InvalidVolume::NotFound)
+        expect(volume).to receive(:status).and_return(:deleting)
+        expect(volume).to receive(:status).and_raise(AWS::EC2::Errors::InvalidVolume::NotFound)
 
         described_class.for_volume(volume: volume, state: :deleted)
       end
@@ -142,15 +142,15 @@ describe Bosh::AwsCloud::ResourceWait do
 
     context 'creation' do
       it 'should wait until the state is completed' do
-        snapshot.should_receive(:status).and_return(:pending)
-        snapshot.should_receive(:status).and_return(:completed)
+        expect(snapshot).to receive(:status).and_return(:pending)
+        expect(snapshot).to receive(:status).and_return(:completed)
 
         described_class.for_snapshot(snapshot: snapshot, state: :completed)
       end
 
       it 'should raise an error if the state is error' do
-        snapshot.should_receive(:status).and_return(:pending)
-        snapshot.should_receive(:status).and_return(:error)
+        expect(snapshot).to receive(:status).and_return(:pending)
+        expect(snapshot).to receive(:status).and_return(:error)
 
         expect {
           described_class.for_snapshot(snapshot: snapshot, state: :completed)
@@ -164,23 +164,23 @@ describe Bosh::AwsCloud::ResourceWait do
 
     context 'creation' do
       it 'should wait until the state is available' do
-        image.should_receive(:state).and_return(:pending)
-        image.should_receive(:state).and_return(:available)
+        expect(image).to receive(:state).and_return(:pending)
+        expect(image).to receive(:state).and_return(:available)
 
         described_class.for_image(image: image, state: :available)
       end
 
       it 'should wait if AWS::EC2::Errors::InvalidAMIID::NotFound raised' do
-        image.should_receive(:state).and_raise(AWS::EC2::Errors::InvalidAMIID::NotFound)
-        image.should_receive(:state).and_return(:pending)
-        image.should_receive(:state).and_return(:available)
+        expect(image).to receive(:state).and_raise(AWS::EC2::Errors::InvalidAMIID::NotFound)
+        expect(image).to receive(:state).and_return(:pending)
+        expect(image).to receive(:state).and_return(:available)
 
         described_class.for_image(image: image, state: :available)
       end
 
       it 'should raise an error if the state is failed' do
-        image.should_receive(:state).and_return(:pending)
-        image.should_receive(:state).and_return(:failed)
+        expect(image).to receive(:state).and_return(:pending)
+        expect(image).to receive(:state).and_return(:failed)
 
         expect {
           described_class.for_image(image: image, state: :available)
@@ -190,9 +190,9 @@ describe Bosh::AwsCloud::ResourceWait do
 
     context 'deletion' do
       it 'should wait until the state is deleted' do
-        image.should_receive(:state).and_return(:available)
-        image.should_receive(:state).and_return(:pending)
-        image.should_receive(:state).and_return(:deleted)
+        expect(image).to receive(:state).and_return(:available)
+        expect(image).to receive(:state).and_return(:pending)
+        expect(image).to receive(:state).and_return(:deleted)
 
         described_class.for_image(image: image, state: :deleted)
       end
@@ -204,8 +204,8 @@ describe Bosh::AwsCloud::ResourceWait do
 
     context 'creation' do
       it 'should wait until the state is completed' do
-        subnet.should_receive(:state).and_return(:pending)
-        subnet.should_receive(:state).and_return(:available)
+        expect(subnet).to receive(:state).and_return(:pending)
+        expect(subnet).to receive(:state).and_return(:available)
 
         described_class.for_subnet(subnet: subnet, state: :available)
       end
@@ -248,11 +248,11 @@ describe Bosh::AwsCloud::ResourceWait do
 
     it 'uses Bosh::Retryable with sleep_callback sleep setting' do
       sleep_cb = double('fake-sleep-callback')
-      described_class.stub(:sleep_callback).and_return(sleep_cb)
+      allow(described_class).to receive(:sleep_callback).and_return(sleep_cb)
 
       retryable = double('Bosh::Retryable', retryer: nil)
-      Bosh::Retryable
-        .should_receive(:new)
+      expect(Bosh::Retryable)
+        .to receive(:new)
         .with(hash_including(sleep: sleep_cb))
         .and_return(retryable)
 

--- a/bosh_aws_cpi/spec/unit/set_vm_metadata_spec.rb
+++ b/bosh_aws_cpi/spec/unit/set_vm_metadata_spec.rb
@@ -5,16 +5,16 @@ describe Bosh::AwsCloud::Cloud, '#set_vm_metadata' do
 
   before :each do
     @cloud = mock_cloud(mock_cloud_options['properties']) do |ec2|
-      ec2.instances.stub(:[]).with('i-foobar').and_return(instance)
+      allow(ec2.instances).to receive(:[]).with('i-foobar').and_return(instance)
     end
   end
 
   it 'should add new tags for regular jobs' do
     metadata = {:job => 'job', :index => 'index'}
 
-    Bosh::AwsCloud::TagManager.should_receive(:tag).with(instance, :job, 'job')
-    Bosh::AwsCloud::TagManager.should_receive(:tag).with(instance, :index, 'index')
-    Bosh::AwsCloud::TagManager.should_receive(:tag).with(instance, 'Name', 'job/index')
+    expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(instance, :job, 'job')
+    expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(instance, :index, 'index')
+    expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(instance, 'Name', 'job/index')
 
     @cloud.set_vm_metadata('i-foobar', metadata)
   end
@@ -22,8 +22,8 @@ describe Bosh::AwsCloud::Cloud, '#set_vm_metadata' do
   it 'should add new tags for compiling jobs' do
     metadata = {:compiling => 'linux'}
 
-    Bosh::AwsCloud::TagManager.should_receive(:tag).with(instance, :compiling, 'linux')
-    Bosh::AwsCloud::TagManager.should_receive(:tag).with(instance, 'Name', 'compiling/linux')
+    expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(instance, :compiling, 'linux')
+    expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(instance, 'Name', 'compiling/linux')
 
     @cloud.set_vm_metadata('i-foobar', metadata)
   end

--- a/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
+++ b/bosh_aws_cpi/spec/unit/snapshot_disk_spec.rb
@@ -19,44 +19,44 @@ describe Bosh::AwsCloud::Cloud do
 
     it 'should take a snapshot of a disk' do
       cloud = mock_cloud do |ec2|
-        ec2.volumes.should_receive(:[]).with('vol-xxxxxxxx').and_return(volume)
+        expect(ec2.volumes).to receive(:[]).with('vol-xxxxxxxx').and_return(volume)
       end
 
 
-      volume.should_receive(:attachments).and_return([attachment])
-      volume.should_receive(:create_snapshot).with('deployment/job/0/sdf').and_return(snapshot)
+      expect(volume).to receive(:attachments).and_return([attachment])
+      expect(volume).to receive(:create_snapshot).with('deployment/job/0/sdf').and_return(snapshot)
 
-      Bosh::AwsCloud::ResourceWait.should_receive(:for_snapshot).with(
+      expect(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot).with(
         snapshot: snapshot, state: :completed
       )
 
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, :agent_id, 'agent')
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, :instance_id, 'instance')
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, :director_name, 'Test Director')
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, :director_uuid, '6d06b0cc-2c08-43c5-95be-f1b2dd247e18')
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, :device, '/dev/sdf')
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, 'Name', 'deployment/job/0/sdf')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, :agent_id, 'agent')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, :instance_id, 'instance')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, :director_name, 'Test Director')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, :director_uuid, '6d06b0cc-2c08-43c5-95be-f1b2dd247e18')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, :device, '/dev/sdf')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, 'Name', 'deployment/job/0/sdf')
 
       cloud.snapshot_disk('vol-xxxxxxxx', metadata)
     end
 
     it 'should take a snapshot of a disk not attached to any instance' do
       cloud = mock_cloud do |ec2|
-        ec2.volumes.should_receive(:[]).with('vol-xxxxxxxx').and_return(volume)
+        expect(ec2.volumes).to receive(:[]).with('vol-xxxxxxxx').and_return(volume)
       end
 
-      volume.should_receive(:attachments).and_return([])
-      volume.should_receive(:create_snapshot).with('deployment/job/0').and_return(snapshot)
+      expect(volume).to receive(:attachments).and_return([])
+      expect(volume).to receive(:create_snapshot).with('deployment/job/0').and_return(snapshot)
 
-      Bosh::AwsCloud::ResourceWait.should_receive(:for_snapshot).with(
+      expect(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot).with(
         snapshot: snapshot, state: :completed
       )
 
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, :agent_id, 'agent')
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, :instance_id, 'instance')
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, :director_name, 'Test Director')
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, :director_uuid, '6d06b0cc-2c08-43c5-95be-f1b2dd247e18')
-      Bosh::AwsCloud::TagManager.should_receive(:tag).with(snapshot, 'Name', 'deployment/job/0')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, :agent_id, 'agent')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, :instance_id, 'instance')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, :director_name, 'Test Director')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, :director_uuid, '6d06b0cc-2c08-43c5-95be-f1b2dd247e18')
+      expect(Bosh::AwsCloud::TagManager).to receive(:tag).with(snapshot, 'Name', 'deployment/job/0')
 
       cloud.snapshot_disk('vol-xxxxxxxx', metadata)
     end

--- a/bosh_aws_cpi/spec/unit/stemcell_finder_spec.rb
+++ b/bosh_aws_cpi/spec/unit/stemcell_finder_spec.rb
@@ -7,20 +7,20 @@ module Bosh::AwsCloud
       context 'when id ends with " light"' do
         let(:region) { double('aws region') }
         let(:stemcell) { double('heavy stemcell') }
-        before { Stemcell.stub(:find).with(region, 'ami-id').and_return(stemcell) }
+        before { allow(Stemcell).to receive(:find).with(region, 'ami-id').and_return(stemcell) }
 
         it 'constructs a light stemcell with a heavy stemcell' do
           light_stemcell = double('light stemcell')
-          LightStemcell.should_receive(:new).with(stemcell, anything).and_return(light_stemcell)
+          expect(LightStemcell).to receive(:new).with(stemcell, anything).and_return(light_stemcell)
 
-          described_class.find_by_region_and_id(region, 'ami-id light').should eq(light_stemcell)
+          expect(described_class.find_by_region_and_id(region, 'ami-id light')).to eq(light_stemcell)
         end
 
         it 'gets the BOSH logger and injects it to the LightStemcell' do
           logger = double('logger')
-          Bosh::Clouds::Config.stub(:logger).and_return(logger)
+          allow(Bosh::Clouds::Config).to receive(:logger).and_return(logger)
 
-          LightStemcell.should_receive(:new).with(stemcell, logger)
+          expect(LightStemcell).to receive(:new).with(stemcell, logger)
           described_class.find_by_region_and_id(region, 'ami-id light')
         end
       end
@@ -30,9 +30,9 @@ module Bosh::AwsCloud
           stemcell = double('heavy stemcell')
           region = double('aws region')
 
-          Stemcell.should_receive(:find).with(region, 'ami-id').and_return(stemcell)
+          expect(Stemcell).to receive(:find).with(region, 'ami-id').and_return(stemcell)
 
-          described_class.find_by_region_and_id(region, 'ami-id').should eq(stemcell)
+          expect(described_class.find_by_region_and_id(region, 'ami-id')).to eq(stemcell)
         end
       end
     end

--- a/bosh_aws_cpi/spec/unit/tag_manager_spec.rb
+++ b/bosh_aws_cpi/spec/unit/tag_manager_spec.rb
@@ -4,26 +4,26 @@ describe Bosh::AwsCloud::TagManager do
   let(:instance) { double('instance', :id => 'i-xxxxxxx') }
 
   it 'should trim key and value length' do
-    instance.should_receive(:add_tag) do |key, options|
-      key.size.should == 127
-      options[:value].size.should == 255
+    expect(instance).to receive(:add_tag) do |key, options|
+      expect(key.size).to eq(127)
+      expect(options[:value].size).to eq(255)
     end
 
     Bosh::AwsCloud::TagManager.tag(instance, 'x'*128, 'y'*256)
   end
 
   it 'casts key and value to strings' do
-    instance.should_receive(:add_tag).with('key', value: 'value')
+    expect(instance).to receive(:add_tag).with('key', value: 'value')
     Bosh::AwsCloud::TagManager.tag(instance, :key, :value)
 
-    instance.should_receive(:add_tag).with('key', value: '8')
+    expect(instance).to receive(:add_tag).with('key', value: '8')
     Bosh::AwsCloud::TagManager.tag(instance, :key, 8)
   end
 
   it 'should retry tagging when the tagged object is not found' do
-    Bosh::AwsCloud::TagManager.stub(:sleep)
+    allow(Bosh::AwsCloud::TagManager).to receive(:sleep)
 
-    instance.should_receive(:add_tag).exactly(3).times do
+    expect(instance).to receive(:add_tag).exactly(3).times do
       @count ||= 0
       if @count < 2
         @count += 1
@@ -35,12 +35,12 @@ describe Bosh::AwsCloud::TagManager do
   end
 
   it 'should do nothing if key is nil' do
-    instance.should_not_receive(:add_tag)
+    expect(instance).not_to receive(:add_tag)
     Bosh::AwsCloud::TagManager.tag(instance, nil, 'value')
   end
 
   it 'should do nothing if value is nil' do
-    instance.should_not_receive(:add_tag)
+    expect(instance).not_to receive(:add_tag)
     Bosh::AwsCloud::TagManager.tag(instance, 'key', nil)
   end
 end

--- a/bosh_aws_cpi/spec/unit/vip_network_spec.rb
+++ b/bosh_aws_cpi/spec/unit/vip_network_spec.rb
@@ -15,11 +15,11 @@ describe Bosh::AwsCloud::VipNetwork do
     vip = described_class.new('vip', {'ip' => '1.2.3.4'})
 
     elastic_ip = double('eip')
-    ec2.stub_chain(:elastic_ips, :[]).and_return(elastic_ip)
-    Bosh::Common.stub(:sleep)
+    allow(ec2).to receive_message_chain(:elastic_ips, :[]).and_return(elastic_ip)
+    allow(Bosh::Common).to receive(:sleep)
 
-    instance.should_receive(:associate_elastic_ip).and_raise(AWS::EC2::Errors::IncorrectInstanceState)
-    instance.should_receive(:associate_elastic_ip).with(elastic_ip).and_return(true)
+    expect(instance).to receive(:associate_elastic_ip).and_raise(AWS::EC2::Errors::IncorrectInstanceState)
+    expect(instance).to receive(:associate_elastic_ip).with(elastic_ip).and_return(true)
 
     vip.configure(ec2, instance)
   end

--- a/bosh_cli/spec/support/command_shared_examples.rb
+++ b/bosh_cli/spec/support/command_shared_examples.rb
@@ -57,7 +57,7 @@ end
 
 module CommandDirectorSharedExamples
   def with_director
-    before { command.stub(director: director) }
+    before { allow(command).to receive(:director).and_return(director) }
     let(:director) { instance_double('Bosh::Cli::Client::Director') }
   end
 end

--- a/bosh_cli/spec/unit/blob_manager_spec.rb
+++ b/bosh_cli/spec/unit/blob_manager_spec.rb
@@ -139,7 +139,7 @@ describe Bosh::Cli::BlobManager do
 
   describe "downloading a blob" do
     it 'fails if blobstore is not configured' do
-      @release.stub(:blobstore).and_return(nil)
+      allow(@release).to receive(:blobstore).and_return(nil)
 
       expect {
         make_manager(@release).download_blob('foo')
@@ -187,7 +187,7 @@ describe Bosh::Cli::BlobManager do
     end
 
     it "fails if blobstore is not configured" do
-      @release.stub(:blobstore).and_return(nil)
+      allow(@release).to receive(:blobstore).and_return(nil)
 
       expect {
         make_manager(@release).upload_blob("foo")

--- a/bosh_cli/spec/unit/config_spec.rb
+++ b/bosh_cli/spec/unit/config_spec.rb
@@ -131,19 +131,19 @@ describe Bosh::Cli::Config do
       add_config(config)
       cfg = create_config
 
-      cfg.max_parallel_downloads.should == 3
+      expect(cfg.max_parallel_downloads).to eq(3)
     end
 
     it "uses global runtime set if available" do
       cfg = create_config
       Bosh::Cli::Config.max_parallel_downloads = 7
-      cfg.max_parallel_downloads.should == 7
+      expect(cfg.max_parallel_downloads).to eq(7)
       Bosh::Cli::Config.max_parallel_downloads = nil
     end
 
     it "defaults parallel download limit to 1 if none is set" do
       cfg = create_config
-      cfg.max_parallel_downloads.should == 1
+      expect(cfg.max_parallel_downloads).to eq(1)
     end
   end
 end

--- a/bosh_cli_plugin_aws/spec/functional/aws_spec.rb
+++ b/bosh_cli_plugin_aws/spec/functional/aws_spec.rb
@@ -8,7 +8,7 @@ describe Bosh::Cli::Command::AWS do
     ))
   end
 
-  before { aws.stub(:sleep) }
+  before { allow(aws).to receive(:sleep) }
 
   describe 'command line tools' do
     describe 'aws generate micro_bosh' do
@@ -26,19 +26,19 @@ describe Bosh::Cli::Command::AWS do
       end
 
       it 'uses some of the normal director keys' do
-        micro_bosh_yaml['name'].should == 'micro-dev102'
-        micro_bosh_yaml['network']['vip'].should == '50.200.100.1'
-        micro_bosh_yaml['network']['cloud_properties']['subnet'].should == 'subnet-4bdf6c26'
-        micro_bosh_yaml['resources']['cloud_properties']['availability_zone'].should == 'us-east-1a'
+        expect(micro_bosh_yaml['name']).to eq('micro-dev102')
+        expect(micro_bosh_yaml['network']['vip']).to eq('50.200.100.1')
+        expect(micro_bosh_yaml['network']['cloud_properties']['subnet']).to eq('subnet-4bdf6c26')
+        expect(micro_bosh_yaml['resources']['cloud_properties']['availability_zone']).to eq('us-east-1a')
 
-        micro_bosh_yaml['cloud']['properties']['aws']['access_key_id'].should == '...'
-        micro_bosh_yaml['cloud']['properties']['aws']['secret_access_key'].should == '...'
-        micro_bosh_yaml['cloud']['properties']['aws']['region'].should == 'us-east-1'
+        expect(micro_bosh_yaml['cloud']['properties']['aws']['access_key_id']).to eq('...')
+        expect(micro_bosh_yaml['cloud']['properties']['aws']['secret_access_key']).to eq('...')
+        expect(micro_bosh_yaml['cloud']['properties']['aws']['region']).to eq('us-east-1')
       end
 
       it 'has a health manager username and password populated' do
-        micro_bosh_yaml['apply_spec']['properties']['hm']['director_account']['user'].should == 'hm'
-        micro_bosh_yaml['apply_spec']['properties']['hm']['director_account']['password'].should_not be_nil
+        expect(micro_bosh_yaml['apply_spec']['properties']['hm']['director_account']['user']).to eq('hm')
+        expect(micro_bosh_yaml['apply_spec']['properties']['hm']['director_account']['password']).not_to be_nil
       end
     end
 
@@ -50,15 +50,15 @@ describe Bosh::Cli::Command::AWS do
       it 'generates required bosh deployment keys' do
         Dir.mktmpdir do |dir|
           Dir.chdir(dir) do
-            aws.stub(:target_required)
-            aws.stub_chain(:director, :uuid).and_return('deadbeef')
+            allow(aws).to receive(:target_required)
+            allow(aws).to receive_message_chain(:director, :uuid).and_return('deadbeef')
             aws.create_bosh_manifest(create_vpc_output_yml, route53_receipt_yml, bosh_rds_receipt_yml)
 
             yaml = Psych.load_file('bosh.yml')
 
-            yaml['name'].should == 'vpc-bosh-dev102'
-            yaml['properties']['hm']['director_account']['user'].should == 'hm'
-            yaml['properties']['hm']['director_account']['password'].should_not be_nil
+            expect(yaml['name']).to eq('vpc-bosh-dev102')
+            expect(yaml['properties']['hm']['director_account']['user']).to eq('hm')
+            expect(yaml['properties']['hm']['director_account']['password']).not_to be_nil
           end
         end
       end
@@ -69,8 +69,8 @@ describe Bosh::Cli::Command::AWS do
       let(:route53_receipt_yml) { asset 'test-aws_route53_receipt.yml' }
 
       it 'has the correct stemcell name' do
-        aws.stub(:target_required)
-        aws.stub_chain(:director, :uuid).and_return('deadbeef')
+        allow(aws).to receive(:target_required)
+        allow(aws).to receive_message_chain(:director, :uuid).and_return('deadbeef')
 
         Dir.mktmpdir do |dir|
           Dir.chdir(dir) do
@@ -102,45 +102,45 @@ describe Bosh::Cli::Command::AWS do
       end
 
       it 'should run the migrations' do
-        Bosh::Aws::Migrator.should_receive(:new).with(YAML.load_yaml_file(config_file)).and_return(migrator)
-        migrator.should_receive(:migrate)
+        expect(Bosh::Aws::Migrator).to receive(:new).with(YAML.load_yaml_file(config_file)).and_return(migrator)
+        expect(migrator).to receive(:migrate)
         aws.create config_file
       end
 
       it 'should default the configuration file when not passed in' do
-        File.exist?(default_config_filename).should == true
-        Bosh::Aws::Migrator.should_receive(:new).and_return(migrator)
-        migrator.should_receive(:migrate)
+        expect(File.exist?(default_config_filename)).to eq(true)
+        expect(Bosh::Aws::Migrator).to receive(:new).and_return(migrator)
+        expect(migrator).to receive(:migrate)
         aws.create
       end
     end
 
     describe 'aws destroy' do
-      before { Bosh::Aws::Destroyer.stub(:new).with(aws, config, rds_destroyer, vpc_destroyer).and_return(destroyer) }
+      before { allow(Bosh::Aws::Destroyer).to receive(:new).with(aws, config, rds_destroyer, vpc_destroyer).and_return(destroyer) }
       let(:destroyer) { instance_double('Bosh::Aws::Destroyer') }
 
-      before { Bosh::Aws::RdsDestroyer.stub(:new).with(aws, config).and_return(rds_destroyer) }
+      before { allow(Bosh::Aws::RdsDestroyer).to receive(:new).with(aws, config).and_return(rds_destroyer) }
       let(:rds_destroyer) { instance_double('Bosh::Aws::RdsDestroyer') }
 
-      before { Bosh::Aws::VpcDestroyer.stub(:new).with(aws, config).and_return(vpc_destroyer) }
+      before { allow(Bosh::Aws::VpcDestroyer).to receive(:new).with(aws, config).and_return(vpc_destroyer) }
       let(:vpc_destroyer) { instance_double('Bosh::Aws::VpcDestroyer') }
 
-      before { aws.stub(:load_config).with(config_file).and_return(config) }
+      before { allow(aws).to receive(:load_config).with(config_file).and_return(config) }
       let(:config_file) { double('config_file') }
       let(:config) { { fake: 'config' } }
 
       it 'destroys the specified VPCs, RDS DBs, and S3 Volumes' do
-        destroyer.should_receive(:ensure_not_production!).ordered
-        destroyer.should_receive(:delete_all_elbs).ordered
-        destroyer.should_receive(:delete_all_ec2).ordered
-        destroyer.should_receive(:delete_all_ebs).ordered
-        destroyer.should_receive(:delete_all_rds).ordered
-        destroyer.should_receive(:delete_all_s3).ordered
-        destroyer.should_receive(:delete_all_vpcs).ordered
-        destroyer.should_receive(:delete_all_key_pairs).ordered
-        destroyer.should_receive(:delete_all_elastic_ips).ordered
-        destroyer.should_receive(:delete_all_security_groups).ordered
-        destroyer.should_receive(:delete_all_route53_records).ordered
+        expect(destroyer).to receive(:ensure_not_production!).ordered
+        expect(destroyer).to receive(:delete_all_elbs).ordered
+        expect(destroyer).to receive(:delete_all_ec2).ordered
+        expect(destroyer).to receive(:delete_all_ebs).ordered
+        expect(destroyer).to receive(:delete_all_rds).ordered
+        expect(destroyer).to receive(:delete_all_s3).ordered
+        expect(destroyer).to receive(:delete_all_vpcs).ordered
+        expect(destroyer).to receive(:delete_all_key_pairs).ordered
+        expect(destroyer).to receive(:delete_all_elastic_ips).ordered
+        expect(destroyer).to receive(:delete_all_security_groups).ordered
+        expect(destroyer).to receive(:delete_all_route53_records).ordered
         aws.destroy(config_file)
       end
     end
@@ -151,14 +151,14 @@ describe Bosh::Cli::Command::AWS do
 
       context 'when a config file is provided' do
         it 'uses the provided file' do
-          Bosh::Aws::AwsConfig.should_receive(:new).with(config_file).and_return(config)
+          expect(Bosh::Aws::AwsConfig).to receive(:new).with(config_file).and_return(config)
           expect(aws.send(:load_config, config_file)).to eq('fake_configuration')
         end
       end
 
       context 'when a config file is not provided' do
         it 'uses a default config' do
-          Bosh::Aws::AwsConfig.should_receive(:new).with(default_config_filename).and_return(config)
+          expect(Bosh::Aws::AwsConfig).to receive(:new).with(default_config_filename).and_return(config)
           expect(aws.send(:load_config)).to eq('fake_configuration')
         end
       end
@@ -173,16 +173,16 @@ describe Bosh::Cli::Command::AWS do
         end
 
         it 'prompts the user for admin password' do
-          fake_bootstrap.should_receive(:start)
-          Bosh::Aws::MicroBoshBootstrap.should_receive(:new).with(
+          expect(fake_bootstrap).to receive(:start)
+          expect(Bosh::Aws::MicroBoshBootstrap).to receive(:new).with(
             anything,
             kind_of(Hash)
           ).and_return(fake_bootstrap)
-          aws.should_receive(:ask).and_return('username')
-          aws.should_receive(:ask).and_return('password')
+          expect(aws).to receive(:ask).and_return('username')
+          expect(aws).to receive(:ask).and_return('password')
 
-          fake_bootstrap.should_receive(:create_user).with('hm', anything).ordered
-          fake_bootstrap.should_receive(:create_user).with('username', 'password').ordered
+          expect(fake_bootstrap).to receive(:create_user).with('hm', anything).ordered
+          expect(fake_bootstrap).to receive(:create_user).with('username', 'password').ordered
 
           aws.bootstrap_micro
         end
@@ -194,14 +194,14 @@ describe Bosh::Cli::Command::AWS do
         end
 
         it 'saves the randomly generated password??' do
-          fake_bootstrap.should_receive(:start)
-          Bosh::Aws::MicroBoshBootstrap.should_receive(:new).with(
+          expect(fake_bootstrap).to receive(:start)
+          expect(Bosh::Aws::MicroBoshBootstrap).to receive(:new).with(
             anything,
             kind_of(Hash)
           ).and_return(fake_bootstrap)
 
-          fake_bootstrap.should_receive(:create_user).with('hm', anything).ordered
-          fake_bootstrap.should_receive(:create_user).with('admin', anything).ordered
+          expect(fake_bootstrap).to receive(:create_user).with('hm', anything).ordered
+          expect(fake_bootstrap).to receive(:create_user).with('admin', anything).ordered
 
           aws.bootstrap_micro
         end

--- a/bosh_cli_plugin_aws/spec/integration/s3_spec.rb
+++ b/bosh_cli_plugin_aws/spec/integration/s3_spec.rb
@@ -15,28 +15,28 @@ describe "S3 buckets integration test", s3_credentials: true do
 
   context "buckets" do
     it "creates, lists, copies, and deletes buckets" do
-      s3.bucket_exists?(bucket_name).should be(false)
+      expect(s3.bucket_exists?(bucket_name)).to be(false)
       s3.create_bucket(bucket_name)
       s3.create_bucket(another_bucket_name)
 
-      s3.bucket_exists?(bucket_name).should be(true)
-      s3.bucket_names.should include(bucket_name)
+      expect(s3.bucket_exists?(bucket_name)).to be(true)
+      expect(s3.bucket_names).to include(bucket_name)
 
-      s3.fetch_object_contents(bucket_name, "file.txt").should be_nil
+      expect(s3.fetch_object_contents(bucket_name, "file.txt")).to be_nil
 
       s3.upload_to_bucket(bucket_name, "file.txt", file)
 
-      s3.objects_in_bucket(bucket_name).should include("file.txt")
-      s3.fetch_object_contents(bucket_name, "file.txt").should == "hello friends"
+      expect(s3.objects_in_bucket(bucket_name)).to include("file.txt")
+      expect(s3.fetch_object_contents(bucket_name, "file.txt")).to eq("hello friends")
 
       s3.move_bucket(bucket_name, another_bucket_name)
-      s3.objects_in_bucket(another_bucket_name).should include("file.txt")
-      s3.fetch_object_contents(another_bucket_name, "file.txt").should == "hello friends"
-      s3.objects_in_bucket(bucket_name).should_not include("file.txt")
+      expect(s3.objects_in_bucket(another_bucket_name)).to include("file.txt")
+      expect(s3.fetch_object_contents(another_bucket_name, "file.txt")).to eq("hello friends")
+      expect(s3.objects_in_bucket(bucket_name)).not_to include("file.txt")
 
       Dir.mktmpdir do |dir|
         file = s3.copy_remote_file(another_bucket_name, "file.txt", File.join(dir, "new_file.txt"))
-        file.read.should == "hello friends"
+        expect(file.read).to eq("hello friends")
       end
 
       expect { s3.copy_remote_file(another_bucket_name, "bad_file_name.txt", "new_file.txt")}.to raise_error(Exception, "Can't find bad_file_name.txt in bucket #{another_bucket_name}")
@@ -53,9 +53,9 @@ describe "S3 buckets integration test", s3_credentials: true do
         sleep 0.5
       end
 
-      bucket_exists.should be(false)
+      expect(bucket_exists).to be(false)
 
-      s3.bucket_names.should_not include(bucket_name)
+      expect(s3.bucket_names).not_to include(bucket_name)
     end
   end
 

--- a/bosh_cli_plugin_aws/spec/migrations/20130529212130_create_more_unique_s3_buckets_spec.rb
+++ b/bosh_cli_plugin_aws/spec/migrations/20130529212130_create_more_unique_s3_buckets_spec.rb
@@ -8,16 +8,16 @@ describe CreateMoreUniqueS3Buckets do
   let(:mock_s3) { double("Bosh::Aws::S3").as_null_object }
 
   before do
-    Bosh::Aws::S3.stub(:new).and_return(mock_s3)
+    allow(Bosh::Aws::S3).to receive(:new).and_return(mock_s3)
   end
 
   context "when the old and new buckets have the same name" do
     it "should not do anything" do
       config['vpc']['domain'] = 'run.pivotal.io'
       config['name'] = 'run-pivotal-io'
-      mock_s3.should_not_receive :create_bucket
-      mock_s3.should_not_receive :move_bucket
-      mock_s3.should_not_receive :delete_bucket
+      expect(mock_s3).not_to receive :create_bucket
+      expect(mock_s3).not_to receive :move_bucket
+      expect(mock_s3).not_to receive :delete_bucket
 
       subject.execute
     end
@@ -25,27 +25,27 @@ describe CreateMoreUniqueS3Buckets do
 
   context "when old buckets exists" do
     before do
-      mock_s3.should_receive(:bucket_exists?).with("dev102-bosh-blobstore").and_return(true)
-      mock_s3.should_receive(:bucket_exists?).with("dev102-cf-com-bosh-artifacts").and_return(true)
-      mock_s3.stub(:move_bucket)
-      mock_s3.stub(:delete_bucket)
+      expect(mock_s3).to receive(:bucket_exists?).with("dev102-bosh-blobstore").and_return(true)
+      expect(mock_s3).to receive(:bucket_exists?).with("dev102-cf-com-bosh-artifacts").and_return(true)
+      allow(mock_s3).to receive(:move_bucket)
+      allow(mock_s3).to receive(:delete_bucket)
     end
 
     it "should create the buckets" do
-      mock_s3.should_not_receive(:create_bucket).with("dev102-cf-com-bosh-artifacts")
-      mock_s3.should_not_receive(:create_bucket).with("dev102-cf-com-bosh-blobstore")
+      expect(mock_s3).not_to receive(:create_bucket).with("dev102-cf-com-bosh-artifacts")
+      expect(mock_s3).not_to receive(:create_bucket).with("dev102-cf-com-bosh-blobstore")
       subject.execute
     end
 
     it "should copy the existing bucket content" do
-      mock_s3.should_receive(:move_bucket).with("dev102-bosh-blobstore", "dev102-cf-com-bosh-blobstore").ordered
-      mock_s3.should_receive(:move_bucket).with("dev102-bosh-artifacts", "dev102-cf-com-bosh-artifacts").ordered
+      expect(mock_s3).to receive(:move_bucket).with("dev102-bosh-blobstore", "dev102-cf-com-bosh-blobstore").ordered
+      expect(mock_s3).to receive(:move_bucket).with("dev102-bosh-artifacts", "dev102-cf-com-bosh-artifacts").ordered
       subject.execute
     end
 
     it "should remove the old buckets" do
-      mock_s3.should_receive(:delete_bucket).with("dev102-bosh-blobstore").ordered
-      mock_s3.should_receive(:delete_bucket).with("dev102-bosh-artifacts").ordered
+      expect(mock_s3).to receive(:delete_bucket).with("dev102-bosh-blobstore").ordered
+      expect(mock_s3).to receive(:delete_bucket).with("dev102-bosh-artifacts").ordered
       subject.execute
     end
   end
@@ -53,25 +53,25 @@ describe CreateMoreUniqueS3Buckets do
   context "when old buckets don't exist" do
 
     before do
-      mock_s3.should_receive(:bucket_exists?).with("dev102-bosh-blobstore").and_return(false)
-      mock_s3.should_receive(:bucket_exists?).with("dev102-bosh-artifacts").and_return(false)
-      mock_s3.should_receive(:bucket_exists?).with("dev102-cf-com-bosh-blobstore").and_return(false)
-      mock_s3.should_receive(:bucket_exists?).with("dev102-cf-com-bosh-artifacts").and_return(false)
+      expect(mock_s3).to receive(:bucket_exists?).with("dev102-bosh-blobstore").and_return(false)
+      expect(mock_s3).to receive(:bucket_exists?).with("dev102-bosh-artifacts").and_return(false)
+      expect(mock_s3).to receive(:bucket_exists?).with("dev102-cf-com-bosh-blobstore").and_return(false)
+      expect(mock_s3).to receive(:bucket_exists?).with("dev102-cf-com-bosh-artifacts").and_return(false)
     end
 
     it "should create the buckets" do
-      mock_s3.should_receive(:create_bucket).with("dev102-cf-com-bosh-blobstore").ordered
-      mock_s3.should_receive(:create_bucket).with("dev102-cf-com-bosh-artifacts").ordered
+      expect(mock_s3).to receive(:create_bucket).with("dev102-cf-com-bosh-blobstore").ordered
+      expect(mock_s3).to receive(:create_bucket).with("dev102-cf-com-bosh-artifacts").ordered
       subject.execute
     end
 
     it "should not copy the existing bucket content" do
-      mock_s3.should_not_receive(:move_bucket)
+      expect(mock_s3).not_to receive(:move_bucket)
       subject.execute
     end
 
     it "should not remove the old buckets" do
-      mock_s3.should_not_receive(:delete_bucket)
+      expect(mock_s3).not_to receive(:delete_bucket)
       subject.execute
     end
   end

--- a/bosh_cli_plugin_aws/spec/migrations/20130531180445_create_bosh_rds_db_spec.rb
+++ b/bosh_cli_plugin_aws/spec/migrations/20130531180445_create_bosh_rds_db_spec.rb
@@ -7,7 +7,7 @@ describe CreateBoshRdsDb do
   subject { described_class.new(config, '')}
 
   before do
-    subject.stub(:load_receipt).and_return(YAML.load_file(asset "test-output.yml"))
+    allow(subject).to receive(:load_receipt).and_return(YAML.load_file(asset "test-output.yml"))
   end
 
   after do
@@ -15,10 +15,10 @@ describe CreateBoshRdsDb do
   end
 
   it "creates the bosh rds if it does not exist" do
-    rds.should_receive(:database_exists?).with("bosh").and_return(false)
+    expect(rds).to receive(:database_exists?).with("bosh").and_return(false)
 
     create_database_params = ["bosh", ["subnet-xxxxxxx5", "subnet-xxxxxxx6"], "vpc-13724979"]
-    rds.should_receive(:create_database).with(*create_database_params).and_return(
+    expect(rds).to receive(:create_database).with(*create_database_params).and_return(
         :engine => "mysql",
         :master_username => "bosh_user",
         :master_user_password => "bosh_password"
@@ -34,18 +34,18 @@ describe CreateBoshRdsDb do
                           endpoint_address: '5.6.7.8',
                           endpoint_port: 5678,
                           db_instance_status: :irrelevant)
-    rds.should_receive(:databases).at_least(:once).and_return([fake_bosh_rds, fake_uaadb_rds])
-    rds.should_receive(:database).with('bosh').and_return(fake_bosh_rds)
+    expect(rds).to receive(:databases).at_least(:once).and_return([fake_bosh_rds, fake_uaadb_rds])
+    expect(rds).to receive(:database).with('bosh').and_return(fake_bosh_rds)
 
     expect { subject.execute }.to_not raise_error
   end
 
   it "does not create the bosh rds if it already exists" do
-    rds.should_receive(:database_exists?).with("bosh").and_return(true)
-    Bosh::Aws::MigrationHelper::RdsDb.should_receive(:deployment_properties).and_return({})
+    expect(rds).to receive(:database_exists?).with("bosh").and_return(true)
+    expect(Bosh::Aws::MigrationHelper::RdsDb).to receive(:deployment_properties).and_return({})
 
     create_database_params = ["bosh", ["subnet-xxxxxxx5", "subnet-xxxxxxx6"], "vpc-13724979"]
-    rds.should_not_receive(:create_database).with(*create_database_params)
+    expect(rds).not_to receive(:create_database).with(*create_database_params)
 
     fake_bosh_rds = double("uaadb",
                          db_name: "uaadb",
@@ -57,7 +57,7 @@ describe CreateBoshRdsDb do
                           endpoint_address: '5.6.7.8',
                           endpoint_port: 5678,
                           db_instance_status: :irrelevant)
-    rds.should_receive(:databases).at_least(:once).and_return([fake_bosh_rds, fake_uaadb_rds])
+    expect(rds).to receive(:databases).at_least(:once).and_return([fake_bosh_rds, fake_uaadb_rds])
 
     expect { subject.execute }.to_not raise_error
   end

--- a/bosh_cli_plugin_aws/spec/migrations/20130826150635_update_elb_for_websockets_spec.rb
+++ b/bosh_cli_plugin_aws/spec/migrations/20130826150635_update_elb_for_websockets_spec.rb
@@ -8,26 +8,26 @@ describe UpdateElbForWebsockets do
 
   it "configures elb and security group for websockets" do
     receipt = YAML.load_file(asset "test-output.yml")
-    subject.stub(load_receipt: receipt)
+    allow(subject).to receive_messages(load_receipt: receipt)
 
     mock_vpc = double(Bosh::Aws::VPC)
     mock_sg = double(AWS::EC2::SecurityGroup)
 
-    Bosh::Aws::VPC.stub(:find).with(ec2, receipt['vpc']['id']).and_return(mock_vpc)
-    mock_vpc.stub(:security_group_by_name).with('web').and_return(mock_sg)
+    allow(Bosh::Aws::VPC).to receive(:find).with(ec2, receipt['vpc']['id']).and_return(mock_vpc)
+    allow(mock_vpc).to receive(:security_group_by_name).with('web').and_return(mock_sg)
 
-    UpdateElbForWebsockets::WebSocketElbHelpers.should_receive(:authorize_ingress).with(mock_sg, {"protocol" => "tcp", "ports" => "4443", "sources" => "0.0.0.0/0"}).and_return(true)
-    UpdateElbForWebsockets::WebSocketElbHelpers.should_receive(:record_ingress).with(receipt, 'web', {"protocol" => "tcp", "ports" => "4443", "sources" => "0.0.0.0/0"})
+    expect(UpdateElbForWebsockets::WebSocketElbHelpers).to receive(:authorize_ingress).with(mock_sg, {"protocol" => "tcp", "ports" => "4443", "sources" => "0.0.0.0/0"}).and_return(true)
+    expect(UpdateElbForWebsockets::WebSocketElbHelpers).to receive(:record_ingress).with(receipt, 'web', {"protocol" => "tcp", "ports" => "4443", "sources" => "0.0.0.0/0"})
 
     mock_elb = double(AWS::ELB::LoadBalancer)
-    elb.stub(:find_by_name).and_return(mock_elb)
+    allow(elb).to receive(:find_by_name).and_return(mock_elb)
 
     params = {port: 443, protocol: :https}
     fake_cert = double(AWS::IAM::ServerCertificate)
-    UpdateElbForWebsockets::WebSocketElbHelpers.stub(:find_server_certificate_from_listeners).with(mock_elb, params).and_return(fake_cert)
+    allow(UpdateElbForWebsockets::WebSocketElbHelpers).to receive(:find_server_certificate_from_listeners).with(mock_elb, params).and_return(fake_cert)
 
     params = {port: 4443, protocol: :ssl, instance_port: 80, instance_protocol: :tcp, server_certificate: fake_cert}
-    UpdateElbForWebsockets::WebSocketElbHelpers.should_receive(:create_listener).with(mock_elb, params)
+    expect(UpdateElbForWebsockets::WebSocketElbHelpers).to receive(:create_listener).with(mock_elb, params)
 
     expect { subject.execute }.to_not raise_error
   end
@@ -35,14 +35,14 @@ describe UpdateElbForWebsockets do
 
   describe "validate_receipt" do
     it "skips configuration if elb doesn't exist" do
-      subject.stub(load_receipt: {})
+      allow(subject).to receive_messages(load_receipt: {})
       expect { subject.execute }.to raise_error Bosh::Cli::CliError, /Unable to find `cfrouter'/
     end
 
     it "skips configuration if vpc isn't in the receipt" do
       receipt = YAML.load_file(asset "test-output.yml")
       receipt.delete('vpc')
-      subject.stub(load_receipt: receipt)
+      allow(subject).to receive_messages(load_receipt: receipt)
 
       expect { subject.execute }.to raise_error Bosh::Cli::CliError, /Unable to find VPC ID in AWS VPC Receipt/
     end
@@ -50,7 +50,7 @@ describe UpdateElbForWebsockets do
     it "skips configuration if elb security group isn't in receipt" do
       receipt = YAML.load_file(asset "test-output.yml")
       receipt['original_configuration']['vpc']['elbs']['cfrouter'].delete('security_group')
-      subject.stub(load_receipt: receipt)
+      allow(subject).to receive_messages(load_receipt: receipt)
 
       expect { subject.execute }.to raise_error Bosh::Cli::CliError, /Unable to find `cfrouter' ELB Security Group in AWS VPC Receipt/
     end
@@ -59,15 +59,15 @@ describe UpdateElbForWebsockets do
   describe UpdateElbForWebsockets::WebSocketElbHelpers do
     before do
       @receipt = YAML.load_file(asset "test-output.yml")
-      subject.stub(load_receipt: @receipt)
+      allow(subject).to receive_messages(load_receipt: @receipt)
 
       @mock_vpc = double(Bosh::Aws::VPC)
-      Bosh::Aws::VPC.stub(:find).with(ec2, @receipt['vpc']['id']).and_return(@mock_vpc)
+      allow(Bosh::Aws::VPC).to receive(:find).with(ec2, @receipt['vpc']['id']).and_return(@mock_vpc)
     end
 
     describe ".find_security_group_by_name" do
       it "errors if the group can't be found" do
-        @mock_vpc.stub(:security_group_by_name).with('web').and_return(nil)
+        allow(@mock_vpc).to receive(:security_group_by_name).with('web').and_return(nil)
 
         expect {
           UpdateElbForWebsockets::WebSocketElbHelpers.find_security_group_by_name(ec2, @receipt['vpc']['id'], 'web')
@@ -76,7 +76,7 @@ describe UpdateElbForWebsockets do
 
       it "returns the security group with that name" do
         mock_sg = double(AWS::EC2::SecurityGroup)
-        @mock_vpc.stub(:security_group_by_name).with('web').and_return(mock_sg)
+        allow(@mock_vpc).to receive(:security_group_by_name).with('web').and_return(mock_sg)
 
         expect(UpdateElbForWebsockets::WebSocketElbHelpers.find_security_group_by_name(ec2, @receipt['vpc']['id'], 'web')).to eq mock_sg
       end
@@ -86,12 +86,12 @@ describe UpdateElbForWebsockets do
       let(:security_group) { double(AWS::EC2::SecurityGroup) }
 
       it "authorizes the ingress through the security group" do
-        security_group.should_receive(:authorize_ingress).with("protocol", 4443, "sources")
+        expect(security_group).to receive(:authorize_ingress).with("protocol", 4443, "sources")
         expect(UpdateElbForWebsockets::WebSocketElbHelpers.authorize_ingress(security_group, 'protocol' => "protocol", 'ports' => "4443", 'sources' => "sources")).to be(true)
       end
 
       it "does not error if ingress rule already exists" do
-        security_group.should_receive(:authorize_ingress).with("protocol", 4443, "sources").and_raise(AWS::EC2::Errors::InvalidPermission::Duplicate)
+        expect(security_group).to receive(:authorize_ingress).with("protocol", 4443, "sources").and_raise(AWS::EC2::Errors::InvalidPermission::Duplicate)
         expect(UpdateElbForWebsockets::WebSocketElbHelpers.authorize_ingress(security_group, 'protocol' => "protocol", 'ports' => "4443", 'sources' => "sources")).to be(false)
       end
     end
@@ -130,17 +130,17 @@ describe UpdateElbForWebsockets do
 
       it "should find a certificate from listeners with given elb and params" do
         mock_certificate = double(AWS::IAM::ServerCertificate)
-        mock_elb.should_receive(:listeners).and_return([mock_listener])
-        mock_listener.should_receive(:port).and_return(443)
-        mock_listener.should_receive(:protocol).and_return(:https)
-        mock_listener.should_receive(:server_certificate).twice.and_return(mock_certificate)
+        expect(mock_elb).to receive(:listeners).and_return([mock_listener])
+        expect(mock_listener).to receive(:port).and_return(443)
+        expect(mock_listener).to receive(:protocol).and_return(:https)
+        expect(mock_listener).to receive(:server_certificate).twice.and_return(mock_certificate)
 
         expect(UpdateElbForWebsockets::WebSocketElbHelpers.find_server_certificate_from_listeners(mock_elb, port: 443, protocol: :https)).to eq mock_certificate
       end
 
       it "errors if listener can't be found" do
-        mock_elb.should_receive(:listeners).and_return([mock_listener])
-        mock_listener.stub(port: 80, protocol: :http)
+        expect(mock_elb).to receive(:listeners).and_return([mock_listener])
+        allow(mock_listener).to receive_messages(port: 80, protocol: :http)
 
         expect {
           UpdateElbForWebsockets::WebSocketElbHelpers.find_server_certificate_from_listeners(mock_elb, port: 443, protocol: :https)
@@ -148,9 +148,9 @@ describe UpdateElbForWebsockets do
       end
 
       it "errors if server certificate can't be found" do
-        mock_elb.should_receive(:listeners).and_return([mock_listener])
-        mock_listener.stub(port: 443, protocol: :https)
-        mock_listener.should_receive(:server_certificate).and_return(nil)
+        expect(mock_elb).to receive(:listeners).and_return([mock_listener])
+        allow(mock_listener).to receive_messages(port: 443, protocol: :https)
+        expect(mock_listener).to receive(:server_certificate).and_return(nil)
 
         expect {
           UpdateElbForWebsockets::WebSocketElbHelpers.find_server_certificate_from_listeners(mock_elb, port: 443, protocol: :https)
@@ -165,8 +165,8 @@ describe UpdateElbForWebsockets do
         mock_listeners = double(AWS::ELB::ListenerCollection)
         params = {port: 4443, protocol: :ssl, instance_port: 80, instance_protocol: :tcp, server_certificate: 'foo'}
 
-        mock_elb.should_receive(:listeners).and_return(mock_listeners)
-        mock_listeners.should_receive(:create).with(params)
+        expect(mock_elb).to receive(:listeners).and_return(mock_listeners)
+        expect(mock_listeners).to receive(:create).with(params)
 
         UpdateElbForWebsockets::WebSocketElbHelpers.create_listener(mock_elb, params)
       end

--- a/bosh_cli_plugin_aws/spec/migrations/20130827000001_add_secondary_az_to_vpc_spec.rb
+++ b/bosh_cli_plugin_aws/spec/migrations/20130827000001_add_secondary_az_to_vpc_spec.rb
@@ -7,8 +7,8 @@ describe AddSecondaryAzToVpc do
   subject { described_class.new(config, '') }
 
   before do
-    subject.stub(:load_receipt).and_return(YAML.load_file(asset "test-output.yml"))
-    Bosh::Aws::VPC.should_receive(:find).with(ec2, "vpc-13724979").and_return(vpc)
+    allow(subject).to receive(:load_receipt).and_return(YAML.load_file(asset "test-output.yml"))
+    expect(Bosh::Aws::VPC).to receive(:find).with(ec2, "vpc-13724979").and_return(vpc)
   end
 
   let(:vpc) { double("vpc") }
@@ -23,12 +23,12 @@ describe AddSecondaryAzToVpc do
       "services2" => { "availability_zone" => "us-east-1b", "cidr" => "10.10.96.0/20", "default_route" => "cf_nat_box1" },
     }
 
-    vpc.should_receive(:create_subnets).with(subnets)
-    vpc.should_receive(:create_nat_instances).with(subnets)
-    vpc.should_receive(:setup_subnet_routes).with(subnets)
+    expect(vpc).to receive(:create_subnets).with(subnets)
+    expect(vpc).to receive(:create_nat_instances).with(subnets)
+    expect(vpc).to receive(:setup_subnet_routes).with(subnets)
 
 
-    vpc.should_receive(:subnets).and_return(
+    expect(vpc).to receive(:subnets).and_return(
       {
         "cf1" => "subnet-xxxxxxx1",
       },
@@ -40,20 +40,20 @@ describe AddSecondaryAzToVpc do
       }
     )
 
-    subject.should_receive(:save_receipt) { |filename, contents|
-      filename.should == "aws_vpc_receipt"
-      contents["vpc"]["id"].should == "vpc-13724979" # quickly check we didn't wipe anything out
-      contents["vpc"]["subnets"]["cf1"].should == "subnet-xxxxxxx1" # quickly check other subnets are there
-      contents["vpc"]["subnets"]["cf2"].should == cf2_id
-      contents["vpc"]["subnets"]["services2"].should == services2_id
-      contents["vpc"]["subnets"]["bosh2"].should == bosh2_id
+    expect(subject).to receive(:save_receipt) { |filename, contents|
+      expect(filename).to eq("aws_vpc_receipt")
+      expect(contents["vpc"]["id"]).to eq("vpc-13724979") # quickly check we didn't wipe anything out
+      expect(contents["vpc"]["subnets"]["cf1"]).to eq("subnet-xxxxxxx1") # quickly check other subnets are there
+      expect(contents["vpc"]["subnets"]["cf2"]).to eq(cf2_id)
+      expect(contents["vpc"]["subnets"]["services2"]).to eq(services2_id)
+      expect(contents["vpc"]["subnets"]["bosh2"]).to eq(bosh2_id)
     }
 
     subject.execute
   end
 
   it "does not create the new subnets if they already exist" do
-    vpc.should_receive(:subnets).and_return(
+    expect(vpc).to receive(:subnets).and_return(
       {
         "cf1" => "subnet-xxxxxxx1",
         "cf2" => cf2_id,  # already there, panic!
@@ -69,17 +69,17 @@ describe AddSecondaryAzToVpc do
 
     missing_subnets = { "services2" => { "availability_zone" => "us-east-1b", "cidr" => "10.10.96.0/20", "default_route" => "cf_nat_box1" }, }
 
-    vpc.should_receive(:create_subnets).with(missing_subnets)
-    vpc.should_receive(:create_nat_instances).with(missing_subnets)
-    vpc.should_receive(:setup_subnet_routes).with(missing_subnets)
+    expect(vpc).to receive(:create_subnets).with(missing_subnets)
+    expect(vpc).to receive(:create_nat_instances).with(missing_subnets)
+    expect(vpc).to receive(:setup_subnet_routes).with(missing_subnets)
 
-    subject.should_receive(:save_receipt) { |filename, contents|
-      filename.should == "aws_vpc_receipt"
-      contents["vpc"]["id"].should == "vpc-13724979" # quickly check we didn't wipe anything out
-      contents["vpc"]["subnets"]["cf1"].should == "subnet-xxxxxxx1" # quickly check other subnets are there
-      contents["vpc"]["subnets"]["cf2"].should == cf2_id
-      contents["vpc"]["subnets"]["services2"].should == services2_id
-      contents["vpc"]["subnets"]["bosh2"].should == bosh2_id
+    expect(subject).to receive(:save_receipt) { |filename, contents|
+      expect(filename).to eq("aws_vpc_receipt")
+      expect(contents["vpc"]["id"]).to eq("vpc-13724979") # quickly check we didn't wipe anything out
+      expect(contents["vpc"]["subnets"]["cf1"]).to eq("subnet-xxxxxxx1") # quickly check other subnets are there
+      expect(contents["vpc"]["subnets"]["cf2"]).to eq(cf2_id)
+      expect(contents["vpc"]["subnets"]["services2"]).to eq(services2_id)
+      expect(contents["vpc"]["subnets"]["bosh2"]).to eq(bosh2_id)
     }
 
     subject.execute

--- a/bosh_cli_plugin_aws/spec/support/migration_spec_helper.rb
+++ b/bosh_cli_plugin_aws/spec/support/migration_spec_helper.rb
@@ -14,15 +14,15 @@ module MigrationSpecHelper
       self.config_file = asset "config.yml"
       self.config = YAML.load_file(config_file)
 
-      Bosh::Aws::S3.stub(:new).and_return(s3)
-      Bosh::Aws::ELB.stub(:new).and_return(elb)
-      Bosh::Aws::EC2.stub(:new).and_return(ec2)
-      Bosh::Aws::RDS.stub(:new).and_return(rds)
-      Bosh::Aws::Route53.stub(:new).and_return(route53)
+      allow(Bosh::Aws::S3).to receive(:new).and_return(s3)
+      allow(Bosh::Aws::ELB).to receive(:new).and_return(elb)
+      allow(Bosh::Aws::EC2).to receive(:new).and_return(ec2)
+      allow(Bosh::Aws::RDS).to receive(:new).and_return(rds)
+      allow(Bosh::Aws::Route53).to receive(:new).and_return(route53)
 
-      subject.stub(:load_receipt).and_return(nil)
-      subject.stub(:save_receipt)
-      subject.stub(:sleep)
+      allow(subject).to receive(:load_receipt).and_return(nil)
+      allow(subject).to receive(:save_receipt)
+      allow(subject).to receive(:sleep)
     end
   end
 end

--- a/bosh_cli_plugin_aws/spec/unit/aws_config_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/aws_config_spec.rb
@@ -71,42 +71,42 @@ describe Bosh::Aws::AwsConfig do
       end
 
       it "loads secret access key" do
-        configuration['aws']['secret_access_key'].should == "secret_access_key"
+        expect(configuration['aws']['secret_access_key']).to eq("secret_access_key")
       end
 
       it "loads access key id" do
-        configuration['aws']['access_key_id'].should == "access_key_id"
+        expect(configuration['aws']['access_key_id']).to eq("access_key_id")
       end
 
       it "loads vpc domains" do
-        configuration['name'].should == "burritos"
-        configuration['vpc']['domain'].should == "burritos.cf-app.com"
+        expect(configuration['name']).to eq("burritos")
+        expect(configuration['vpc']['domain']).to eq("burritos.cf-app.com")
       end
 
       it "loads the primary availability zone" do
-        configuration['vpc']['subnets']['bosh1']['availability_zone'].should == "primary_az"
-        configuration['vpc']['subnets']['cf1']['availability_zone'].should == "primary_az"
-        configuration['vpc']['subnets']['services1']['availability_zone'].should == "primary_az"
-        configuration['vpc']['subnets']['cf_rds1']['availability_zone'].should == "primary_az"
+        expect(configuration['vpc']['subnets']['bosh1']['availability_zone']).to eq("primary_az")
+        expect(configuration['vpc']['subnets']['cf1']['availability_zone']).to eq("primary_az")
+        expect(configuration['vpc']['subnets']['services1']['availability_zone']).to eq("primary_az")
+        expect(configuration['vpc']['subnets']['cf_rds1']['availability_zone']).to eq("primary_az")
       end
 
       it "loads the secondary availability zone" do
-        configuration['vpc']['subnets']['cf_rds2']['availability_zone'].should == "secondary_az"
+        expect(configuration['vpc']['subnets']['cf_rds2']['availability_zone']).to eq("secondary_az")
       end
 
       context "when the key pair name is set" do
         it "loads the key pair name" do
           environment["BOSH_KEY_PAIR_NAME"] = "key name"
 
-          configuration['vpc']['subnets']['bosh1']['nat_instance']['key_name'].should == "key name"
-          configuration['key_pairs'].should have_key "key name"
+          expect(configuration['vpc']['subnets']['bosh1']['nat_instance']['key_name']).to eq("key name")
+          expect(configuration['key_pairs']).to have_key "key name"
         end
       end
 
       context "when the key pair name is not set" do
         it "loads the default key pair name" do
-          configuration['vpc']['subnets']['bosh1']['nat_instance']['key_name'].should == "bosh"
-          configuration['key_pairs'].should have_key "bosh"
+          expect(configuration['vpc']['subnets']['bosh1']['nat_instance']['key_name']).to eq("bosh")
+          expect(configuration['key_pairs']).to have_key "bosh"
         end
       end
 
@@ -114,7 +114,7 @@ describe Bosh::Aws::AwsConfig do
         it "loads the key path" do
           environment["BOSH_KEY_PATH"] = "key path"
 
-          configuration['key_pairs']["bosh"].should == "key path"
+          expect(configuration['key_pairs']["bosh"]).to eq("key path")
         end
       end
 
@@ -122,7 +122,7 @@ describe Bosh::Aws::AwsConfig do
         it "loads the default key path" do
           environment["HOME"] = "/home/bosh"
 
-          configuration['key_pairs']["bosh"].should == "/home/bosh/.ssh/id_rsa_bosh"
+          expect(configuration['key_pairs']["bosh"]).to eq("/home/bosh/.ssh/id_rsa_bosh")
         end
       end
 
@@ -130,13 +130,13 @@ describe Bosh::Aws::AwsConfig do
         it "loads the ssh key file name" do
           environment["BOSH_AWS_ELB_SSL_KEY"] = "ssl_key"
 
-          configuration['ssl_certs']['cfrouter_cert']['private_key_path'].should == "ssl_key"
+          expect(configuration['ssl_certs']['cfrouter_cert']['private_key_path']).to eq("ssl_key")
         end
       end
 
       context "when the ssl key file name is not set" do
         it "loads the default ssl key file name" do
-          configuration['ssl_certs']['cfrouter_cert']['private_key_path'].should == "elb-cfrouter.key"
+          expect(configuration['ssl_certs']['cfrouter_cert']['private_key_path']).to eq("elb-cfrouter.key")
         end
       end
 
@@ -144,13 +144,13 @@ describe Bosh::Aws::AwsConfig do
         it "loads the ssh key file name" do
           environment["BOSH_DIRECTOR_SSL_KEY"] = "ssl_key"
 
-          configuration['ssl_certs']['director_cert']['private_key_path'].should == "ssl_key"
+          expect(configuration['ssl_certs']['director_cert']['private_key_path']).to eq("ssl_key")
         end
       end
 
       context "when the director ssl key file name is not set" do
         it "loads the default ssl key file name" do
-          configuration['ssl_certs']['director_cert']['private_key_path'].should == "director.key"
+          expect(configuration['ssl_certs']['director_cert']['private_key_path']).to eq("director.key")
         end
       end
 
@@ -158,13 +158,13 @@ describe Bosh::Aws::AwsConfig do
         it "loads the domain name" do
           environment["BOSH_VPC_DOMAIN"] = "domain"
 
-          configuration['vpc']['domain'].should == "burritos.domain"
+          expect(configuration['vpc']['domain']).to eq("burritos.domain")
         end
       end
 
       context "when the domain name is not set" do
         it "loads the default domain name" do
-          configuration['vpc']['domain'].should == "burritos.cf-app.com"
+          expect(configuration['vpc']['domain']).to eq("burritos.cf-app.com")
         end
       end
 
@@ -172,13 +172,13 @@ describe Bosh::Aws::AwsConfig do
         it "loads the ssh cert file name" do
           environment["BOSH_AWS_ELB_SSL_CERT"] = "ssl_cert"
 
-          configuration['ssl_certs']['cfrouter_cert']['certificate_path'].should == "ssl_cert"
+          expect(configuration['ssl_certs']['cfrouter_cert']['certificate_path']).to eq("ssl_cert")
         end
       end
 
       context "when the ssl cert file name is not set" do
         it "loads the default ssl cert file name" do
-          configuration['ssl_certs']['cfrouter_cert']['certificate_path'].should == "elb-cfrouter.pem"
+          expect(configuration['ssl_certs']['cfrouter_cert']['certificate_path']).to eq("elb-cfrouter.pem")
         end
       end
 
@@ -186,23 +186,23 @@ describe Bosh::Aws::AwsConfig do
         it "loads the ssh cert file name" do
           environment["BOSH_DIRECTOR_SSL_CERT"] = "ssl_cert"
 
-          configuration['ssl_certs']['director_cert']['certificate_path'].should == "ssl_cert"
+          expect(configuration['ssl_certs']['director_cert']['certificate_path']).to eq("ssl_cert")
         end
       end
 
       context "when the director ssl cert file name is not set" do
         it "loads the default ssl cert file name" do
-          configuration['ssl_certs']['director_cert']['certificate_path'].should == "director.pem"
+          expect(configuration['ssl_certs']['director_cert']['certificate_path']).to eq("director.pem")
         end
       end
 
       it "loads the bosh ssl chain zone" do
         environment["BOSH_AWS_ELB_SSL_CHAIN"] = "ssl_chain"
-        configuration['ssl_certs']['cfrouter_cert']['certificate_chain_path'].should == "ssl_chain"
+        expect(configuration['ssl_certs']['cfrouter_cert']['certificate_chain_path']).to eq("ssl_chain")
       end
 
       it "should not use a larger database size by default" do
-        configuration["rds"][0]["aws_creation_options"]["db_instance_class"].should == "db.t1.micro"
+        expect(configuration["rds"][0]["aws_creation_options"]["db_instance_class"]).to eq("db.t1.micro")
       end
 
       context "when the cache credentials are not set" do
@@ -211,11 +211,11 @@ describe Bosh::Aws::AwsConfig do
         end
 
         it "should not set the package cache keys" do
-          configuration.should_not have_key("compiled_package_cache")
+          expect(configuration).not_to have_key("compiled_package_cache")
         end
 
         it "should not have package cache configured" do
-          config.should_not have_package_cache_configuration
+          expect(config).not_to have_package_cache_configuration
         end
       end
 
@@ -230,19 +230,19 @@ describe Bosh::Aws::AwsConfig do
           it "loads the default value for the bucket name" do
             environment.delete("BOSH_CACHE_BUCKET_NAME")
 
-            configuration["compiled_package_cache"]["bucket_name"].should == "bosh-global-package-cache"
+            expect(configuration["compiled_package_cache"]["bucket_name"]).to eq("bosh-global-package-cache")
           end
         end
 
         it "should have package cache configured" do
-          config.should have_package_cache_configuration
+          expect(config).to have_package_cache_configuration
         end
 
         it "loads the cache access key id" do
-          configuration.should have_key("compiled_package_cache")
-          configuration["compiled_package_cache"]["access_key_id"].should == "cache_access_key_id"
-          configuration["compiled_package_cache"]["secret_access_key"].should == "cache_secret_access_key"
-          configuration["compiled_package_cache"]["bucket_name"].should == "gimme_mah_bukkit"
+          expect(configuration).to have_key("compiled_package_cache")
+          expect(configuration["compiled_package_cache"]["access_key_id"]).to eq("cache_access_key_id")
+          expect(configuration["compiled_package_cache"]["secret_access_key"]).to eq("cache_secret_access_key")
+          expect(configuration["compiled_package_cache"]["bucket_name"]).to eq("gimme_mah_bukkit")
         end
       end
 
@@ -252,7 +252,7 @@ describe Bosh::Aws::AwsConfig do
         end
 
         it "should use a larger database size" do
-          configuration["rds"][0]["aws_creation_options"]["db_instance_class"].should == "db.m1.large"
+          expect(configuration["rds"][0]["aws_creation_options"]["db_instance_class"]).to eq("db.m1.large")
         end
       end
     end
@@ -281,8 +281,8 @@ describe Bosh::Aws::AwsConfig do
     end
 
     it "loads vpc domains" do
-      configuration['name'].should == "example-com"
-      configuration['vpc']['domain'].should == "example.com"
+      expect(configuration['name']).to eq("example-com")
+      expect(configuration['vpc']['domain']).to eq("example.com")
     end
   end
 end

--- a/bosh_cli_plugin_aws/spec/unit/aws_provider_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/aws_provider_spec.rb
@@ -21,13 +21,13 @@ module Bosh::Aws
       end
 
       it 'returns a correctly configured AWS::EC2 object' do
-        AWS::EC2.should_receive(:new).with(expected_arguments).and_return(ec2)
+        expect(AWS::EC2).to receive(:new).with(expected_arguments).and_return(ec2)
 
         expect(aws_provider.ec2).to eq(ec2)
       end
 
       it 'memoizes the AWS::EC2 object' do
-        AWS::EC2.should_receive(:new).once.and_return(ec2)
+        expect(AWS::EC2).to receive(:new).once.and_return(ec2)
 
         2.times { aws_provider.ec2 }
       end
@@ -43,13 +43,13 @@ module Bosh::Aws
       end
 
       it 'returns a correctly configured AWS::ELB object' do
-        AWS::ELB.should_receive(:new).with(credentials).and_return(elb)
+        expect(AWS::ELB).to receive(:new).with(credentials).and_return(elb)
 
         expect(aws_provider.elb).to eq(elb)
       end
 
       it 'memoizes the AWS::S3 object' do
-        AWS::ELB.should_receive(:new).once.and_return(elb)
+        expect(AWS::ELB).to receive(:new).once.and_return(elb)
 
         2.times { aws_provider.elb }
       end
@@ -59,12 +59,12 @@ module Bosh::Aws
       let(:iam) { instance_double('AWS::IAM') }
 
       it 'returns a correctly configured AWS::IAM object' do
-        AWS::IAM.should_receive(:new).with(credentials).and_return(iam)
+        expect(AWS::IAM).to receive(:new).with(credentials).and_return(iam)
 
         expect(aws_provider.iam).to eq(iam)
       end
       it 'memoizes the AWS::ELB object' do
-        AWS::IAM.should_receive(:new).once.and_return(iam)
+        expect(AWS::IAM).to receive(:new).once.and_return(iam)
 
         2.times { aws_provider.iam }
       end
@@ -80,13 +80,13 @@ module Bosh::Aws
       end
 
       it 'returns a correctly configured AWS::RDS object' do
-        AWS::RDS.should_receive(:new).with(credentials).and_return(rds)
+        expect(AWS::RDS).to receive(:new).with(credentials).and_return(rds)
 
         expect(aws_provider.rds).to eq(rds)
       end
 
       it 'memoizes the AWS::RDS object' do
-        AWS::RDS.should_receive(:new).once.and_return(rds)
+        expect(AWS::RDS).to receive(:new).once.and_return(rds)
 
         2.times { aws_provider.rds }
       end
@@ -102,13 +102,13 @@ module Bosh::Aws
       end
 
       it 'returns a correctly configured AWS::RDS::Client object' do
-        AWS::RDS::Client.should_receive(:new).with(credentials).and_return(rds_client)
+        expect(AWS::RDS::Client).to receive(:new).with(credentials).and_return(rds_client)
 
         expect(aws_provider.rds_client).to eq(rds_client)
       end
 
       it 'memoizes the AWS::RDS::Client object' do
-        AWS::RDS::Client.should_receive(:new).once.and_return(rds_client)
+        expect(AWS::RDS::Client).to receive(:new).once.and_return(rds_client)
 
         2.times { aws_provider.rds_client }
       end
@@ -118,13 +118,13 @@ module Bosh::Aws
       let(:route53) { instance_double('AWS::Route53') }
 
       it 'returns a correctly configured AWS::Route53 object' do
-        AWS::Route53.should_receive(:new).with(credentials).and_return(route53)
+        expect(AWS::Route53).to receive(:new).with(credentials).and_return(route53)
 
         expect(aws_provider.route53).to eq(route53)
       end
 
       it 'memoizes the AWS::Route53 object' do
-        AWS::Route53.should_receive(:new).once.and_return(route53)
+        expect(AWS::Route53).to receive(:new).once.and_return(route53)
 
         2.times { aws_provider.route53 }
       end
@@ -134,12 +134,12 @@ module Bosh::Aws
       let(:s3) { instance_double('AWS::S3') }
 
       it 'returns a correctly configured AWS::S3 object' do
-        AWS::S3.should_receive(:new).with(credentials).and_return(s3)
+        expect(AWS::S3).to receive(:new).with(credentials).and_return(s3)
 
         expect(aws_provider.s3).to eq(s3)
       end
       it 'memoizes the AWS::S3 object' do
-        AWS::S3.should_receive(:new).once.and_return(s3)
+        expect(AWS::S3).to receive(:new).once.and_return(s3)
 
         2.times { aws_provider.s3 }
       end

--- a/bosh_cli_plugin_aws/spec/unit/bat_manifest_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/bat_manifest_spec.rb
@@ -106,7 +106,7 @@ properties:
     before { route53_receipt['elastic_ips']['bat']['ips'] = [] }
 
     it 'warns' do
-      subject.should_receive(:warning).with('Missing vip field')
+      expect(subject).to receive(:warning).with('Missing vip field')
       subject.to_y
     end
   end

--- a/bosh_cli_plugin_aws/spec/unit/bosh_manifest_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/bosh_manifest_spec.rb
@@ -8,14 +8,14 @@ describe Bosh::Aws::BoshManifest do
   let(:stemcell_name) { nil }
 
   it "sets the correct elastic ip" do
-    described_class.new(vpc_receipt, route53_receipt, 'deadbeef', rds_receipt, manifest_options).vip.should == "50.200.100.3"
+    expect(described_class.new(vpc_receipt, route53_receipt, 'deadbeef', rds_receipt, manifest_options).vip).to eq("50.200.100.3")
   end
 
   it "warns when vip is missing" do
     route53_receipt['elastic_ips']['bosh']['ips'] = []
 
     manifest = described_class.new(vpc_receipt, route53_receipt, 'deadbeef', rds_receipt, manifest_options)
-    manifest.should_receive(:warning).with("Missing vip field")
+    expect(manifest).to receive(:warning).with("Missing vip field")
     manifest.to_y
   end
 

--- a/bosh_cli_plugin_aws/spec/unit/destroyer_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/destroyer_spec.rb
@@ -9,14 +9,14 @@ module Bosh::Aws
     let(:vpc_destroyer) { instance_double('Bosh::Aws::VpcDestroyer') }
 
     describe '#ensure_not_production!' do
-      before { Bosh::Aws::EC2.stub(:new).with(fake: 'aws config').and_return(ec2) }
+      before { allow(Bosh::Aws::EC2).to receive(:new).with(fake: 'aws config').and_return(ec2) }
       let(:ec2) { instance_double('Bosh::Aws::EC2') }
 
-      before { ec2.stub(instances_count: 0) }
-      before { ec2.stub(volume_count: 0) }
+      before { allow(ec2).to receive_messages(instances_count: 0) }
+      before { allow(ec2).to receive_messages(volume_count: 0) }
 
       context 'when the environment has more than 20 instances' do
-        before { ec2.stub(instances_count: 21) }
+        before { allow(ec2).to receive_messages(instances_count: 21) }
 
         it 'assumes it is production and aborts' do
           expect {
@@ -26,7 +26,7 @@ module Bosh::Aws
       end
 
       context 'when the environment has 20 or less instances' do
-        before { ec2.stub(instances_count: 20) }
+        before { allow(ec2).to receive_messages(instances_count: 20) }
 
         it 'assumes it is not production and continues' do
           destroyer.ensure_not_production!
@@ -34,7 +34,7 @@ module Bosh::Aws
       end
 
       context 'when the environment has more than 20 volumes' do
-        before { ec2.stub(volume_count: 21) }
+        before { allow(ec2).to receive_messages(volume_count: 21) }
 
         it 'assumes it is production and aborts' do
           expect {
@@ -44,7 +44,7 @@ module Bosh::Aws
       end
 
       context 'when the environment has 20 or less volumes' do
-        before { ec2.stub(volume_count: 20) }
+        before { allow(ec2).to receive_messages(volume_count: 20) }
 
         it 'assumes it is not production and continues' do
           destroyer.ensure_not_production!
@@ -54,32 +54,32 @@ module Bosh::Aws
 
     describe '#delete_all_elbs' do
       it 'removes all ELBs' do
-        ui.stub(confirmed?: true)
+        allow(ui).to receive_messages(confirmed?: true)
 
         fake_elb = instance_double('Bosh::Aws::ELB')
-        Bosh::Aws::ELB.stub(:new).with(fake: 'aws config').and_return(fake_elb)
+        allow(Bosh::Aws::ELB).to receive(:new).with(fake: 'aws config').and_return(fake_elb)
 
-        fake_elb.should_receive(:delete_elbs)
-        fake_elb.should_receive(:names).and_return(%w(one two))
+        expect(fake_elb).to receive(:delete_elbs)
+        expect(fake_elb).to receive(:names).and_return(%w(one two))
 
         destroyer.delete_all_elbs
       end
     end
 
     describe '#destroy_all_ec2' do
-      before { Bosh::Aws::EC2.stub(:new).with(fake: 'aws config').and_return(ec2) }
+      before { allow(Bosh::Aws::EC2).to receive(:new).with(fake: 'aws config').and_return(ec2) }
       let(:ec2) { instance_double('Bosh::Aws::EC2') }
 
-      before { ui.stub(say: nil) }
+      before { allow(ui).to receive_messages(say: nil) }
 
       context 'when there is at least one instance' do
-        before { ec2.stub(instance_names: { 'i1' => 'instance1-name', 'i2' => 'instance2-name' }) }
+        before { allow(ec2).to receive_messages(instance_names: { 'i1' => 'instance1-name', 'i2' => 'instance2-name' }) }
 
         it 'warns the user that the operation is destructive and list the instances' do
-          ui.should_receive(:say).with(/DESTRUCTIVE OPERATION/)
-          ui.should_receive(:say).with("Instances:\n\tinstance1-name (id: i1)\n\tinstance2-name (id: i2)")
+          expect(ui).to receive(:say).with(/DESTRUCTIVE OPERATION/)
+          expect(ui).to receive(:say).with("Instances:\n\tinstance1-name (id: i1)\n\tinstance2-name (id: i2)")
 
-          ui.should_receive(:confirmed?)
+          expect(ui).to receive(:confirmed?)
             .with(/terminate all .* EC2 instances .* non-persistent EBS/)
             .and_return(false)
 
@@ -87,52 +87,52 @@ module Bosh::Aws
         end
 
         context 'when the user agrees to terminate all the instances' do
-          before { ui.stub(confirmed?: true) }
+          before { allow(ui).to receive_messages(confirmed?: true) }
 
           it 'terminates all instances' do
-            ec2.should_receive(:terminate_instances)
+            expect(ec2).to receive(:terminate_instances)
             destroyer.delete_all_ec2
           end
         end
 
         context 'when the user wants to bail out of ec2 termination' do
-          before { ui.stub(confirmed?: false) }
+          before { allow(ui).to receive_messages(confirmed?: false) }
 
           it 'does not terminate any instances' do
-            ec2.should_not_receive(:terminate_instances)
+            expect(ec2).not_to receive(:terminate_instances)
             destroyer.delete_all_ec2
           end
         end
       end
 
       context 'when there is no instances' do
-        before { ec2.stub(instance_names: {}) }
+        before { allow(ec2).to receive_messages(instance_names: {}) }
 
         it 'notifies user that there is no ec2 instances' do
-          ui.should_receive(:say).with(/No EC2 instances/)
+          expect(ui).to receive(:say).with(/No EC2 instances/)
           destroyer.delete_all_ec2
         end
 
         it 'does not terminate any instances' do
-          ec2.should_not_receive(:terminate_instances)
+          expect(ec2).not_to receive(:terminate_instances)
           destroyer.delete_all_ec2
         end
       end
     end
 
     describe '#delete_all_ebs' do
-      before { Bosh::Aws::EC2.stub(:new).with(fake: 'aws config').and_return(ec2) }
+      before { allow(Bosh::Aws::EC2).to receive(:new).with(fake: 'aws config').and_return(ec2) }
       let(:ec2) { instance_double('Bosh::Aws::EC2') }
 
-      before { ui.stub(:say) }
+      before { allow(ui).to receive(:say) }
 
       it 'should warn the user that the operation is destructive and list number of volumes to be deleted' do
-        ec2.stub(volume_count: 2)
+        allow(ec2).to receive_messages(volume_count: 2)
 
-        ui.should_receive(:say).with(/DESTRUCTIVE OPERATION/)
-        ui.should_receive(:say).with('It will delete 2 EBS volume(s)')
+        expect(ui).to receive(:say).with(/DESTRUCTIVE OPERATION/)
+        expect(ui).to receive(:say).with('It will delete 2 EBS volume(s)')
 
-        ui.should_receive(:confirmed?)
+        expect(ui).to receive(:confirmed?)
           .with('Are you sure you want to delete all unattached EBS volumes?')
           .and_return(false)
 
@@ -140,37 +140,37 @@ module Bosh::Aws
       end
 
       context 'where there is at least one volume' do
-        before { ec2.stub(volume_count: 1) }
+        before { allow(ec2).to receive_messages(volume_count: 1) }
 
         context 'when the user agrees to terminate all the instances' do
-          before { ui.stub(confirmed?: true) }
+          before { allow(ui).to receive_messages(confirmed?: true) }
 
           it 'terminates all instances' do
-            ec2.should_receive(:delete_volumes)
+            expect(ec2).to receive(:delete_volumes)
             destroyer.delete_all_ebs
           end
         end
 
         context 'when the user wants to bail out of ec2 termination' do
-          before { ui.stub(confirmed?: false) }
+          before { allow(ui).to receive_messages(confirmed?: false) }
 
           it 'does not terminate any instances' do
-            ec2.should_not_receive(:delete_volumes)
+            expect(ec2).not_to receive(:delete_volumes)
             destroyer.delete_all_ebs
           end
         end
       end
 
       context 'where there are no volumes' do
-        before { ec2.stub(volume_count: 0) }
+        before { allow(ec2).to receive_messages(volume_count: 0) }
 
         it 'notifies user that there is no volumes' do
-          ui.should_receive(:say).with(/No EBS volumes/)
+          expect(ui).to receive(:say).with(/No EBS volumes/)
           destroyer.delete_all_ebs
         end
 
         it 'does not try to terminate any volumes' do
-          ec2.should_not_receive(:delete_volumes)
+          expect(ec2).not_to receive(:delete_volumes)
           destroyer.delete_all_ebs
         end
       end
@@ -178,54 +178,54 @@ module Bosh::Aws
 
     describe '#delete_all_rds' do
       it 'delegates to rds_destroyer' do
-        rds_destroyer.should_receive(:delete_all)
+        expect(rds_destroyer).to receive(:delete_all)
         destroyer.delete_all_rds
       end
     end
 
     describe '#delete_all_s3' do
-      before { Bosh::Aws::S3.stub(:new).with(fake: 'aws config').and_return(s3) }
+      before { allow(Bosh::Aws::S3).to receive(:new).with(fake: 'aws config').and_return(s3) }
       let(:s3) { instance_double('Bosh::Aws::S3') }
 
       context 'when there is at least one bucket' do
-        before { s3.stub(bucket_names: ['bucket1-name', 'bucket2-name']) }
+        before { allow(s3).to receive_messages(bucket_names: ['bucket1-name', 'bucket2-name']) }
 
         it 'warns the user that the operation is destructive and list the buckets' do
-          ui.should_receive(:say).with(/DESTRUCTIVE OPERATION/)
-          ui.should_receive(:say).with("Buckets:\n\tbucket1-name\n\tbucket2-name")
-          ui.should_receive(:confirmed?).with('Are you sure you want to empty and delete all buckets?').and_return(false)
+          expect(ui).to receive(:say).with(/DESTRUCTIVE OPERATION/)
+          expect(ui).to receive(:say).with("Buckets:\n\tbucket1-name\n\tbucket2-name")
+          expect(ui).to receive(:confirmed?).with('Are you sure you want to empty and delete all buckets?').and_return(false)
           destroyer.delete_all_s3
         end
 
         context 'when user confirmed deletion' do
-          before { ui.stub(confirmed?: true) }
+          before { allow(ui).to receive_messages(confirmed?: true) }
 
           it 'delete all S3 buckets associated with an account' do
-            s3.should_receive(:empty)
+            expect(s3).to receive(:empty)
             destroyer.delete_all_s3
           end
         end
 
         context 'when user does not confirm deletion' do
-          before { ui.stub(confirmed?: false) }
+          before { allow(ui).to receive_messages(confirmed?: false) }
 
           it 'does not delete any S3 buckets' do
-            s3.should_not_receive(:empty)
+            expect(s3).not_to receive(:empty)
             destroyer.delete_all_s3
           end
         end
       end
 
       context 'where there are no s3 buckets' do
-        before { s3.stub(bucket_names: []) }
+        before { allow(s3).to receive_messages(bucket_names: []) }
 
         it 'notifies user that there is no buckets' do
-          ui.should_receive(:say).with(/No S3 buckets/)
+          expect(ui).to receive(:say).with(/No S3 buckets/)
           destroyer.delete_all_s3
         end
 
         it 'does not delete any S3 buckets' do
-          s3.should_not_receive(:empty)
+          expect(s3).not_to receive(:empty)
           destroyer.delete_all_s3
         end
       end
@@ -233,70 +233,70 @@ module Bosh::Aws
 
     describe '#delete_all_vpcs' do
       it 'delegates to vpc_destroyer' do
-        vpc_destroyer.should_receive(:delete_all)
+        expect(vpc_destroyer).to receive(:delete_all)
         destroyer.delete_all_vpcs
       end
     end
 
     describe '#delete_all_key_pairs' do
-      before { Bosh::Aws::EC2.stub(:new).with(fake: 'aws config').and_return(ec2) }
+      before { allow(Bosh::Aws::EC2).to receive(:new).with(fake: 'aws config').and_return(ec2) }
       let(:ec2) { instance_double('Bosh::Aws::EC2') }
 
       context 'when user confirmed deletion' do
-        before { ui.stub(confirmed?: true) }
+        before { allow(ui).to receive_messages(confirmed?: true) }
 
         it 'removes all key pairs' do
-          ec2.should_receive(:remove_all_key_pairs)
+          expect(ec2).to receive(:remove_all_key_pairs)
           destroyer.delete_all_key_pairs
         end
       end
 
       context 'when user did not confirm deletion' do
-        before { ui.stub(confirmed?: false) }
+        before { allow(ui).to receive_messages(confirmed?: false) }
 
         it 'does not remove any key pairs' do
-          ec2.should_not_receive(:remove_all_key_pairs)
+          expect(ec2).not_to receive(:remove_all_key_pairs)
           destroyer.delete_all_key_pairs
         end
       end
     end
 
     describe '#delete_all_elastic_ips' do
-      before { Bosh::Aws::EC2.stub(:new).with(fake: 'aws config').and_return(ec2) }
+      before { allow(Bosh::Aws::EC2).to receive(:new).with(fake: 'aws config').and_return(ec2) }
       let(:ec2) { instance_double('Bosh::Aws::EC2') }
 
       context 'when user confirmed deletion' do
-        before { ui.stub(confirmed?: true) }
+        before { allow(ui).to receive_messages(confirmed?: true) }
 
         it 'removes all elastic ips' do
-          ec2.should_receive(:release_all_elastic_ips)
+          expect(ec2).to receive(:release_all_elastic_ips)
           destroyer.delete_all_elastic_ips
         end
       end
 
       context 'when user did not confirm deletion' do
-        before { ui.stub(confirmed?: false) }
+        before { allow(ui).to receive_messages(confirmed?: false) }
 
         it 'does not remove elastic ips' do
-          ec2.should_not_receive(:release_all_elastic_ips)
+          expect(ec2).not_to receive(:release_all_elastic_ips)
           destroyer.delete_all_elastic_ips
         end
       end
     end
 
     describe '#delete_all_security_groups' do
-      before { Bosh::Aws::EC2.stub(:new).with(fake: 'aws config').and_return(ec2) }
+      before { allow(Bosh::Aws::EC2).to receive(:new).with(fake: 'aws config').and_return(ec2) }
       let(:ec2) { instance_double('Bosh::Aws::EC2') }
 
       context 'when user confirmed deletion' do
-        before { ui.stub(confirmed?: true) }
+        before { allow(ui).to receive_messages(confirmed?: true) }
 
         it 'retries if it can not delete security groups due to eventual consistency' do
-          ec2.should_receive(:delete_all_security_groups)
+          expect(ec2).to receive(:delete_all_security_groups)
             .ordered
             .exactly(119).times
             .and_raise(::AWS::EC2::Errors::InvalidGroup::InUse)
-          ec2.should_receive(:delete_all_security_groups)
+          expect(ec2).to receive(:delete_all_security_groups)
             .ordered
             .once
             .and_return(true)
@@ -305,58 +305,58 @@ module Bosh::Aws
       end
 
       context 'when user did not confirm deletion' do
-        before { ui.stub(confirmed?: false) }
+        before { allow(ui).to receive_messages(confirmed?: false) }
 
         it 'should not delete security groups' do
-          ec2.should_not_receive(:delete_all_security_groups)
+          expect(ec2).not_to receive(:delete_all_security_groups)
           destroyer.delete_all_security_groups
         end
       end
     end
 
     describe '#delete_all_route53_records' do
-      before { Bosh::Aws::Route53.stub(:new).with(fake: 'aws config').and_return(route53) }
+      before { allow(Bosh::Aws::Route53).to receive(:new).with(fake: 'aws config').and_return(route53) }
       let(:route53) { instance_double('Bosh::Aws::Route53') }
 
       context 'when omit types are specified' do
-        before { ui.stub(options: {omit_types: %w(custom)}) }
+        before { allow(ui).to receive_messages(options: {omit_types: %w(custom)}) }
 
         context 'when user confirmed deletion' do
-          before { ui.stub(confirmed?: true) }
+          before { allow(ui).to receive_messages(confirmed?: true) }
 
           it 'removes all route 53 records except user specified' do
-            route53.should_receive(:delete_all_records).with(omit_types: %w(custom))
+            expect(route53).to receive(:delete_all_records).with(omit_types: %w(custom))
             destroyer.delete_all_route53_records
           end
         end
 
         context 'when user did not confirm deletion' do
-          before { ui.stub(confirmed?: false) }
+          before { allow(ui).to receive_messages(confirmed?: false) }
 
           it 'does not remove 53 records' do
-            route53.should_not_receive(:delete_all_records)
+            expect(route53).not_to receive(:delete_all_records)
             destroyer.delete_all_route53_records
           end
         end
       end
 
       context 'when omit types are not specified' do
-        before { ui.stub(options: {}) }
+        before { allow(ui).to receive_messages(options: {}) }
 
         context 'when user confirmed deletion' do
-          before { ui.stub(confirmed?: true) }
+          before { allow(ui).to receive_messages(confirmed?: true) }
 
           it 'removes all route 53 records except NS and SOA' do
-            route53.should_receive(:delete_all_records).with(omit_types: %w(NS SOA))
+            expect(route53).to receive(:delete_all_records).with(omit_types: %w(NS SOA))
             destroyer.delete_all_route53_records
           end
         end
 
         context 'when user did not confirm deletion' do
-          before { ui.stub(confirmed?: false) }
+          before { allow(ui).to receive_messages(confirmed?: false) }
 
           it 'does not remove 53 records' do
-            route53.should_not_receive(:delete_all_records)
+            expect(route53).not_to receive(:delete_all_records)
             destroyer.delete_all_route53_records
           end
         end

--- a/bosh_cli_plugin_aws/spec/unit/microbosh_bootstrap_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/microbosh_bootstrap_spec.rb
@@ -15,17 +15,17 @@ describe Bosh::Aws::MicroBoshBootstrap do
       end
 
       it "uses the given AMI" do
-        bootstrap.micro_ami.should == 'ami-tgupta'
+        expect(bootstrap.micro_ami).to eq('ami-tgupta')
       end
     end
 
     context "when the environment does not provide an override AMI" do
       before do
-        Net::HTTP.should_receive(:get).with("bosh-jenkins-artifacts.s3.amazonaws.com", "/last_successful-bosh-stemcell-aws_ami_us-east-1").and_return("ami-david")
+        expect(Net::HTTP).to receive(:get).with("bosh-jenkins-artifacts.s3.amazonaws.com", "/last_successful-bosh-stemcell-aws_ami_us-east-1").and_return("ami-david")
       end
 
       it "returns the content from S3" do
-        bootstrap.micro_ami.should == "ami-david"
+        expect(bootstrap.micro_ami).to eq("ami-david")
       end
     end
   end
@@ -34,11 +34,11 @@ describe Bosh::Aws::MicroBoshBootstrap do
     let(:microbosh_bootstrap) { described_class.new(nil, hm_director_account_options.merge(non_interactive: true)) }
 
     before do
-      Bosh::Cli::Command::Micro.any_instance.stub(:micro_deployment)
-      Bosh::Cli::Command::Micro.any_instance.stub(:perform)
-      Bosh::Cli::Command::User.any_instance.stub(:create)
-      Bosh::Cli::Command::Misc.any_instance.stub(:login)
-      Bosh::Aws::MicroBoshBootstrap.any_instance.stub(:micro_ami).and_return("ami-123456")
+      allow_any_instance_of(Bosh::Cli::Command::Micro).to receive(:micro_deployment)
+      allow_any_instance_of(Bosh::Cli::Command::Micro).to receive(:perform)
+      allow_any_instance_of(Bosh::Cli::Command::User).to receive(:create)
+      allow_any_instance_of(Bosh::Cli::Command::Misc).to receive(:login)
+      allow_any_instance_of(Bosh::Aws::MicroBoshBootstrap).to receive(:micro_ami).and_return("ami-123456")
     end
 
     around do |example|
@@ -52,34 +52,34 @@ describe Bosh::Aws::MicroBoshBootstrap do
     end
 
     it "should generate a microbosh.yml in the right location" do
-      ::Bosh::Cli::Command::Base.any_instance.stub(:non_interactive?).and_return(true)
-      File.exist?("deployments/micro/micro_bosh.yml").should == false
+      allow_any_instance_of(::Bosh::Cli::Command::Base).to receive(:non_interactive?).and_return(true)
+      expect(File.exist?("deployments/micro/micro_bosh.yml")).to eq(false)
       microbosh_bootstrap.start
-      File.exist?("deployments/micro/micro_bosh.yml").should == true
+      expect(File.exist?("deployments/micro/micro_bosh.yml")).to eq(true)
     end
 
     it "should remove any existing deployment artifacts first" do
-      ::Bosh::Cli::Command::Base.any_instance.stub(:non_interactive?).and_return(true)
+      allow_any_instance_of(::Bosh::Cli::Command::Base).to receive(:non_interactive?).and_return(true)
       FileUtils.mkdir_p("deployments/micro")
       File.open("deployments/bosh-registry.log", "w") { |f| f.write("old stuff!") }
       File.open("deployments/micro/leftover.yml", "w") { |f| f.write("old stuff!") }
-      File.exist?("deployments/bosh-registry.log").should == true
-      File.exist?("deployments/micro/leftover.yml").should == true
+      expect(File.exist?("deployments/bosh-registry.log")).to eq(true)
+      expect(File.exist?("deployments/micro/leftover.yml")).to eq(true)
       microbosh_bootstrap.start
-      File.exist?("deployments/bosh-registry.log").should == false
-      File.exist?("deployments/micro/leftover.yml").should == false
+      expect(File.exist?("deployments/bosh-registry.log")).to eq(false)
+      expect(File.exist?("deployments/micro/leftover.yml")).to eq(false)
     end
 
     it "should deploy a micro bosh" do
-      ::Bosh::Cli::Command::Base.any_instance.stub(:non_interactive?).and_return(true)
-      Bosh::Cli::Command::Micro.any_instance.should_receive(:micro_deployment).with("micro")
-      Bosh::Cli::Command::Micro.any_instance.should_receive(:perform).with("ami-123456")
+      allow_any_instance_of(::Bosh::Cli::Command::Base).to receive(:non_interactive?).and_return(true)
+      expect_any_instance_of(Bosh::Cli::Command::Micro).to receive(:micro_deployment).with("micro")
+      expect_any_instance_of(Bosh::Cli::Command::Micro).to receive(:perform).with("ami-123456")
       microbosh_bootstrap.start
     end
 
     it "should login with admin/admin with non-interactive mode" do
-      ::Bosh::Cli::Command::Base.any_instance.stub(:non_interactive?).and_return(true)
-      Bosh::Cli::Command::Misc.any_instance.should_receive(:login).with("admin", "admin")
+      allow_any_instance_of(::Bosh::Cli::Command::Base).to receive(:non_interactive?).and_return(true)
+      expect_any_instance_of(Bosh::Cli::Command::Misc).to receive(:login).with("admin", "admin")
       microbosh_bootstrap.start
     end
 
@@ -87,13 +87,13 @@ describe Bosh::Aws::MicroBoshBootstrap do
       misc_admin = double('Misc command for admin', :options= => nil)
       misc_foo = double('Misc command for foo', :options= => nil)
 
-      misc_admin.should_receive(:login).with('admin', 'admin')
-      misc_foo.should_receive(:login).with('foo', 'foo')
+      expect(misc_admin).to receive(:login).with('admin', 'admin')
+      expect(misc_foo).to receive(:login).with('foo', 'foo')
 
-      Bosh::Cli::Command::User.any_instance.should_receive(:create).with("foo", "foo")
-      Bosh::Cli::Command::Misc.should_receive(:new).and_return(misc_admin, misc_foo)
+      expect_any_instance_of(Bosh::Cli::Command::User).to receive(:create).with("foo", "foo")
+      expect(Bosh::Cli::Command::Misc).to receive(:new).and_return(misc_admin, misc_foo)
 
-      microbosh_bootstrap.stub(:ask).and_return("foo")
+      allow(microbosh_bootstrap).to receive(:ask).and_return("foo")
       microbosh_bootstrap.start
       microbosh_bootstrap.create_user("foo", "foo")
     end

--- a/bosh_cli_plugin_aws/spec/unit/microbosh_manifest_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/microbosh_manifest_spec.rb
@@ -13,20 +13,20 @@ describe Bosh::Aws::MicroboshManifest do
   its(:network_type) { should eq('manual') }
 
   it 'sets health manager director credentials' do
-    manifest.hm_director_user.should == 'hm'
-    manifest.hm_director_password.should == 'hmpasswd'
+    expect(manifest.hm_director_user).to eq('hm')
+    expect(manifest.hm_director_password).to eq('hmpasswd')
   end
 
   it 'warns when name is missing' do
     vpc_config['name'] = nil
-    manifest.stub(:private_key_path)
-    manifest.should_receive(:warning).with('Missing name field').at_least(1).times
+    allow(manifest).to receive(:private_key_path)
+    expect(manifest).to receive(:warning).with('Missing name field').at_least(1).times
     manifest.to_y
   end
 
   it 'warns when vip is missing' do
     route53_receipt['elastic_ips']['micro']['ips'] = []
-    manifest.should_receive(:warning).with('Missing vip field').at_least(1).times
+    expect(manifest).to receive(:warning).with('Missing vip field').at_least(1).times
     manifest.to_y
   end
 
@@ -34,7 +34,7 @@ describe Bosh::Aws::MicroboshManifest do
     before { vpc_receipt['vpc']['subnets'] = {} }
 
     it 'warns that the subnet is missing' do
-      manifest.should_receive(:warning).with('Missing bosh subnet field').at_least(1).times
+      expect(manifest).to receive(:warning).with('Missing bosh subnet field').at_least(1).times
       manifest.to_y
     end
 
@@ -43,37 +43,37 @@ describe Bosh::Aws::MicroboshManifest do
 
   it 'warns when availability_zone is missing' do
     vpc_config['vpc']['subnets']['bosh1'].delete('availability_zone')
-    manifest.should_receive(:warning).with('Missing availability zone in vpc.subnets.bosh').at_least(1).times
+    expect(manifest).to receive(:warning).with('Missing availability zone in vpc.subnets.bosh').at_least(1).times
     manifest.to_y
   end
 
   it 'warns when access_key_id is missing' do
     vpc_config['aws'].delete('access_key_id')
-    manifest.should_receive(:warning).with("Missing aws access_key_id field").at_least(1).times
+    expect(manifest).to receive(:warning).with("Missing aws access_key_id field").at_least(1).times
     manifest.to_y
   end
 
   it 'warns when secret_access_key is missing' do
     vpc_config['aws'].delete('secret_access_key')
-    manifest.should_receive(:warning).with("Missing aws secret_access_key field").at_least(1).times
+    expect(manifest).to receive(:warning).with("Missing aws secret_access_key field").at_least(1).times
     manifest.to_y
   end
 
   it 'warns when region is missing' do
     vpc_config['aws'].delete('region')
-    manifest.should_receive(:warning).with("Missing aws region field").at_least(1).times
+    expect(manifest).to receive(:warning).with("Missing aws region field").at_least(1).times
     manifest.to_y
   end
 
   it 'warns when private_key is missing' do
     vpc_config['key_pairs'] = {}
-    manifest.should_receive(:warning).with("Missing key_pairs field, must have at least 1 keypair").at_least(1).times
+    expect(manifest).to receive(:warning).with("Missing key_pairs field, must have at least 1 keypair").at_least(1).times
     manifest.to_y
   end
 
   it 'does not warn when name is present' do
     vpc_config['name'] = 'bill'
-    manifest.should_not_receive(:warning).with('Missing name field')
+    expect(manifest).not_to receive(:warning).with('Missing name field')
     manifest.to_y
   end
 
@@ -83,8 +83,8 @@ describe Bosh::Aws::MicroboshManifest do
         vpc_receipt['ssl_certs']['director_cert']['certificate'] = asset('ca/bosh.pem')
         vpc_receipt['ssl_certs']['director_cert']['private_key'] = asset('ca/bosh.key')
 
-        manifest.director_ssl_cert.should match /BEGIN CERTIFICATE/
-        manifest.director_ssl_key.should match /BEGIN RSA PRIVATE KEY/
+        expect(manifest.director_ssl_cert).to match /BEGIN CERTIFICATE/
+        expect(manifest.director_ssl_key).to match /BEGIN RSA PRIVATE KEY/
       end
     end
 
@@ -101,8 +101,8 @@ describe Bosh::Aws::MicroboshManifest do
         vpc_receipt['ssl_certs']['director_cert']['certificate'] = non_existant_cert
         vpc_receipt['ssl_certs']['director_cert']['private_key'] = non_existant_key
 
-        manifest.director_ssl_cert.should match /BEGIN CERTIFICATE/
-        manifest.director_ssl_key.should match /BEGIN RSA PRIVATE KEY/
+        expect(manifest.director_ssl_cert).to match /BEGIN CERTIFICATE/
+        expect(manifest.director_ssl_key).to match /BEGIN RSA PRIVATE KEY/
       end
     end
   end

--- a/bosh_cli_plugin_aws/spec/unit/migration_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/migration_spec.rb
@@ -11,7 +11,7 @@ describe Bosh::Aws::Migration do
   end
 
   before do
-    Bosh::Aws::S3.stub(new: s3)
+    allow(Bosh::Aws::S3).to receive_messages(new: s3)
   end
 
   around do |example|
@@ -23,14 +23,14 @@ describe Bosh::Aws::Migration do
   end
 
   it "saves receipts in s3" do
-    s3.should_receive(:upload_to_bucket).with("bucket", "receipts/aws_dummy_receipt.yml", YAML.dump(receipt))
+    expect(s3).to receive(:upload_to_bucket).with("bucket", "receipts/aws_dummy_receipt.yml", YAML.dump(receipt))
 
     migration = described_class.new(config, 'bucket')
     migration.save_receipt("aws_dummy_receipt", receipt)
   end
 
   it "saves receipts in the local filesystem" do
-    s3.stub(:upload_to_bucket)
+    allow(s3).to receive(:upload_to_bucket)
 
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
@@ -38,16 +38,16 @@ describe Bosh::Aws::Migration do
         migration.save_receipt("aws_dummy_receipt", receipt)
 
         receipt_contents = YAML.load_file("aws_dummy_receipt.yml")
-        receipt_contents.should == receipt
+        expect(receipt_contents).to eq(receipt)
       end
     end
   end
 
   it "loads the receipt from S3" do
-    s3.should_receive(:fetch_object_contents).with("bucket", "receipts/aws_dummy_receipt.yml").and_return(YAML.dump(receipt))
+    expect(s3).to receive(:fetch_object_contents).with("bucket", "receipts/aws_dummy_receipt.yml").and_return(YAML.dump(receipt))
 
     migration = described_class.new(config, 'bucket')
-    migration.load_receipt("aws_dummy_receipt").should == receipt
+    expect(migration.load_receipt("aws_dummy_receipt")).to eq(receipt)
   end
 
   it "initializes AWS helpers" do
@@ -55,16 +55,16 @@ describe Bosh::Aws::Migration do
     ec2 = double("EC2")
     route53 = double("Route53")
 
-    Bosh::Aws::S3.should_receive(:new).with(config["aws"]).and_return(s3)
-    Bosh::Aws::ELB.should_receive(:new).with(config["aws"]).and_return(elb)
-    Bosh::Aws::EC2.should_receive(:new).with(config["aws"]).and_return(ec2)
-    Bosh::Aws::Route53.should_receive(:new).with(config["aws"]).and_return(route53)
+    expect(Bosh::Aws::S3).to receive(:new).with(config["aws"]).and_return(s3)
+    expect(Bosh::Aws::ELB).to receive(:new).with(config["aws"]).and_return(elb)
+    expect(Bosh::Aws::EC2).to receive(:new).with(config["aws"]).and_return(ec2)
+    expect(Bosh::Aws::Route53).to receive(:new).with(config["aws"]).and_return(route53)
 
     migration = described_class.new(config, 'bucket')
-    migration.ec2.should == ec2
-    migration.s3.should == s3
-    migration.elb.should == elb
-    migration.route53.should == route53
-    migration.logger.should_not be_nil
+    expect(migration.ec2).to eq(ec2)
+    expect(migration.s3).to eq(s3)
+    expect(migration.elb).to eq(elb)
+    expect(migration.route53).to eq(route53)
+    expect(migration.logger).not_to be_nil
   end
 end

--- a/bosh_cli_plugin_aws/spec/unit/route53_spec.rb
+++ b/bosh_cli_plugin_aws/spec/unit/route53_spec.rb
@@ -25,21 +25,21 @@ describe Bosh::Aws::Route53 do
 
   it "can create a new hosted zone" do
     unique_name = "xxx-yyy-zzz-111"
-    r53.should_receive(:generate_unique_name).and_return(unique_name)
+    expect(r53).to receive(:generate_unique_name).and_return(unique_name)
     aws_r53 = double("aws_r53")
-    r53.stub_chain(:aws_route53, :client).and_return(aws_r53)
-    aws_r53.should_receive(:create_hosted_zone).with(name: "example.com.", caller_reference: unique_name)
+    allow(r53).to receive_message_chain(:aws_route53, :client).and_return(aws_r53)
+    expect(aws_r53).to receive(:create_hosted_zone).with(name: "example.com.", caller_reference: unique_name)
 
     r53.create_zone("example.com")
   end
 
   it "can create a new A record in that zone" do
     zone_id = "???"
-    r53.stub(:get_zone_id).with("example.com.").and_return(zone_id)
+    allow(r53).to receive(:get_zone_id).with("example.com.").and_return(zone_id)
 
     aws_r53 = double("aws_r53")
-    r53.stub_chain(:aws_route53, :client).and_return(aws_r53)
-    aws_r53.should_receive(:change_resource_record_sets).with(resource_set("CREATE", "\\052", "example.com.", "10.0.22.5"))
+    allow(r53).to receive_message_chain(:aws_route53, :client).and_return(aws_r53)
+    expect(aws_r53).to receive(:change_resource_record_sets).with(resource_set("CREATE", "\\052", "example.com.", "10.0.22.5"))
 
     r53.add_record("*", "example.com", "10.0.22.5")
   end
@@ -47,16 +47,16 @@ describe Bosh::Aws::Route53 do
   context "delete records" do
     it "can delete an A record from a zone" do
       zone_id = "???"
-      r53.stub(:get_zone_id).with("example.com.").and_return(zone_id)
+      allow(r53).to receive(:get_zone_id).with("example.com.").and_return(zone_id)
       fake_aws_response = double("aws_response")
 
       aws_r53 = double("aws_r53")
-      r53.stub_chain(:aws_route53, :client).and_return(aws_r53)
-      aws_r53.should_receive(:change_resource_record_sets).
+      allow(r53).to receive_message_chain(:aws_route53, :client).and_return(aws_r53)
+      expect(aws_r53).to receive(:change_resource_record_sets).
           with(resource_set("DELETE", "\\052", "example.com.", "10.0.22.5"))
-      aws_r53.should_receive(:list_resource_record_sets).
+      expect(aws_r53).to receive(:list_resource_record_sets).
           with(:hosted_zone_id => "???").and_return(fake_aws_response)
-      fake_aws_response.stub(:data).and_return(
+      allow(fake_aws_response).to receive(:data).and_return(
         resource_record_sets: [{
           name: "\\052.example.com.",
           type: "A",
@@ -72,14 +72,14 @@ describe Bosh::Aws::Route53 do
 
     it "throws an error when it can't find the record to delete" do
       zone_id = "???"
-      r53.stub(:get_zone_id).with("example.com.").and_return(zone_id)
+      allow(r53).to receive(:get_zone_id).with("example.com.").and_return(zone_id)
       fake_aws_response = double("aws_response")
 
       aws_r53 = double("aws_r53")
-      r53.stub_chain(:aws_route53, :client).and_return(aws_r53)
-      aws_r53.stub(:list_resource_record_sets).
+      allow(r53).to receive_message_chain(:aws_route53, :client).and_return(aws_r53)
+      allow(aws_r53).to receive(:list_resource_record_sets).
           with(:hosted_zone_id => "???").and_return(fake_aws_response)
-      fake_aws_response.stub(:data).and_return(
+      allow(fake_aws_response).to receive(:data).and_return(
         resource_record_sets: [{
           name: "\\052.foobar.org.",
           type: "A",
@@ -102,25 +102,25 @@ describe Bosh::Aws::Route53 do
       let(:fake_aws_r53) { double(AWS::Route53) }
 
       before do
-        r53.stub(:aws_route53).and_return(fake_aws_r53)
+        allow(r53).to receive(:aws_route53).and_return(fake_aws_r53)
       end
 
       it "can delete all" do
-        fake_aws_r53.should_receive(:hosted_zones).and_return([fake_zone])
-        fake_zone.should_receive(:rrsets)
-        fake_ns_record.should_receive(:delete)
-        fake_soa_record.should_receive(:delete)
-        fake_a_record.should_receive(:delete)
+        expect(fake_aws_r53).to receive(:hosted_zones).and_return([fake_zone])
+        expect(fake_zone).to receive(:rrsets)
+        expect(fake_ns_record).to receive(:delete)
+        expect(fake_soa_record).to receive(:delete)
+        expect(fake_a_record).to receive(:delete)
 
         r53.delete_all_records
       end
 
       it "can delete all except omissions" do
-        fake_aws_r53.should_receive(:hosted_zones).and_return([fake_zone])
-        fake_zone.should_receive(:rrsets)
-        fake_ns_record.should_not_receive(:delete)
-        fake_soa_record.should_not_receive(:delete)
-        fake_a_record.should_receive(:delete)
+        expect(fake_aws_r53).to receive(:hosted_zones).and_return([fake_zone])
+        expect(fake_zone).to receive(:rrsets)
+        expect(fake_ns_record).not_to receive(:delete)
+        expect(fake_soa_record).not_to receive(:delete)
+        expect(fake_a_record).to receive(:delete)
 
         r53.delete_all_records(omit_types: %w[NS SOA])
       end
@@ -129,11 +129,11 @@ describe Bosh::Aws::Route53 do
 
   it "can delete a hosted zone" do
     zone_id = "???"
-    r53.stub(:get_zone_id).with("example.com.").and_return(zone_id)
+    allow(r53).to receive(:get_zone_id).with("example.com.").and_return(zone_id)
 
     aws_r53 = double("aws_r53")
-    r53.stub_chain(:aws_route53, :client).and_return(aws_r53)
-    aws_r53.should_receive(:delete_hosted_zone).with(id: zone_id)
+    allow(r53).to receive_message_chain(:aws_route53, :client).and_return(aws_r53)
+    expect(aws_r53).to receive(:delete_hosted_zone).with(id: zone_id)
 
     r53.delete_zone("example.com")
   end

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/aws/config_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/aws/config_spec.rb
@@ -10,9 +10,9 @@ describe Bosh::Deployer::Config do
     Bosh::Deployer::Config.configure(config)
 
     properties = Bosh::Deployer::Config.cloud_options['properties']
-    properties['agent'].should be_kind_of(Hash)
-    properties['agent']['mbus'].start_with?('https://').should be(true)
-    properties['agent']['blobstore'].should be_kind_of(Hash)
+    expect(properties['agent']).to be_kind_of(Hash)
+    expect(properties['agent']['mbus'].start_with?('https://')).to be(true)
+    expect(properties['agent']['blobstore']).to be_kind_of(Hash)
   end
 
   it 'should map network properties' do
@@ -21,37 +21,37 @@ describe Bosh::Deployer::Config do
     Bosh::Deployer::Config.configure(config)
 
     networks = Bosh::Deployer::Config.networks
-    networks.should be_kind_of(Hash)
+    expect(networks).to be_kind_of(Hash)
 
     net = networks['bosh']
-    net.should be_kind_of(Hash)
+    expect(net).to be_kind_of(Hash)
     %w(cloud_properties type).each do |key|
-      net[key].should_not be_nil
+      expect(net[key]).not_to be_nil
     end
   end
 
   it 'should default vm env properties' do
     env = Bosh::Deployer::Config.env
-    env.should be_kind_of(Hash)
-    env.should have_key('bosh')
-    env['bosh'].should be_kind_of(Hash)
-    env['bosh']['password'].should_not be_nil
-    env['bosh']['password'].should be_kind_of(String)
-    env['bosh']['password'].should == '$6$salt$password'
+    expect(env).to be_kind_of(Hash)
+    expect(env).to have_key('bosh')
+    expect(env['bosh']).to be_kind_of(Hash)
+    expect(env['bosh']['password']).not_to be_nil
+    expect(env['bosh']['password']).to be_kind_of(String)
+    expect(env['bosh']['password']).to eq('$6$salt$password')
   end
 
   it 'should contain default vm resource properties' do
     Bosh::Deployer::Config.configure('dir' => @dir, 'cloud' => { 'plugin' => 'aws' })
     resources = Bosh::Deployer::Config.resources
-    resources.should be_kind_of(Hash)
+    expect(resources).to be_kind_of(Hash)
 
-    resources['persistent_disk'].should be_kind_of(Integer)
+    expect(resources['persistent_disk']).to be_kind_of(Integer)
 
     cloud_properties = resources['cloud_properties']
-    cloud_properties.should be_kind_of(Hash)
+    expect(cloud_properties).to be_kind_of(Hash)
 
     ['instance_type'].each do |key|
-      cloud_properties[key].should_not be_nil
+      expect(cloud_properties[key]).not_to be_nil
     end
   end
 
@@ -60,9 +60,9 @@ describe Bosh::Deployer::Config do
     config['dir'] = @dir
     Bosh::Deployer::Config.configure(config)
     cloud = Bosh::Deployer::Config.cloud
-    cloud.respond_to?(:ec2).should be(true)
-    cloud.ec2.should be_kind_of(AWS::EC2)
-    cloud.respond_to?(:registry).should be(true)
-    cloud.registry.should be_kind_of(Bosh::Registry::Client)
+    expect(cloud.respond_to?(:ec2)).to be(true)
+    expect(cloud.ec2).to be_kind_of(AWS::EC2)
+    expect(cloud.respond_to?(:registry)).to be(true)
+    expect(cloud.registry).to be_kind_of(Bosh::Registry::Client)
   end
 end

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/aws/instance_manager_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/aws/instance_manager_spec.rb
@@ -14,10 +14,10 @@ module Bosh::Deployer
       @deployer = Bosh::Deployer::InstanceManager.create(@config)
       @cloud = double('cloud')
       @ec2 = double('ec2')
-      @cloud.stub(:ec2).and_return(@ec2)
-      Bosh::Deployer::Config.stub(:cloud).and_return(@cloud)
+      allow(@cloud).to receive(:ec2).and_return(@ec2)
+      allow(Bosh::Deployer::Config).to receive(:cloud).and_return(@cloud)
       @agent = double('agent')
-      @deployer.stub(:agent).and_return(@agent)
+      allow(@deployer).to receive(:agent).and_return(@agent)
 
       allow(MicroboshJobInstance).to receive(:new).and_return(FakeMicroboshJobInstance.new)
     end
@@ -52,43 +52,43 @@ module Bosh::Deployer
 
     it 'should not populate disk model' do
       disk_model = @deployer.infrastructure.disk_model
-      disk_model.should == nil
+      expect(disk_model).to eq(nil)
     end
 
     it 'should create a Bosh instance' do
-      @deployer.infrastructure.stub(:service_ip).and_return('10.0.0.10')
+      allow(@deployer.infrastructure).to receive(:service_ip).and_return('10.0.0.10')
       spec = Psych.load_file(spec_asset('apply_spec_aws.yml'))
-      Bosh::Deployer::Specification.should_receive(:load_apply_spec).and_return(spec)
+      expect(Bosh::Deployer::Specification).to receive(:load_apply_spec).and_return(spec)
 
-      @deployer.stub(:run_command)
-      @deployer.stub(:wait_until_agent_ready)
-      @deployer.stub(:wait_until_director_ready)
-      @deployer.stub(:load_apply_spec).and_return(spec)
-      @deployer.stub(:load_stemcell_manifest).and_return('cloud_properties' => {})
+      allow(@deployer).to receive(:run_command)
+      allow(@deployer).to receive(:wait_until_agent_ready)
+      allow(@deployer).to receive(:wait_until_director_ready)
+      allow(@deployer).to receive(:load_apply_spec).and_return(spec)
+      allow(@deployer).to receive(:load_stemcell_manifest).and_return('cloud_properties' => {})
 
-      @deployer.state.uuid.should_not be_nil
+      expect(@deployer.state.uuid).not_to be_nil
 
-      @deployer.state.stemcell_cid.should be_nil
-      @deployer.state.vm_cid.should be_nil
+      expect(@deployer.state.stemcell_cid).to be_nil
+      expect(@deployer.state.vm_cid).to be_nil
 
-      @cloud.should_receive(:create_stemcell).and_return('SC-CID-CREATE')
-      @cloud.should_receive(:create_vm).and_return('VM-CID-CREATE')
-      @cloud.should_receive(:create_disk).and_return('DISK-CID-CREATE')
-      @cloud.should_receive(:attach_disk).with('VM-CID-CREATE', 'DISK-CID-CREATE')
-      @agent.should_receive(:run_task).with(:mount_disk, 'DISK-CID-CREATE').and_return({})
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:apply, spec)
-      @agent.should_receive(:run_task).with(:start)
+      expect(@cloud).to receive(:create_stemcell).and_return('SC-CID-CREATE')
+      expect(@cloud).to receive(:create_vm).and_return('VM-CID-CREATE')
+      expect(@cloud).to receive(:create_disk).and_return('DISK-CID-CREATE')
+      expect(@cloud).to receive(:attach_disk).with('VM-CID-CREATE', 'DISK-CID-CREATE')
+      expect(@agent).to receive(:run_task).with(:mount_disk, 'DISK-CID-CREATE').and_return({})
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:apply, spec)
+      expect(@agent).to receive(:run_task).with(:start)
 
       stub_stuff_in_discover_bosh_ip('10.0.0.1', 'VM-CID-CREATE')
       @deployer.create(BOSH_STEMCELL_TGZ, nil)
 
-      @deployer.state.stemcell_cid.should == 'SC-CID-CREATE'
-      @deployer.state.vm_cid.should == 'VM-CID-CREATE'
-      @deployer.state.disk_cid.should == 'DISK-CID-CREATE'
-      load_deployment.should == @deployer.state.values
+      expect(@deployer.state.stemcell_cid).to eq('SC-CID-CREATE')
+      expect(@deployer.state.vm_cid).to eq('VM-CID-CREATE')
+      expect(@deployer.state.disk_cid).to eq('DISK-CID-CREATE')
+      expect(load_deployment).to eq(@deployer.state.values)
 
-      @deployer.renderer.total.should == @deployer.renderer.index
+      expect(@deployer.renderer.total).to eq(@deployer.renderer.index)
     end
 
     it 'should destroy a Bosh instance' do
@@ -99,64 +99,64 @@ module Bosh::Deployer
 
       @deployer.state.vm_cid = 'VM-CID-DESTROY'
 
-      @agent.should_receive(:list_disk).and_return([disk_cid])
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
-      @cloud.should_receive(:detach_disk).with('VM-CID-DESTROY', disk_cid)
-      @cloud.should_receive(:delete_disk).with(disk_cid)
-      @cloud.should_receive(:delete_vm).with('VM-CID-DESTROY')
+      expect(@agent).to receive(:list_disk).and_return([disk_cid])
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
+      expect(@cloud).to receive(:detach_disk).with('VM-CID-DESTROY', disk_cid)
+      expect(@cloud).to receive(:delete_disk).with(disk_cid)
+      expect(@cloud).to receive(:delete_vm).with('VM-CID-DESTROY')
 
       @deployer.destroy
 
-      @deployer.state.stemcell_cid.should be_nil
-      @deployer.state.stemcell_name.should be_nil
-      @deployer.state.vm_cid.should be_nil
-      @deployer.state.disk_cid.should be_nil
+      expect(@deployer.state.stemcell_cid).to be_nil
+      expect(@deployer.state.stemcell_name).to be_nil
+      expect(@deployer.state.vm_cid).to be_nil
+      expect(@deployer.state.disk_cid).to be_nil
 
-      load_deployment.should == @deployer.state.values
+      expect(load_deployment).to eq(@deployer.state.values)
 
-      @deployer.renderer.total.should == @deployer.renderer.index
+      expect(@deployer.renderer.total).to eq(@deployer.renderer.index)
     end
 
     it 'should update a Bosh instance' do
-      @deployer.infrastructure.stub(:service_ip).and_return('10.0.0.10')
+      allow(@deployer.infrastructure).to receive(:service_ip).and_return('10.0.0.10')
       spec = Psych.load_file(spec_asset('apply_spec_aws.yml'))
-      Bosh::Deployer::Specification.should_receive(:load_apply_spec).and_return(spec)
+      expect(Bosh::Deployer::Specification).to receive(:load_apply_spec).and_return(spec)
 
       disk_cid = '22'
-      @deployer.stub(:run_command)
-      @deployer.stub(:wait_until_agent_ready)
-      @deployer.stub(:wait_until_director_ready)
-      @deployer.stub(:load_apply_spec).and_return(spec)
-      @deployer.stub(:load_stemcell_manifest).and_return('cloud_properties' => {})
-      @deployer.infrastructure.stub(:persistent_disk_changed?).and_return(false)
+      allow(@deployer).to receive(:run_command)
+      allow(@deployer).to receive(:wait_until_agent_ready)
+      allow(@deployer).to receive(:wait_until_director_ready)
+      allow(@deployer).to receive(:load_apply_spec).and_return(spec)
+      allow(@deployer).to receive(:load_stemcell_manifest).and_return('cloud_properties' => {})
+      allow(@deployer.infrastructure).to receive(:persistent_disk_changed?).and_return(false)
 
       @deployer.state.stemcell_cid = 'SC-CID-UPDATE'
       @deployer.state.vm_cid = 'VM-CID-UPDATE'
       @deployer.state.disk_cid = disk_cid
 
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
-      @cloud.should_receive(:detach_disk).with('VM-CID-UPDATE', disk_cid)
-      @cloud.should_receive(:delete_vm).with('VM-CID-UPDATE')
-      @cloud.should_receive(:delete_stemcell).with('SC-CID-UPDATE')
-      @cloud.should_receive(:create_stemcell).and_return('SC-CID')
-      @cloud.should_receive(:create_vm).and_return('VM-CID')
-      @cloud.should_receive(:attach_disk).with('VM-CID', disk_cid)
-      @agent.should_receive(:run_task).with(:mount_disk, disk_cid).and_return({})
-      @agent.should_receive(:list_disk).and_return([disk_cid])
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:apply, spec)
-      @agent.should_receive(:run_task).with(:start)
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
+      expect(@cloud).to receive(:detach_disk).with('VM-CID-UPDATE', disk_cid)
+      expect(@cloud).to receive(:delete_vm).with('VM-CID-UPDATE')
+      expect(@cloud).to receive(:delete_stemcell).with('SC-CID-UPDATE')
+      expect(@cloud).to receive(:create_stemcell).and_return('SC-CID')
+      expect(@cloud).to receive(:create_vm).and_return('VM-CID')
+      expect(@cloud).to receive(:attach_disk).with('VM-CID', disk_cid)
+      expect(@agent).to receive(:run_task).with(:mount_disk, disk_cid).and_return({})
+      expect(@agent).to receive(:list_disk).and_return([disk_cid])
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:apply, spec)
+      expect(@agent).to receive(:run_task).with(:start)
 
       stub_stuff_in_discover_bosh_ip('10.0.0.2', 'VM-CID')
       @deployer.update(BOSH_STEMCELL_TGZ, nil)
 
-      @deployer.state.stemcell_cid.should == 'SC-CID'
-      @deployer.state.vm_cid.should == 'VM-CID'
-      @deployer.state.disk_cid.should == disk_cid
+      expect(@deployer.state.stemcell_cid).to eq('SC-CID')
+      expect(@deployer.state.vm_cid).to eq('VM-CID')
+      expect(@deployer.state.disk_cid).to eq(disk_cid)
 
-      load_deployment.should == @deployer.state.values
+      expect(load_deployment).to eq(@deployer.state.values)
     end
 
     context 'with vm_cid missing but disk_cid present' do
@@ -209,8 +209,8 @@ module Bosh::Deployer
 
     it 'should fail to destroy a Bosh instance unless stemcell CID exists' do
       @deployer.state.vm_cid = 'VM-CID'
-      @agent.should_receive(:run_task).with(:stop)
-      @cloud.should_receive(:delete_vm).with('VM-CID')
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@cloud).to receive(:delete_vm).with('VM-CID')
       expect {
         @deployer.destroy
       }.to raise_error(Bosh::Cli::CliError)
@@ -218,7 +218,7 @@ module Bosh::Deployer
 
     it 'should fail to destroy a Bosh instance unless VM CID exists' do
       @deployer.state.stemcell_cid = 'SC-CID'
-      @agent.should_receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:stop)
       expect {
         @deployer.destroy
       }.to raise_error(Bosh::Cli::CliError)

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/configuration_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/configuration_spec.rb
@@ -18,31 +18,31 @@ module Bosh::Deployer
 
       it 'should default agent properties' do
         properties = config.cloud_options['properties']
-        properties['agent'].should be_kind_of(Hash)
-        properties['agent']['mbus'].start_with?('https://').should be(true)
-        properties['agent']['blobstore'].should be_kind_of(Hash)
+        expect(properties['agent']).to be_kind_of(Hash)
+        expect(properties['agent']['mbus'].start_with?('https://')).to be(true)
+        expect(properties['agent']['blobstore']).to be_kind_of(Hash)
       end
 
       it 'should default vm env properties' do
         env = config.env
-        env.should be_kind_of(Hash)
-        env.should have_key('bosh')
-        env['bosh'].should be_kind_of(Hash)
-        env['bosh']['password'].should be_nil
+        expect(env).to be_kind_of(Hash)
+        expect(env).to have_key('bosh')
+        expect(env['bosh']).to be_kind_of(Hash)
+        expect(env['bosh']['password']).to be_nil
       end
 
       it 'should contain default vm resource properties' do
         resources = config.resources
-        resources.should be_kind_of(Hash)
+        expect(resources).to be_kind_of(Hash)
 
-        resources['persistent_disk'].should be_kind_of(Integer)
+        expect(resources['persistent_disk']).to be_kind_of(Integer)
 
         cloud_properties = resources['cloud_properties']
-        cloud_properties.should be_kind_of(Hash)
+        expect(cloud_properties).to be_kind_of(Hash)
 
         %w(ram disk cpu).each do |key|
-          cloud_properties[key].should_not be_nil
-          cloud_properties[key].should be > 0
+          expect(cloud_properties[key]).not_to be_nil
+          expect(cloud_properties[key]).to be > 0
         end
       end
 
@@ -50,10 +50,10 @@ module Bosh::Deployer
         it 'should map network properties to the bosh network' do
           networks = config.networks
           net = networks['bosh']
-          net.should be_kind_of(Hash)
+          expect(net).to be_kind_of(Hash)
           expect(net['default']).to match_array(%w(dns gateway))
           %w(cloud_properties netmask gateway ip dns type).each do |key|
-            net[key].should eq(configuration_hash['network'][key])
+            expect(net[key]).to eq(configuration_hash['network'][key])
           end
         end
       end
@@ -69,7 +69,7 @@ module Bosh::Deployer
         networks = config.networks
         expect(networks['bosh']['default']).to match_array(%w(dns gateway))
         %w(cloud_properties netmask gateway ip dns type).each do |key|
-          networks['bosh'][key].should eq(configuration_hash['network'][key])
+          expect(networks['bosh'][key]).to eq(configuration_hash['network'][key])
         end
 
         expect(networks).to include('deployment' => 'deployment network')
@@ -86,7 +86,7 @@ module Bosh::Deployer
         networks = config.networks
         expect(networks['bosh']['default']).to match_array(%w(dns gateway))
         %w(cloud_properties netmask gateway ip dns type).each do |key|
-          networks['bosh'][key].should eq(configuration_hash['network'][key])
+          expect(networks['bosh'][key]).to eq(configuration_hash['network'][key])
         end
 
         vip_hash = {

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/instance_manager/aws_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/instance_manager/aws_spec.rb
@@ -93,8 +93,10 @@ module Bosh::Deployer
           let(:instance) { instance_double('AWS::EC2::Instance') }
 
           before do
-            instance_manager.stub_chain(:state, :vm_cid).and_return('fake-vm-cid')
-            instance_manager.stub_chain(:cloud, :ec2, :instances, :[]).and_return(instance)
+            allow(instance_manager).to receive_message_chain(:state, :vm_cid)
+                                           .and_return('fake-vm-cid')
+            allow(instance_manager).to receive_message_chain(:cloud, :ec2, :instances, :[])
+                                           .and_return(instance)
           end
 
           context 'when there is a bosh VM with a public ip' do
@@ -120,14 +122,15 @@ module Bosh::Deployer
 
             context 'when elastic public ip is set' do
               it 'returns the elastic public ip' do
-                instance.stub_chain(:elastic_ip, :public_ip).and_return('fake-elastic-ip')
+                allow(instance).to receive_message_chain(:elastic_ip, :public_ip)
+                                       .and_return('fake-elastic-ip')
                 expect(aws.send(method)).to eq('fake-elastic-ip')
               end
             end
 
             context 'when elastic public ip is not set' do
               it 'raises RuntimeError error' do
-                instance.stub_chain(:elastic_ip, :public_ip).and_return(nil)
+                allow(instance).to receive_message_chain(:elastic_ip, :public_ip).and_return(nil)
                 expect { aws.send(method) }.to raise_error(
                   RuntimeError, /Failed to discover elastic public ip address/)
               end
@@ -136,7 +139,8 @@ module Bosh::Deployer
         end
 
         context 'when there is no bosh VM' do
-          before { instance_manager.stub_chain(:state, :vm_cid).and_return(nil) }
+          before { allow(instance_manager).to receive_message_chain(:state, :vm_cid)
+                                                  .and_return(nil) }
 
           it 'returns client services ip according to the configuration' do
             expect(aws.send(method)).to eq('fake-client-services-ip')

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/instance_manager/openstack_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/instance_manager/openstack_spec.rb
@@ -43,8 +43,10 @@ module Bosh::Deployer
         let(:instance) { instance_double('Fog::Compute::OpenStack::Server') }
 
         before do
-          instance_manager.stub_chain(:state, :vm_cid).and_return('fake-vm-cid')
-          instance_manager.stub_chain(:cloud, :openstack, :servers, :get).and_return(instance)
+          allow(instance_manager).to receive_message_chain(:state, :vm_cid)
+                                         .and_return('fake-vm-cid')
+          allow(instance_manager).to receive_message_chain(:cloud, :openstack, :servers, :get)
+                                         .and_return(instance)
         end
 
         context 'when there is a floating ip' do
@@ -71,7 +73,7 @@ module Bosh::Deployer
       end
 
       context 'when there is no bosh VM' do
-        before { instance_manager.stub_chain(:state, :vm_cid).and_return(nil) }
+        before { allow(instance_manager).to receive_message_chain(:state, :vm_cid).and_return(nil) }
 
         it 'returns client services ip according to the configuration' do
           expect(subject.client_services_ip).to eq('fake-client-services-ip')
@@ -85,8 +87,10 @@ module Bosh::Deployer
         let(:instance) { instance_double('Fog::Compute::OpenStack::Server') }
 
         before do
-          instance_manager.stub_chain(:state, :vm_cid).and_return('fake-vm-cid')
-          instance_manager.stub_chain(:cloud, :openstack, :servers, :get).and_return(instance)
+          allow(instance_manager).to receive_message_chain(:state, :vm_cid)
+                                         .and_return('fake-vm-cid')
+          allow(instance_manager).to receive_message_chain(:cloud, :openstack, :servers, :get)
+                                         .and_return(instance)
           allow(instance).to receive(:private_ip_address).and_return('fake-private-ip')
         end
 
@@ -97,7 +101,7 @@ module Bosh::Deployer
 
       context 'when there is no bosh VM' do
         before do
-          instance_manager.stub_chain(:state, :vm_cid).and_return(nil)
+          allow(instance_manager).to receive_message_chain(:state, :vm_cid).and_return(nil)
           allow(config).to receive(:agent_services_ip).
                              and_return('fake-agent-services-ip')
         end

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/instance_manager_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/instance_manager_spec.rb
@@ -52,7 +52,7 @@ module Bosh::Deployer
 
       it 'tries to require instance manager specific class' +
            '(this allows custom gems to specify instance manager plugin)' do
-        described_class.should_receive(:require).with(
+        expect(described_class).to receive(:require).with(
           'bosh/deployer/instance_manager/fake')
         allow(described_class).to receive(:new)
         described_class.create(config_hash)
@@ -74,21 +74,21 @@ module Bosh::Deployer
       end
 
       it 'returns the plugin specific instance manager' do
-        described_class.stub(:require)
+        allow(described_class).to receive(:require)
 
         fingerprinter = instance_double('Bosh::Deployer::HashFingerprinter')
-        HashFingerprinter
-        .should_receive(:new)
+        expect(HashFingerprinter)
+        .to receive(:new)
         .and_return(fingerprinter)
 
-        fingerprinter
-        .should_receive(:sha1)
+        expect(fingerprinter)
+        .to receive(:sha1)
         .with(config_hash)
         .and_return('fake-config-hash-sha1')
 
         ui_messager = instance_double('Bosh::Deployer::UiMessager')
-        UiMessager
-        .should_receive(:for_deployer)
+        expect(UiMessager)
+        .to receive(:for_deployer)
         .and_return(ui_messager)
 
         expect(Config).to receive(:configure).with(config_hash)

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/openstack/config_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/openstack/config_spec.rb
@@ -11,9 +11,9 @@ describe Bosh::Deployer::Config do
     Bosh::Deployer::Config.configure(config)
 
     properties = Bosh::Deployer::Config.cloud_options['properties']
-    properties['agent'].should be_kind_of(Hash)
-    properties['agent']['mbus'].start_with?('https://').should be(true)
-    properties['agent']['blobstore'].should be_kind_of(Hash)
+    expect(properties['agent']).to be_kind_of(Hash)
+    expect(properties['agent']['mbus'].start_with?('https://')).to be(true)
+    expect(properties['agent']['blobstore']).to be_kind_of(Hash)
   end
 
   it 'should map network properties' do
@@ -22,37 +22,37 @@ describe Bosh::Deployer::Config do
     Bosh::Deployer::Config.configure(config)
 
     networks = Bosh::Deployer::Config.networks
-    networks.should be_kind_of(Hash)
+    expect(networks).to be_kind_of(Hash)
 
     net = networks['bosh']
-    net.should be_kind_of(Hash)
+    expect(net).to be_kind_of(Hash)
     %w(cloud_properties type).each do |key|
-      net[key].should_not be_nil
+      expect(net[key]).not_to be_nil
     end
   end
 
   it 'should default vm env properties' do
     env = Bosh::Deployer::Config.env
-    env.should be_kind_of(Hash)
-    env.should have_key('bosh')
-    env['bosh'].should be_kind_of(Hash)
-    env['bosh']['password'].should_not be_nil
-    env['bosh']['password'].should be_kind_of(String)
-    env['bosh']['password'].should == '$6$salt$password'
+    expect(env).to be_kind_of(Hash)
+    expect(env).to have_key('bosh')
+    expect(env['bosh']).to be_kind_of(Hash)
+    expect(env['bosh']['password']).not_to be_nil
+    expect(env['bosh']['password']).to be_kind_of(String)
+    expect(env['bosh']['password']).to eq('$6$salt$password')
   end
 
   it 'should contain default vm resource properties' do
     Bosh::Deployer::Config.configure('dir' => @dir, 'cloud' => { 'plugin' => 'openstack' })
     resources = Bosh::Deployer::Config.resources
-    resources.should be_kind_of(Hash)
+    expect(resources).to be_kind_of(Hash)
 
-    resources['persistent_disk'].should be_kind_of(Integer)
+    expect(resources['persistent_disk']).to be_kind_of(Integer)
 
     cloud_properties = resources['cloud_properties']
-    cloud_properties.should be_kind_of(Hash)
+    expect(cloud_properties).to be_kind_of(Hash)
 
     ['instance_type'].each do |key|
-      cloud_properties[key].should_not be_nil
+      expect(cloud_properties[key]).not_to be_nil
     end
   end
 
@@ -61,14 +61,14 @@ describe Bosh::Deployer::Config do
     config['dir'] = @dir
     Bosh::Deployer::Config.configure(config)
     openstack = double(Fog::Compute)
-    Fog::Compute.stub(:new).and_return(openstack)
+    allow(Fog::Compute).to receive(:new).and_return(openstack)
     glance = double(Fog::Image)
-    Fog::Image.stub(:new).and_return(glance)
+    allow(Fog::Image).to receive(:new).and_return(glance)
     volume = double(Fog::Volume)
-    Fog::Volume.stub(:new).and_return(volume)
+    allow(Fog::Volume).to receive(:new).and_return(volume)
     cloud = Bosh::Deployer::Config.cloud
-    cloud.respond_to?(:openstack).should be(true)
-    cloud.respond_to?(:registry).should be(true)
-    cloud.registry.should be_kind_of(Bosh::Registry::Client)
+    expect(cloud.respond_to?(:openstack)).to be(true)
+    expect(cloud.respond_to?(:registry)).to be(true)
+    expect(cloud.registry).to be_kind_of(Bosh::Registry::Client)
   end
 end

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/openstack/instance_manager_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/openstack/instance_manager_spec.rb
@@ -15,10 +15,10 @@ module Bosh::Deployer
       @deployer = Bosh::Deployer::InstanceManager.create(@config)
       @cloud = double('cloud')
       @openstack = double('openstack')
-      @cloud.stub(:openstack).and_return(@openstack)
-      Bosh::Deployer::Config.stub(:cloud).and_return(@cloud)
+      allow(@cloud).to receive(:openstack).and_return(@openstack)
+      allow(Bosh::Deployer::Config).to receive(:cloud).and_return(@cloud)
       @agent = double('agent')
-      @deployer.stub(:agent).and_return(@agent)
+      allow(@deployer).to receive(:agent).and_return(@agent)
 
       allow(MicroboshJobInstance).to receive(:new).and_return(FakeMicroboshJobInstance.new)
     end
@@ -53,43 +53,43 @@ module Bosh::Deployer
 
     it 'should not populate disk model' do
       disk_model = @deployer.infrastructure.disk_model
-      disk_model.should == nil
+      expect(disk_model).to eq(nil)
     end
 
     it 'should create a Bosh instance' do
-      @deployer.infrastructure.stub(:service_ip).and_return('10.0.0.10')
+      allow(@deployer.infrastructure).to receive(:service_ip).and_return('10.0.0.10')
       spec = Psych.load_file(spec_asset('apply_spec_openstack.yml'))
-      Bosh::Deployer::Specification.should_receive(:load_apply_spec).and_return(spec)
+      expect(Bosh::Deployer::Specification).to receive(:load_apply_spec).and_return(spec)
 
-      @deployer.stub(:run_command)
-      @deployer.stub(:wait_until_agent_ready)
-      @deployer.stub(:wait_until_director_ready)
-      @deployer.stub(:load_apply_spec).and_return(spec)
-      @deployer.stub(:load_stemcell_manifest).and_return('cloud_properties' => {})
+      allow(@deployer).to receive(:run_command)
+      allow(@deployer).to receive(:wait_until_agent_ready)
+      allow(@deployer).to receive(:wait_until_director_ready)
+      allow(@deployer).to receive(:load_apply_spec).and_return(spec)
+      allow(@deployer).to receive(:load_stemcell_manifest).and_return('cloud_properties' => {})
 
-      @deployer.state.uuid.should_not be_nil
+      expect(@deployer.state.uuid).not_to be_nil
 
-      @deployer.state.stemcell_cid.should be_nil
-      @deployer.state.vm_cid.should be_nil
+      expect(@deployer.state.stemcell_cid).to be_nil
+      expect(@deployer.state.vm_cid).to be_nil
 
-      @cloud.should_receive(:create_stemcell).and_return('SC-CID-CREATE')
-      @cloud.should_receive(:create_vm).and_return('VM-CID-CREATE')
-      @cloud.should_receive(:create_disk).and_return('DISK-CID-CREATE')
-      @cloud.should_receive(:attach_disk).with('VM-CID-CREATE', 'DISK-CID-CREATE')
-      @agent.should_receive(:run_task).with(:mount_disk, 'DISK-CID-CREATE').and_return({})
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:apply, spec)
-      @agent.should_receive(:run_task).with(:start)
+      expect(@cloud).to receive(:create_stemcell).and_return('SC-CID-CREATE')
+      expect(@cloud).to receive(:create_vm).and_return('VM-CID-CREATE')
+      expect(@cloud).to receive(:create_disk).and_return('DISK-CID-CREATE')
+      expect(@cloud).to receive(:attach_disk).with('VM-CID-CREATE', 'DISK-CID-CREATE')
+      expect(@agent).to receive(:run_task).with(:mount_disk, 'DISK-CID-CREATE').and_return({})
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:apply, spec)
+      expect(@agent).to receive(:run_task).with(:start)
 
       stub_stuff_in_discover_bosh_ip('10.0.0.1', 'VM-CID-CREATE')
       @deployer.create(BOSH_STEMCELL_TGZ, nil)
 
-      @deployer.state.stemcell_cid.should == 'SC-CID-CREATE'
-      @deployer.state.vm_cid.should == 'VM-CID-CREATE'
-      @deployer.state.disk_cid.should == 'DISK-CID-CREATE'
-      load_deployment.should == @deployer.state.values
+      expect(@deployer.state.stemcell_cid).to eq('SC-CID-CREATE')
+      expect(@deployer.state.vm_cid).to eq('VM-CID-CREATE')
+      expect(@deployer.state.disk_cid).to eq('DISK-CID-CREATE')
+      expect(load_deployment).to eq(@deployer.state.values)
 
-      @deployer.renderer.total.should == @deployer.renderer.index
+      expect(@deployer.renderer.total).to eq(@deployer.renderer.index)
     end
 
     it 'should destroy a Bosh instance' do
@@ -100,64 +100,64 @@ module Bosh::Deployer
 
       @deployer.state.vm_cid = 'VM-CID-DESTROY'
 
-      @agent.should_receive(:list_disk).and_return([disk_cid])
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
-      @cloud.should_receive(:detach_disk).with('VM-CID-DESTROY', disk_cid)
-      @cloud.should_receive(:delete_disk).with(disk_cid)
-      @cloud.should_receive(:delete_vm).with('VM-CID-DESTROY')
+      expect(@agent).to receive(:list_disk).and_return([disk_cid])
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
+      expect(@cloud).to receive(:detach_disk).with('VM-CID-DESTROY', disk_cid)
+      expect(@cloud).to receive(:delete_disk).with(disk_cid)
+      expect(@cloud).to receive(:delete_vm).with('VM-CID-DESTROY')
 
       @deployer.destroy
 
-      @deployer.state.stemcell_cid.should be_nil
-      @deployer.state.stemcell_name.should be_nil
-      @deployer.state.vm_cid.should be_nil
-      @deployer.state.disk_cid.should be_nil
+      expect(@deployer.state.stemcell_cid).to be_nil
+      expect(@deployer.state.stemcell_name).to be_nil
+      expect(@deployer.state.vm_cid).to be_nil
+      expect(@deployer.state.disk_cid).to be_nil
 
-      load_deployment.should == @deployer.state.values
+      expect(load_deployment).to eq(@deployer.state.values)
 
-      @deployer.renderer.total.should == @deployer.renderer.index
+      expect(@deployer.renderer.total).to eq(@deployer.renderer.index)
     end
 
     it 'should update a Bosh instance' do
-      @deployer.infrastructure.stub(:service_ip).and_return('10.0.0.10')
+      allow(@deployer.infrastructure).to receive(:service_ip).and_return('10.0.0.10')
       spec = Psych.load_file(spec_asset('apply_spec_openstack.yml'))
-      Bosh::Deployer::Specification.should_receive(:load_apply_spec).and_return(spec)
+      expect(Bosh::Deployer::Specification).to receive(:load_apply_spec).and_return(spec)
 
       disk_cid = '22'
-      @deployer.stub(:run_command)
-      @deployer.stub(:wait_until_agent_ready)
-      @deployer.stub(:wait_until_director_ready)
-      @deployer.stub(:load_apply_spec).and_return(spec)
-      @deployer.stub(:load_stemcell_manifest).and_return('cloud_properties' => {})
-      @deployer.infrastructure.stub(:persistent_disk_changed?).and_return(false)
+      allow(@deployer).to receive(:run_command)
+      allow(@deployer).to receive(:wait_until_agent_ready)
+      allow(@deployer).to receive(:wait_until_director_ready)
+      allow(@deployer).to receive(:load_apply_spec).and_return(spec)
+      allow(@deployer).to receive(:load_stemcell_manifest).and_return('cloud_properties' => {})
+      allow(@deployer.infrastructure).to receive(:persistent_disk_changed?).and_return(false)
 
       @deployer.state.stemcell_cid = 'SC-CID-UPDATE'
       @deployer.state.vm_cid = 'VM-CID-UPDATE'
       @deployer.state.disk_cid = disk_cid
 
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
-      @cloud.should_receive(:detach_disk).with('VM-CID-UPDATE', disk_cid)
-      @cloud.should_receive(:delete_vm).with('VM-CID-UPDATE')
-      @cloud.should_receive(:delete_stemcell).with('SC-CID-UPDATE')
-      @cloud.should_receive(:create_stemcell).and_return('SC-CID')
-      @cloud.should_receive(:create_vm).and_return('VM-CID')
-      @cloud.should_receive(:attach_disk).with('VM-CID', disk_cid)
-      @agent.should_receive(:run_task).with(:mount_disk, disk_cid).and_return({})
-      @agent.should_receive(:list_disk).and_return([disk_cid])
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:apply, spec)
-      @agent.should_receive(:run_task).with(:start)
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
+      expect(@cloud).to receive(:detach_disk).with('VM-CID-UPDATE', disk_cid)
+      expect(@cloud).to receive(:delete_vm).with('VM-CID-UPDATE')
+      expect(@cloud).to receive(:delete_stemcell).with('SC-CID-UPDATE')
+      expect(@cloud).to receive(:create_stemcell).and_return('SC-CID')
+      expect(@cloud).to receive(:create_vm).and_return('VM-CID')
+      expect(@cloud).to receive(:attach_disk).with('VM-CID', disk_cid)
+      expect(@agent).to receive(:run_task).with(:mount_disk, disk_cid).and_return({})
+      expect(@agent).to receive(:list_disk).and_return([disk_cid])
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:apply, spec)
+      expect(@agent).to receive(:run_task).with(:start)
 
       stub_stuff_in_discover_bosh_ip('10.0.0.2', 'VM-CID')
       @deployer.update(BOSH_STEMCELL_TGZ, nil)
 
-      @deployer.state.stemcell_cid.should == 'SC-CID'
-      @deployer.state.vm_cid.should == 'VM-CID'
-      @deployer.state.disk_cid.should == disk_cid
+      expect(@deployer.state.stemcell_cid).to eq('SC-CID')
+      expect(@deployer.state.vm_cid).to eq('VM-CID')
+      expect(@deployer.state.disk_cid).to eq(disk_cid)
 
-      load_deployment.should == @deployer.state.values
+      expect(load_deployment).to eq(@deployer.state.values)
     end
 
     context 'with vm_cid missing but disk_cid present' do
@@ -210,8 +210,8 @@ module Bosh::Deployer
 
     it 'should fail to destroy a Bosh instance unless stemcell CID exists' do
       @deployer.state.vm_cid = 'VM-CID'
-      @agent.should_receive(:run_task).with(:stop)
-      @cloud.should_receive(:delete_vm).with('VM-CID')
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@cloud).to receive(:delete_vm).with('VM-CID')
       expect {
         @deployer.destroy
       }.to raise_error(Bosh::Cli::CliError)
@@ -219,7 +219,7 @@ module Bosh::Deployer
 
     it 'should fail to destroy a Bosh instance unless VM CID exists' do
       @deployer.state.stemcell_cid = 'SC-CID'
-      @agent.should_receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:stop)
       expect {
         @deployer.destroy
       }.to raise_error(Bosh::Cli::CliError)

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/ui_messager_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/ui_messager_spec.rb
@@ -10,7 +10,7 @@ describe Bosh::Deployer::UiMessager do
     context 'when the message is known' do
       context 'when silent option is not set' do
         it 'shows the message to the user' do
-          ui_messenger.should_receive(:say).with('known-message-text')
+          expect(ui_messenger).to receive(:say).with('known-message-text')
           ui_messenger.info(:known)
         end
       end
@@ -19,7 +19,7 @@ describe Bosh::Deployer::UiMessager do
         before { options[:silent] = true }
 
         it 'does not show message to the user' do
-          ui_messenger.should_not_receive(:say)
+          expect(ui_messenger).not_to receive(:say)
           ui_messenger.info(:known)
         end
       end
@@ -33,7 +33,7 @@ describe Bosh::Deployer::UiMessager do
         end
 
         it 'does show any message to the user' do
-          ui_messenger.should_not_receive(:say)
+          expect(ui_messenger).not_to receive(:say)
           expect { ui_messenger.info(:unknown) }.to raise_error # expect to silent
         end
       end
@@ -58,7 +58,7 @@ describe Bosh::Deployer::UiMessager do
         end
 
         it 'does show any message to the user' do
-          ui_messenger.should_not_receive(:say)
+          expect(ui_messenger).not_to receive(:say)
           expect { ui_messenger.info(invalid_value) }.to raise_error # expect to silent
         end
       end

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/vcloud/config_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/vcloud/config_spec.rb
@@ -10,9 +10,9 @@ describe Bosh::Deployer::Config do
     Bosh::Deployer::Config.configure(config)
 
     properties = Bosh::Deployer::Config.cloud_options['properties']
-    properties['agent'].should be_kind_of(Hash)
-    properties['agent']['mbus'].start_with?('https://').should be(true)
-    properties['agent']['blobstore'].should be_kind_of(Hash)
+    expect(properties['agent']).to be_kind_of(Hash)
+    expect(properties['agent']['mbus'].start_with?('https://')).to be(true)
+    expect(properties['agent']['blobstore']).to be_kind_of(Hash)
   end
 
   it 'should map network properties' do
@@ -21,37 +21,37 @@ describe Bosh::Deployer::Config do
     Bosh::Deployer::Config.configure(config)
 
     networks = Bosh::Deployer::Config.networks
-    networks.should be_kind_of(Hash)
+    expect(networks).to be_kind_of(Hash)
 
     net = networks['bosh']
-    net.should be_kind_of(Hash)
+    expect(net).to be_kind_of(Hash)
     %w(cloud_properties dns).each do |key|
-      net[key].should_not be_nil
+      expect(net[key]).not_to be_nil
     end
   end
 
   it 'should default vm env properties' do
     env = Bosh::Deployer::Config.env
-    env.should be_kind_of(Hash)
-    env.should have_key('bosh')
-    env['bosh'].should be_kind_of(Hash)
-    env['bosh']['password'].should_not be_nil
-    env['bosh']['password'].should be_kind_of(String)
-    env['bosh']['password'].should == '$6$salt$password'
+    expect(env).to be_kind_of(Hash)
+    expect(env).to have_key('bosh')
+    expect(env['bosh']).to be_kind_of(Hash)
+    expect(env['bosh']['password']).not_to be_nil
+    expect(env['bosh']['password']).to be_kind_of(String)
+    expect(env['bosh']['password']).to eq('$6$salt$password')
   end
 
   it 'should contain default vm resource properties' do
     Bosh::Deployer::Config.configure('dir' => @dir, 'cloud' => { 'plugin' => 'vcloud' })
     resources = Bosh::Deployer::Config.resources
-    resources.should be_kind_of(Hash)
+    expect(resources).to be_kind_of(Hash)
 
-    resources['persistent_disk'].should be_kind_of(Integer)
+    expect(resources['persistent_disk']).to be_kind_of(Integer)
 
     cloud_properties = resources['cloud_properties']
-    cloud_properties.should be_kind_of(Hash)
+    expect(cloud_properties).to be_kind_of(Hash)
 
     %w(ram disk cpu).each do |key|
-      cloud_properties[key].should_not be_nil
+      expect(cloud_properties[key]).not_to be_nil
     end
   end
 end

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/vcloud/instance_manager_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/vcloud/instance_manager_spec.rb
@@ -14,9 +14,9 @@ module Bosh::Deployer
       @config['logging'] = { 'file' => "#{@dir}/bmim.log" }
       @deployer = Bosh::Deployer::InstanceManager.create(@config)
       @cloud = double('cloud')
-      Bosh::Deployer::Config.stub(:cloud).and_return(@cloud)
+      allow(Bosh::Deployer::Config).to receive(:cloud).and_return(@cloud)
       @agent = double('agent')
-      @deployer.stub(:agent).and_return(@agent)
+      allow(@deployer).to receive(:agent).and_return(@agent)
 
       allow(MicroboshJobInstance).to receive(:new).and_return(FakeMicroboshJobInstance.new)
     end
@@ -43,31 +43,31 @@ module Bosh::Deployer
     context 'remote_tunnel_check' do
       it 'should successfully deploy when remote_tunnel method is over-ridden ' +
            'to not establish a socket connection' do
-        @deployer.stub(:service_ip).and_return('10.0.0.10')
+        allow(@deployer).to receive(:service_ip).and_return('10.0.0.10')
         @spec = Psych.load_file(spec_asset('apply_spec_vcloud.yml'))
-        Bosh::Deployer::Specification.should_receive(:load_apply_spec).and_return(@spec)
-        Bosh::Deployer::Config.stub(:agent_properties).and_return({})
+        expect(Bosh::Deployer::Specification).to receive(:load_apply_spec).and_return(@spec)
+        allow(Bosh::Deployer::Config).to receive(:agent_properties).and_return({})
 
         @registry_port = 1234
 
-        @deployer.stub(:run_command)
-        @deployer.stub(:wait_until_ready)
-        @deployer.stub(:wait_until_director_ready)
-        @deployer.stub(:load_apply_spec).and_return(@spec)
-        @deployer.stub(:load_stemcell_manifest).and_return('cloud_properties' => {})
+        allow(@deployer).to receive(:run_command)
+        allow(@deployer).to receive(:wait_until_ready)
+        allow(@deployer).to receive(:wait_until_director_ready)
+        allow(@deployer).to receive(:load_apply_spec).and_return(@spec)
+        allow(@deployer).to receive(:load_stemcell_manifest).and_return('cloud_properties' => {})
 
-        @deployer.state.uuid.should_not be_nil
-        @deployer.state.stemcell_cid.should be_nil
-        @deployer.state.vm_cid.should be_nil
+        expect(@deployer.state.uuid).not_to be_nil
+        expect(@deployer.state.stemcell_cid).to be_nil
+        expect(@deployer.state.vm_cid).to be_nil
 
-        @cloud.should_receive(:create_stemcell).and_return('SC-CID-CREATE')
-        @cloud.should_receive(:create_vm).and_return('VM-CID-CREATE')
-        @cloud.should_receive(:create_disk).and_return('DISK-CID-CREATE')
-        @cloud.should_receive(:attach_disk).with('VM-CID-CREATE', 'DISK-CID-CREATE')
-        @agent.should_receive(:run_task).with(:mount_disk, 'DISK-CID-CREATE').and_return({})
-        @agent.should_receive(:run_task).with(:stop)
-        @agent.should_receive(:run_task).with(:apply, @spec)
-        @agent.should_receive(:run_task).with(:start)
+        expect(@cloud).to receive(:create_stemcell).and_return('SC-CID-CREATE')
+        expect(@cloud).to receive(:create_vm).and_return('VM-CID-CREATE')
+        expect(@cloud).to receive(:create_disk).and_return('DISK-CID-CREATE')
+        expect(@cloud).to receive(:attach_disk).with('VM-CID-CREATE', 'DISK-CID-CREATE')
+        expect(@agent).to receive(:run_task).with(:mount_disk, 'DISK-CID-CREATE').and_return({})
+        expect(@agent).to receive(:run_task).with(:stop)
+        expect(@agent).to receive(:run_task).with(:apply, @spec)
+        expect(@agent).to receive(:run_task).with(:start)
 
         expect {
           Timeout.timeout(5) do
@@ -75,53 +75,53 @@ module Bosh::Deployer
           end
         }.to_not raise_error
 
-        @deployer.state.stemcell_cid.should == 'SC-CID-CREATE'
-        @deployer.state.vm_cid.should == 'VM-CID-CREATE'
-        @deployer.state.disk_cid.should == 'DISK-CID-CREATE'
-        load_deployment.should == @deployer.state.values
-        @deployer.renderer.total.should == @deployer.renderer.index
+        expect(@deployer.state.stemcell_cid).to eq('SC-CID-CREATE')
+        expect(@deployer.state.vm_cid).to eq('VM-CID-CREATE')
+        expect(@deployer.state.disk_cid).to eq('DISK-CID-CREATE')
+        expect(load_deployment).to eq(@deployer.state.values)
+        expect(@deployer.renderer.total).to eq(@deployer.renderer.index)
       end
     end
 
     it 'should not populate disk model' do
       disk_model = @deployer.infrastructure.disk_model
-      disk_model.should == nil
+      expect(disk_model).to eq(nil)
     end
 
     it 'should create a Bosh instance' do
-      @deployer.stub(:service_ip).and_return('10.0.0.10')
+      allow(@deployer).to receive(:service_ip).and_return('10.0.0.10')
       spec = Psych.load_file(spec_asset('apply_spec_vcloud.yml'))
-      Bosh::Deployer::Specification.should_receive(:load_apply_spec).and_return(spec)
-      Bosh::Deployer::Config.stub(:agent_properties).and_return({})
+      expect(Bosh::Deployer::Specification).to receive(:load_apply_spec).and_return(spec)
+      allow(Bosh::Deployer::Config).to receive(:agent_properties).and_return({})
 
-      @deployer.stub(:run_command)
-      @deployer.stub(:wait_until_agent_ready)
-      @deployer.stub(:wait_until_director_ready)
-      @deployer.stub(:load_apply_spec).and_return(spec)
-      @deployer.stub(:load_stemcell_manifest).and_return('cloud_properties' => {})
+      allow(@deployer).to receive(:run_command)
+      allow(@deployer).to receive(:wait_until_agent_ready)
+      allow(@deployer).to receive(:wait_until_director_ready)
+      allow(@deployer).to receive(:load_apply_spec).and_return(spec)
+      allow(@deployer).to receive(:load_stemcell_manifest).and_return('cloud_properties' => {})
 
-      @deployer.state.uuid.should_not be_nil
+      expect(@deployer.state.uuid).not_to be_nil
 
-      @deployer.state.stemcell_cid.should be_nil
-      @deployer.state.vm_cid.should be_nil
+      expect(@deployer.state.stemcell_cid).to be_nil
+      expect(@deployer.state.vm_cid).to be_nil
 
-      @cloud.should_receive(:create_stemcell).and_return('SC-CID-CREATE')
-      @cloud.should_receive(:create_vm).and_return('VM-CID-CREATE')
-      @cloud.should_receive(:create_disk).and_return('DISK-CID-CREATE')
-      @cloud.should_receive(:attach_disk).with('VM-CID-CREATE', 'DISK-CID-CREATE')
-      @agent.should_receive(:run_task).with(:mount_disk, 'DISK-CID-CREATE').and_return({})
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:apply, spec)
-      @agent.should_receive(:run_task).with(:start)
+      expect(@cloud).to receive(:create_stemcell).and_return('SC-CID-CREATE')
+      expect(@cloud).to receive(:create_vm).and_return('VM-CID-CREATE')
+      expect(@cloud).to receive(:create_disk).and_return('DISK-CID-CREATE')
+      expect(@cloud).to receive(:attach_disk).with('VM-CID-CREATE', 'DISK-CID-CREATE')
+      expect(@agent).to receive(:run_task).with(:mount_disk, 'DISK-CID-CREATE').and_return({})
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:apply, spec)
+      expect(@agent).to receive(:run_task).with(:start)
 
       @deployer.create(BOSH_STEMCELL_TGZ, nil)
 
-      @deployer.state.stemcell_cid.should == 'SC-CID-CREATE'
-      @deployer.state.vm_cid.should == 'VM-CID-CREATE'
-      @deployer.state.disk_cid.should == 'DISK-CID-CREATE'
-      load_deployment.should == @deployer.state.values
+      expect(@deployer.state.stemcell_cid).to eq('SC-CID-CREATE')
+      expect(@deployer.state.vm_cid).to eq('VM-CID-CREATE')
+      expect(@deployer.state.disk_cid).to eq('DISK-CID-CREATE')
+      expect(load_deployment).to eq(@deployer.state.values)
 
-      @deployer.renderer.total.should == @deployer.renderer.index
+      expect(@deployer.renderer.total).to eq(@deployer.renderer.index)
     end
 
     it 'should destroy a Bosh instance' do
@@ -132,64 +132,64 @@ module Bosh::Deployer
 
       @deployer.state.vm_cid = 'VM-CID-DESTROY'
 
-      @agent.should_receive(:list_disk).and_return([disk_cid])
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
-      @cloud.should_receive(:detach_disk).with('VM-CID-DESTROY', disk_cid)
-      @cloud.should_receive(:delete_disk).with(disk_cid)
-      @cloud.should_receive(:delete_vm).with('VM-CID-DESTROY')
+      expect(@agent).to receive(:list_disk).and_return([disk_cid])
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
+      expect(@cloud).to receive(:detach_disk).with('VM-CID-DESTROY', disk_cid)
+      expect(@cloud).to receive(:delete_disk).with(disk_cid)
+      expect(@cloud).to receive(:delete_vm).with('VM-CID-DESTROY')
 
       @deployer.destroy
 
-      @deployer.state.stemcell_cid.should be_nil
-      @deployer.state.stemcell_name.should be_nil
-      @deployer.state.vm_cid.should be_nil
-      @deployer.state.disk_cid.should be_nil
+      expect(@deployer.state.stemcell_cid).to be_nil
+      expect(@deployer.state.stemcell_name).to be_nil
+      expect(@deployer.state.vm_cid).to be_nil
+      expect(@deployer.state.disk_cid).to be_nil
 
-      load_deployment.should == @deployer.state.values
+      expect(load_deployment).to eq(@deployer.state.values)
 
-      @deployer.renderer.total.should == @deployer.renderer.index
+      expect(@deployer.renderer.total).to eq(@deployer.renderer.index)
     end
 
     it 'should update a Bosh instance' do
-      @deployer.infrastructure.stub(:service_ip).and_return('10.0.0.10')
+      allow(@deployer.infrastructure).to receive(:service_ip).and_return('10.0.0.10')
       spec = Psych.load_file(spec_asset('apply_spec_vcloud.yml'))
       disk_cid = '22'
-      Bosh::Deployer::Specification.should_receive(:load_apply_spec).and_return(spec)
-      Bosh::Deployer::Config.stub(:agent_properties).and_return({})
+      expect(Bosh::Deployer::Specification).to receive(:load_apply_spec).and_return(spec)
+      allow(Bosh::Deployer::Config).to receive(:agent_properties).and_return({})
 
-      @deployer.stub(:run_command)
-      @deployer.stub(:wait_until_agent_ready)
-      @deployer.stub(:wait_until_director_ready)
-      @deployer.stub(:load_apply_spec).and_return(spec)
-      @deployer.stub(:load_stemcell_manifest).and_return('cloud_properties' => {})
-      @deployer.infrastructure.stub(:persistent_disk_changed?).and_return(false)
+      allow(@deployer).to receive(:run_command)
+      allow(@deployer).to receive(:wait_until_agent_ready)
+      allow(@deployer).to receive(:wait_until_director_ready)
+      allow(@deployer).to receive(:load_apply_spec).and_return(spec)
+      allow(@deployer).to receive(:load_stemcell_manifest).and_return('cloud_properties' => {})
+      allow(@deployer.infrastructure).to receive(:persistent_disk_changed?).and_return(false)
 
       @deployer.state.stemcell_cid = 'SC-CID-UPDATE'
       @deployer.state.vm_cid = 'VM-CID-UPDATE'
       @deployer.state.disk_cid = disk_cid
 
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
-      @cloud.should_receive(:detach_disk).with('VM-CID-UPDATE', disk_cid)
-      @cloud.should_receive(:delete_vm).with('VM-CID-UPDATE')
-      @cloud.should_receive(:delete_stemcell).with('SC-CID-UPDATE')
-      @cloud.should_receive(:create_stemcell).and_return('SC-CID')
-      @cloud.should_receive(:create_vm).and_return('VM-CID')
-      @cloud.should_receive(:attach_disk).with('VM-CID', disk_cid)
-      @agent.should_receive(:run_task).with(:mount_disk, disk_cid).and_return({})
-      @agent.should_receive(:list_disk).and_return([disk_cid])
-      @agent.should_receive(:run_task).with(:stop)
-      @agent.should_receive(:run_task).with(:apply, spec)
-      @agent.should_receive(:run_task).with(:start)
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:unmount_disk, disk_cid).and_return({})
+      expect(@cloud).to receive(:detach_disk).with('VM-CID-UPDATE', disk_cid)
+      expect(@cloud).to receive(:delete_vm).with('VM-CID-UPDATE')
+      expect(@cloud).to receive(:delete_stemcell).with('SC-CID-UPDATE')
+      expect(@cloud).to receive(:create_stemcell).and_return('SC-CID')
+      expect(@cloud).to receive(:create_vm).and_return('VM-CID')
+      expect(@cloud).to receive(:attach_disk).with('VM-CID', disk_cid)
+      expect(@agent).to receive(:run_task).with(:mount_disk, disk_cid).and_return({})
+      expect(@agent).to receive(:list_disk).and_return([disk_cid])
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:apply, spec)
+      expect(@agent).to receive(:run_task).with(:start)
 
       @deployer.update(BOSH_STEMCELL_TGZ, nil)
 
-      @deployer.state.stemcell_cid.should == 'SC-CID'
-      @deployer.state.vm_cid.should == 'VM-CID'
-      @deployer.state.disk_cid.should == disk_cid
+      expect(@deployer.state.stemcell_cid).to eq('SC-CID')
+      expect(@deployer.state.vm_cid).to eq('VM-CID')
+      expect(@deployer.state.disk_cid).to eq(disk_cid)
 
-      load_deployment.should == @deployer.state.values
+      expect(load_deployment).to eq(@deployer.state.values)
     end
 
     it 'should fail to create a Bosh instance if stemcell CID exists' do
@@ -210,8 +210,8 @@ module Bosh::Deployer
 
     it 'should fail to destroy a Bosh instance unless stemcell CID exists' do
       @deployer.state.vm_cid = 'VM-CID'
-      @agent.should_receive(:run_task).with(:stop)
-      @cloud.should_receive(:delete_vm).with('VM-CID')
+      expect(@agent).to receive(:run_task).with(:stop)
+      expect(@cloud).to receive(:delete_vm).with('VM-CID')
       expect {
         @deployer.destroy
       }.to raise_error(Bosh::Cli::CliError)
@@ -219,7 +219,7 @@ module Bosh::Deployer
 
     it 'should fail to destroy a Bosh instance unless VM CID exists' do
       @deployer.state.stemcell_cid = 'SC-CID'
-      @agent.should_receive(:run_task).with(:stop)
+      expect(@agent).to receive(:run_task).with(:stop)
       expect {
         @deployer.destroy
       }.to raise_error(Bosh::Cli::CliError)

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/vsphere/config_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/vsphere/config_spec.rb
@@ -10,9 +10,9 @@ describe Bosh::Deployer::Config do
     Bosh::Deployer::Config.configure(config)
 
     properties = Bosh::Deployer::Config.cloud_options['properties']
-    properties['agent'].should be_kind_of(Hash)
-    properties['agent']['mbus'].start_with?('https://').should be(true)
-    properties['agent']['blobstore'].should be_kind_of(Hash)
+    expect(properties['agent']).to be_kind_of(Hash)
+    expect(properties['agent']['mbus'].start_with?('https://')).to be(true)
+    expect(properties['agent']['blobstore']).to be_kind_of(Hash)
   end
 
   it 'should map network properties' do
@@ -21,36 +21,36 @@ describe Bosh::Deployer::Config do
     Bosh::Deployer::Config.configure(config)
 
     networks = Bosh::Deployer::Config.networks
-    networks.should be_kind_of(Hash)
+    expect(networks).to be_kind_of(Hash)
 
     net = networks['bosh']
-    net.should be_kind_of(Hash)
+    expect(net).to be_kind_of(Hash)
     %w(cloud_properties netmask gateway ip dns default).each do |key|
-      net[key].should_not be_nil
+      expect(net[key]).not_to be_nil
     end
   end
 
   it 'should default vm env properties' do
     env = Bosh::Deployer::Config.env
-    env.should be_kind_of(Hash)
-    env.should have_key('bosh')
-    env['bosh'].should be_kind_of(Hash)
-    env['bosh']['password'].should be_nil
+    expect(env).to be_kind_of(Hash)
+    expect(env).to have_key('bosh')
+    expect(env['bosh']).to be_kind_of(Hash)
+    expect(env['bosh']['password']).to be_nil
   end
 
   it 'should contain default vm resource properties' do
     Bosh::Deployer::Config.configure('dir' => @dir, 'cloud' => { 'plugin' => 'vsphere' })
     resources = Bosh::Deployer::Config.resources
-    resources.should be_kind_of(Hash)
+    expect(resources).to be_kind_of(Hash)
 
-    resources['persistent_disk'].should be_kind_of(Integer)
+    expect(resources['persistent_disk']).to be_kind_of(Integer)
 
     cloud_properties = resources['cloud_properties']
-    cloud_properties.should be_kind_of(Hash)
+    expect(cloud_properties).to be_kind_of(Hash)
 
     %w(ram disk cpu).each do |key|
-      cloud_properties[key].should_not be_nil
-      cloud_properties[key].should be > 0
+      expect(cloud_properties[key]).not_to be_nil
+      expect(cloud_properties[key]).to be > 0
     end
   end
 end

--- a/bosh_common/spec/unit/retryable_spec.rb
+++ b/bosh_common/spec/unit/retryable_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'common/retryable'
 
 describe Bosh::Retryable do
-  before { Kernel.stub(:sleep) }
+  before { allow(Kernel).to receive(:sleep) }
 
   class CustomMatcher
     def initialize(messages)
@@ -28,7 +28,7 @@ describe Bosh::Retryable do
        tries < 3 ? false : true
     end
 
-    count.should == 3
+    expect(count).to eq(3)
   end
 
   it 'should retry the given number of times when given error is raised' do
@@ -41,7 +41,7 @@ describe Bosh::Retryable do
       true
     end
 
-    count.should == 3
+    expect(count).to eq(3)
   end
 
   context 'when sleeper raises retryable error' do
@@ -56,7 +56,7 @@ describe Bosh::Retryable do
           count += 1
           tries == 2 ? true : false
         end
-        count.should == 2
+        expect(count).to eq(2)
       end
     end
 
@@ -67,7 +67,7 @@ describe Bosh::Retryable do
           count += 1
           tries == 2 ? true : raise(block_error_class, 'yield-error')
         end
-        count.should == 2
+        expect(count).to eq(2)
       end
     end
   end
@@ -86,7 +86,7 @@ describe Bosh::Retryable do
             false
           end
         }.to raise_error(sleeper_error_class, 'error-message')
-        count.should == 1
+        expect(count).to eq(1)
       end
     end
 
@@ -99,7 +99,7 @@ describe Bosh::Retryable do
             raise(block_error_class, 'yield-error')
           end
         }.to raise_error(sleeper_error_class, 'error-message')
-        count.should == 1
+        expect(count).to eq(1)
       end
     end
   end
@@ -118,7 +118,7 @@ describe Bosh::Retryable do
       tries == 4
     end
 
-    count.should == 4
+    expect(count).to eq(4)
   end
 
   it 'should retry the given number of times when matcher matches an error raise from the sleeper' do
@@ -136,7 +136,7 @@ describe Bosh::Retryable do
       described_class.new(tries: 10, on: matcher, sleep: sleeper).retryer { false }
     }.to raise_error(RuntimeError, /fake-msg2/)
 
-    count.should == 2
+    expect(count).to eq(2)
   end
 
   it 'should retry when given error is raised and given message matches' do
@@ -149,11 +149,11 @@ describe Bosh::Retryable do
       end
     }.to raise_error StandardError
 
-    count.should == 3
+    expect(count).to eq(3)
   end
 
   it 'should sleep on each retry the given number of seconds' do
-    Kernel.should_receive(:sleep).with(5).twice
+    expect(Kernel).to receive(:sleep).with(5).twice
 
     described_class.new(tries: 3, on: StandardError, sleep: 5).retryer do |tries|
       raise StandardError if tries <= 2
@@ -164,8 +164,8 @@ describe Bosh::Retryable do
   it 'should pass error to sleep callback proc' do
     count = 0
     sleep_cb = lambda { |retries, error|
-      error.is_a?(ArgumentError).should be(true) if retries == 1
-      error.is_a?(RuntimeError).should be(true) if retries == 2
+      expect(error.is_a?(ArgumentError)).to be(true) if retries == 1
+      expect(error.is_a?(RuntimeError)).to be(true) if retries == 2
     }
 
     described_class.new(tries: 3, on: [ArgumentError, RuntimeError], sleep: sleep_cb).retryer do |tries|
@@ -175,7 +175,7 @@ describe Bosh::Retryable do
       true
     end
 
-    count.should == 3
+    expect(count).to eq(3)
   end
 
   it 'should raise an error if that error is raised and is not in the specified list' do
@@ -189,7 +189,7 @@ describe Bosh::Retryable do
       end
     }.to raise_error(ZeroDivisionError)
 
-    count.should == 2
+    expect(count).to eq(2)
   end
 
   it 'should raise a RetryCountExceeded error if retries exceeded and block returns false' do
@@ -202,7 +202,7 @@ describe Bosh::Retryable do
       end
     }.to raise_error(Bosh::Common::RetryCountExceeded)
 
-    count.should == 3
+    expect(count).to eq(3)
   end
 
   it 'should raise the original error if retries exceeded and error is raised in block' do
@@ -215,7 +215,7 @@ describe Bosh::Retryable do
       end
     }.to raise_error(StandardError)
 
-    count.should == 3
+    expect(count).to eq(3)
   end
 end
 

--- a/bosh_common/spec/unit/ssl_spec.rb
+++ b/bosh_common/spec/unit/ssl_spec.rb
@@ -47,7 +47,7 @@ describe Bosh::Ssl::Certificate do
         end
 
         it 'returns self so that it can be appended on to the constructor easily' do
-          server_certificate.load_or_create.should == server_certificate
+          expect(server_certificate.load_or_create).to eq(server_certificate)
         end
 
         it 'creates a new, valid certificate' do
@@ -56,17 +56,17 @@ describe Bosh::Ssl::Certificate do
           key = OpenSSL::PKey::RSA.new(File.read(key_path))
           certificate = OpenSSL::X509::Certificate.new(File.read(certificate_path))
 
-          key.to_s.should include('BEGIN RSA PRIVATE KEY')
-          certificate.to_s.should include('BEGIN CERTIFICATE')
+          expect(key.to_s).to include('BEGIN RSA PRIVATE KEY')
+          expect(certificate.to_s).to include('BEGIN CERTIFICATE')
 
-          certificate.verify(key).should be(true)
+          expect(certificate.verify(key)).to be(true)
         end
 
         it 'sets the subject from the domain we ask for' do
           server_certificate.load_or_create
 
           certificate = OpenSSL::X509::Certificate.new(File.read(certificate_path))
-          certificate.subject.to_s.should == subject_name
+          expect(certificate.subject.to_s).to eq(subject_name)
         end
 
         it 'has a sensible certificate lifetime' do
@@ -76,7 +76,7 @@ describe Bosh::Ssl::Certificate do
           start_time = certificate.not_before
           end_time = certificate.not_after
 
-          (end_time - start_time).should == ((3 * 365) + 1) * 24 * 60 * 60 # 3 Years and 1 Day
+          expect(end_time - start_time).to eq(((3 * 365) + 1) * 24 * 60 * 60) # 3 Years and 1 Day
         end
 
         it 'should start being valid some time in the past' do
@@ -85,7 +85,7 @@ describe Bosh::Ssl::Certificate do
           certificate = OpenSSL::X509::Certificate.new(File.read(certificate_path))
           start_time = certificate.not_before
 
-          start_time.should < (Time.now - 60 * 60 * 12)
+          expect(start_time).to be < (Time.now - 60 * 60 * 12)
         end
       end
     end
@@ -101,12 +101,12 @@ describe Bosh::Ssl::Certificate do
 
         server_certificate.load_or_create
 
-        server_certificate.key.should == key_contents_before
-        server_certificate.certificate.should == certificate_contents_before
+        expect(server_certificate.key).to eq(key_contents_before)
+        expect(server_certificate.certificate).to eq(certificate_contents_before)
       end
 
       it 'does not write to the file unnecessarily' do
-        File.should_not_receive(:write).with(any_args)
+        expect(File).not_to receive(:write).with(any_args)
         server_certificate.load_or_create
       end
 
@@ -117,7 +117,7 @@ describe Bosh::Ssl::Certificate do
         it 'allows the user to read the contents of the chain file' do
           server_certificate.load_or_create
 
-          server_certificate.chain.should include "BEGIN CERTIFICATE"
+          expect(server_certificate.chain).to include "BEGIN CERTIFICATE"
         end
       end
 
@@ -127,7 +127,7 @@ describe Bosh::Ssl::Certificate do
         it 'the certificate chain should be nil' do
           server_certificate.load_or_create
 
-          server_certificate.chain.should be_nil
+          expect(server_certificate.chain).to be_nil
         end
       end
     end

--- a/bosh_common/spec/unit/thread_pool_spec.rb
+++ b/bosh_common/spec/unit/thread_pool_spec.rb
@@ -30,11 +30,11 @@ describe Bosh::ThreadPool do
         end
       end
     end
-    max.should be <= 2
+    expect(max).to be <= 2
   end
 
   it "should raise exceptions" do
-    lambda {
+    expect {
       Bosh::ThreadPool.new(:max_threads => 2, :logger => @logger).wrap do |pool|
         5.times do |index|
           pool.process do
@@ -43,14 +43,14 @@ describe Bosh::ThreadPool do
           end
         end
       end
-    }.should raise_exception("bad")
+    }.to raise_exception("bad")
   end
 
   it "should stop processing new work when there was an exception" do
     max = 0
     lock = Mutex.new
 
-    lambda {
+    expect {
       Bosh::ThreadPool.new(:max_threads => 1, :logger => @logger).wrap do |pool|
         10.times do |index|
           pool.process do
@@ -60,9 +60,9 @@ describe Bosh::ThreadPool do
           end
         end
       end
-    }.should raise_exception("bad")
+    }.to raise_exception("bad")
 
-    max.should be == 4
+    expect(max).to eq(4)
   end
 
 end

--- a/bosh_cpi/spec/unit/config_spec.rb
+++ b/bosh_cpi/spec/unit/config_spec.rb
@@ -3,18 +3,18 @@ require 'logging'
 
 describe Bosh::Clouds::Config do
   it 'should configure a logger' do
-    Bosh::Clouds::Config.logger.should be_kind_of(Logging::Logger)
+    expect(Bosh::Clouds::Config.logger).to be_kind_of(Logging::Logger)
   end
 
   it 'should configure a uuid' do
-    Bosh::Clouds::Config.uuid.should be_kind_of(String)
+    expect(Bosh::Clouds::Config.uuid).to be_kind_of(String)
   end
 
   it 'should not have a db configured' do
-    Bosh::Clouds::Config.db.should be_nil
+    expect(Bosh::Clouds::Config.db).to be_nil
   end
 
   it 'should configure a task_checkpoint' do
-    Bosh::Clouds::Config.respond_to?(:task_checkpoint).should be(true)
+    expect(Bosh::Clouds::Config.respond_to?(:task_checkpoint)).to be(true)
   end
 end

--- a/bosh_openstack_cpi/spec/unit/attach_disk_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/attach_disk_spec.rb
@@ -9,9 +9,9 @@ describe Bosh::OpenStackCloud::Cloud do
   let(:flavor) { double('flavor', :id => 'f-test', :ephemeral => 10, :swap => '') }
   let(:cloud) do
     mock_cloud(cloud_options['properties']) do |openstack|
-      openstack.servers.should_receive(:get).with('i-test').and_return(server)
-      openstack.volumes.should_receive(:get).with('v-foobar').and_return(volume)
-      openstack.flavors.should_receive(:find).and_return(flavor)
+      expect(openstack.servers).to receive(:get).with('i-test').and_return(server)
+      expect(openstack.volumes).to receive(:get).with('v-foobar').and_return(volume)
+      expect(openstack.flavors).to receive(:find).and_return(flavor)
     end
   end
   let(:cloud_options) { mock_cloud_options }
@@ -24,9 +24,9 @@ describe Bosh::OpenStackCloud::Cloud do
     volume_attachments = []
     attachment = double('attachment', :device => '/dev/sdc')
 
-    server.should_receive(:volume_attachments).and_return(volume_attachments)
-    volume.should_receive(:attach).with(server.id, '/dev/sdc').and_return(attachment)
-    cloud.should_receive(:wait_resource).with(volume, :'in-use')
+    expect(server).to receive(:volume_attachments).and_return(volume_attachments)
+    expect(volume).to receive(:attach).with(server.id, '/dev/sdc').and_return(attachment)
+    expect(cloud).to receive(:wait_resource).with(volume, :'in-use')
 
     old_settings = { 'foo' => 'bar'}
     new_settings = {
@@ -38,8 +38,8 @@ describe Bosh::OpenStackCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).with('i-test').and_return(old_settings)
-    @registry.should_receive(:update_settings).with('i-test', new_settings)
+    expect(@registry).to receive(:read_settings).with('i-test').and_return(old_settings)
+    expect(@registry).to receive(:update_settings).with('i-test', new_settings)
 
     cloud.attach_disk('i-test', 'v-foobar')
   end
@@ -49,9 +49,9 @@ describe Bosh::OpenStackCloud::Cloud do
                           {'volumeId' => 'v-d', 'device' => '/dev/xvdd'}]
     attachment = double('attachment', :device => '/dev/sdd')
 
-    server.should_receive(:volume_attachments).and_return(volume_attachments)
-    volume.should_receive(:attach).with(server.id, '/dev/sde').and_return(attachment)
-    cloud.should_receive(:wait_resource).with(volume, :'in-use')
+    expect(server).to receive(:volume_attachments).and_return(volume_attachments)
+    expect(volume).to receive(:attach).with(server.id, '/dev/sde').and_return(attachment)
+    expect(cloud).to receive(:wait_resource).with(volume, :'in-use')
 
     old_settings = { 'foo' => 'bar'}
     new_settings = {
@@ -63,8 +63,8 @@ describe Bosh::OpenStackCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).with('i-test').and_return(old_settings)
-    @registry.should_receive(:update_settings).with('i-test', new_settings)
+    expect(@registry).to receive(:read_settings).with('i-test').and_return(old_settings)
+    expect(@registry).to receive(:update_settings).with('i-test', new_settings)
 
     cloud.attach_disk('i-test', 'v-foobar')
   end
@@ -75,7 +75,7 @@ describe Bosh::OpenStackCloud::Cloud do
       array
     end
 
-    server.should_receive(:volume_attachments).and_return(volume_attachments)
+    expect(server).to receive(:volume_attachments).and_return(volume_attachments)
 
     expect {
       cloud.attach_disk('i-test', 'v-foobar')
@@ -87,12 +87,12 @@ describe Bosh::OpenStackCloud::Cloud do
     attachment = double('attachment', :device => '/dev/sdd')
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with('i-test').and_return(server)
-      openstack.volumes.should_receive(:get).with('v-foobar').and_return(volume)
+      expect(openstack.servers).to receive(:get).with('i-test').and_return(server)
+      expect(openstack.volumes).to receive(:get).with('v-foobar').and_return(volume)
     end
 
-    server.should_receive(:volume_attachments).and_return(volume_attachments)
-    volume.should_not_receive(:attach)
+    expect(server).to receive(:volume_attachments).and_return(volume_attachments)
+    expect(volume).not_to receive(:attach)
 
     old_settings = { 'foo' => 'bar'}
     new_settings = {
@@ -104,17 +104,17 @@ describe Bosh::OpenStackCloud::Cloud do
         }
     }
 
-    @registry.should_receive(:read_settings).with('i-test').and_return(old_settings)
-    @registry.should_receive(:update_settings).with('i-test', new_settings)
+    expect(@registry).to receive(:read_settings).with('i-test').and_return(old_settings)
+    expect(@registry).to receive(:update_settings).with('i-test', new_settings)
 
     cloud.attach_disk('i-test', 'v-foobar')
   end
 
   context 'first device name letter' do
     before do
-      server.stub(:volume_attachments).and_return([])
-      cloud.stub(:wait_resource)
-      cloud.stub(:update_agent_settings)
+      allow(server).to receive(:volume_attachments).and_return([])
+      allow(cloud).to receive(:wait_resource)
+      allow(cloud).to receive(:update_agent_settings)
     end
     subject(:attach_disk) { cloud.attach_disk('i-test', 'v-foobar') }
 
@@ -122,7 +122,7 @@ describe Bosh::OpenStackCloud::Cloud do
 
     context 'when there is no ephemeral, swap disk and config drive' do
       it 'return letter b' do
-        volume.should_receive(:attach).with(server.id, '/dev/sdb')
+        expect(volume).to receive(:attach).with(server.id, '/dev/sdb')
         attach_disk
       end
     end
@@ -131,7 +131,7 @@ describe Bosh::OpenStackCloud::Cloud do
       let(:flavor) { double('flavor', :id => 'f-test', :ephemeral => 1024, :swap => '') }
 
       it 'return letter c' do
-        volume.should_receive(:attach).with(server.id, '/dev/sdc')
+        expect(volume).to receive(:attach).with(server.id, '/dev/sdc')
         attach_disk
       end
     end
@@ -140,7 +140,7 @@ describe Bosh::OpenStackCloud::Cloud do
       let(:flavor) { double('flavor', :id => 'f-test', :ephemeral => 0, :swap => 200) }
 
       it 'return letter c' do
-        volume.should_receive(:attach).with(server.id, '/dev/sdc')
+        expect(volume).to receive(:attach).with(server.id, '/dev/sdc')
         attach_disk
       end
     end
@@ -153,7 +153,7 @@ describe Bosh::OpenStackCloud::Cloud do
       end
 
       it 'returns letter c' do
-        volume.should_receive(:attach).with(server.id, '/dev/sdc')
+        expect(volume).to receive(:attach).with(server.id, '/dev/sdc')
         attach_disk
       end
     end
@@ -162,7 +162,7 @@ describe Bosh::OpenStackCloud::Cloud do
       let(:flavor) { double('flavor', :id => 'f-test', :ephemeral => 1024, :swap => 200) }
 
       it 'returns letter d' do
-        volume.should_receive(:attach).with(server.id, '/dev/sdd')
+        expect(volume).to receive(:attach).with(server.id, '/dev/sdd')
         attach_disk
       end
     end
@@ -176,7 +176,7 @@ describe Bosh::OpenStackCloud::Cloud do
       end
 
       it 'returns letter e' do
-        volume.should_receive(:attach).with(server.id, '/dev/sde')
+        expect(volume).to receive(:attach).with(server.id, '/dev/sde')
         attach_disk
       end
     end
@@ -185,7 +185,7 @@ describe Bosh::OpenStackCloud::Cloud do
       let(:flavor) { nil }
 
       it 'returns letter b' do
-        volume.should_receive(:attach).with(server.id, '/dev/sdb')
+        expect(volume).to receive(:attach).with(server.id, '/dev/sdb')
         attach_disk
       end
     end

--- a/bosh_openstack_cpi/spec/unit/configure_networks_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/configure_networks_spec.rb
@@ -13,19 +13,19 @@ describe Bosh::OpenStackCloud::Cloud do
     server = double("server", :id => "i-test", :name => "i-test", :private_ip_addresses => ["10.10.10.1"])
     security_group = double("security_groups", :name => "default")
 
-    server.should_receive(:security_groups).and_return([security_group])
+    expect(server).to receive(:security_groups).and_return([security_group])
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
-      openstack.addresses.should_receive(:each)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
+      expect(openstack.addresses).to receive(:each)
     end
 
     network_spec = { "net_a" => dynamic_network_spec }
     old_settings = { "foo" => "bar", "networks" => network_spec }
     new_settings = { "foo" => "bar", "networks" => network_spec }
 
-    @registry.should_receive(:read_settings).with("i-test").and_return(old_settings)
-    @registry.should_receive(:update_settings).with("i-test", new_settings)
+    expect(@registry).to receive(:read_settings).with("i-test").and_return(old_settings)
+    expect(@registry).to receive(:update_settings).with("i-test", new_settings)
 
     cloud.configure_networks("i-test", network_spec)
   end
@@ -34,11 +34,11 @@ describe Bosh::OpenStackCloud::Cloud do
     server = double("server", :id => "i-test", :name => "i-test", :private_ip_addresses => ["10.10.10.1"])
     security_group = double("security_groups", :name => "default")
 
-    server.should_receive(:security_groups).and_return([security_group])
+    expect(server).to receive(:security_groups).and_return([security_group])
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
-      openstack.addresses.should_receive(:each)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
+      expect(openstack.addresses).to receive(:each)
     end
 
     network_spec = { "net_a" => manual_network_spec }
@@ -46,8 +46,8 @@ describe Bosh::OpenStackCloud::Cloud do
     old_settings = { "foo" => "bar", "networks" => network_spec }
     new_settings = { "foo" => "bar", "networks" => network_spec }
 
-    @registry.should_receive(:read_settings).with("i-test").and_return(old_settings)
-    @registry.should_receive(:update_settings).with("i-test", new_settings)
+    expect(@registry).to receive(:read_settings).with("i-test").and_return(old_settings)
+    expect(@registry).to receive(:update_settings).with("i-test", new_settings)
 
     cloud.configure_networks("i-test", network_spec)
   end
@@ -56,11 +56,11 @@ describe Bosh::OpenStackCloud::Cloud do
     server = double("server", :id => "i-test", :name => "i-test", :private_ip_addresses => ["10.10.10.1", "10.10.10.2"])
     security_group = double("security_groups", :name => "default")
 
-    server.should_receive(:security_groups).and_return([security_group, security_group])
+    expect(server).to receive(:security_groups).and_return([security_group, security_group])
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
-      openstack.addresses.should_receive(:each)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
+      expect(openstack.addresses).to receive(:each)
     end
 
     network_spec = { "net_a" => manual_network_spec, "net_b" => manual_network_spec }
@@ -70,8 +70,8 @@ describe Bosh::OpenStackCloud::Cloud do
     old_settings = { "foo" => "bar", "networks" => network_spec }
     new_settings = { "foo" => "bar", "networks" => network_spec }
 
-    @registry.should_receive(:read_settings).with("i-test").and_return(old_settings)
-    @registry.should_receive(:update_settings).with("i-test", new_settings)
+    expect(@registry).to receive(:read_settings).with("i-test").and_return(old_settings)
+    expect(@registry).to receive(:update_settings).with("i-test", new_settings)
 
     cloud.configure_networks("i-test", network_spec)
   end
@@ -80,10 +80,10 @@ describe Bosh::OpenStackCloud::Cloud do
     server = double("server", :id => "i-test", :name => "i-test")
     security_group = double("security_groups", :name => "newgroups")
 
-    server.should_receive(:security_groups).and_return([security_group])
+    expect(server).to receive(:security_groups).and_return([security_group])
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
     end
 
     expect {
@@ -95,10 +95,10 @@ describe Bosh::OpenStackCloud::Cloud do
     server = double("server", :id => "i-test", :name => "i-test", :private_ip_addresses => ["10.10.10.1"])
     security_group = double("security_groups", :name => "default")
 
-    server.should_receive(:security_groups).and_return([security_group])
+    expect(server).to receive(:security_groups).and_return([security_group])
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
     end
 
     network_spec = { "net_a" => manual_network_spec }
@@ -112,10 +112,10 @@ describe Bosh::OpenStackCloud::Cloud do
     server = double("server", :id => "i-test", :name => "i-test", :private_ip_addresses => ["10.10.10.1", "10.10.10.2"])
     security_group = double("security_groups", :name => "default")
 
-    server.should_receive(:security_groups).and_return([security_group, security_group])
+    expect(server).to receive(:security_groups).and_return([security_group, security_group])
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
     end
 
     network_spec = { "net_a" => manual_network_spec, "net_b" => manual_network_spec }
@@ -132,10 +132,10 @@ describe Bosh::OpenStackCloud::Cloud do
     server = double("server", :id => "i-test", :name => "i-test", :private_ip_addresses => ["10.10.10.1"])
     security_group = double("security_groups", :name => "default")
 
-    server.should_receive(:security_groups).and_return([security_group, security_group])
+    expect(server).to receive(:security_groups).and_return([security_group, security_group])
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
     end
 
     network_spec = { "net_a" => manual_network_spec, "net_b" => manual_network_spec }
@@ -153,21 +153,21 @@ describe Bosh::OpenStackCloud::Cloud do
     address = double("address", :id => "a-test", :ip => "10.0.0.1", :instance_id => nil)
     security_group = double("security_groups", :name => "default")
 
-    server.should_receive(:security_groups).and_return([security_group])
+    expect(server).to receive(:security_groups).and_return([security_group])
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
-      openstack.addresses.should_receive(:find).and_return(address)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
+      expect(openstack.addresses).to receive(:find).and_return(address)
     end
 
-    address.should_receive(:server=).with(server)
+    expect(address).to receive(:server=).with(server)
 
     old_settings = { "foo" => "bar", "networks" => "baz" }
     new_settings = { "foo" => "bar", "networks" => combined_network_spec }
 
-    @registry.should_receive(:read_settings).with("i-test").
+    expect(@registry).to receive(:read_settings).with("i-test").
         and_return(old_settings)
-    @registry.should_receive(:update_settings).with("i-test", new_settings)
+    expect(@registry).to receive(:update_settings).with("i-test", new_settings)
 
     cloud.configure_networks("i-test", combined_network_spec)
   end
@@ -178,23 +178,23 @@ describe Bosh::OpenStackCloud::Cloud do
                      :instance_id => "i-test")
     security_group = double("security_groups", :name => "default")
 
-    server.should_receive(:security_groups).and_return([security_group])
+    expect(server).to receive(:security_groups).and_return([security_group])
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
-      openstack.addresses.should_receive(:each).and_yield(address)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
+      expect(openstack.addresses).to receive(:each).and_yield(address)
     end
 
-    address.should_receive(:server=).with(nil)
+    expect(address).to receive(:server=).with(nil)
 
     old_settings = { "foo" => "bar",
                      "networks" => combined_network_spec }
     new_settings = { "foo" => "bar",
                      "networks" => { "net_a" => dynamic_network_spec } }
 
-    @registry.should_receive(:read_settings).with("i-test").
+    expect(@registry).to receive(:read_settings).with("i-test").
         and_return(old_settings)
-    @registry.should_receive(:update_settings).with("i-test", new_settings)
+    expect(@registry).to receive(:update_settings).with("i-test", new_settings)
 
     cloud.configure_networks("i-test", "net_a" => dynamic_network_spec)
   end

--- a/bosh_openstack_cpi/spec/unit/create_disk_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/create_disk_spec.rb
@@ -15,14 +15,14 @@ describe Bosh::OpenStackCloud::Cloud do
     volume = double("volume", :id => "v-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:create).
+      expect(openstack.volumes).to receive(:create).
         with(disk_params).and_return(volume)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    cloud.should_receive(:wait_resource).with(volume, :available)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:wait_resource).with(volume, :available)
 
-    cloud.create_disk(2048, {}).should == "v-foobar"
+    expect(cloud.create_disk(2048, {})).to eq("v-foobar")
   end
 
   it "creates an OpenStack volume with a volume_type" do
@@ -36,14 +36,14 @@ describe Bosh::OpenStackCloud::Cloud do
     volume = double("volume", :id => "v-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:create).
+      expect(openstack.volumes).to receive(:create).
         with(disk_params).and_return(volume)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    cloud.should_receive(:wait_resource).with(volume, :available)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:wait_resource).with(volume, :available)
 
-    cloud.create_disk(2048, {"type" => "foo"}).should == "v-foobar"
+    expect(cloud.create_disk(2048, {"type" => "foo"})).to eq("v-foobar")
   end
 
   it "creates an OpenStack boot volume" do
@@ -57,14 +57,14 @@ describe Bosh::OpenStackCloud::Cloud do
     boot_volume = double("volume", :id => "v-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:create).
+      expect(openstack.volumes).to receive(:create).
         with(disk_params).and_return(boot_volume)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    cloud.should_receive(:wait_resource).with(boot_volume, :available)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:wait_resource).with(boot_volume, :available)
 
-    cloud.create_boot_disk(2048, stemcell_id).should == "v-foobar"
+    expect(cloud.create_boot_disk(2048, stemcell_id)).to eq("v-foobar")
   end
 
   it "creates an OpenStack boot volume with an availability_zone" do
@@ -79,14 +79,14 @@ describe Bosh::OpenStackCloud::Cloud do
     boot_volume = double("volume", :id => "v-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:create).
+      expect(openstack.volumes).to receive(:create).
         with(disk_params).and_return(boot_volume)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    cloud.should_receive(:wait_resource).with(boot_volume, :available)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:wait_resource).with(boot_volume, :available)
 
-    cloud.create_boot_disk(2048, stemcell_id, "foobar-land").should == "v-foobar"
+    expect(cloud.create_boot_disk(2048, stemcell_id, "foobar-land")).to eq("v-foobar")
   end
 
   it "creates an OpenStack boot volume ignoring the server availability zone" do
@@ -103,13 +103,13 @@ describe Bosh::OpenStackCloud::Cloud do
     cloud_options['properties']['openstack']['ignore_server_availability_zone'] = true
 
     cloud = mock_cloud(cloud_options['properties']) do |openstack|
-      openstack.volumes.should_receive(:create).with(disk_params).and_return(boot_volume)
+      expect(openstack.volumes).to receive(:create).with(disk_params).and_return(boot_volume)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    cloud.should_receive(:wait_resource).with(boot_volume, :available)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:wait_resource).with(boot_volume, :available)
 
-    cloud.create_boot_disk(2048, stemcell_id, nil).should == "v-foobar"
+    expect(cloud.create_boot_disk(2048, stemcell_id, nil)).to eq("v-foobar")
   end
 
   it "creates an OpenStack boot volume with a volume_type" do
@@ -124,14 +124,14 @@ describe Bosh::OpenStackCloud::Cloud do
     boot_volume = double("volume", :id => "v-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:create).
+      expect(openstack.volumes).to receive(:create).
         with(disk_params).and_return(boot_volume)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    cloud.should_receive(:wait_resource).with(boot_volume, :available)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:wait_resource).with(boot_volume, :available)
 
-    cloud.create_boot_disk(2048, stemcell_id, nil, {"type" => "foo"}).should == "v-foobar"
+    expect(cloud.create_boot_disk(2048, stemcell_id, nil, {"type" => "foo"})).to eq("v-foobar")
   end
 
   it "rounds up disk size" do
@@ -144,12 +144,12 @@ describe Bosh::OpenStackCloud::Cloud do
     volume = double("volume", :id => "v-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:create).
+      expect(openstack.volumes).to receive(:create).
         with(disk_params).and_return(volume)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    cloud.should_receive(:wait_resource).with(volume, :available)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:wait_resource).with(volume, :available)
 
     cloud.create_disk(2049, {})
   end
@@ -177,14 +177,14 @@ describe Bosh::OpenStackCloud::Cloud do
     volume = double("volume", :id => "v-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).
+      expect(openstack.servers).to receive(:get).
         with("i-test").and_return(server)
-      openstack.volumes.should_receive(:create).
+      expect(openstack.volumes).to receive(:create).
         with(disk_params).and_return(volume)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    cloud.should_receive(:wait_resource).with(volume, :available)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:wait_resource).with(volume, :available)
 
     cloud.create_disk(1024, {}, "i-test")
   end
@@ -204,12 +204,12 @@ describe Bosh::OpenStackCloud::Cloud do
     cloud_options['properties']['openstack']['ignore_server_availability_zone'] = true
 
     cloud = mock_cloud(cloud_options['properties']) do |openstack|
-      openstack.volumes.should_receive(:create).
+      expect(openstack.volumes).to receive(:create).
           with(disk_params).and_return(volume)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    cloud.should_receive(:wait_resource).with(volume, :available)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:wait_resource).with(volume, :available)
 
     cloud.create_disk(1024, {}, "i-test")
   end

--- a/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
@@ -84,26 +84,26 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
                      :instance_id => "i-test")
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:create).with(openstack_params).and_return(server)
-      openstack.security_groups.should_receive(:collect).and_return(%w[default])
-      openstack.images.should_receive(:find).and_return(image)
-      openstack.flavors.should_receive(:find).and_return(flavor)
-      openstack.key_pairs.should_receive(:find).and_return(key_pair)
-      openstack.addresses.should_receive(:each).and_yield(address)
+      expect(openstack.servers).to receive(:create).with(openstack_params).and_return(server)
+      expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+      expect(openstack.images).to receive(:find).and_return(image)
+      expect(openstack.flavors).to receive(:find).and_return(flavor)
+      expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
+      expect(openstack.addresses).to receive(:each).and_yield(address)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
-    address.should_receive(:server=).with(nil)
-    cloud.should_receive(:wait_resource).with(server, :active, :state)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+    expect(address).to receive(:server=).with(nil)
+    expect(cloud).to receive(:wait_resource).with(server, :active, :state)
 
-    @registry.should_receive(:update_settings).
+    expect(@registry).to receive(:update_settings).
         with("i-test", agent_settings(unique_name))
 
     vm_id = cloud.create_vm("agent-id", "sc-id",
                             resource_pool_spec,
                             { "network_a" => dynamic_network_spec },
                             nil, { "test_env" => "value" })
-    vm_id.should == "i-test"
+    expect(vm_id).to eq("i-test")
   end
 
   context "with nameserver" do
@@ -116,26 +116,26 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
         :instance_id => "i-test")
 
       cloud = mock_cloud do |openstack|
-        openstack.servers.should_receive(:create).with(openstack_params).and_return(server)
-        openstack.security_groups.should_receive(:collect).and_return(%w[default])
-        openstack.images.should_receive(:find).and_return(image)
-        openstack.flavors.should_receive(:find).and_return(flavor)
-        openstack.key_pairs.should_receive(:find).and_return(key_pair)
-        openstack.addresses.should_receive(:each).and_yield(address)
+        expect(openstack.servers).to receive(:create).with(openstack_params).and_return(server)
+        expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+        expect(openstack.images).to receive(:find).and_return(image)
+        expect(openstack.flavors).to receive(:find).and_return(flavor)
+        expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
+        expect(openstack.addresses).to receive(:each).and_yield(address)
       end
 
-      cloud.should_receive(:generate_unique_name).and_return(unique_name)
-      address.should_receive(:server=).with(nil)
-      cloud.should_receive(:wait_resource).with(server, :active, :state)
+      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+      expect(address).to receive(:server=).with(nil)
+      expect(cloud).to receive(:wait_resource).with(server, :active, :state)
 
-      @registry.should_receive(:update_settings).
+      expect(@registry).to receive(:update_settings).
         with("i-test", agent_settings(unique_name, network_spec))
 
       vm_id = cloud.create_vm("agent-id", "sc-id",
         resource_pool_spec,
         { "network_a" => network_spec },
         nil, { "test_env" => "value" })
-      vm_id.should == "i-test"
+      expect(vm_id).to eq("i-test")
     end
   end
 
@@ -150,25 +150,25 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
         :instance_id => nil)
 
       cloud = mock_cloud do |openstack|
-        openstack.servers.should_receive(:create).with(openstack_params).and_return(server)
-        openstack.security_groups.should_receive(:collect).and_return(security_groups)
-        openstack.images.should_receive(:find).and_return(image)
-        openstack.flavors.should_receive(:find).and_return(flavor)
-        openstack.key_pairs.should_receive(:find).and_return(key_pair)
-        openstack.addresses.should_receive(:each).and_yield(address)
+        expect(openstack.servers).to receive(:create).with(openstack_params).and_return(server)
+        expect(openstack.security_groups).to receive(:collect).and_return(security_groups)
+        expect(openstack.images).to receive(:find).and_return(image)
+        expect(openstack.flavors).to receive(:find).and_return(flavor)
+        expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
+        expect(openstack.addresses).to receive(:each).and_yield(address)
       end
 
-      cloud.should_receive(:generate_unique_name).and_return(unique_name)
-      cloud.should_receive(:wait_resource).with(server, :active, :state)
+      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+      expect(cloud).to receive(:wait_resource).with(server, :active, :state)
 
-      @registry.should_receive(:update_settings).
+      expect(@registry).to receive(:update_settings).
         with("i-test", agent_settings(unique_name, network_spec))
 
       vm_id = cloud.create_vm("agent-id", "sc-id",
         resource_pool_spec,
         { "network_a" => network_spec },
         nil, { "test_env" => "value" })
-      vm_id.should == "i-test"
+      expect(vm_id).to eq("i-test")
     end
   end
 
@@ -187,25 +187,25 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
       network_spec["cloud_properties"]["net_id"] = nics[0]["net_id"]
 
       cloud = mock_cloud do |openstack|
-        openstack.servers.should_receive(:create).with(openstack_params).and_return(server)
-        openstack.security_groups.should_receive(:collect).and_return(%w[default])
-        openstack.images.should_receive(:find).and_return(image)
-        openstack.flavors.should_receive(:find).and_return(flavor)
-        openstack.key_pairs.should_receive(:find).and_return(key_pair)
-        openstack.addresses.should_receive(:each).and_yield(address)
+        expect(openstack.servers).to receive(:create).with(openstack_params).and_return(server)
+        expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+        expect(openstack.images).to receive(:find).and_return(image)
+        expect(openstack.flavors).to receive(:find).and_return(flavor)
+        expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
+        expect(openstack.addresses).to receive(:each).and_yield(address)
       end
 
-      cloud.should_receive(:generate_unique_name).and_return(unique_name)
-      cloud.should_receive(:wait_resource).with(server, :active, :state)
+      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+      expect(cloud).to receive(:wait_resource).with(server, :active, :state)
 
-      @registry.should_receive(:update_settings).
+      expect(@registry).to receive(:update_settings).
         with("i-test", agent_settings(unique_name, network_spec))
 
       vm_id = cloud.create_vm("agent-id", "sc-id",
         resource_pool_spec,
         { "network_a" => network_spec },
         nil, { "test_env" => "value" })
-      vm_id.should == "i-test"
+      expect(vm_id).to eq("i-test")
     end
   end
 
@@ -225,25 +225,25 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
       network_spec["cloud_properties"]["net_id"] = nics[0]["net_id"]
 
       cloud = mock_cloud do |openstack|
-        openstack.servers.should_receive(:create).with(openstack_params).and_return(server)
-        openstack.security_groups.should_receive(:collect).and_return(%w[default])
-        openstack.images.should_receive(:find).and_return(image)
-        openstack.flavors.should_receive(:find).and_return(flavor)
-        openstack.key_pairs.should_receive(:find).and_return(key_pair)
-        openstack.addresses.should_receive(:each).and_yield(address)
+        expect(openstack.servers).to receive(:create).with(openstack_params).and_return(server)
+        expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+        expect(openstack.images).to receive(:find).and_return(image)
+        expect(openstack.flavors).to receive(:find).and_return(flavor)
+        expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
+        expect(openstack.addresses).to receive(:each).and_yield(address)
       end
 
-      cloud.should_receive(:generate_unique_name).and_return(unique_name)
-      cloud.should_receive(:wait_resource).with(server, :active, :state)
+      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
+      expect(cloud).to receive(:wait_resource).with(server, :active, :state)
 
-      @registry.should_receive(:update_settings).
+      expect(@registry).to receive(:update_settings).
         with("i-test", agent_settings(unique_name, network_spec))
 
       vm_id = cloud.create_vm("agent-id", "sc-id",
         resource_pool_spec,
         { "network_a" => network_spec },
         nil, { "test_env" => "value" })
-      vm_id.should == "i-test"
+      expect(vm_id).to eq("i-test")
     end
   end
 
@@ -252,19 +252,19 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
                      :instance_id => "i-test")
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:create).and_return(server)
-      openstack.security_groups.should_receive(:collect).and_return(%w[default])
-      openstack.images.should_receive(:find).and_return(image)
-      openstack.flavors.should_receive(:find).and_return(flavor)
-      openstack.key_pairs.should_receive(:find).and_return(key_pair)
-      openstack.addresses.should_receive(:find).and_return(address)
+      expect(openstack.servers).to receive(:create).and_return(server)
+      expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+      expect(openstack.images).to receive(:find).and_return(image)
+      expect(openstack.flavors).to receive(:find).and_return(flavor)
+      expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
+      expect(openstack.addresses).to receive(:find).and_return(address)
     end
 
-    address.should_receive(:server=).with(nil)
-    address.should_receive(:server=).with(server)
-    cloud.should_receive(:wait_resource).with(server, :active, :state)
+    expect(address).to receive(:server=).with(nil)
+    expect(address).to receive(:server=).with(server)
+    expect(cloud).to receive(:wait_resource).with(server, :active, :state)
 
-    @registry.should_receive(:update_settings)
+    expect(@registry).to receive(:update_settings)
 
     cloud.create_vm("agent-id", "sc-id", resource_pool_spec, combined_network_spec)
   end
@@ -279,19 +279,19 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
                       :instance_id => "i-test")
 
       cloud = mock_cloud do |openstack|
-        openstack.servers.should_receive(:create).with(openstack_params).and_return(server)
-        openstack.security_groups.should_receive(:collect).and_return(%w[default])
-        openstack.images.should_receive(:find).and_return(image)
-        openstack.flavors.should_receive(:find).and_return(flavor)
-        openstack.key_pairs.should_receive(:find).and_return(key_pair)
-        openstack.addresses.should_receive(:find).and_return(address)
+        expect(openstack.servers).to receive(:create).with(openstack_params).and_return(server)
+        expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+        expect(openstack.images).to receive(:find).and_return(image)
+        expect(openstack.flavors).to receive(:find).and_return(flavor)
+        expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
+        expect(openstack.addresses).to receive(:find).and_return(address)
       end
 
-      cloud.should_receive(:generate_unique_name).and_return(openstack_params[:name].gsub(/^vm-/,''))
-      cloud.should_receive(:wait_resource).with(server, :active, :state)
-      address.should_receive(:server=).exactly(2).times
+      expect(cloud).to receive(:generate_unique_name).and_return(openstack_params[:name].gsub(/^vm-/,''))
+      expect(cloud).to receive(:wait_resource).with(server, :active, :state)
+      expect(address).to receive(:server=).exactly(2).times
 
-      @registry.should_receive(:update_settings)
+      expect(@registry).to receive(:update_settings)
 
       cloud.create_vm("agent-id", "sc-id",
                       resource_pool_spec.merge('scheduler_hints' => scheduler_hints),
@@ -319,28 +319,28 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
       cloud_options['properties']['openstack']['boot_from_volume'] = true
 
       cloud = mock_cloud(cloud_options['properties']) do |openstack|
-        openstack.servers.should_receive(:create).with(openstack_params).and_return(server)
-        openstack.security_groups.should_receive(:collect).and_return(%w[default])
-        openstack.images.should_receive(:find).and_return(image)
-        openstack.flavors.should_receive(:find).and_return(flavor)
-        openstack.volumes.should_receive(:create).with(disk_params).and_return(boot_volume)
-        openstack.key_pairs.should_receive(:find).and_return(key_pair)
-        openstack.addresses.should_receive(:each).and_yield(address)
+        expect(openstack.servers).to receive(:create).with(openstack_params).and_return(server)
+        expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+        expect(openstack.images).to receive(:find).and_return(image)
+        expect(openstack.flavors).to receive(:find).and_return(flavor)
+        expect(openstack.volumes).to receive(:create).with(disk_params).and_return(boot_volume)
+        expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
+        expect(openstack.addresses).to receive(:each).and_yield(address)
       end
 
-      cloud.should_receive(:generate_unique_name).exactly(2).times.and_return(unique_name, unique_vol_name)
-      address.should_receive(:server=).with(nil)
-      cloud.should_receive(:wait_resource).with(server, :active, :state)
-      cloud.should_receive(:wait_resource).with(boot_volume, :available)
+      expect(cloud).to receive(:generate_unique_name).exactly(2).times.and_return(unique_name, unique_vol_name)
+      expect(address).to receive(:server=).with(nil)
+      expect(cloud).to receive(:wait_resource).with(server, :active, :state)
+      expect(cloud).to receive(:wait_resource).with(boot_volume, :available)
 
-      @registry.should_receive(:update_settings).
+      expect(@registry).to receive(:update_settings).
         with("i-test", agent_settings(unique_name, network_spec))
 
       vm_id = cloud.create_vm("agent-id", "sc-id",
         resource_pool_spec,
         { "network_a" => network_spec },
         nil, { "test_env" => "value" })
-      vm_id.should == "i-test"
+      expect(vm_id).to eq("i-test")
     end
   end
 
@@ -369,19 +369,19 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
       }
 
       cloud = mock_cloud(cloud_options['properties']) do |openstack|
-        openstack.servers.should_receive(:create).with(openstack_params).and_return(server)
-        openstack.security_groups.should_receive(:collect).and_return(%w[default])
-        openstack.images.should_receive(:find).and_return(image)
-        openstack.flavors.should_receive(:find).and_return(flavor)
-        openstack.volumes.should_receive(:create).with(disk_params).and_return(boot_volume)
-        openstack.key_pairs.should_receive(:find).and_return(key_pair)
-        openstack.addresses.should_receive(:each).and_yield(address)
+        expect(openstack.servers).to receive(:create).with(openstack_params).and_return(server)
+        expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+        expect(openstack.images).to receive(:find).and_return(image)
+        expect(openstack.flavors).to receive(:find).and_return(flavor)
+        expect(openstack.volumes).to receive(:create).with(disk_params).and_return(boot_volume)
+        expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
+        expect(openstack.addresses).to receive(:each).and_yield(address)
       end
 
-      cloud.should_receive(:generate_unique_name).exactly(2).times.and_return(unique_name, unique_vol_name)
-      address.should_receive(:server=).with(nil)
-      cloud.should_receive(:wait_resource).with(server, :active, :state)
-      cloud.should_receive(:wait_resource).with(boot_volume, :available)
+      expect(cloud).to receive(:generate_unique_name).exactly(2).times.and_return(unique_name, unique_vol_name)
+      expect(address).to receive(:server=).with(nil)
+      expect(cloud).to receive(:wait_resource).with(server, :active, :state)
+      expect(cloud).to receive(:wait_resource).with(boot_volume, :available)
 
       expect(@registry).to receive(:update_settings).
         with("i-test", agent_settings(unique_name, network_spec))
@@ -430,11 +430,11 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
   context "when cannot create an OpenStack server" do
     let(:cloud) do
       c = mock_cloud do |openstack|
-        openstack.servers.should_receive(:create).and_return(server)
-        openstack.security_groups.should_receive(:collect).and_return(%w[default])
-        openstack.images.should_receive(:find).and_return(image)
-        openstack.flavors.should_receive(:find).and_return(flavor)
-        openstack.key_pairs.should_receive(:find).and_return(key_pair)
+        expect(openstack.servers).to receive(:create).and_return(server)
+        expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+        expect(openstack.images).to receive(:find).and_return(image)
+        expect(openstack.flavors).to receive(:find).and_return(flavor)
+        expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
       end
 
       allow(c).to receive(:wait_resource).with(server, :active, :state).and_raise(Bosh::Clouds::CloudError)
@@ -464,7 +464,7 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
 
   it "raises an error when a security group doesn't exist" do
     cloud = mock_cloud do |openstack|
-      openstack.security_groups.should_receive(:collect).and_return(%w[foo])
+      expect(openstack.security_groups).to receive(:collect).and_return(%w[foo])
     end
 
     expect {
@@ -476,9 +476,9 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
   it "raises an error when flavor doesn't have enough ephemeral disk capacity" do
     flavor = double("flavor", :id => "f-test", :name => "m1.tiny", :ram => 1024, :ephemeral => 1)
     cloud = mock_cloud do |openstack|
-      openstack.security_groups.should_receive(:collect).and_return(%w[default])
-      openstack.images.should_receive(:find).and_return(image)
-      openstack.flavors.should_receive(:find).and_return(flavor)
+      expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
+      expect(openstack.images).to receive(:find).and_return(image)
+      expect(openstack.flavors).to receive(:find).and_return(flavor)
     end
 
     expect {
@@ -496,12 +496,12 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
   describe "#select_availability_zone" do
     it "should return nil when all values are nil" do
       cloud = mock_cloud
-      cloud.select_availability_zone(nil, nil).should == nil
+      expect(cloud.select_availability_zone(nil, nil)).to eq(nil)
     end
 
     it "should select the resource pool availability_zone when disks are nil" do
       cloud = mock_cloud
-      cloud.select_availability_zone(nil, "foobar-1a").should == "foobar-1a"
+      expect(cloud.select_availability_zone(nil, "foobar-1a")).to eq("foobar-1a")
     end
 
     it "should select the resource pool availability_zone when we are ignoring the disks zone" do
@@ -510,21 +510,21 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
       cloud_options['properties']['openstack']['ignore_server_availability_zone'] = true
 
       cloud = mock_cloud(cloud_options["properties"]) do |openstack|
-        openstack.volumes.stub(:get).and_return(volume("foo"), volume("foo"))
+        allow(openstack.volumes).to receive(:get).and_return(volume("foo"), volume("foo"))
       end
       expect(cloud.select_availability_zone(%w[cid1 cid2], "foobar-1a")).to eq("foobar-1a")
     end
 
     it "should select the zone from a list of disks" do
       cloud = mock_cloud do |openstack|
-        openstack.volumes.stub(:get).and_return(volume("foo"), volume("foo"))
+        allow(openstack.volumes).to receive(:get).and_return(volume("foo"), volume("foo"))
       end
       expect(cloud.select_availability_zone(%w[cid1 cid2], nil)).to eq("foo")
     end
 
     it "should select the zone from a list of disks and a default" do
       cloud = mock_cloud do |openstack|
-        openstack.volumes.stub(:get).and_return(volume("foo"), volume("foo"))
+        allow(openstack.volumes).to receive(:get).and_return(volume("foo"), volume("foo"))
       end
       expect(cloud.select_availability_zone(%w[cid1 cid2], "foo")).to eq("foo")
     end

--- a/bosh_openstack_cpi/spec/unit/delete_disk_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/delete_disk_spec.rb
@@ -9,13 +9,13 @@ describe Bosh::OpenStackCloud::Cloud do
     volume = double("volume", :id => "v-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:get).
+      expect(openstack.volumes).to receive(:get).
         with("v-foobar").and_return(volume)
     end
 
-    volume.should_receive(:status).and_return(:available)
-    volume.should_receive(:destroy).and_return(true)
-    cloud.should_receive(:wait_resource).with(volume, :deleted, :status, true)
+    expect(volume).to receive(:status).and_return(:available)
+    expect(volume).to receive(:destroy).and_return(true)
+    expect(cloud).to receive(:wait_resource).with(volume, :deleted, :status, true)
 
     cloud.delete_disk("v-foobar")
   end
@@ -24,10 +24,10 @@ describe Bosh::OpenStackCloud::Cloud do
     volume = double("volume", :id => "v-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:get).with("v-foobar").and_return(volume)
+      expect(openstack.volumes).to receive(:get).with("v-foobar").and_return(volume)
     end
 
-    volume.should_receive(:status).and_return(:busy)
+    expect(volume).to receive(:status).and_return(:busy)
 
     expect {
       cloud.delete_disk("v-foobar")

--- a/bosh_openstack_cpi/spec/unit/delete_snapshot_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/delete_snapshot_spec.rb
@@ -8,12 +8,12 @@ describe Bosh::OpenStackCloud::Cloud do
     snapshot = double("snapshot", :id => "snap-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.snapshots.should_receive(:get).with("snap-foobar").and_return(snapshot)
+      expect(openstack.snapshots).to receive(:get).with("snap-foobar").and_return(snapshot)
     end
 
-    snapshot.should_receive(:status).and_return(:available)
-    snapshot.should_receive(:destroy).and_return(true)
-    cloud.should_receive(:wait_resource).with(snapshot, :deleted, :status, true)
+    expect(snapshot).to receive(:status).and_return(:available)
+    expect(snapshot).to receive(:destroy).and_return(true)
+    expect(cloud).to receive(:wait_resource).with(snapshot, :deleted, :status, true)
 
     cloud.delete_snapshot("snap-foobar")
   end
@@ -22,10 +22,10 @@ describe Bosh::OpenStackCloud::Cloud do
     snapshot = double("snapshot", :id => "snap-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.snapshots.should_receive(:get).with("snap-foobar").and_return(snapshot)
+      expect(openstack.snapshots).to receive(:get).with("snap-foobar").and_return(snapshot)
     end
 
-    snapshot.should_receive(:status).and_return(:busy)
+    expect(snapshot).to receive(:status).and_return(:busy)
 
     expect {
       cloud.delete_snapshot("snap-foobar")

--- a/bosh_openstack_cpi/spec/unit/delete_stemcell_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/delete_stemcell_spec.rb
@@ -9,10 +9,10 @@ describe Bosh::OpenStackCloud::Cloud do
     image = double("image", :id => "i-foo", :name => "i-foo", :properties => {})
 
     cloud = mock_glance do |glance|
-      glance.images.stub(:find_by_id).with("i-foo").and_return(image)
+      allow(glance.images).to receive(:find_by_id).with("i-foo").and_return(image)
     end
 
-    image.should_receive(:destroy)
+    expect(image).to receive(:destroy)
 
     cloud.delete_stemcell("i-foo")
   end

--- a/bosh_openstack_cpi/spec/unit/delete_vm_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/delete_vm_spec.rb
@@ -13,13 +13,13 @@ describe Bosh::OpenStackCloud::Cloud do
     server = double("server", :id => "i-foobar", :name => "i-foobar")
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-foobar").and_return(server)
+      expect(openstack.servers).to receive(:get).with("i-foobar").and_return(server)
     end
 
-    server.should_receive(:destroy).and_return(true)
-    cloud.should_receive(:wait_resource).with(server, [:terminated, :deleted], :state, true)
+    expect(server).to receive(:destroy).and_return(true)
+    expect(cloud).to receive(:wait_resource).with(server, [:terminated, :deleted], :state, true)
 
-    @registry.should_receive(:delete_settings).with("i-foobar")
+    expect(@registry).to receive(:delete_settings).with("i-foobar")
 
     cloud.delete_vm("i-foobar")
   end

--- a/bosh_openstack_cpi/spec/unit/detach_disk_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/detach_disk_spec.rb
@@ -15,13 +15,13 @@ describe Bosh::OpenStackCloud::Cloud do
     volume_attachments = [{"id" => "a1", "volumeId" => "v-foobar"}, {"id" => "a2", "volumeId" => "v-barfoo"}]
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
-      openstack.volumes.should_receive(:get).with("v-foobar").and_return(volume)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
+      expect(openstack.volumes).to receive(:get).with("v-foobar").and_return(volume)
     end
 
-    server.should_receive(:volume_attachments).and_return(volume_attachments)
-    volume.should_receive(:detach).with(server.id, "a1").and_return(true)
-    cloud.should_receive(:wait_resource).with(volume, :available)
+    expect(server).to receive(:volume_attachments).and_return(volume_attachments)
+    expect(volume).to receive(:detach).with(server.id, "a1").and_return(true)
+    expect(cloud).to receive(:wait_resource).with(volume, :available)
 
     old_settings = {
       "foo" => "bar",
@@ -42,8 +42,8 @@ describe Bosh::OpenStackCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).with("i-test").and_return(old_settings)
-    @registry.should_receive(:update_settings).with("i-test", new_settings)
+    expect(@registry).to receive(:read_settings).with("i-test").and_return(old_settings)
+    expect(@registry).to receive(:update_settings).with("i-test", new_settings)
 
     cloud.detach_disk("i-test", "v-foobar")
   end
@@ -54,12 +54,12 @@ describe Bosh::OpenStackCloud::Cloud do
     volume_attachments = [{"volumeId" => "v-foobar"}]
 
     cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-test").and_return(server)
-      openstack.volumes.should_receive(:get).with("v-barfoo").and_return(volume)
+      expect(openstack.servers).to receive(:get).with("i-test").and_return(server)
+      expect(openstack.volumes).to receive(:get).with("v-barfoo").and_return(volume)
     end
 
-    server.should_receive(:volume_attachments).and_return(volume_attachments)
-    volume.should_not_receive(:detach)
+    expect(server).to receive(:volume_attachments).and_return(volume_attachments)
+    expect(volume).not_to receive(:detach)
 
     old_settings = {
       "foo" => "bar",
@@ -80,8 +80,8 @@ describe Bosh::OpenStackCloud::Cloud do
       }
     }
 
-    @registry.should_receive(:read_settings).with("i-test").and_return(old_settings)
-    @registry.should_receive(:update_settings).with("i-test", new_settings)
+    expect(@registry).to receive(:read_settings).with("i-test").and_return(old_settings)
+    expect(@registry).to receive(:update_settings).with("i-test", new_settings)
 
     cloud.detach_disk("i-test", "v-barfoo")
   end

--- a/bosh_openstack_cpi/spec/unit/excon_logging_instrumentor_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/excon_logging_instrumentor_spec.rb
@@ -11,10 +11,10 @@ describe Bosh::OpenStackCloud::ExconLoggingInstrumentor do
     }
 
     before do
-      Bosh::Clouds::Config.stub(:cpi_task_log).and_return(cpi_log)
-      Logger.stub(:new).with(cpi_log).and_return(logger)
-      logger.stub(:debug)
-      logger.stub(:close)
+      allow(Bosh::Clouds::Config).to receive(:cpi_task_log).and_return(cpi_log)
+      allow(Logger).to receive(:new).with(cpi_log).and_return(logger)
+      allow(logger).to receive(:debug)
+      allow(logger).to receive(:close)
     end
 
     it "logs requests" do

--- a/bosh_openstack_cpi/spec/unit/has_vm_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/has_vm_spec.rb
@@ -8,31 +8,31 @@ describe Bosh::OpenStackCloud::Cloud do
   it 'has_vm? returns true if OpenStack server exists' do
     server = double('server', :id => 'i-foobar', :state => :active)
     cloud = mock_cloud(mock_cloud_options['properties']) do |openstack|
-      openstack.servers.stub(:get).with('i-foobar').and_return(server)
+      allow(openstack.servers).to receive(:get).with('i-foobar').and_return(server)
     end
-    cloud.has_vm?('i-foobar').should be(true)
+    expect(cloud.has_vm?('i-foobar')).to be(true)
   end
 
   it "has_vm? returns false if OpenStack server doesn't exists" do
     cloud = mock_cloud(mock_cloud_options['properties']) do |openstack|
-      openstack.servers.stub(:get).with('i-foobar').and_return(nil)
+      allow(openstack.servers).to receive(:get).with('i-foobar').and_return(nil)
     end
-    cloud.has_vm?('i-foobar').should be(false)
+    expect(cloud.has_vm?('i-foobar')).to be(false)
   end
 
   it 'has_vm? returns false if OpenStack server state is :terminated' do
     server = double('server', :id => 'i-foobar', :state => :terminated)
     cloud = mock_cloud(mock_cloud_options['properties']) do |openstack|
-      openstack.servers.stub(:get).with('i-foobar').and_return(server)
+      allow(openstack.servers).to receive(:get).with('i-foobar').and_return(server)
     end
-    cloud.has_vm?('i-foobar').should be(false)
+    expect(cloud.has_vm?('i-foobar')).to be(false)
   end
 
   it 'has_vm? returns false if OpenStack server state is :deleted' do
     server = double('server', :id => 'i-foobar', :state => :deleted)
     cloud = mock_cloud(mock_cloud_options['properties']) do |openstack|
-      openstack.servers.stub(:get).with('i-foobar').and_return(server)
+      allow(openstack.servers).to receive(:get).with('i-foobar').and_return(server)
     end
-    cloud.has_vm?('i-foobar').should be(false)
+    expect(cloud.has_vm?('i-foobar')).to be(false)
   end
 end

--- a/bosh_openstack_cpi/spec/unit/manual_network_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/manual_network_spec.rb
@@ -8,6 +8,6 @@ describe Bosh::OpenStackCloud::ManualNetwork do
     network_spec["ip"] = "172.20.214.10"
     mn = Bosh::OpenStackCloud::ManualNetwork.new("default", network_spec)
 
-    mn.private_ip.should == "172.20.214.10"
+    expect(mn.private_ip).to eq("172.20.214.10")
   end
 end

--- a/bosh_openstack_cpi/spec/unit/network_configurator_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/network_configurator_spec.rb
@@ -67,7 +67,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
       set_security_groups(spec["network_b"], %w[bar])
 
       nc = Bosh::OpenStackCloud::NetworkConfigurator.new(spec)
-      nc.security_groups(nil).should == %w[bar foo]
+      expect(nc.security_groups(nil)).to eq(%w[bar foo])
     end
 
     it "should be extracted from both manual and vip network" do
@@ -78,7 +78,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
       set_security_groups(spec["network_b"], %w[bar])
 
       nc = Bosh::OpenStackCloud::NetworkConfigurator.new(spec)
-      nc.security_groups(nil).should == %w[bar foo]
+      expect(nc.security_groups(nil)).to eq(%w[bar foo])
     end
 
     it "should return the default groups if none are extracted" do
@@ -86,7 +86,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
       spec["network_a"] = {"type" => "dynamic"}
 
       nc = Bosh::OpenStackCloud::NetworkConfigurator.new(spec)
-      nc.security_groups(%w[foo]).should == %w[foo]
+      expect(nc.security_groups(%w[foo])).to eq(%w[foo])
     end
 
     it "should return an empty list if no default group is set" do
@@ -94,7 +94,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
       spec["network_a"] = {"type" => "dynamic"}
 
       nc = Bosh::OpenStackCloud::NetworkConfigurator.new(spec)
-      nc.security_groups(nil).should == []
+      expect(nc.security_groups(nil)).to eq([])
     end
 
     it "should raise an error when it isn't an array" do
@@ -151,7 +151,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
       spec["network_a"]["cloud_properties"]["net_id"] = "foo"
 
       nc = Bosh::OpenStackCloud::NetworkConfigurator.new(spec)
-      nc.nics.should == [{ "net_id" => "foo" }]
+      expect(nc.nics).to eq([{ "net_id" => "foo" }])
     end
 
     it "should extract net_id and IP address from all manual networks" do
@@ -169,7 +169,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
       spec["network_a"]["cloud_properties"]["net_id"] = "foo"
 
       nc = Bosh::OpenStackCloud::NetworkConfigurator.new(spec)
-      nc.nics.should == [{ "net_id" => "foo" }]
+      expect(nc.nics).to eq([{ "net_id" => "foo" }])
     end
   end
 end

--- a/bosh_openstack_cpi/spec/unit/reboot_vm_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/reboot_vm_spec.rb
@@ -9,24 +9,24 @@ describe Bosh::OpenStackCloud::Cloud do
     @server = double('server', :id => 'i-foobar')
 
     @cloud = mock_cloud(mock_cloud_options['properties']) do |openstack|
-      openstack.servers.stub(:get).with('i-foobar').and_return(@server)
+      allow(openstack.servers).to receive(:get).with('i-foobar').and_return(@server)
     end
   end
 
   it 'reboots an OpenStack server (CPI call picks soft reboot)' do
-    @cloud.should_receive(:soft_reboot).with(@server)
+    expect(@cloud).to receive(:soft_reboot).with(@server)
     @cloud.reboot_vm('i-foobar')
   end
 
   it 'soft reboots an OpenStack server' do
-    @server.should_receive(:reboot)
-    @cloud.should_receive(:wait_resource).with(@server, :active, :state)
+    expect(@server).to receive(:reboot)
+    expect(@cloud).to receive(:wait_resource).with(@server, :active, :state)
     @cloud.send(:soft_reboot, @server)
   end
 
   it 'hard reboots an OpenStack server' do
-    @server.should_receive(:reboot)
-    @cloud.should_receive(:wait_resource).with(@server, :active, :state)
+    expect(@server).to receive(:reboot)
+    expect(@cloud).to receive(:wait_resource).with(@server, :active, :state)
     @cloud.send(:hard_reboot, @server)
   end
 

--- a/bosh_openstack_cpi/spec/unit/set_vm_metadata_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/set_vm_metadata_spec.rb
@@ -8,15 +8,15 @@ describe Bosh::OpenStackCloud::Cloud do
 
   before :each do
     @cloud = mock_cloud do |openstack|
-      openstack.servers.should_receive(:get).with("i-foobar").and_return(server)
+      expect(openstack.servers).to receive(:get).with("i-foobar").and_return(server)
     end
   end
 
   it "should set metadata" do
     metadata = {:job => "job", :index => "index"}
 
-    Bosh::OpenStackCloud::TagManager.should_receive(:tag).with(server, :job, "job")
-    Bosh::OpenStackCloud::TagManager.should_receive(:tag).with(server, :index, "index")
+    expect(Bosh::OpenStackCloud::TagManager).to receive(:tag).with(server, :job, "job")
+    expect(Bosh::OpenStackCloud::TagManager).to receive(:tag).with(server, :index, "index")
 
     @cloud.set_vm_metadata("i-foobar", metadata)
   end

--- a/bosh_openstack_cpi/spec/unit/snapshot_disk_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/snapshot_disk_spec.rb
@@ -25,19 +25,19 @@ describe Bosh::OpenStackCloud::Cloud do
     }
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:get).with("v-foobar").and_return(volume)
-      openstack.snapshots.should_receive(:new).with(snapshot_params).and_return(snapshot)
+      expect(openstack.volumes).to receive(:get).with("v-foobar").and_return(volume)
+      expect(openstack.snapshots).to receive(:new).with(snapshot_params).and_return(snapshot)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
     
-    volume.should_receive(:attachments).and_return([attachment])
+    expect(volume).to receive(:attachments).and_return([attachment])
     
-    snapshot.should_receive(:save).with(true)
+    expect(snapshot).to receive(:save).with(true)
 
-    cloud.should_receive(:wait_resource).with(snapshot, :available)
+    expect(cloud).to receive(:wait_resource).with(snapshot, :available)
 
-    cloud.snapshot_disk("v-foobar", metadata).should == "snap-foobar"
+    expect(cloud.snapshot_disk("v-foobar", metadata)).to eq("snap-foobar")
   end
 
   it "creates an OpenStack snapshot when volume doesn't have any attachment" do
@@ -60,24 +60,24 @@ describe Bosh::OpenStackCloud::Cloud do
     }
 
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:get).with("v-foobar").and_return(volume)
-      openstack.snapshots.should_receive(:new).with(snapshot_params).and_return(snapshot)
+      expect(openstack.volumes).to receive(:get).with("v-foobar").and_return(volume)
+      expect(openstack.snapshots).to receive(:new).with(snapshot_params).and_return(snapshot)
     end
 
-    cloud.should_receive(:generate_unique_name).and_return(unique_name)
+    expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
     
-    volume.should_receive(:attachments).and_return([{}])
+    expect(volume).to receive(:attachments).and_return([{}])
     
-    snapshot.should_receive(:save).with(true)
+    expect(snapshot).to receive(:save).with(true)
 
-    cloud.should_receive(:wait_resource).with(snapshot, :available)
+    expect(cloud).to receive(:wait_resource).with(snapshot, :available)
 
-    cloud.snapshot_disk("v-foobar", metadata).should == "snap-foobar"
+    expect(cloud.snapshot_disk("v-foobar", metadata)).to eq("snap-foobar")
   end
   
   it "should raise an Exception if OpenStack volume is not found" do
     cloud = mock_cloud do |openstack|
-      openstack.volumes.should_receive(:get).with("v-foobar").and_return(nil)
+      expect(openstack.volumes).to receive(:get).with("v-foobar").and_return(nil)
     end
 
     expect {

--- a/bosh_openstack_cpi/spec/unit/tag_manager_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/tag_manager_spec.rb
@@ -7,23 +7,23 @@ describe Bosh::OpenStackCloud::TagManager do
   let(:metadata) { double("metadata") }
 
   it 'should trim key and value length' do
-    server.should_receive(:metadata).and_return(metadata)
-    metadata.should_receive(:update) do |parms|
-      parms.size.should == 1
-      parms.keys.first.size.should == 255
-      parms.values.first.size.should == 255
+    expect(server).to receive(:metadata).and_return(metadata)
+    expect(metadata).to receive(:update) do |parms|
+      expect(parms.size).to eq(1)
+      expect(parms.keys.first.size).to eq(255)
+      expect(parms.values.first.size).to eq(255)
     end
 
     Bosh::OpenStackCloud::TagManager.tag(server, 'x'*256, 'y'*256)
   end
 
   it 'should do nothing if key is nil' do
-    server.should_not_receive(:metadata)
+    expect(server).not_to receive(:metadata)
     Bosh::OpenStackCloud::TagManager.tag(server, nil, 'value')
   end
 
   it 'should do nothing if value is nil' do
-    server.should_not_receive(:metadata)
+    expect(server).not_to receive(:metadata)
     Bosh::OpenStackCloud::TagManager.tag(server, 'key', nil)
   end
 

--- a/bosh_vsphere_cpi/spec/unit/cloud/vsphere/path_finder_spec.rb
+++ b/bosh_vsphere_cpi/spec/unit/cloud/vsphere/path_finder_spec.rb
@@ -11,7 +11,7 @@ describe VSphereCloud::PathFinder do
     subject(:path_finder) { VSphereCloud::PathFinder.new }
 
     it 'returns path for managed object' do
-      datacenter.stub(:instance_of?).with(VimSdk::Vim::Datacenter).and_return(true)
+      allow(datacenter).to receive(:instance_of?).with(VimSdk::Vim::Datacenter).and_return(true)
 
       expect(path_finder.path(managed_object)).to eq('parent_folder/fake_managed_object')
     end

--- a/bosh_vsphere_cpi/spec/unit/cloud/vsphere/resources/scorer_spec.rb
+++ b/bosh_vsphere_cpi/spec/unit/cloud/vsphere/resources/scorer_spec.rb
@@ -7,7 +7,7 @@ describe VSphereCloud::Resources::Scorer do
     datastores = {}
     sizes.each_with_index do |size, i|
       datastore = double(:datastore)
-      datastore.stub(:free_space).and_return(size)
+      allow(datastore).to receive(:free_space).and_return(size)
       datastores["ds_#{i}"] = datastore
     end
     datastores
@@ -15,13 +15,13 @@ describe VSphereCloud::Resources::Scorer do
 
   def create_cluster(memory, ephemeral, persistent, shared)
     cluster = double(:cluster)
-    cluster.stub(:name).and_return("foo")
-    cluster.stub(:free_memory).and_return(memory)
-    cluster.stub(:ephemeral_datastores).
+    allow(cluster).to receive(:name).and_return("foo")
+    allow(cluster).to receive(:free_memory).and_return(memory)
+    allow(cluster).to receive(:ephemeral_datastores).
         and_return(create_datastores(ephemeral))
-    cluster.stub(:persistent_datastores).
+    allow(cluster).to receive(:persistent_datastores).
         and_return(create_datastores(persistent))
-    cluster.stub(:shared_datastores).
+    allow(cluster).to receive(:shared_datastores).
         and_return(create_datastores(shared))
     cluster
   end
@@ -30,43 +30,43 @@ describe VSphereCloud::Resources::Scorer do
     it "should return 0 when memory is not available" do
       cluster = create_cluster(500, [32 * 1024], [32 * 1024], [])
       scorer = VSphereCloud::Resources::Scorer.new(config, cluster, 512, 1, [])
-      scorer.score.should == 0
+      expect(scorer.score).to eq(0)
     end
 
     it "should return 0 when ephemeral space is not available" do
       cluster = create_cluster(16 * 1024, [512], [32 * 1024], [])
       scorer = VSphereCloud::Resources::Scorer.new(config, cluster, 1, 1024, [])
-      scorer.score.should == 0
+      expect(scorer.score).to eq(0)
     end
 
     it "should return 0 when persistent space is not available" do
       cluster = create_cluster(16 * 1024, [32 * 1024], [512], [])
       scorer = VSphereCloud::Resources::Scorer.new(config, cluster, 1, 1, [1024])
-      scorer.score.should == 0
+      expect(scorer.score).to eq(0)
     end
 
     it "should calculate memory bound score" do
       cluster = create_cluster(16 * 1024, [32 * 1024], [32 * 1024], [])
       scorer = VSphereCloud::Resources::Scorer.new(config, cluster, 512, 1, [])
-      scorer.score.should == 31
+      expect(scorer.score).to eq(31)
     end
 
     it "should calculate ephemeral bound score" do
       cluster = create_cluster(16 * 1024, [32 * 1024], [32 * 1024], [])
       scorer = VSphereCloud::Resources::Scorer.new(config, cluster, 1, 512, [])
-      scorer.score.should == 62
+      expect(scorer.score).to eq(62)
     end
 
     it "should calculate persistent bound score" do
       cluster = create_cluster(16 * 1024, [32 * 1024], [32 * 1024], [])
       scorer = VSphereCloud::Resources::Scorer.new(config, cluster, 1, 1, [512])
-      scorer.score.should == 62
+      expect(scorer.score).to eq(62)
     end
 
     it "should calculate shared bound score" do
       cluster = create_cluster(16 * 1024, [], [], [32 * 1024])
       scorer = VSphereCloud::Resources::Scorer.new(config, cluster, 1, 1024, [512])
-      scorer.score.should == 20
+      expect(scorer.score).to eq(20)
     end
   end
 end

--- a/bosh_vsphere_cpi/spec/unit/cloud/vsphere/resources/util_spec.rb
+++ b/bosh_vsphere_cpi/spec/unit/cloud/vsphere/resources/util_spec.rb
@@ -5,31 +5,31 @@ require File.expand_path("../../../../../spec_helper", __FILE__)
 describe VSphereCloud::Resources::Util do
   describe :average_csv do
     it "should compute the average integer value" do
-      VSphereCloud::Resources::Util.average_csv("1,2,3").should == 2
+      expect(VSphereCloud::Resources::Util.average_csv("1,2,3")).to eq(2)
     end
 
     it "should compute the average float value" do
-      VSphereCloud::Resources::Util.average_csv("1.5,2.5,3.5").should == 2.5
+      expect(VSphereCloud::Resources::Util.average_csv("1.5,2.5,3.5")).to eq(2.5)
     end
 
     it "should return 0 when there is no data" do
-      VSphereCloud::Resources::Util.average_csv("").should == 0
+      expect(VSphereCloud::Resources::Util.average_csv("")).to eq(0)
     end
   end
 
   describe :weighted_random do
     it "should calculate the weighted random" do
       util = VSphereCloud::Resources::Util
-      util.should_receive(:rand).with(3).and_return(0)
-      util.should_receive(:rand).with(3).and_return(1)
-      util.should_receive(:rand).with(3).and_return(2)
-      util.weighted_random([[:a, 1], [:b, 2]]).should == :a
-      util.weighted_random([[:a, 1], [:b, 2]]).should == :b
-      util.weighted_random([[:a, 1], [:b, 2]]).should == :b
+      expect(util).to receive(:rand).with(3).and_return(0)
+      expect(util).to receive(:rand).with(3).and_return(1)
+      expect(util).to receive(:rand).with(3).and_return(2)
+      expect(util.weighted_random([[:a, 1], [:b, 2]])).to eq(:a)
+      expect(util.weighted_random([[:a, 1], [:b, 2]])).to eq(:b)
+      expect(util.weighted_random([[:a, 1], [:b, 2]])).to eq(:b)
     end
 
     it "should return nil when there are no elements" do
-      VSphereCloud::Resources::Util.weighted_random([]).should be_nil
+      expect(VSphereCloud::Resources::Util.weighted_random([])).to be_nil
     end
   end
 end

--- a/bosh_vsphere_cpi/spec/unit/cloud/vsphere/resources_spec.rb
+++ b/bosh_vsphere_cpi/spec/unit/cloud/vsphere/resources_spec.rb
@@ -10,7 +10,7 @@ module VSphereCloud
 
       it "should fetch the datacenters the first time" do
         fake_datacenter = instance_double('VSphereCloud::Resources::Datacenter', name: 'fake-datacenter-name')
-        VSphereCloud::Resources::Datacenter.should_receive(:new).with(config).once.and_return(fake_datacenter)
+        expect(VSphereCloud::Resources::Datacenter).to receive(:new).with(config).once.and_return(fake_datacenter)
 
         resources = VSphereCloud::Resources.new(config)
 
@@ -19,7 +19,7 @@ module VSphereCloud
 
       it "should use cached datacenters" do
         fake_datacenter = instance_double('VSphereCloud::Resources::Datacenter', name: 'fake-datacenter-name')
-        VSphereCloud::Resources::Datacenter.should_receive(:new).with(config).once.and_return(fake_datacenter)
+        expect(VSphereCloud::Resources::Datacenter).to receive(:new).with(config).once.and_return(fake_datacenter)
 
         resources = VSphereCloud::Resources.new(config)
         2.times do
@@ -29,10 +29,10 @@ module VSphereCloud
 
       it "should flush stale cached datacenters" do
         fake_datacenter = instance_double('VSphereCloud::Resources::Datacenter', name: 'fake-datacenter-name')
-        VSphereCloud::Resources::Datacenter.should_receive(:new).with(config).twice.and_return(fake_datacenter)
+        expect(VSphereCloud::Resources::Datacenter).to receive(:new).with(config).twice.and_return(fake_datacenter)
 
         now = Time.now.to_i
-        Time.should_receive(:now).and_return(now,
+        expect(Time).to receive(:now).and_return(now,
                                              now,
                                              now + Resources::STALE_TIMEOUT + 1,
                                              now + Resources::STALE_TIMEOUT + 1)
@@ -48,13 +48,13 @@ module VSphereCloud
       it "should return the persistent datastore" do
         dc = double(:dc)
         cluster = double(:cluster)
-        dc.stub(:clusters).and_return({ "bar" => cluster })
+        allow(dc).to receive(:clusters).and_return({ "bar" => cluster })
         datastore = double(:datastore)
-        cluster.stub(:persistent).with("baz").and_return(datastore)
+        allow(cluster).to receive(:persistent).with("baz").and_return(datastore)
         resources = VSphereCloud::Resources.new(config)
-        resources.stub(:datacenters).and_return({ "foo" => dc })
-        resources.persistent_datastore("foo", "bar", "baz").should == datastore
-        resources.persistent_datastore("foo", "ba", "baz").should be_nil
+        allow(resources).to receive(:datacenters).and_return({ "foo" => dc })
+        expect(resources.persistent_datastore("foo", "bar", "baz")).to eq(datastore)
+        expect(resources.persistent_datastore("foo", "ba", "baz")).to be_nil
       end
     end
 
@@ -62,22 +62,22 @@ module VSphereCloud
       it "should return true if the provided datastore is still persistent" do
         dc = double(:dc)
         cluster = double(:cluster)
-        dc.stub(:clusters).and_return({ "bar" => cluster })
+        allow(dc).to receive(:clusters).and_return({ "bar" => cluster })
         datastore = double(:datastore)
-        cluster.stub(:persistent).with("baz").and_return(datastore)
+        allow(cluster).to receive(:persistent).with("baz").and_return(datastore)
         resources = VSphereCloud::Resources.new(config)
-        resources.stub(:datacenters).and_return({ "foo" => dc })
-        resources.validate_persistent_datastore("foo", "baz").should be(true)
+        allow(resources).to receive(:datacenters).and_return({ "foo" => dc })
+        expect(resources.validate_persistent_datastore("foo", "baz")).to be(true)
       end
 
       it "should return false if the provided datastore is not persistent" do
         dc = double(:dc)
         cluster = double(:cluster)
-        dc.stub(:clusters).and_return({ "bar" => cluster })
-        cluster.stub(:persistent).with("baz").and_return(nil)
+        allow(dc).to receive(:clusters).and_return({ "bar" => cluster })
+        allow(cluster).to receive(:persistent).with("baz").and_return(nil)
         resources = VSphereCloud::Resources.new(config)
-        resources.stub(:datacenters).and_return({ "foo" => dc })
-        resources.validate_persistent_datastore("foo", "baz").should be(false)
+        allow(resources).to receive(:datacenters).and_return({ "foo" => dc })
+        expect(resources.validate_persistent_datastore("foo", "baz")).to be(false)
       end
     end
 
@@ -85,25 +85,25 @@ module VSphereCloud
       it "should return the datastore when it was placed successfully" do
         dc = double(:dc)
         cluster = double(:cluster)
-        dc.stub(:clusters).and_return({ "bar" => cluster })
+        allow(dc).to receive(:clusters).and_return({ "bar" => cluster })
         datastore = double(:datastore)
-        datastore.should_receive(:allocate).with(1024)
-        cluster.should_receive(:pick_persistent).with(1024).and_return(datastore)
+        expect(datastore).to receive(:allocate).with(1024)
+        expect(cluster).to receive(:pick_persistent).with(1024).and_return(datastore)
         resources = VSphereCloud::Resources.new(config)
-        resources.stub(:datacenters).and_return({ "foo" => dc })
-        resources.place_persistent_datastore("foo", "bar", 1024).
-          should == datastore
+        allow(resources).to receive(:datacenters).and_return({ "foo" => dc })
+        expect(resources.place_persistent_datastore("foo", "bar", 1024)).
+          to eq(datastore)
       end
 
       it "should return nil when it wasn't placed successfully" do
         dc = double(:dc)
         cluster = double(:cluster)
-        dc.stub(:clusters).and_return({ "bar" => cluster })
-        cluster.should_receive(:pick_persistent).with(1024).and_return(nil)
+        allow(dc).to receive(:clusters).and_return({ "bar" => cluster })
+        expect(cluster).to receive(:pick_persistent).with(1024).and_return(nil)
         resources = VSphereCloud::Resources.new(config)
-        resources.stub(:datacenters).and_return({ "foo" => dc })
-        resources.place_persistent_datastore("foo", "bar", 1024).
-          should be_nil
+        allow(resources).to receive(:datacenters).and_return({ "foo" => dc })
+        expect(resources.place_persistent_datastore("foo", "bar", 1024)).
+          to be_nil
       end
     end
 
@@ -111,97 +111,97 @@ module VSphereCloud
       it "should allocate memory and ephemeral disk space" do
         dc = double(:dc)
         cluster = double(:cluster)
-        dc.stub(:clusters).and_return({ "bar" => cluster })
+        allow(dc).to receive(:clusters).and_return({ "bar" => cluster })
         datastore = double(:datastore)
-        cluster.stub(:name).and_return("bar")
-        cluster.stub(:persistent).with("baz").and_return(datastore)
+        allow(cluster).to receive(:name).and_return("bar")
+        allow(cluster).to receive(:persistent).with("baz").and_return(datastore)
         resources = VSphereCloud::Resources.new(config)
-        resources.stub(:datacenters).and_return({ "foo" => dc })
+        allow(resources).to receive(:datacenters).and_return({ "foo" => dc })
 
         scorer = double(:scorer)
-        scorer.should_receive(:score).and_return(4)
-        VSphereCloud::Resources::Scorer.should_receive(:new).
+        expect(scorer).to receive(:score).and_return(4)
+        expect(VSphereCloud::Resources::Scorer).to receive(:new).
           with(config, cluster, 512, 1024, []).and_return(scorer)
 
-        cluster.should_receive(:allocate).with(512)
-        cluster.should_receive(:pick_ephemeral).with(1024).and_return(datastore)
-        datastore.should_receive(:allocate).with(1024)
+        expect(cluster).to receive(:allocate).with(512)
+        expect(cluster).to receive(:pick_ephemeral).with(1024).and_return(datastore)
+        expect(datastore).to receive(:allocate).with(1024)
 
-        resources.place(512, 1024, []).should == [cluster, datastore]
+        expect(resources.place(512, 1024, [])).to eq([cluster, datastore])
       end
 
       it "should prioritize persistent locality" do
         dc = double(:dc)
         cluster_a = double(:cluster_a)
         cluster_b = double(:cluster_b)
-        dc.stub(:clusters).and_return({ "a" => cluster_a, "b" => cluster_b })
+        allow(dc).to receive(:clusters).and_return({ "a" => cluster_a, "b" => cluster_b })
 
         datastore_a = double(:datastore_a)
-        cluster_a.stub(:name).and_return("ds_a")
-        cluster_a.stub(:persistent).with("ds_a").and_return(datastore_a)
-        cluster_a.stub(:persistent).with("ds_b").and_return(nil)
+        allow(cluster_a).to receive(:name).and_return("ds_a")
+        allow(cluster_a).to receive(:persistent).with("ds_a").and_return(datastore_a)
+        allow(cluster_a).to receive(:persistent).with("ds_b").and_return(nil)
 
         datastore_b = double(:datastore_b)
-        cluster_b.stub(:name).and_return("ds_b")
-        cluster_b.stub(:persistent).with("ds_a").and_return(nil)
-        cluster_b.stub(:persistent).with("ds_b").and_return(datastore_b)
+        allow(cluster_b).to receive(:name).and_return("ds_b")
+        allow(cluster_b).to receive(:persistent).with("ds_a").and_return(nil)
+        allow(cluster_b).to receive(:persistent).with("ds_b").and_return(datastore_b)
 
         resources = VSphereCloud::Resources.new(config)
-        resources.stub(:datacenters).and_return({ "foo" => dc })
+        allow(resources).to receive(:datacenters).and_return({ "foo" => dc })
 
         scorer_b = double(:scorer_a)
-        scorer_b.should_receive(:score).and_return(4)
-        VSphereCloud::Resources::Scorer.should_receive(:new).
+        expect(scorer_b).to receive(:score).and_return(4)
+        expect(VSphereCloud::Resources::Scorer).to receive(:new).
           with(config, cluster_b, 512, 1024, [2048]).and_return(scorer_b)
 
-        cluster_b.should_receive(:allocate).with(512)
-        cluster_b.should_receive(:pick_ephemeral).with(1024).
+        expect(cluster_b).to receive(:allocate).with(512)
+        expect(cluster_b).to receive(:pick_ephemeral).with(1024).
           and_return(datastore_b)
-        datastore_b.should_receive(:allocate).with(1024)
+        expect(datastore_b).to receive(:allocate).with(1024)
 
-        resources.place(512, 1024,
+        expect(resources.place(512, 1024,
                         [{ :size => 2048, :dc_name => "foo", :ds_name => "ds_a" },
-                         { :size => 4096, :dc_name => "foo", :ds_name => "ds_b" }]).
-          should == [cluster_b, datastore_b]
+                         { :size => 4096, :dc_name => "foo", :ds_name => "ds_b" }])).
+          to eq([cluster_b, datastore_b])
       end
 
       it "should ignore locality when there is no space" do
         dc = double(:dc)
         cluster_a = double(:cluster_a)
         cluster_b = double(:cluster_b)
-        dc.stub(:clusters).and_return({ "a" => cluster_a, "b" => cluster_b })
+        allow(dc).to receive(:clusters).and_return({ "a" => cluster_a, "b" => cluster_b })
 
         datastore_a = double(:datastore_a)
-        cluster_a.stub(:name).and_return("ds_a")
-        cluster_a.stub(:persistent).with("ds_a").and_return(datastore_a)
-        cluster_a.stub(:persistent).with("ds_b").and_return(nil)
+        allow(cluster_a).to receive(:name).and_return("ds_a")
+        allow(cluster_a).to receive(:persistent).with("ds_a").and_return(datastore_a)
+        allow(cluster_a).to receive(:persistent).with("ds_b").and_return(nil)
 
         datastore_b = double(:datastore_b)
-        cluster_b.stub(:name).and_return("ds_b")
-        cluster_b.stub(:persistent).with("ds_a").and_return(nil)
-        cluster_b.stub(:persistent).with("ds_b").and_return(datastore_b)
+        allow(cluster_b).to receive(:name).and_return("ds_b")
+        allow(cluster_b).to receive(:persistent).with("ds_a").and_return(nil)
+        allow(cluster_b).to receive(:persistent).with("ds_b").and_return(datastore_b)
 
         resources = VSphereCloud::Resources.new(config)
-        resources.stub(:datacenters).and_return({ "foo" => dc })
+        allow(resources).to receive(:datacenters).and_return({ "foo" => dc })
 
         scorer_a = double(:scorer_a)
-        scorer_a.should_receive(:score).twice.and_return(0)
-        VSphereCloud::Resources::Scorer.should_receive(:new).
+        expect(scorer_a).to receive(:score).twice.and_return(0)
+        expect(VSphereCloud::Resources::Scorer).to receive(:new).
           with(config, cluster_a, 512, 1024, []).twice.and_return(scorer_a)
 
         scorer_b = double(:scorer_b)
-        scorer_b.should_receive(:score).and_return(4)
-        VSphereCloud::Resources::Scorer.should_receive(:new).
+        expect(scorer_b).to receive(:score).and_return(4)
+        expect(VSphereCloud::Resources::Scorer).to receive(:new).
           with(config, cluster_b, 512, 1024, [2048]).and_return(scorer_b)
 
-        cluster_b.should_receive(:allocate).with(512)
-        cluster_b.should_receive(:pick_ephemeral).with(1024).
+        expect(cluster_b).to receive(:allocate).with(512)
+        expect(cluster_b).to receive(:pick_ephemeral).with(1024).
           and_return(datastore_b)
-        datastore_b.should_receive(:allocate).with(1024)
+        expect(datastore_b).to receive(:allocate).with(1024)
 
-        resources.place(512, 1024,
-                        [{ :size => 2048, :dc_name => "foo", :ds_name => "ds_a" }]).
-          should == [cluster_b, datastore_b]
+        expect(resources.place(512, 1024,
+                        [{ :size => 2048, :dc_name => "foo", :ds_name => "ds_a" }])).
+          to eq([cluster_b, datastore_b])
       end
 
       context 'when clusters have been manually specified' do
@@ -225,24 +225,24 @@ module VSphereCloud
           cluster_a = double(:cluster_a)
           cluster_b = double(:cluster_b)
           datastore_a = double(:datastore_a)
-          cluster_a.stub(:name).and_return("ds_a")
-          cluster_a.stub(:persistent).with("ds_a").and_return(datastore_a)
-          cluster_a.stub(:persistent).with("ds_b").and_return(nil)
+          allow(cluster_a).to receive(:name).and_return("ds_a")
+          allow(cluster_a).to receive(:persistent).with("ds_a").and_return(datastore_a)
+          allow(cluster_a).to receive(:persistent).with("ds_b").and_return(nil)
 
           datastore_b = double(:datastore_b)
-          cluster_b.stub(:name).and_return("ds_b")
-          cluster_b.stub(:persistent).with("ds_a").and_return(nil)
-          cluster_b.stub(:persistent).with("ds_b").and_return(datastore_b)
+          allow(cluster_b).to receive(:name).and_return("ds_b")
+          allow(cluster_b).to receive(:persistent).with("ds_a").and_return(nil)
+          allow(cluster_b).to receive(:persistent).with("ds_b").and_return(datastore_b)
           resources = VSphereCloud::Resources.new(config)
-          resources.stub(:datacenters).and_return({ "foo" => dc })
+          allow(resources).to receive(:datacenters).and_return({ "foo" => dc })
           scorer_a = double(:scorer_a)
-          scorer_a.should_receive(:score).twice.and_return(0)
-          VSphereCloud::Resources::Scorer.should_receive(:new).
+          expect(scorer_a).to receive(:score).twice.and_return(0)
+          expect(VSphereCloud::Resources::Scorer).to receive(:new).
             with(config, cluster_a, 512, 1024, []).twice.and_return(scorer_a)
 
           scorer_b = double(:scorer_b)
-          scorer_b.should_receive(:score).and_return(4)
-          VSphereCloud::Resources::Scorer.should_receive(:new).
+          expect(scorer_b).to receive(:score).and_return(4)
+          expect(VSphereCloud::Resources::Scorer).to receive(:new).
             with(config, cluster_b, 512, 1024, []).and_return(scorer_b)
 
 
@@ -335,7 +335,7 @@ module VSphereCloud
 
         it 'should ignore locality when there is no space' do
           allow(datacenter).to receive(:name).and_return('foo')
-          datacenter.stub(:clusters).and_return({ "a" => cluster_a, "b" => cluster_b })
+          allow(datacenter).to receive(:clusters).and_return({ "a" => cluster_a, "b" => cluster_b })
 
           scorer_a = instance_double('VSphereCloud::Resources::Scorer')
           allow(scorer_a).to receive(:score).twice.and_return(0)

--- a/bosh_vsphere_cpi/spec/unit/ruby_vim_sdk/soap/deserializer_spec.rb
+++ b/bosh_vsphere_cpi/spec/unit/ruby_vim_sdk/soap/deserializer_spec.rb
@@ -37,7 +37,7 @@ describe VimSdk::Soap::SoapDeserializer do
       :bool_test => true,
       :string_test => 'test value'
     }.each do |key, value|
-      result.send(key).should == value
+      expect(result.send(key)).to eq(value)
     end
   end
 
@@ -60,7 +60,7 @@ describe VimSdk::Soap::SoapDeserializer do
     {
       :time_test => Time.at(1301174932)
     }.each do |key, value|
-      result.send(key).should == value
+      expect(result.send(key)).to eq(value)
     end
   end
 
@@ -83,7 +83,7 @@ describe VimSdk::Soap::SoapDeserializer do
     {
       :binary_test => 'some binary string'
     }.each do |key, value|
-      result.send(key).should == value
+      expect(result.send(key)).to eq(value)
     end
   end
 
@@ -106,7 +106,7 @@ describe VimSdk::Soap::SoapDeserializer do
     {
       :array_test => ['foo', 'bar']
     }.each do |key, value|
-      result.send(key).should == value
+      expect(result.send(key)).to eq(value)
     end
   end
 
@@ -132,7 +132,7 @@ describe VimSdk::Soap::SoapDeserializer do
       :class_test => String,
       :type_name_test => VimSdk::Vmodl::DataObject
     }.each do |key, value|
-      result.send(key).should == value
+      expect(result.send(key)).to eq(value)
     end
   end
 
@@ -150,7 +150,7 @@ describe VimSdk::Soap::SoapDeserializer do
       ])
     end
     test_class2.finalize
-    VimSdk::VmomiSupport.stub(:loaded_wsdl_type).with('urn:test', 'Test2').and_return(test_class2)
+    allow(VimSdk::VmomiSupport).to receive(:loaded_wsdl_type).with('urn:test', 'Test2').and_return(test_class2)
 
     stub = double('stub')
     deserializer = VimSdk::Soap::SoapDeserializer.new(stub, 'test_version')
@@ -164,7 +164,7 @@ describe VimSdk::Soap::SoapDeserializer do
       :test => 'foo',
       :test2 => 'bar'
     }.each do |key, value|
-      result.send(key).should == value
+      expect(result.send(key)).to eq(value)
     end
   end
 
@@ -189,8 +189,8 @@ RESPONSE
 
     result = deserializer.result
     value = result.val
-    value.class.should == VimSdk::Vmodl::Fault::SystemError
-    value.msg.should == 'A general system error occurred: Error deleting disk Device or resource busy'
-    value.reason.should == 'Error deleting disk Device or resource busy'
+    expect(value.class).to eq(VimSdk::Vmodl::Fault::SystemError)
+    expect(value.msg).to eq('A general system error occurred: Error deleting disk Device or resource busy')
+    expect(value.reason).to eq('Error deleting disk Device or resource busy')
   end
 end

--- a/bosh_vsphere_cpi/spec/unit/ruby_vim_sdk/soap/serializer_spec.rb
+++ b/bosh_vsphere_cpi/spec/unit/ruby_vim_sdk/soap/serializer_spec.rb
@@ -18,8 +18,8 @@ describe VimSdk::Soap::SoapSerializer do
     end
     test_class.finalize
 
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class, 'test_version').and_return(test_class)
-    VimSdk::VmomiSupport.stub(:wsdl_namespace).with('test_version').and_return('urn:test')
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class, 'test_version').and_return(test_class)
+    allow(VimSdk::VmomiSupport).to receive(:wsdl_namespace).with('test_version').and_return('urn:test')
 
     writer = StringIO.new
     serializer = VimSdk::Soap::SoapSerializer.new(writer, 'test_version', VimSdk::SOAP_NAMESPACE_MAP.dup)
@@ -29,9 +29,9 @@ describe VimSdk::Soap::SoapSerializer do
                            :double_test => 2.0, :bool_test => true, :string_test => 'test value')
 
     serializer.serialize(value, property)
-    writer.string.should == "<test xmlns=\"urn:test\"><byte_test>1</byte_test><short_test>2</short_test>" +
+    expect(writer.string).to eq("<test xmlns=\"urn:test\"><byte_test>1</byte_test><short_test>2</short_test>" +
         '<long_test>3</long_test><int_test>4</int_test><float_test>1.0</float_test><double_test>2.0</double_test>' +
-        '<bool_test>true</bool_test><string_test>test value</string_test></test>'
+        '<bool_test>true</bool_test><string_test>test value</string_test></test>')
   end
 
   it 'should serialize time' do
@@ -42,8 +42,8 @@ describe VimSdk::Soap::SoapSerializer do
     end
     test_class.finalize
 
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class, 'test_version').and_return(test_class)
-    VimSdk::VmomiSupport.stub(:wsdl_namespace).with('test_version').and_return('urn:test')
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class, 'test_version').and_return(test_class)
+    allow(VimSdk::VmomiSupport).to receive(:wsdl_namespace).with('test_version').and_return('urn:test')
 
     writer = StringIO.new
     serializer = VimSdk::Soap::SoapSerializer.new(writer, 'test_version', VimSdk::SOAP_NAMESPACE_MAP.dup)
@@ -52,7 +52,7 @@ describe VimSdk::Soap::SoapSerializer do
     value = test_class.new(:time_test => Time.at(1301174932))
 
     serializer.serialize(value, property)
-    writer.string.should == "<test xmlns=\"urn:test\"><time_test>2011-03-26T21:28:52Z</time_test></test>"
+    expect(writer.string).to eq("<test xmlns=\"urn:test\"><time_test>2011-03-26T21:28:52Z</time_test></test>")
   end
 
   it 'should serialize binary' do
@@ -63,8 +63,8 @@ describe VimSdk::Soap::SoapSerializer do
     end
     test_class.finalize
 
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class, 'test_version').and_return(test_class)
-    VimSdk::VmomiSupport.stub(:wsdl_namespace).with('test_version').and_return('urn:test')
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class, 'test_version').and_return(test_class)
+    allow(VimSdk::VmomiSupport).to receive(:wsdl_namespace).with('test_version').and_return('urn:test')
 
     writer = StringIO.new
     serializer = VimSdk::Soap::SoapSerializer.new(writer, 'test_version', VimSdk::SOAP_NAMESPACE_MAP.dup)
@@ -73,7 +73,7 @@ describe VimSdk::Soap::SoapSerializer do
     value = test_class.new(:binary_test => 'some binary string')
 
     serializer.serialize(value, property)
-    writer.string.should == "<test xmlns=\"urn:test\"><binary_test>c29tZSBiaW5hcnkgc3RyaW5n\n</binary_test></test>"
+    expect(writer.string).to eq("<test xmlns=\"urn:test\"><binary_test>c29tZSBiaW5hcnkgc3RyaW5n\n</binary_test></test>")
   end
 
   it 'should serialize classes' do
@@ -85,8 +85,8 @@ describe VimSdk::Soap::SoapSerializer do
     end
     test_class.finalize
 
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class, 'test_version').and_return(test_class)
-    VimSdk::VmomiSupport.stub(:wsdl_namespace).with('test_version').and_return('urn:test')
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class, 'test_version').and_return(test_class)
+    allow(VimSdk::VmomiSupport).to receive(:wsdl_namespace).with('test_version').and_return('urn:test')
 
     writer = StringIO.new
     serializer = VimSdk::Soap::SoapSerializer.new(writer, 'test_version', VimSdk::SOAP_NAMESPACE_MAP.dup)
@@ -95,8 +95,8 @@ describe VimSdk::Soap::SoapSerializer do
     value = test_class.new(:class_test => String, :type_name_test => VimSdk::Vmodl::TypeName.new('DataObject'))
 
     serializer.serialize(value, property)
-    writer.string.should == "<test xmlns=\"urn:test\"><class_test>string</class_test>" +
-        '<type_name_test>DataObject</type_name_test></test>'
+    expect(writer.string).to eq("<test xmlns=\"urn:test\"><class_test>string</class_test>" +
+        '<type_name_test>DataObject</type_name_test></test>')
   end
 
   it 'should serialize arrays' do
@@ -107,8 +107,8 @@ describe VimSdk::Soap::SoapSerializer do
     end
     test_class.finalize
 
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class, 'test_version').and_return(test_class)
-    VimSdk::VmomiSupport.stub(:wsdl_namespace).with('test_version').and_return('urn:test')
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class, 'test_version').and_return(test_class)
+    allow(VimSdk::VmomiSupport).to receive(:wsdl_namespace).with('test_version').and_return('urn:test')
 
     writer = StringIO.new
     serializer = VimSdk::Soap::SoapSerializer.new(writer, 'test_version', VimSdk::SOAP_NAMESPACE_MAP.dup)
@@ -117,7 +117,7 @@ describe VimSdk::Soap::SoapSerializer do
     value = test_class.new(:array_test => ['foo', 'bar'])
 
     serializer.serialize(value, property)
-    writer.string.should == "<test xmlns=\"urn:test\"><array_test>foo</array_test><array_test>bar</array_test></test>"
+    expect(writer.string).to eq("<test xmlns=\"urn:test\"><array_test>foo</array_test><array_test>bar</array_test></test>")
   end
 
   it 'should serialize managed objects' do
@@ -133,8 +133,8 @@ describe VimSdk::Soap::SoapSerializer do
     end
     test_class.finalize
 
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class, 'test_version').and_return(test_class)
-    VimSdk::VmomiSupport.stub(:wsdl_namespace).with('test_version').and_return('urn:test')
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class, 'test_version').and_return(test_class)
+    allow(VimSdk::VmomiSupport).to receive(:wsdl_namespace).with('test_version').and_return('urn:test')
 
     writer = StringIO.new
     serializer = VimSdk::Soap::SoapSerializer.new(writer, 'test_version', VimSdk::SOAP_NAMESPACE_MAP.dup)
@@ -143,7 +143,7 @@ describe VimSdk::Soap::SoapSerializer do
     value = test_class.new(:mob_test => test_managed_class.new('some mob id'))
 
     serializer.serialize(value, property)
-    writer.string.should == "<test xmlns=\"urn:test\"><mob_test type=\"ManagedTest\">some mob id</mob_test></test>"
+    expect(writer.string).to eq("<test xmlns=\"urn:test\"><mob_test type=\"ManagedTest\">some mob id</mob_test></test>")
   end
 
   it 'should serialize any type' do
@@ -169,8 +169,8 @@ describe VimSdk::Soap::SoapSerializer do
     end
     test_class.finalize
 
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class, 'test_version').and_return(test_class)
-    VimSdk::VmomiSupport.stub(:wsdl_namespace).with('test_version').and_return('urn:test')
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class, 'test_version').and_return(test_class)
+    allow(VimSdk::VmomiSupport).to receive(:wsdl_namespace).with('test_version').and_return('urn:test')
 
     writer = StringIO.new
     serializer = VimSdk::Soap::SoapSerializer.new(writer, 'test_version', VimSdk::SOAP_NAMESPACE_MAP.dup)
@@ -184,7 +184,7 @@ describe VimSdk::Soap::SoapSerializer do
                            :mob_test => test_managed_class.new('some mob id'))
 
     serializer.serialize(value, property)
-    writer.string.should == "<test xmlns=\"urn:test\"><byte_test xsi:type=\"xsd:byte\">1</byte_test>" +
+    expect(writer.string).to eq("<test xmlns=\"urn:test\"><byte_test xsi:type=\"xsd:byte\">1</byte_test>" +
         "<short_test xsi:type=\"xsd:short\">2</short_test><long_test xsi:type=\"xsd:long\">3</long_test>" +
         "<int_test xsi:type=\"xsd:int\">4</int_test><float_test xsi:type=\"xsd:float\">1.0</float_test>" +
         "<double_test xsi:type=\"xsd:double\">2.0</double_test><bool_test xsi:type=\"xsd:boolean\">true</bool_test>" +
@@ -192,7 +192,7 @@ describe VimSdk::Soap::SoapSerializer do
         "<time_test xsi:type=\"xsd:dateTime\">2011-03-26T21:28:52Z</time_test>" +
         "<binary_test xsi:type=\"xsd:base64Binary\">c29tZSBiaW5hcnkgc3RyaW5n\n</binary_test>" +
         "<mob_test xmlns:vim25=\"urn:vim25\" xsi:type=\"vim25:ManagedObject\" type=\"ManagedTest\">" +
-        'some mob id</mob_test></test>'
+        'some mob id</mob_test></test>')
   end
 
   it 'should serialize any type array' do
@@ -210,8 +210,8 @@ describe VimSdk::Soap::SoapSerializer do
     end
     test_class.finalize
 
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class, 'test_version').and_return(test_class)
-    VimSdk::VmomiSupport.stub(:wsdl_namespace).with('test_version').and_return('urn:test')
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class, 'test_version').and_return(test_class)
+    allow(VimSdk::VmomiSupport).to receive(:wsdl_namespace).with('test_version').and_return('urn:test')
 
     writer = StringIO.new
     serializer = VimSdk::Soap::SoapSerializer.new(writer, 'test_version', VimSdk::SOAP_NAMESPACE_MAP.dup)
@@ -221,12 +221,12 @@ describe VimSdk::Soap::SoapSerializer do
                            :mob_test => [test_managed_class.new('some mob id')])
 
     serializer.serialize(value, property)
-    writer.string.should == "<test xmlns=\"urn:test\">" +
+    expect(writer.string).to eq("<test xmlns=\"urn:test\">" +
         "<basic_test xmlns:vim25=\"urn:vim25\" xsi:type=\"vim25:ArrayOfString\"><string>hello</string>" +
         "<string>world</string></basic_test><class_test xmlns:vim25=\"urn:vim25\" xsi:type=\"vim25:ArrayOfString\">" +
         '<string>string</string><string>float</string><string>DataObject</string></class_test>' +
         "<mob_test xmlns:vim25=\"urn:vim25\" xsi:type=\"vim25:ArrayOfManagedObject\">" +
-        "<ManagedObjectReference type=\"ManagedTest\">some mob id</ManagedObjectReference></mob_test></test>"
+        "<ManagedObjectReference type=\"ManagedTest\">some mob id</ManagedObjectReference></mob_test></test>")
   end
 
   it 'should serialize inherited types' do
@@ -244,9 +244,9 @@ describe VimSdk::Soap::SoapSerializer do
     end
     test_class2.finalize
 
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class, 'test_version').and_return(test_class)
-    VimSdk::VmomiSupport.stub(:compatible_type).with(test_class2, 'test_version').and_return(test_class2)
-    VimSdk::VmomiSupport.stub(:wsdl_namespace).with('test_version').and_return('urn:test')
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class, 'test_version').and_return(test_class)
+    allow(VimSdk::VmomiSupport).to receive(:compatible_type).with(test_class2, 'test_version').and_return(test_class2)
+    allow(VimSdk::VmomiSupport).to receive(:wsdl_namespace).with('test_version').and_return('urn:test')
 
     writer = StringIO.new
     serializer = VimSdk::Soap::SoapSerializer.new(writer, 'test_version', VimSdk::SOAP_NAMESPACE_MAP.dup)
@@ -254,6 +254,6 @@ describe VimSdk::Soap::SoapSerializer do
     property = VimSdk::Property.new('test', test_class, 'test_version')
     value = test_class2.new(:test => 'foo', :test2 => 'bar')
     serializer.serialize(value, property)
-    writer.string.should == "<test xmlns=\"urn:test\" xsi:type=\"Test2\"><test>foo</test><test2>bar</test2></test>"
+    expect(writer.string).to eq("<test xmlns=\"urn:test\" xsi:type=\"Test2\"><test>foo</test><test2>bar</test2></test>")
   end
 end

--- a/bosh_vsphere_cpi/spec/unit/ruby_vim_sdk/vmodl_helper_spec.rb
+++ b/bosh_vsphere_cpi/spec/unit/ruby_vim_sdk/vmodl_helper_spec.rb
@@ -3,33 +3,34 @@ require 'spec_helper'
 describe VimSdk::VmodlHelper do
   describe :camelize do
     it 'should camelize simple forms' do
-      VimSdk::VmodlHelper.camelize('Foo').should == 'Foo'
-      VimSdk::VmodlHelper.camelize('foo').should == 'Foo'
-      VimSdk::VmodlHelper.camelize('foo_bar').should == 'FooBar'
+      expect(VimSdk::VmodlHelper.camelize('Foo')).to eq('Foo')
+      expect(VimSdk::VmodlHelper.camelize('foo')).to eq('Foo')
+      expect(VimSdk::VmodlHelper.camelize('foo_bar')).to eq('FooBar')
     end
   end
 
   describe :underscore do
     it 'should underscore simple forms' do
-      VimSdk::VmodlHelper.underscore('test').should == 'test'
-      VimSdk::VmodlHelper.underscore('thisIsAProperty').should == 'this_is_a_property'
+      expect(VimSdk::VmodlHelper.underscore('test')).to eq('test')
+      expect(VimSdk::VmodlHelper.underscore('thisIsAProperty')).to eq('this_is_a_property')
     end
 
     it 'should underscore exceptional forms' do
-      VimSdk::VmodlHelper.underscore('numCPUs').should == 'num_cpus'
+      expect(VimSdk::VmodlHelper.underscore('numCPUs')).to eq('num_cpus')
     end
   end
 
   describe :vmodl_type_to_ruby do
     it 'should convert VMODL type name to ruby' do
-      VimSdk::VmodlHelper.vmodl_type_to_ruby('vmodl.query.PropertyCollector.Change.Op').should ==
+      expect(VimSdk::VmodlHelper.vmodl_type_to_ruby('vmodl.query.PropertyCollector.Change.Op')).to eq(
           'Vmodl.Query.PropertyCollector.Change.Op'
+      )
     end
   end
 
   describe :vmodl_property_to_ruby do
     it 'should convert VMODL property name to ruby' do
-      VimSdk::VmodlHelper.vmodl_property_to_ruby('testProperty').should == 'test_property'
+      expect(VimSdk::VmodlHelper.vmodl_property_to_ruby('testProperty')).to eq('test_property')
     end
   end
 end

--- a/simple_blobstore_server/spec/functional/simple_blogstore_server_spec.rb
+++ b/simple_blobstore_server/spec/functional/simple_blogstore_server_spec.rb
@@ -32,27 +32,27 @@ describe Bosh::Blobstore::SimpleBlobstoreServer do
 
     it "should accept valid users" do
       get "/resources/foo" , {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 404
+      expect(last_response.status).to eq(404)
     end
 
     it "should reject invalid password" do
       get "/resources/foo" , {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "bad_password")}
-      last_response.status.should == 401
+      expect(last_response.status).to eq(401)
     end
 
     it "should reject invalid user" do
       get "/resources/foo" , {}, {"HTTP_AUTHORIZATION" => encode_credentials("bad_user", "doe")}
-      last_response.status.should == 401
+      expect(last_response.status).to eq(401)
     end
 
     it "should reject invalid user and password" do
       get "/resources/foo" , {}, {"HTTP_AUTHORIZATION" => encode_credentials("bad_user", "bad_password")}
-      last_response.status.should == 401
+      expect(last_response.status).to eq(401)
     end
 
     it "should reject unauthenticated users" do
       get "/resources/foo"
-      last_response.status.should == 401
+      expect(last_response.status).to eq(401)
     end
 
   end
@@ -72,35 +72,35 @@ describe Bosh::Blobstore::SimpleBlobstoreServer do
     it "should create a token for a new resource" do
       post "/resources", {"content" => Rack::Test::UploadedFile.new(@resource_file.path, "plain/text") },
            {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
       object_id = last_response.body
 
       get "/resources/#{object_id}", {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 200
-      last_response.body.should == "test contents"
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq("test contents")
     end
 
     it 'should accept object id suggestion' do
       post "/resources/foobar", {"content" => Rack::Test::UploadedFile.new(@resource_file.path, "plain/text") },
            {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
       object_id = last_response.body
 
-      object_id.should == "foobar"
+      expect(object_id).to eq("foobar")
 
       get "/resources/#{object_id}", {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 200
-      last_response.body.should == "test contents"
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq("test contents")
     end
 
     it 'should return a 409 error if the suggested id is taken' do
       post "/resources/foobar", {"content" => Rack::Test::UploadedFile.new(@resource_file.path, "plain/text") },
            {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
 
       post "/resources/foobar", {"content" => Rack::Test::UploadedFile.new(@resource_file.path, "plain/text") },
            {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 409
+      expect(last_response.status).to eq(409)
     end
   end
 
@@ -108,7 +108,7 @@ describe Bosh::Blobstore::SimpleBlobstoreServer do
 
     it "should return an error if the resource is not found" do
       get "/resources/foo" , {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 404
+      expect(last_response.status).to eq(404)
     end
 
     it "should set Nginx header when Nginx support is enabled" do
@@ -127,13 +127,14 @@ describe Bosh::Blobstore::SimpleBlobstoreServer do
         resource_file.close
         post "/resources", {"content" => Rack::Test::UploadedFile.new(resource_file.path, "plain/text") },
              {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
         object_id = last_response.body
         get "/resources/#{object_id}", {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-        last_response.status.should == 200
-        last_response.body.should == ""
-        last_response.headers["X-Accel-Redirect"].should ==
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq("")
+        expect(last_response.headers["X-Accel-Redirect"]).to eq(
             "/protected/#{Digest::SHA1.hexdigest(object_id)[0, 2]}/#{object_id}"
+        )
       ensure
         resource_file.delete
       end
@@ -149,18 +150,18 @@ describe Bosh::Blobstore::SimpleBlobstoreServer do
         resource_file.close
         post "/resources/foo", {"content" => Rack::Test::UploadedFile.new(resource_file.path, "plain/text") },
              {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
       ensure
         resource_file.delete
       end
 
       head "/resources/foo", {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 200
+      expect(last_response.status).to eq(200)
     end
 
     it 'should return 404 if it does not exist' do
       head "/resources/foo", {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 404
+      expect(last_response.status).to eq(404)
     end
   end
 
@@ -173,18 +174,18 @@ describe Bosh::Blobstore::SimpleBlobstoreServer do
         resource_file.close
         post "/resources", {"content" => Rack::Test::UploadedFile.new(resource_file.path, "plain/text") },
              {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
         object_id = last_response.body
 
         get "/resources/#{object_id}", {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-        last_response.status.should == 200
-        last_response.body.should == "test contents"
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to eq("test contents")
 
         delete "/resources/#{object_id}", {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-        last_response.status.should == 204
+        expect(last_response.status).to eq(204)
 
         get "/resources/#{object_id}", {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-        last_response.status.should == 404
+        expect(last_response.status).to eq(404)
       ensure
         resource_file.delete
       end
@@ -192,7 +193,7 @@ describe Bosh::Blobstore::SimpleBlobstoreServer do
 
     it "should return an error if the resource is not found" do
       delete "/resources/foo" , {}, {"HTTP_AUTHORIZATION" => encode_credentials("john", "doe")}
-      last_response.status.should == 404
+      expect(last_response.status).to eq(404)
     end
 
   end

--- a/spec/external/aws_bootstrap_spec.rb
+++ b/spec/external/aws_bootstrap_spec.rb
@@ -41,7 +41,7 @@ describe 'bosh_cli_plugin_aws_external' do
   end
 
   after(:all) do
-    ec2.key_pairs.map(&:name).should == ['bosh']
+    expect(ec2.key_pairs.map(&:name)).to eq(['bosh'])
     run_bosh "aws destroy"
     Bosh::Common.retryable(tries: 15) do
       ec2.vpcs.count == 0 &&
@@ -67,127 +67,127 @@ describe 'bosh_cli_plugin_aws_external' do
     let(:services_rds2_subnet) { vpc.subnets.detect { |subnet| subnet.cidr_block == "10.10.72.0/21" } }
 
     it "builds the VPC" do
-      vpc.should_not be_nil
+      expect(vpc).not_to be_nil
     end
 
     it "builds the VPC subnets" do
-      bosh1_subnet.availability_zone.name.should == ENV["BOSH_VPC_PRIMARY_AZ"]
-      bosh1_subnet.instances.first.tags["Name"].should == "cf_nat_box1"
+      expect(bosh1_subnet.availability_zone.name).to eq(ENV["BOSH_VPC_PRIMARY_AZ"])
+      expect(bosh1_subnet.instances.first.tags["Name"]).to eq("cf_nat_box1")
 
       [cf1_subnet, services1_subnet].each do |subnet|
-        subnet.availability_zone.name.should == ENV["BOSH_VPC_PRIMARY_AZ"]
-        subnet.instances.count.should == 0
+        expect(subnet.availability_zone.name).to eq(ENV["BOSH_VPC_PRIMARY_AZ"])
+        expect(subnet.instances.count).to eq(0)
 
-        subnet.route_table.routes.any? do |route|
+        expect(subnet.route_table.routes.any? do |route|
           route.instance && route.instance.private_ip_address == "10.10.0.10"
-        end.should be(true)
+        end).to be(true)
       end
 
       [bosh_rds1_subnet, cf_rds1_subnet, cf_elb1_subnet, services_rds1_subnet].each do |subnet|
-        subnet.availability_zone.name.should == ENV["BOSH_VPC_PRIMARY_AZ"]
-        subnet.instances.count.should == 0
+        expect(subnet.availability_zone.name).to eq(ENV["BOSH_VPC_PRIMARY_AZ"])
+        expect(subnet.instances.count).to eq(0)
       end
 
       [bosh_rds2_subnet, cf_rds2_subnet, cf_elb2_subnet, services_rds2_subnet].each do |subnet|
-        subnet.availability_zone.name.should == ENV["BOSH_VPC_SECONDARY_AZ"]
-        subnet.instances.count.should == 0
+        expect(subnet.availability_zone.name).to eq(ENV["BOSH_VPC_SECONDARY_AZ"])
+        expect(subnet.instances.count).to eq(0)
       end
     end
 
     it "associates route tables with subnets" do
       bosh_routes = bosh1_subnet.route_table.routes
       bosh_default_route = bosh_routes.detect { |route| route.destination_cidr_block == "0.0.0.0/0" }
-      bosh_default_route.target.id.should match(/igw/)
+      expect(bosh_default_route.target.id).to match(/igw/)
       bosh_local_route = bosh_routes.detect { |route| route.destination_cidr_block == "10.10.0.0/16" }
-      bosh_local_route.target.id.should == "local"
+      expect(bosh_local_route.target.id).to eq("local")
 
       [cf1_subnet, services1_subnet].each do |subnet|
         routes = subnet.route_table.routes
         default_route = routes.detect { |route| route.destination_cidr_block == "0.0.0.0/0" }
-        default_route.target.should == bosh1_subnet.instances.first
+        expect(default_route.target).to eq(bosh1_subnet.instances.first)
         local_route = routes.detect { |route| route.destination_cidr_block == "10.10.0.0/16" }
-        local_route.target.id.should == "local"
+        expect(local_route.target.id).to eq("local")
       end
     end
 
     it "assigns DHCP options" do
-      vpc.dhcp_options.configuration[:domain_name_servers].should =~ ['10.10.0.6', '10.10.0.2']
+      expect(vpc.dhcp_options.configuration[:domain_name_servers]).to match_array(['10.10.0.6', '10.10.0.2'])
     end
 
     it "assigns security groups" do
       open = vpc.security_groups.detect { |sg| sg.name == "open" }
 
       tcp_permissions = open.ingress_ip_permissions.detect { |p| p.protocol == :tcp }
-      tcp_permissions.should_not be_nil
-      tcp_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      tcp_permissions.port_range.should == (0..65535)
+      expect(tcp_permissions).not_to be_nil
+      expect(tcp_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(tcp_permissions.port_range).to eq(0..65535)
 
       udp_permissions = open.ingress_ip_permissions.detect { |p| p.protocol == :udp }
-      udp_permissions.should_not be_nil
-      udp_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      udp_permissions.port_range.should == (0..65535)
+      expect(udp_permissions).not_to be_nil
+      expect(udp_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(udp_permissions.port_range).to eq(0..65535)
 
       bosh = vpc.security_groups.detect { |sg| sg.name == "bosh" }
 
       tcp_permissions = bosh.ingress_ip_permissions.detect { |p| p.protocol == :tcp }
-      tcp_permissions.should_not be_nil
-      tcp_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      tcp_permissions.port_range.should == (0..65535)
+      expect(tcp_permissions).not_to be_nil
+      expect(tcp_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(tcp_permissions.port_range).to eq(0..65535)
 
       udp_permissions = bosh.ingress_ip_permissions.detect { |p| p.protocol == :udp }
-      udp_permissions.should_not be_nil
-      udp_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      udp_permissions.port_range.should == (0..65535)
+      expect(udp_permissions).not_to be_nil
+      expect(udp_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(udp_permissions.port_range).to eq(0..65535)
 
       bat = vpc.security_groups.detect { |sg| sg.name == "bat" }
 
       ssh_permissions = bat.ingress_ip_permissions.detect { |p| p.port_range == (22..22) }
-      ssh_permissions.should_not be_nil
-      ssh_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      ssh_permissions.protocol.should == :tcp
+      expect(ssh_permissions).not_to be_nil
+      expect(ssh_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(ssh_permissions.protocol).to eq(:tcp)
 
       other_permissions = bat.ingress_ip_permissions.detect { |p| p.port_range == (4567..4567) }
-      other_permissions.should_not be_nil
-      other_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      other_permissions.protocol.should == :tcp
+      expect(other_permissions).not_to be_nil
+      expect(other_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(other_permissions.protocol).to eq(:tcp)
 
       cf = vpc.security_groups.detect { |sg| sg.name == "cf" }
 
       tcp_permissions = cf.ingress_ip_permissions.detect { |p| p.protocol == :tcp }
-      tcp_permissions.should_not be_nil
-      tcp_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      tcp_permissions.port_range.should == (0..65535)
+      expect(tcp_permissions).not_to be_nil
+      expect(tcp_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(tcp_permissions.port_range).to eq(0..65535)
 
       udp_permissions = cf.ingress_ip_permissions.detect { |p| p.protocol == :udp }
-      udp_permissions.should_not be_nil
-      udp_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      udp_permissions.port_range.should == (0..65535)
+      expect(udp_permissions).not_to be_nil
+      expect(udp_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(udp_permissions.port_range).to eq(0..65535)
 
       web = vpc.security_groups.detect { |sg| sg.name == "web" }
 
       http_permissions = web.ingress_ip_permissions.detect { |p| p.port_range == (80..80) }
-      http_permissions.should_not be_nil
-      http_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      http_permissions.protocol.should == :tcp
+      expect(http_permissions).not_to be_nil
+      expect(http_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(http_permissions.protocol).to eq(:tcp)
 
       https_permissions = web.ingress_ip_permissions.detect { |p| p.port_range == (443..443) }
-      https_permissions.should_not be_nil
-      https_permissions.ip_ranges.should == ["0.0.0.0/0"]
-      https_permissions.protocol.should == :tcp
+      expect(https_permissions).not_to be_nil
+      expect(https_permissions.ip_ranges).to eq(["0.0.0.0/0"])
+      expect(https_permissions.protocol).to eq(:tcp)
     end
 
     it "configures ELBs" do
       load_balancer = elb.load_balancers.detect { |lb| lb.name == "cfrouter" }
-      load_balancer.should_not be_nil
-      load_balancer.subnets.sort {|s1, s2| s1.id <=> s2.id }.should == [cf_elb1_subnet, cf_elb2_subnet].sort {|s1, s2| s1.id <=> s2.id }
-      load_balancer.security_groups.map(&:name).should == ["web"]
+      expect(load_balancer).not_to be_nil
+      expect(load_balancer.subnets.sort {|s1, s2| s1.id <=> s2.id }).to eq([cf_elb1_subnet, cf_elb2_subnet].sort {|s1, s2| s1.id <=> s2.id })
+      expect(load_balancer.security_groups.map(&:name)).to eq(["web"])
 
       config = Bosh::Aws::AwsConfig.new(aws_configuration_template)
       hosted_zone = route53.hosted_zones.detect { |zone| zone.name == "#{config.vpc_generated_domain}." }
       record_set = hosted_zone.resource_record_sets["\\052.#{config.vpc_generated_domain}.", 'CNAME'] # E.g. "*.midway.cf-app.com."
-      record_set.should_not be_nil
+      expect(record_set).not_to be_nil
       record_set.resource_records.first[:value] == load_balancer.dns_name
-      record_set.ttl.should == 60
+      expect(record_set.ttl).to eq(60)
     end
   end
 
@@ -199,13 +199,13 @@ describe 'bosh_cli_plugin_aws_external' do
     let(:resource_record_sets) { hosted_zone.resource_record_sets }
 
     it "creates A records, allocates IPs, and deletes A records" do
-      resource_record_sets.count { |record_set| record_set.type == "A" }.should == 0
+      expect(resource_record_sets.count { |record_set| record_set.type == "A" }).to eq(0)
       run_bosh "aws create route53 records #{aws_configuration_template}"
       a_records = resource_record_sets.select { |record_set| record_set.type == "A" }
-      a_records.map { |record| record.name.split(".")[0] }.should =~ ["bosh", "bat", "micro"]
-      a_records.map(&:ttl).uniq.should == [60]
+      expect(a_records.map { |record| record.name.split(".")[0] }).to match_array(["bosh", "bat", "micro"])
+      expect(a_records.map(&:ttl).uniq).to eq([60])
       a_records.each do |record|
-        record.resource_records.first[:value].should =~ /\d+\.\d+\.\d+\.\d+/ # should be an IP address
+        expect(record.resource_records.first[:value]).to match(/\d+\.\d+\.\d+\.\d+/) # should be an IP address
       end
     end
 


### PR DESCRIPTION
Converting to new rspec syntax with 'transpec --keep oneliner,have_items,its,pending,deprecated -s'