### PR TITLE
Allow passing --all flag to `bosh cleanup`

### DIFF
--- a/bosh_cli/spec/unit/commands/maintenance_spec.rb
+++ b/bosh_cli/spec/unit/commands/maintenance_spec.rb
@@ -18,30 +18,30 @@ describe Bosh::Cli::Command::Maintenance do
     describe 'stemcells' do
       before do
         stemcells = [
-          {
-            'name' => 'bosh-aws-xen-ubuntu',
-            'version' => '1471.2',
-            'cid' => 'fake-ami-1 light',
-            'deployments' =>[]
-          },
-          {
-            'name' => 'bosh-aws-xen-ubuntu',
-            'version' => '2555',
-            'cid' => 'fake-ami-2 light',
-            'deployments' =>['fake-deployment']
-          },
-          {
-            'name' => 'bosh-aws-xen-ubuntu',
-            'version' => '2579',
-            'cid' => 'fake-ami-3 light',
-            'deployments' =>[]
-          },
-          {
-            'name' => 'bosh-aws-xen-ubuntu',
-            'version' => '2578',
-            'cid' => 'fake-ami-4 light',
-            'deployments' =>[]
-          }
+            {
+                'name' => 'bosh-aws-xen-ubuntu',
+                'version' => '1471.2',
+                'cid' => 'fake-ami-1 light',
+                'deployments' => []
+            },
+            {
+                'name' => 'bosh-aws-xen-ubuntu',
+                'version' => '2555',
+                'cid' => 'fake-ami-2 light',
+                'deployments' => ['fake-deployment']
+            },
+            {
+                'name' => 'bosh-aws-xen-ubuntu',
+                'version' => '2579',
+                'cid' => 'fake-ami-3 light',
+                'deployments' => []
+            },
+            {
+                'name' => 'bosh-aws-xen-ubuntu',
+                'version' => '2578',
+                'cid' => 'fake-ami-4 light',
+                'deployments' => []
+            }
         ]
         allow(director).to receive(:list_stemcells).and_return(stemcells)
         allow(director).to receive(:list_releases).and_return([])
@@ -67,114 +67,114 @@ describe Bosh::Cli::Command::Maintenance do
     end
 
     describe 'releases' do
-       context 'old releases format' do
-    let(:release) do
-      {
-          'name' => 'release-1',
-          'versions' => ['15', '2', '1', '8.1-dev', '8.2-dev', '8.3-dev'],
-          'in_use' => ['8.3-dev']
-      }
-    end
+      context 'old releases format' do
+        let(:release) do
+          {
+              'name' => 'release-1',
+              'versions' => ['15', '2', '1', '8.1-dev', '8.2-dev', '8.3-dev'],
+              'in_use' => ['8.3-dev']
+          }
+        end
 
-    context 'when --all flag is passed' do
-      before { command.options[:all] = true }
+        context 'when --all flag is passed' do
+          before { command.options[:all] = true }
 
-      it 'should cleanup all unused releases' do
-        allow(director).to receive(:list_releases).and_return([release])
+          it 'should cleanup all unused releases' do
+            allow(director).to receive(:list_releases).and_return([release])
 
-        expect(director).to receive(:delete_release).
-                                with('release-1', force: false, version: '1', quiet: true).
-                                and_return([:done, 1])
-        expect(director).to receive(:delete_release).
-                                with('release-1', force: false, version: '2', quiet: true).
-                                and_return([:done, 2])
-        expect(director).to receive(:delete_release).
-                                with('release-1', force: false, version: '8.1-dev', quiet: true).
-                                and_return([:done, 2])
-        expect(director).to receive(:delete_release).
-                                with('release-1', force: false, version: '8.2-dev', quiet: true).
-                                and_return([:done, 2])
-        expect(director).to receive(:delete_release).
-                                with('release-1', force: false, version: '15', quiet: true).
-                                and_return([:done, 2])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '1', quiet: true).
+                                    and_return([:done, 1])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '2', quiet: true).
+                                    and_return([:done, 2])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '8.1-dev', quiet: true).
+                                    and_return([:done, 2])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '8.2-dev', quiet: true).
+                                    and_return([:done, 2])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '15', quiet: true).
+                                    and_return([:done, 2])
 
-        command.cleanup
+            command.cleanup
+          end
+        end
+
+        context 'when no flag is passed' do
+          it 'should cleanup unused releases, making sure to leave the two most recent' do
+            allow(director).to receive(:list_releases).and_return([release])
+
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '1', quiet: true).
+                                    and_return([:done, 1])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '2', quiet: true).
+                                    and_return([:done, 2])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '8.1-dev', quiet: true).
+                                    and_return([:done, 2])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '8.2-dev', quiet: true).
+                                    and_return([:done, 2])
+
+            command.cleanup
+          end
+        end
       end
-    end
 
