### PR TITLE
[stemcell-builder] Fix calling `apt-get distr-upgrade` command in base_apt stage

### DIFF
--- a/stemcell_builder/stages/base_apt/apply.sh
+++ b/stemcell_builder/stages/base_apt/apply.sh
@@ -16,4 +16,8 @@ EOS
 
 # Upgrade upstart first, to prevent it from messing up our stubs and starting daemons anyway
 pkg_mgr install upstart
+run_in_chroot $chroot "apt-get download libudev1"
+run_in_chroot $chroot "apt-get download udev"
+run_in_chroot $chroot "dpkg -i --force-confmiss libudev1*.deb"
+run_in_chroot $chroot "dpkg -i --force-confmiss udev_*.deb"
 pkg_mgr dist-upgrade


### PR DESCRIPTION
Hey, all.

I tried to build base os image using following command `bundle exec rake stemcell:build_os_image[ubuntu,trusty,base_os_image_path]` and got this error stack trace: https://gist.github.com/allomov/7f51891b0e502638f7cf. I used base os image from this URL: http://s3.amazonaws.com/bosh-os-images/bosh-ubuntu-trusty-os-image.tgz.

Using advices from [this ticket](https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1377624) I was able to fix this problem and run `stemcell:build_os_image` without errors.

This PR shows what I needed to do for the fix.