### PR TITLE
Add 'available' option for the cloud_properties of network definition

### DIFF
--- a/bosh-director/lib/bosh/director/errors.rb
+++ b/bosh-director/lib/bosh/director/errors.rb
@@ -162,6 +162,7 @@ module Bosh::Director
   NetworkInvalidDns = err(160004)
   NetworkReservedIpOutOfRange = err(160005)
   NetworkStaticIpOutOfRange = err(160006)
+  NetworkAvailableIpOutOfRange = err(160007)
 
   ResourcePoolUnknownNetwork = err(170001)
   ResourcePoolNotEnoughCapacity = err(170002)


### PR DESCRIPTION
e.g.

networks:
- name: test
  type: manual
  subnets:
  - cloud_properties:
    available:
    - 192.168.100.1 - 192.168.100.20
      ...

When 'available' is given, the available_dynamic_ips is derived from it instead of 'range'.
The reason to introduce this option is as following:
When deploying multiple bosh releases, we often get conflicting vm ip allocations related
to dynamic ips if releases share the same network. It is unnecessary and complex to use
different network for each release.
To make things easy and clear, we use 'available' to isolate multiple releases' address ranges
in one network. And it's very convenient to arrange vm networks of multiple releases when we
put them in one file and use the 'available' option.
