### PR TITLE
UAA asymmetric key encryption support for oAuth tokens

### DIFF
--- a/bosh-director/lib/bosh/director.rb
+++ b/bosh-director/lib/bosh/director.rb
@@ -130,6 +130,8 @@ require 'bosh/director/models/helpers/model_helper'
 require 'bosh/director/db_backup'
 require 'bosh/director/blobstores'
 require 'bosh/director/api/local_identity_provider'
+require 'bosh/director/api/uaa_verification_key'
+require 'bosh/director/api/uaa_token_decoder'
 require 'bosh/director/api/uaa_identity_provider'
 require 'bosh/director/app'
 

--- a/bosh-director/lib/bosh/director/api/uaa_token_decoder.rb
+++ b/bosh-director/lib/bosh/director/api/uaa_token_decoder.rb
@@ -1,0 +1,83 @@
+require 'uaa/info'
+
+module Bosh
+  module Director
+    module Api
+      class UAATokenDecoder
+        class BadToken < StandardError
+        end
+
+        attr_reader :config
+
+        def initialize(config, grace_period_in_seconds=0)
+          @config = config
+          @logger = Config.logger
+
+          raise ArgumentError.new('grace period should be an integer') unless grace_period_in_seconds.is_a? Integer
+
+          @grace_period_in_seconds = grace_period_in_seconds
+          if grace_period_in_seconds < 0
+            @grace_period_in_seconds = 0
+            @logger.warn("negative grace period interval '#{grace_period_in_seconds}' is invalid, changed to 0")
+          end
+        end
+
+        def decode_token(auth_token)
+          return unless token_format_valid?(auth_token)
+
+          if symmetric_key
+            decode_token_with_symmetric_key(auth_token)
+          else
+            decode_token_with_asymmetric_key(auth_token)
+          end
+        rescue CF::UAA::TokenExpired => e
+          @logger.warn('Token expired')
+          raise BadToken.new(e.message)
+        rescue CF::UAA::DecodeError, CF::UAA::AuthError => e
+          @logger.warn("Invalid bearer token: #{e.inspect} #{e.backtrace}")
+          raise BadToken.new(e.message)
+        end
+
+        private
+
+        def token_format_valid?(auth_token)
+          auth_token && auth_token.upcase.start_with?('BEARER')
+        end
+
+        def decode_token_with_symmetric_key(auth_token)
+          decode_token_with_key(auth_token, skey: symmetric_key)
+        end
+
+        def decode_token_with_asymmetric_key(auth_token)
+          tries = 2
+          begin
+            tries -= 1
+            decode_token_with_key(auth_token, pkey: asymmetric_key.value)
+          rescue CF::UAA::InvalidSignature
+            asymmetric_key.refresh
+            tries > 0 ? retry : raise
+          end
+        end
+
+        def decode_token_with_key(auth_token, options)
+          options = { audience_ids: config[:resource_id] }.merge(options)
+          token = CF::UAA::TokenCoder.new(options).decode_at_reference_time(auth_token, Time.now.utc.to_i - @grace_period_in_seconds)
+          expiration_time = token['exp'] || token[:exp]
+          if expiration_time && expiration_time < Time.now.utc.to_i
+            @logger.warn("token currently expired but accepted within grace period of #{@grace_period_in_seconds} seconds")
+          end
+          token
+        end
+
+        def symmetric_key
+          config[:symmetric_secret]
+        end
+
+        def asymmetric_key
+          info = CF::UAA::Info.new(config[:url])
+          @asymmetric_key ||= UAAVerificationKey.new(config[:verification_key], info)
+        end
+      end
+    end
+  end
+end

--- a/bosh-director/lib/bosh/director/api/uaa_token_decoder.rb
+++ b/bosh-director/lib/bosh/director/api/uaa_token_decoder.rb
@@ -1,4 +1,4 @@
-require 'uaa/info'
+require 'uaa'
 
 module Bosh
   module Director
