### PR TITLE
respect color flag if explicitly given

### DIFF
--- a/bosh_cli/lib/cli/config.rb
+++ b/bosh_cli/lib/cli/config.rb
@@ -25,7 +25,7 @@ module Bosh::Cli
     end
 
     @commands = {}
-    @colorize = true
+    @colorize = nil
     @output = nil
     @interactive = false
 

--- a/bosh_cli/lib/cli/core_ext.rb
+++ b/bosh_cli/lib/cli/core_ext.rb
@@ -125,11 +125,17 @@ module BoshStringExtensions
   end
 
   def make_color(color_code)
-    if Bosh::Cli::Config.output &&
-       Bosh::Cli::Config.output.tty? &&
-       Bosh::Cli::Config.colorize &&
-       COLOR_CODES[color_code]
+    # invalid color
+    return self if !COLOR_CODES[color_code]
 
+    # output disabled
+    return self if !Bosh::Cli::Config.output
+
+    # colorization explicitly disabled
+    return self if Bosh::Cli::Config.colorize == false
+
+    # colorization explicitly enabled, or output is tty
+    if Bosh::Cli::Config.colorize || Bosh::Cli::Config.output.tty?
       "#{COLOR_CODES[color_code]}#{self}\e[0m"
     else
       self

--- a/bosh_cli/lib/cli/runner.rb
+++ b/bosh_cli/lib/cli/runner.rb
@@ -24,7 +24,7 @@ module Bosh::Cli
       banner = "Usage: bosh [<options>] <command> [<args>]"
       @option_parser = OptionParser.new(banner)
 
-      Config.colorize = true
+      Config.colorize = nil
       Config.output ||= STDOUT
 
       parse_global_options

--- a/bosh_cli/spec/unit/core_ext_spec.rb
+++ b/bosh_cli/spec/unit/core_ext_spec.rb
@@ -39,6 +39,13 @@ describe String do
     expect("string".make_color(:green)).to eq("\e[0m\e[32mstring\e[0m")
 
     allow(Bosh::Cli::Config.output).to receive(:tty?).and_return(false)
+
+    expect("string".make_green).to eq("\e[0m\e[32mstring\e[0m")
+
+    Bosh::Cli::Config.colorize = nil
+    expect("string".make_green).to eq("string")
+
+    Bosh::Cli::Config.colorize = false
     expect("string".make_green).to eq("string")
   end
 


### PR DESCRIPTION
previously, even if --color was provided, if the output was not a TTY it
would not use colors. now, if explicitly given, the value is always
respected.

the default value is changed to `nil` so that we can when it's not
specified (in which case we color only if output is a tty).