### PR TITLE
Ensure that the call to Net::SSH.start only uses the key provided in the manifest, by feeding it the keys_only: true parameter.

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/deployer/ssh_server.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/ssh_server.rb
@@ -34,7 +34,7 @@ module Bosh::Deployer
 
     def start_session(ip)
       logger.info("Starting SSH session for port forwarding to #{user}@#{ip}...")
-      session = Net::SSH.start(ip, user, keys: [key], paranoid: false, port: port)
+      session = Net::SSH.start(ip, user, keys: [key], paranoid: false, port: port, keys_only: true)
       logger.debug("ssh #{user}@#{ip}: ESTABLISHED")
       session
     rescue *SSH_EXCEPTIONS => e

--- a/bosh_cli_plugin_micro/spec/unit/bosh/deployer/ssh_server_spec.rb
+++ b/bosh_cli_plugin_micro/spec/unit/bosh/deployer/ssh_server_spec.rb
@@ -78,6 +78,7 @@ module Bosh::Deployer
                               keys: ['fake-key'],
                               paranoid: false,
                               port: 'fake-port',
+                              keys_only: true
                             )
       end
 


### PR DESCRIPTION
I ran into a little-known issue when trying to deploy a MicroBOSH.  After deploying to my OpenStack, the bosh micro plugin was trying to ssh into my new instance, but was unsuccessful.  The stemcell used was bosh-stemcell-2889-openstack-kvm-ubuntu-trusty-go_agent, deploying to Openstack Havana.

The problem turned out to be that I have more than 5 keys in my ~/.ssh directory.  The instance in question only allowed 5 attempts before refusing the ssh connection.  The way Ruby's Net::SSH.start works, is it tries the keys in your ~/.ssh directory AND the keys you provide as a parameter to it.  So, what was happening is 5 of my own keys were used first in trying to connect.  When they failed, the key in the manifest was never actually tried.  Next attempt would start... and the cycle would continue.

To limit Net::SSH.start to just using the key provided as a parameter (i.e.:  the key provided in the MicroBOSH manifest) is to add the following parameter:

keys_only: true

This solved my issue.