### PR TITLE
Add a cloud_property 'boot_volume_size' ...

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -276,7 +276,7 @@ module Bosh::OpenStackCloud
         server_params[:availability_zone] = availability_zone if availability_zone
 
         if @boot_from_volume
-          boot_vol_size = flavor.disk * 1024
+          boot_vol_size = resource_pool['boot_volume_size'] || (flavor.disk * 1024)
 
           boot_vol_id = create_boot_disk(boot_vol_size, stemcell_id, availability_zone, @boot_volume_cloud_properties)
           cloud_error("Failed to create boot volume.") if boot_vol_id.nil?


### PR DESCRIPTION
which allows user to customize the volume size in MB when 'boot_from_volume' is enabled.
Besides, some Openstack deployments set the flavor.disk of flavors to zero, which cause the following 'create_boot_disk' call fail. This patch can also handle this.

To use it, add this option in the 'cloud_properties' section of a 'resource_pools' instance or the 'compilation' configuration. Use case:

compilation:
  cloud_properties:
    boot_volume_size: 8192
    ......
resource_pools:
  - name: pool1
    cloud_properties:
      boot_volume_size: 32768
      ......
  - name: pool2
    cloud_properties:
      boot_volume_size: 4096
      ......