### PR TITLE
[stemcell builder]: don't fetch release candidate if it is already downloaded

### DIFF
--- a/bosh-dev/lib/bosh/dev/build.rb
+++ b/bosh-dev/lib/bosh/dev/build.rb
@@ -129,7 +129,7 @@ module Bosh::Dev
         filename = promotable_artifacts.release_file
         source = UriProvider.pipeline_uri(remote_dir, filename)
         destination = "tmp/#{filename}"
-        download_adapter.download(source, destination)
+        download_adapter.download(source, destination) unless File.exists?(destination)
         destination
       end
     end


### PR DESCRIPTION
Hi, everyone.

Currently I need to rebuild stemcell several times a day. I've noticed that bosh release it fetched each time, so I decided to make this update to enhance speed of stemcell rebuilding.

Best wishes,
Alex L.
