### PR TITLE
Add templates to bosh release

### DIFF
--- a/release/templates/bosh-deployment.yml
+++ b/release/templates/bosh-deployment.yml
@@ -1,0 +1,31 @@
+---
+name: (( meta.environment "-bosh" ))
+director_uuid: (( merge ))
+
+releases: (( merge ))
+
+compilation:
+  workers: (( merge ))
+  cloud_properties: (( merge ))
+  network: default
+  reuse_compilation_vms: true
+
+update:
+  canaries: 1
+  canary_watch_time: 3000-120000
+  update_watch_time: 3000-120000
+  max_in_flight: 4
+  max_errors: 1
+
+networks: (( merge ))
+
+resource_pools:
+  - name: common
+    network: default
+    size: (( auto ))
+    stemcell: (( merge ))
+    cloud_properties: (( merge ))
+
+jobs: (( merge ))
+
+properties: (( merge ))

--- a/release/templates/bosh-floating-ip-director.yml
+++ b/release/templates/bosh-floating-ip-director.yml
@@ -1,0 +1,22 @@
+meta:
+  director:
+    floating_ip: (( merge ))
+
+networks: 
+  - <<: (( merge ))
+  - name: floating
+    type: vip
+    cloud_properties: {}
+
+resource_pools: (( merge ))
+
+jobs:
+  - <<: (( merge ))
+  - name: director
+    <<: (( merge ))
+    networks:
+      - <<: (( merge ))
+      - name: floating
+        static_ips: (( meta.director.floating_ip ))
+
+properties: (( merge ))

--- a/release/templates/bosh-infrastructure-openstack.yml
+++ b/release/templates/bosh-infrastructure-openstack.yml
@@ -1,0 +1,34 @@
+meta:
+  releases:
+    - name: bosh
+      version: latest
+
+  compilation:
+    workers: (( merge || 2 ))
+    cloud_properties:
+      instance_type: (( merge || "m1.medium" ))
+
+  resource_pools:
+    cloud_properties:
+      instance_type: (( merge || "m1.medium" ))
+    stemcell: (( merge || meta.stemcell ))
+
+  stemcell: (( merge ))
+
+  openstack: (( merge ))
+
+
+releases: (( merge || meta.releases ))
+
+compilation:
+  workers: (( meta.compilation.workers ))
+  cloud_properties: (( meta.compilation.cloud_properties ))
+
+resource_pools:
+  - name: common
+    cloud_properties: (( meta.resource_pools.cloud_properties ))
+    stemcell: (( meta.resource_pools.stemcell ))
+
+properties:
+  <<: (( merge ))
+  openstack: (( meta.openstack ))