-    context 'when no flag is passed' do
-      it 'should cleanup unused releases, making sure to leave the two most recent' do
-        allow(director).to receive(:list_releases).and_return([release])
+      context 'new releases format' do
+        let(:release) do
+          {
+              'name' => 'release-1',
+              'release_versions' => [
+                  {'version' => '15', 'commit_hash' => '1a2b3c4d', 'uncommitted_changes' => true, 'currently_deployed' => false},
+                  {'version' => '2', 'commit_hash' => '00000000', 'uncommitted_changes' => true, 'currently_deployed' => false},
+                  {'version' => '1', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => false},
+                  {'version' => '8.1-dev', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => false},
+                  {'version' => '8.2-dev', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => true},
+                  {'version' => '8.3-dev', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => false},
+              ]
+          }
+        end
 
-        expect(director).to receive(:delete_release).
-            with('release-1', force: false, version: '1', quiet: true).
-            and_return([:done, 1])
-        expect(director).to receive(:delete_release).
-            with('release-1', force: false, version: '2', quiet: true).
-            and_return([:done, 2])
-        expect(director).to receive(:delete_release).
-            with('release-1', force: false, version: '8.1-dev', quiet: true).
-            and_return([:done, 2])
-        expect(director).to receive(:delete_release).
-            with('release-1', force: false, version: '8.2-dev', quiet: true).
-            and_return([:done, 2])
+        context 'when --all flag is passed' do
+          it 'should cleanup all unused releases' do
+            allow(director).to receive(:list_releases).and_return([release])
 
-        command.cleanup
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '1', quiet: true).
+                                    and_return([:done, 1])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '2', quiet: true).
+                                    and_return([:done, 2])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '8.1-dev', quiet: true).
+                                    and_return([:done, 2])
+
+            command.cleanup
+          end
+        end
+
+        context 'when no flag is passed' do
+          it 'should cleanup unused releases, making sure to leave the two most recent' do
+            allow(director).to receive(:list_releases).and_return([release])
+
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '1', quiet: true).
+                                    and_return([:done, 1])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '2', quiet: true).
+                                    and_return([:done, 2])
+            expect(director).to receive(:delete_release).
+                                    with('release-1', force: false, version: '8.1-dev', quiet: true).
+                                    and_return([:done, 2])
+
+            command.cleanup
+          end
+        end
       end
-    end
-  end
-
-  context 'new releases format' do
-    let(:release) do
-      {
-          'name' => 'release-1',
-          'release_versions' => [
-              {'version' => '15', 'commit_hash' => '1a2b3c4d', 'uncommitted_changes' => true, 'currently_deployed' => false},
-              {'version' => '2', 'commit_hash' => '00000000', 'uncommitted_changes' => true, 'currently_deployed' => false},
-              {'version' => '1', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => false},
-              {'version' => '8.1-dev', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => false},
-              {'version' => '8.2-dev', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => true},
-              {'version' => '8.3-dev', 'commit_hash' => 'unknown', 'uncommitted_changes' => false, 'currently_deployed' => false},
-          ]
-      }
-    end
-
-    context 'when --all flag is passed' do
-      it 'should cleanup all unused releases' do
-        allow(director).to receive(:list_releases).and_return([release])
-
-        expect(director).to receive(:delete_release).
-                                with('release-1', force: false, version: '1', quiet: true).
-                                and_return([:done, 1])
-        expect(director).to receive(:delete_release).
-                                with('release-1', force: false, version: '2', quiet: true).
-                                and_return([:done, 2])
-        expect(director).to receive(:delete_release).
-                                with('release-1', force: false, version: '8.1-dev', quiet: true).
-                                and_return([:done, 2])
-
-        command.cleanup
-      end
-    end
-
-    context 'when no flag is passed' do
-      it 'should cleanup unused releases, making sure to leave the two most recent' do
-        allow(director).to receive(:list_releases).and_return([release])
-
-        expect(director).to receive(:delete_release).
-            with('release-1', force: false, version: '1', quiet: true).
-            and_return([:done, 1])
-        expect(director).to receive(:delete_release).
-            with('release-1', force: false, version: '2', quiet: true).
-            and_return([:done, 2])
-        expect(director).to receive(:delete_release).
-            with('release-1', force: false, version: '8.1-dev', quiet: true).
-            and_return([:done, 2])
-
-        command.cleanup
-      end
-    end
-  end
     end
   end
 end

--- a/bosh_cli/spec/unit/commands/maintenance_spec.rb
+++ b/bosh_cli/spec/unit/commands/maintenance_spec.rb
@@ -47,9 +47,22 @@ describe Bosh::Cli::Command::Maintenance do
         allow(director).to receive(:list_releases).and_return([])
       end
 
-      it 'removes stemcells excepts last 2 and the used one' do
-        expect(director).to receive(:delete_stemcell).with('bosh-aws-xen-ubuntu', '1471.2', quiet: true)
-        command.cleanup
+      context 'when --all flag is passes' do
+        before { command.options[:all] = true }
+
+        it 'removes all unused stemcells' do
+          expect(director).to receive(:delete_stemcell).with('bosh-aws-xen-ubuntu', '1471.2', quiet: true)
+          expect(director).to receive(:delete_stemcell).with('bosh-aws-xen-ubuntu', '2579', quiet: true)
+          expect(director).to receive(:delete_stemcell).with('bosh-aws-xen-ubuntu', '2578', quiet: true)
+          command.cleanup
+        end
+      end
+
+      context 'when no flags are passed' do
+        it 'removes stemcells excepts last 2 and the used one' do
+          expect(director).to receive(:delete_stemcell).with('bosh-aws-xen-ubuntu', '1471.2', quiet: true)
+          command.cleanup
+        end
       end
     end
 