@@ -23,7 +23,10 @@ module Bosh
         end
 
         def decode_token(auth_token)
-          return unless token_format_valid?(auth_token)
+          unless token_format_valid?(auth_token)
+            @logger.warn("Invalid authentication token: #{auth_token}")
+            raise BadToken.new("No bearer token provided")
+          end
 
           if symmetric_key
             decode_token_with_symmetric_key(auth_token)

--- a/bosh-director/lib/bosh/director/api/uaa_verification_key.rb
+++ b/bosh-director/lib/bosh/director/api/uaa_verification_key.rb
@@ -1,0 +1,26 @@
+module Bosh
+  module Director
+    module Api
+      class UAAVerificationKey
+        def initialize(verification_key, info)
+          @verification_key = verification_key
+          @info = info
+        end
+
+        def value
+          @value ||= fetch
+        end
+
+        def refresh
+          @value = nil
+        end
+
+        private
+
+        def fetch
+          @verification_key || @info.validation_key['value']
+        end
+      end
+    end
+  end
+end

--- a/bosh-director/spec/unit/api/uaa_identity_provider_spec.rb
+++ b/bosh-director/spec/unit/api/uaa_identity_provider_spec.rb
@@ -25,7 +25,7 @@ module Bosh::Director
       let(:auth_header) { 'bearer encodedtoken' }
       let(:request_env) { {'HTTP_AUTHORIZATION' => auth_header } }
       let(:audiences) { ['bosh_cli'] }