--- a/release/templates/bosh-jobs.yml
+++ b/release/templates/bosh-jobs.yml
@@ -1,0 +1,122 @@
+networks: (( merge ))
+
+resource_pools: (( merge ))
+
+jobs:
+  - name: nats
+    templates:
+      - name: nats
+        release: bosh
+    instances: 1
+    resource_pool: common
+    networks:
+      - name: default
+        default: [dns, gateway]
+        static_ips: (( static_ips(0) ))
+
+  - name: redis
+    templates:
+      - name: redis
+        release: bosh
+    instances: 1
+    resource_pool: common
+    networks:
+      - name: default
+        default: [dns, gateway]
+        static_ips: (( static_ips(1) ))
+
+  - name: postgres
+    templates:
+      - name: postgres
+        release: bosh
+    instances: 1
+    resource_pool: common
+    persistent_disk: 16384
+    networks:
+      - name: default
+        default: [dns, gateway]
+        static_ips: (( static_ips(2) ))
+
+  - name: blobstore
+    templates:
+      - name: blobstore
+        release: bosh
+    instances: 1
+    resource_pool: common
+    persistent_disk: 51200
+    networks:
+      - name: default
+        default: [dns, gateway]
+        static_ips: (( static_ips(3) ))
+
+  - name: registry
+    templates:
+      - name: registry
+        release: bosh
+    instances: 1
+    resource_pool: common
+    networks:
+      - name: default
+        default: [dns, gateway]
+        static_ips: (( static_ips(4) ))
+
+  - name: director
+    templates:
+      - name: director
+        release: bosh
+    instances: 1
+    resource_pool: common
+    persistent_disk: 16384
+    networks:
+      - name: default
+        default: [dns, gateway]
+        static_ips: (( static_ips(5) ))
+
+  - name: health_monitor
+    templates:
+      - name: health_monitor
+        release: bosh
+    instances: 1
+    resource_pool: common
+    networks:
+      - name: default
+        default: [dns, gateway]
+        static_ips: (( static_ips(6) ))
+
+properties:
+  <<: (( merge ))
+  nats:
+    address: (( jobs.nats.networks.default.static_ips.[0] ))
+    user: (( merge ))
+    password: (( merge ))
+
+  redis:
+    address: (( jobs.redis.networks.default.static_ips.[0] ))
+    password: (( merge ))
+
+  postgres: &bosh_db
+    host: (( jobs.postgres.networks.default.static_ips.[0] ))
+    user: (( merge ))
+    password: (( merge ))
+    database: (( merge ))
+
+  blobstore:
+    address: (( jobs.blobstore.networks.default.static_ips.[0] ))
+    agent:
+      user: (( merge ))
+      password: (( merge ))
+    director:
+      user: (( merge ))
+      password: (( merge ))
+
+  registry:
+    address: (( jobs.registry.networks.default.static_ips.[0] ))
+    db: *bosh_db
+    http:
+      user: (( merge ))
+      password: (( merge ))
+
+  director:
+    name: bosh
+    address: (( jobs.director.networks.default.static_ips.[0] ))
+    db: *bosh_db

--- a/release/templates/bosh-logsearch-shipper-colocation.yml
+++ b/release/templates/bosh-logsearch-shipper-colocation.yml
@@ -1,0 +1,51 @@
+jobs: 
+  - <<: (( merge ))
+
+  - name: nats
+    <<: (( merge ))
+    templates:
+      - <<: (( merge )) 
+      - name: "logsearch-shipper"
+        release: "logsearch-shipper"
+
+  - name: redis
+    <<: (( merge ))
+    templates:
+      - <<: (( merge )) 
+      - name: "logsearch-shipper"
+        release: "logsearch-shipper"
+
+  - name: postgres
+    <<: (( merge ))
+    templates:
+      - <<: (( merge )) 
+      - name: "logsearch-shipper"
+        release: "logsearch-shipper"
+
+  - name: blobstore
+    <<: (( merge ))
+    templates:
+      - <<: (( merge )) 
+      - name: "logsearch-shipper"
+        release: "logsearch-shipper"
+
+  - name: registry
+    <<: (( merge ))
+    templates:
+      - <<: (( merge )) 
+      - name: "logsearch-shipper"
+        release: "logsearch-shipper"
+
+  - name: director
+    <<: (( merge ))
+    templates:
+      - <<: (( merge )) 
+      - name: "logsearch-shipper"
+        release: "logsearch-shipper"
+
+  - name: health_monitor
+    <<: (( merge ))
+    templates:
+      - <<: (( merge )) 
+      - name: "logsearch-shipper"
+        release: "logsearch-shipper"

--- a/release/templates/bosh-networking.yml
+++ b/release/templates/bosh-networking.yml
@@ -1,0 +1,26 @@
+meta:
+  networks:
+    default:
+      range: (( merge ))
+      gateway: (( merge ))
+      dns: (( merge || nil ))
+      reserved: (( merge ))
+      static: (( merge ))
+      cloud_properties:
+        net_id: (( merge ))
+        subnet: (( merge ))
+        security_groups: (( merge || [] ))
+
+networks:
+  - name: default
+    type: manual
+    subnets:
+    - name: private
+      range: (( meta.networks.default.range ))
+      gateway: (( meta.networks.default.gateway ))
+      reserved: (( meta.networks.default.reserved ))
+      static: (( meta.networks.default.static ))
+      cloud_properties:
+        net_id: (( meta.networks.default.cloud_properties.net_id ))
+        subnet: (( meta.networks.default.cloud_properties.subnet ))
+        security_groups: (( meta.networks.default.cloud_properties.security_groups ))