@@ -59,24 +72,55 @@ describe Bosh::Cli::Command::Maintenance do
       {
           'name' => 'release-1',
           'versions' => ['15', '2', '1', '8.1-dev', '8.2-dev', '8.3-dev'],
-          'in_use' => ['8.2-dev']
+          'in_use' => ['8.3-dev']
       }
     end
 
-    it 'should cleanup releases' do
-      allow(director).to receive(:list_releases).and_return([release])
+    context 'when --all flag is passed' do
+      before { command.options[:all] = true }
 
-      expect(director).to receive(:delete_release).
-          with('release-1', force: false, version: '1', quiet: true).
-          and_return([:done, 1])
-      expect(director).to receive(:delete_release).
-          with('release-1', force: false, version: '2', quiet: true).
-          and_return([:done, 2])
-      expect(director).to receive(:delete_release).
-          with('release-1', force: false, version: '8.1-dev', quiet: true).
-          and_return([:done, 2])
+      it 'should cleanup all unused releases' do
+        allow(director).to receive(:list_releases).and_return([release])
 
-      command.cleanup
+        expect(director).to receive(:delete_release).
+                                with('release-1', force: false, version: '1', quiet: true).
+                                and_return([:done, 1])
+        expect(director).to receive(:delete_release).
+                                with('release-1', force: false, version: '2', quiet: true).
+                                and_return([:done, 2])
+        expect(director).to receive(:delete_release).
+                                with('release-1', force: false, version: '8.1-dev', quiet: true).
+                                and_return([:done, 2])
+        expect(director).to receive(:delete_release).
+                                with('release-1', force: false, version: '8.2-dev', quiet: true).
+                                and_return([:done, 2])
+        expect(director).to receive(:delete_release).
+                                with('release-1', force: false, version: '15', quiet: true).
+                                and_return([:done, 2])
+
+        command.cleanup
+      end
+    end
+
+    context 'when no flag is passed' do
+      it 'should cleanup unused releases, making sure to leave the two most recent' do
+        allow(director).to receive(:list_releases).and_return([release])
+
+        expect(director).to receive(:delete_release).
+            with('release-1', force: false, version: '1', quiet: true).
+            and_return([:done, 1])
+        expect(director).to receive(:delete_release).
+            with('release-1', force: false, version: '2', quiet: true).
+            and_return([:done, 2])
+        expect(director).to receive(:delete_release).
+            with('release-1', force: false, version: '8.1-dev', quiet: true).
+            and_return([:done, 2])
+        expect(director).to receive(:delete_release).
+            with('release-1', force: false, version: '8.2-dev', quiet: true).
+            and_return([:done, 2])
+
+        command.cleanup
+      end
     end
   end
 
@@ -95,20 +139,40 @@ describe Bosh::Cli::Command::Maintenance do
       }
     end
 
-    it 'should cleanup releases' do
-      allow(director).to receive(:list_releases).and_return([release])
+    context 'when --all flag is passed' do
+      it 'should cleanup all unused releases' do
+        allow(director).to receive(:list_releases).and_return([release])
 
-      expect(director).to receive(:delete_release).
-          with('release-1', force: false, version: '1', quiet: true).
-          and_return([:done, 1])
-      expect(director).to receive(:delete_release).
-          with('release-1', force: false, version: '2', quiet: true).
-          and_return([:done, 2])
-      expect(director).to receive(:delete_release).
-          with('release-1', force: false, version: '8.1-dev', quiet: true).
-          and_return([:done, 2])
+        expect(director).to receive(:delete_release).
+                                with('release-1', force: false, version: '1', quiet: true).
+                                and_return([:done, 1])
+        expect(director).to receive(:delete_release).
+                                with('release-1', force: false, version: '2', quiet: true).
+                                and_return([:done, 2])
+        expect(director).to receive(:delete_release).
+                                with('release-1', force: false, version: '8.1-dev', quiet: true).
+                                and_return([:done, 2])
 
-      command.cleanup
+        command.cleanup
+      end
+    end
+
+    context 'when no flag is passed' do
+      it 'should cleanup unused releases, making sure to leave the two most recent' do
+        allow(director).to receive(:list_releases).and_return([release])
+
+        expect(director).to receive(:delete_release).
+            with('release-1', force: false, version: '1', quiet: true).
+            and_return([:done, 1])
+        expect(director).to receive(:delete_release).
+            with('release-1', force: false, version: '2', quiet: true).
+            and_return([:done, 2])
+        expect(director).to receive(:delete_release).
+            with('release-1', force: false, version: '8.1-dev', quiet: true).
+            and_return([:done, 2])
+
+        command.cleanup
+      end
     end
   end
     end


### PR DESCRIPTION
 * Including `--all` deletes all unused releases and stemcells from BOSH, rather than leaving two most recent
 * Helpful for fully cleaning up soon to be killed BOSH