-      let(:token_info) { double(:token_info, ) }
+      let(:token_info) { double(:token_info) }
 
       before do
         expect(Bosh::Director::Api::UAATokenDecoder).to receive(:new).with(

--- a/bosh-director/spec/unit/api/uaa_identity_provider_spec.rb
+++ b/bosh-director/spec/unit/api/uaa_identity_provider_spec.rb
@@ -4,8 +4,9 @@ require 'rack/test'
 module Bosh::Director
   describe Api::UAAIdentityProvider do
     subject(:identity_provider) { Api::UAAIdentityProvider.new(provider_options) }
-    let(:provider_options) { {'url' => 'http://localhost:8080/uaa', 'key' => key} }
-    let(:key) { 'tokenkey' }
+    let(:uaa_url) { 'http://localhost:8080/uaa' }
+    let(:provider_options) { {'url' => uaa_url, 'key' => key} }
+    let(:key) { 'symmetric tokenkey' }
     let(:app) { Support::TestController.new(double(:config, identity_provider: identity_provider)) }
 
     describe 'client info' do
@@ -13,78 +14,59 @@ module Bosh::Director
         expect(identity_provider.client_info).to eq(
             'type' => 'uaa',
             'options' => {
-              'url' => 'http://localhost:8080/uaa'
+              'url' => uaa_url
             }
           )
       end
     end
 
     context 'given an OAuth token' do
-      let(:request_env) { {'HTTP_AUTHORIZATION' => "bearer #{encoded_token}"} }
-      let(:encoded_token) { CF::UAA::TokenCoder.encode(token, skey: encoding_key) }
-      let(:encoding_key) { key }
-      let(:token) do
-        {
-          'jti' => 'd64209e4-d150-45c9-9569-a352f42149b1',
-          'sub' => 'faf835ea-c582-4a28-b500-6e6ac1515690',
-          'scope' => ['scim.userids', 'password.write', 'openid', 'cloud_controller.write', 'cloud_controller.read'],
-          'client_id' => 'cf',
-          'cid' => 'cf',
-          'azp' => 'cf',
-          'user_id' => 'faf835ea-c582-4a28-b500-6e6ac1515690',
-          'user_name' => 'marissa',
-          'email' => 'marissa@test.org',
-          'iat' => Time.now.to_i,
-          'exp' => token_expiry_time,
-          'iss' => 'http://localhost:8080/uaa/oauth/token',
-          'aud' => audiences
-        }
-      end
-      let(:token_expiry_time) { (Time.now + 1000).to_i }
+      let(:token_decoder) { instance_double('Bosh::Director::Api::UAATokenDecoder') }
+      let(:auth_header) { 'bearer encodedtoken' }
+      let(:request_env) { {'HTTP_AUTHORIZATION' => auth_header } }
       let(:audiences) { ['bosh_cli'] }
+      let(:token_info) { double(:token_info, ) }
 
-      it 'returns the username of the authenticated user' do
-        expect(identity_provider.corroborate_user(request_env)).to eq('marissa')
+      before do
+        expect(Bosh::Director::Api::UAATokenDecoder).to receive(:new).with(
+          url: uaa_url, resource_id: audiences, symmetric_secret: key)
+          .and_return(token_decoder)
       end
 
-      context 'when the token is encoded with an incorrect key' do
-        let(:encoding_key) { "another-key" }
+      context 'when using a valid token' do
+        before do
+          expect(token_decoder).to receive(:decode_token).with(auth_header)
+            .and_return({ 'user_name' => 'marissa' })
+        end
 
-        it 'raises' do
-          expect { identity_provider.corroborate_user(request_env) }.to raise_error(AuthenticationError)
+        it 'returns the username of the authenticated user' do
+          expect(identity_provider.corroborate_user(request_env)).to eq('marissa')
+        end
+
+        context 'without symmetric key' do
+          let(:key) { nil }
+
+          before do
+            provider_options.delete('key')
+          end
+
+          it 'returns the username of the authenticated user' do
+            expect(identity_provider.corroborate_user(request_env)).to eq('marissa')
+          end
         end
       end
 
-      context 'when the token has expired' do
-        let(:token_expiry_time) { (Time.now - 1000).to_i }
+
+      context 'when using a bad token' do
+        before do
+          expect(token_decoder).to receive(:decode_token)
+            .and_raise(Bosh::Director::Api::UAATokenDecoder::BadToken)
+        end
 
         it 'raises' do
-          expect { identity_provider.corroborate_user(request_env) }.to raise_error(AuthenticationError)
+          expect { identity_provider.corroborate_user(request_env) }
+            .to raise_error(AuthenticationError)
         end
-      end
-
-      context "when bosh isn't in the token's audience list" do
-        let(:audiences) { ['nonbosh'] }
-
-        it 'raises' do
-          expect { identity_provider.corroborate_user(request_env) }.to raise_error(AuthenticationError)
-        end
-      end
-    end
-
-    context 'given valid HTTP basic authentication credentials' do
-      let(:request_env) { {'HTTP_AUTHORIZATION' => 'Basic YWRtaW46YWRtaW4='} }
-
-      it 'raises' do
-        expect { identity_provider.corroborate_user(request_env) }.to raise_error(AuthenticationError)
-      end
-    end
-
-    context 'given missing HTTP authentication credentials' do
-      let(:request_env) { { } }
-
-      it 'raises' do
-        expect { identity_provider.corroborate_user(request_env) }.to raise_error(AuthenticationError)
       end
     end
 

--- a/bosh-director/spec/unit/api/uaa_token_decoder_spec.rb
+++ b/bosh-director/spec/unit/api/uaa_token_decoder_spec.rb
@@ -200,5 +200,25 @@ module Bosh::Director
         end
       end
     end
+
+    context 'given valid HTTP basic authentication credentials' do
+      subject { described_class.new(config_hash, 100) }
+
+      it 'raises' do
+        expect {
+          subject.decode_token('Basic YWRtaW46YWRtaW4=')
+        }.to raise_error(Bosh::Director::Api::UAATokenDecoder::BadToken)
+      end
+    end
+
+    context 'given empty token' do
+      subject { described_class.new(config_hash, 100) }
+
+      it 'raises' do
+        expect {
+          subject.decode_token('')
+        }.to raise_error(Bosh::Director::Api::UAATokenDecoder::BadToken)
+      end
+    end
   end
 end

--- a/bosh-director/spec/unit/api/uaa_token_decoder_spec.rb
+++ b/bosh-director/spec/unit/api/uaa_token_decoder_spec.rb
@@ -1,0 +1,204 @@
+require 'spec_helper'
+require 'timecop'
+require 'uaa'
+
+module Bosh::Director
+  describe Api::UAATokenDecoder do
+    subject { described_class.new(config_hash) }
+
+    let(:config_hash) do
+      {
+        resource_id: 'resource-id',
+        symmetric_secret: nil
+      }
+    end
+
+    let(:uaa_info) { double(CF::UAA::Info) }
+
+    before do
+      allow(CF::UAA::Info).to receive(:new).and_return(uaa_info)
+    end
+
+    describe '.new' do
+      context 'when the decoder is created with a grace period' do
+        context 'and that grace period is negative' do
+          subject { described_class.new(config_hash, -10) }
+
+          it 'logs a warning that the grace period was changed to 0' do
+            expect(logger).to receive(:warn).with(/negative grace period interval.*-10.*is invalid, changed to 0/i)
+            subject
+          end
+        end
+
+        context 'and that grace period is not an integer' do
+          subject { described_class.new(config_hash, 'blabla') }
+
+          it 'raises an ArgumentError' do
+            expect {
+              subject
+            }.to raise_error(ArgumentError, /grace period should be an integer/i)
+          end
+        end
+      end
+    end
+
+    describe '#decode_token' do
+      before { Timecop.freeze(Time.now.utc) }
+      after { Timecop.return }
+
+      context 'when symmetric key is used' do
+        let(:token_content) do
+          { 'aud' => 'resource-id', 'payload' => 123, 'exp' => Time.now.utc.to_i + 10_000 }
+        end
+
+        before { config_hash[:symmetric_secret] = 'symmetric-key' }
+
+        context 'when token is valid' do
+          it 'uses UAA::TokenCoder to decode the token with skey' do
+            token = CF::UAA::TokenCoder.encode(token_content, { skey: 'symmetric-key' })
+
+            expect(subject.decode_token("bearer #{token}")).to eq(token_content)
+          end
+        end
+
+        context 'when token is invalid' do
+          it 'raises BadToken exception' do
+            expect(logger).to receive(:warn).with(/invalid bearer token/i)
+
+            expect {
+              subject.decode_token('bearer token')
+            }.to raise_error(Bosh::Director::Api::UAATokenDecoder::BadToken)
+          end
+        end
+      end
+
+      context 'when asymmetric key is used' do
+        before { config_hash[:symmetric_secret] = nil }
+
+        let(:rsa_key) { OpenSSL::PKey::RSA.new(2048) }
+        before { allow(uaa_info).to receive_messages(validation_key: { 'value' => rsa_key.public_key.to_pem }) }
+
+        context 'when token is valid' do
+          let(:token_content) do
+            { 'aud' => 'resource-id', 'payload' => 123, 'exp' => Time.now.utc.to_i + 10_000 }
+          end
+
+          it 'successfully decodes token and caches key' do
+            token = generate_token(rsa_key, token_content)
+
+            expect(uaa_info).to receive(:validation_key)
+            expect(subject.decode_token("bearer #{token}")).to eq(token_content)
+
+            expect(uaa_info).not_to receive(:validation_key)
+            expect(subject.decode_token("bearer #{token}")).to eq(token_content)
+          end
+
+          describe 're-fetching key' do
+            let(:old_rsa_key) { OpenSSL::PKey::RSA.new(2048) }
+
+            it 'retries to decode token with newly fetched asymmetric key' do
+              allow(uaa_info).to receive(:validation_key).and_return(
+                  { 'value' => old_rsa_key.public_key.to_pem },
+                  { 'value' => rsa_key.public_key.to_pem },
+              )
+              expect(subject.decode_token("bearer #{generate_token(rsa_key, token_content)}")).to eq(token_content)
+            end
+
+            it 'stops retrying to decode token with newly fetched asymmetric key after 1 try' do
+              allow(uaa_info).to receive(:validation_key).and_return('value' => old_rsa_key.public_key.to_pem)
+
+              expect(logger).to receive(:warn).with(/invalid bearer token/i)
+              expect {
+                subject.decode_token("bearer #{generate_token(rsa_key, token_content)}")
+              }.to raise_error(Bosh::Director::Api::UAATokenDecoder::BadToken)
+            end
+          end
+        end
+
+        context 'when token has invalid audience' do
+          let(:token_content) do
+            { 'aud' => 'invalid-audience', 'payload' => 123, 'exp' => Time.now.utc.to_i + 10_000 }
+          end
+
+          it 'raises an BadToken error' do
+            expect(logger).to receive(:warn).with(/invalid bearer token/i)
+            expect {
+              subject.decode_token("bearer #{generate_token(rsa_key, token_content)}")
+            }.to raise_error(Bosh::Director::Api::UAATokenDecoder::BadToken)
+          end
+        end
+
+        context 'when token has expired' do
+          let(:token_content) do
+            { 'aud' => 'resource-id', 'payload' => 123, 'exp' => Time.now.utc.to_i }
+          end
+
+          it 'raises a BadToken error' do
+            expect(logger).to receive(:warn).with(/token expired/i)
+            expect {
+              subject.decode_token("bearer #{generate_token(rsa_key, token_content)}")
+            }.to raise_error(Bosh::Director::Api::UAATokenDecoder::BadToken)
+          end
+        end
+
+        context 'when token is invalid' do
+          it 'raises BadToken error' do
+            expect(logger).to receive(:warn).with(/invalid bearer token/i)
+            expect {
+              subject.decode_token('bearer invalid-token')
+            }.to raise_error(Bosh::Director::Api::UAATokenDecoder::BadToken)
+          end
+        end
+
+        context 'when the decoder has an grace period specified' do
+          subject { described_class.new(config_hash, 100) }
+
+          let(:token_content) do
+            { 'aud' => 'resource-id', 'payload' => 123, 'exp' => Time.now.utc.to_i }
+          end
+
+          let(:token) { generate_token(rsa_key, token_content) }
+
+          context 'and the token is currently expired but had not expired within the grace period' do
+            it 'decodes the token and logs a warning about expiration within the grace period' do
+              token_content['exp'] = Time.now.utc.to_i - 50
+              expect(logger).to receive(:warn).with(/token currently expired but accepted within grace period of 100 seconds/i)
+              expect(subject.decode_token("bearer #{token}")).to eq token_content
+            end
+          end
+
+          context 'and the token expired outside of the grace period' do
+            it 'raises and logs a warning about the expired token' do
+              token_content['exp'] = Time.now.utc.to_i - 150
+              expect(logger).to receive(:warn).with(/token expired/i)
+              expect {
+                subject.decode_token("bearer #{token}")
+              }.to raise_error(Bosh::Director::Api::UAATokenDecoder::BadToken)
+            end
+          end
+
+          context 'and that grace period interval is negative' do
+            subject { described_class.new(config_hash, -10) }
+
+            it 'sets the grace period to be 0 instead' do
+              token_content['exp'] = Time.now.utc.to_i
+              expired_token = generate_token(rsa_key, token_content)
+              allow(logger).to receive(:warn)
+              expect {
+                subject.decode_token("bearer #{expired_token}")
+              }.to raise_error(Bosh::Director::Api::UAATokenDecoder::BadToken)
+
+              token_content['exp'] = Time.now.utc.to_i + 1
+              valid_token = generate_token(rsa_key, token_content)
+              expect(subject.decode_token("bearer #{valid_token}")).to eq token_content
+            end
+          end
+        end
+
+        def generate_token(rsa_key, content)
+          CF::UAA::TokenCoder.encode(content, pkey: rsa_key, algorithm: 'RS256')
+        end
+      end
+    end
+  end
+end

--- a/bosh-director/spec/unit/api/uaa_verification_key_spec.rb
+++ b/bosh-director/spec/unit/api/uaa_verification_key_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+module Bosh::Director
+  describe Api::UAAVerificationKey do
+    subject { described_class.new(config_hash[:verification_key], uaa_info) }
+
+    let(:config_hash) do
+      { url: 'http://uaa-url' }
+    end
+
+    let(:uaa_info) { double(CF::UAA::Info) }
+
+    describe '#value' do
+      context 'when config does not specify verification key' do
+        before { config_hash[:verification_key] = nil }
+        before { allow(uaa_info).to receive_messages(validation_key: { 'value' => 'value-from-uaa' }) }
+
+        context 'when key was never fetched' do
+          it 'is fetched' do
+            expect(uaa_info).to receive(:validation_key)
+            expect(subject.value).to eq 'value-from-uaa'
+          end
+        end
+
+        context 'when key was fetched before' do
+          before do
+            expect(uaa_info).to receive(:validation_key) # sanity
+            subject.value
+          end
+
+          it 'is not fetched again' do
+            expect(uaa_info).not_to receive(:validation_key)
+            expect(subject.value).to eq('value-from-uaa')
+          end
+        end
+      end
+
+      context 'when config specified verification key' do
+        before { config_hash[:verification_key] = 'value-from-config' }
+
+        it 'returns key specified in config' do
+          expect(subject.value).to eq('value-from-config')
+        end
+
+        it 'is not fetched' do
+          expect(uaa_info).not_to receive(:validation_key)
+          subject.value
+        end
+      end
+    end
+
+    describe '#refresh' do
+      context 'when config does not specify verification key' do
+        before { config_hash[:verification_key] = nil }
+        before { allow(uaa_info).to receive_messages(validation_key: { 'value' => 'value-from-uaa' }) }
+
+        context 'when key was never fetched' do
+          it 'is fetched' do
+            expect(uaa_info).to receive(:validation_key)
+            subject.refresh
+            expect(subject.value).to eq('value-from-uaa')
+          end
+        end
+
+        context 'when key was fetched before' do
+          before do
+            expect(uaa_info).to receive(:validation_key) # sanity
+            subject.value
+          end
+
+          it 'is RE-fetched again' do
+            expect(uaa_info).to receive(:validation_key)
+            subject.refresh
+            expect(subject.value).to eq('value-from-uaa')
+          end
+        end
+      end
+
+      context 'when config specified verification key' do
+        before { config_hash[:verification_key] = 'value-from-config' }
+
+        it 'returns key specified in config' do
+          subject.refresh
+          expect(subject.value).to eq('value-from-config')
+        end
+
+        it 'is not fetched' do
+          expect(uaa_info).not_to receive(:validation_key)
+          subject.refresh
+          expect(subject.value).to eq('value-from-config')
+        end
+      end
+    end
+  end
+end

--- a/bosh-director/spec/unit/config_spec.rb
+++ b/bosh-director/spec/unit/config_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'uaa'
 
 #
 # This supplants the config_old_spec.rb behavior. We are


### PR DESCRIPTION
This PR adds support for [asymmetric token signing](https://github.com/cloudfoundry/uaa/blob/master/docs/Sysadmin-Guide.rst#token-signing). Most of the implementation has been borrowed from the cloud_controller_ng: [UaaTokenDecoder](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/lib/vcap/uaa_token_decoder.rb) and [UaaVerificationKey](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/lib/vcap/uaa_verification_key.rb).