--- a/release/templates/bosh-properties.yml
+++ b/release/templates/bosh-properties.yml
@@ -1,0 +1,101 @@
+meta:
+  nats:
+    user: (( merge || "nats" ))
+    password: (( merge || "nats" ))
+
+  logsearch:
+    logs:
+      server: (( merge || "127.0.0.1:5514" ))
+
+  redis:
+    password: (( merge || "redis" ))
+
+  postgres:
+    user: (( merge || "postgres" ))
+    password: (( merge || "postgres" ))
+    database: (( merge || "bosh" ))
+
+  blobstore:
+    agent:
+      user: (( merge || "agent" ))
+      password: (( merge || "agent" ))
+    director:
+      user: (( merge || "director" ))
+      password: (( merge || "director" ))
+
+  registry:
+    http:
+      user: (( merge || "registry" ))
+      password: (( merge || "registry" ))
+
+  hm:
+    http:
+      user: (( merge || "hm" ))
+      password: (( merge || "hm" ))
+    director_account:
+      user: (( merge || "resurrector" ))
+      password: (( merge || "resurrector" ))
+
+  ntp_defaults:
+    - 0.pool.ntp.org
+    - 1.pool.ntp.org
+    - 2.pool.ntp.org
+    - 3.pool.ntp.org
+  ntp: (( merge || meta.ntp_defaults ))
+
+  compiled_package_cache: (( merge || nil ))
+
+properties:
+  <<: (( merge ))
+  nats:
+    user: (( meta.nats.user ))
+    password: (( meta.nats.password ))
+
+  logsearch:
+    logs:
+      server: (( meta.logsearch.logs.server ))
+
+  redis:
+    password: (( meta.redis.password ))
+
+  postgres: &bosh_db
+    user: (( meta.postgres.user ))
+    password: (( meta.postgres.password ))
+    database: (( meta.postgres.database ))
+
+  blobstore:
+    agent:
+      user: (( meta.blobstore.agent.user ))
+      password: (( meta.blobstore.agent.password ))
+    director:
+      user: (( meta.blobstore.director.user ))
+      password: (( meta.blobstore.director.password ))
+
+  registry:
+    db:
+      user: (( meta.postgres.user ))
+      password: (( meta.postgres.password ))
+      database: (( meta.postgres.database ))
+    http:
+      user: (( meta.registry.http.user ))
+      password: (( meta.registry.http.password ))
+
+  director:
+    name: bosh
+    db:
+      user: (( meta.postgres.user ))
+      password: (( meta.postgres.password ))
+      database: (( meta.postgres.database ))
+
+  hm:
+    http:
+      user: (( meta.hm.http.user ))
+      password: (( meta.hm.http.password ))
+    director_account:
+      user: (( meta.hm.director_account.user ))
+      password: (( meta.hm.director_account.password ))
+    resurrector_enabled: true
+
+  ntp: (( meta.ntp ))
+
+  compiled_package_cache: (( meta.compiled_package_cache ))


### PR DESCRIPTION
Example usage order in deployment manifest:
```yaml
- bosh-deployment.yml
- bosh-floating-ip-director.yml # for openstack
- bosh-logsearch-shipper-colocation.yml
- bosh-jobs.yml
- bosh-properties.yml
- bosh-infrastructure-openstack.yml # for openstack
- bosh-networking.yml
```

Signed-off-by: Fabio Berchtold <fabio.berchtold@swisscom.com>