### PR TITLE
Freeze fog-aws gem version to avoid errors.

### DIFF
--- a/blobstore_client/blobstore_client.gemspec
+++ b/blobstore_client/blobstore_client.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.executables  = %w(blobstore_client_console)
 
   s.add_dependency 'aws-sdk',         '1.60.2'
+  s.add_dependency 'fog-aws',         '<=0.1.1'
   s.add_dependency 'fog',             '~>1.27.0'
   s.add_dependency 'httpclient',      '=2.4.0'
   s.add_dependency 'multi_json',      '~> 1.1'

--- a/bosh-director/bosh-director.gemspec
+++ b/bosh-director/bosh-director.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bosh_vsphere_cpi',   "~>#{version}"
   s.add_dependency 'bosh_vcloud_cpi',    '=0.7.6'
   s.add_dependency 'eventmachine',       '~>1.0.0'
+  s.add_dependency 'fog-aws',          '<=0.1.1'
   s.add_dependency 'fog',              '~>1.27.0'
   s.add_dependency 'httpclient',       '=2.4.0'
   s.add_dependency 'logging',          '~>1.8.2'

--- a/bosh-registry/bosh-registry.gemspec
+++ b/bosh-registry/bosh-registry.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sinatra',   '~>1.4.2'
   s.add_dependency 'thin',      '~>1.5.0'
   s.add_dependency 'yajl-ruby', '~>1.2.0'
+  s.add_dependency 'fog-aws',   '<=0.1.1'
   s.add_dependency 'fog',       '~>1.27.0'
   s.add_dependency 'aws-sdk',   '1.60.2'
   s.add_dependency 'bosh_cpi', "~>#{version}"

--- a/bosh_openstack_cpi/bosh_openstack_cpi.gemspec
+++ b/bosh_openstack_cpi/bosh_openstack_cpi.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.bindir       = 'bin'
   s.executables  = %w(bosh_openstack_console openstack_cpi)
 
+  s.add_dependency 'fog-aws',       '<=0.1.1'
   s.add_dependency 'fog',           '~>1.27.0'
   s.add_dependency 'bosh_common',   "~>#{version}"
   s.add_dependency 'bosh_cpi',      "~>#{version}"


### PR DESCRIPTION
Hello, everyone. 

This PR fixes a problem that can occur if you run `bundle install` to install current versions of BOSH components.

### When the problem occurs

I've just met an issue trying to deploy a OpenStack CPI release with bosh-init. In my case I needed to update some gems and in order to do it I run (./scripts/vendor_gems)[https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/blob/master/scripts/vendor_gems] script. [Here](https://gist.github.com/allomov/9fd78c0977fa32ec0246) is a gist with an error stacktrace. It says:
```
Unmarshalling external CPI command output: STDOUT: '', STDERR: '/home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/fog-aws-0.4.0/lib/fog/aws/auto_scaling.rb:4:in `<class:AutoScaling>': uninitialized constant Fog::AWS::CredentialFetcher (NameError)
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/fog-aws-0.4.0/lib/fog/aws/auto_scaling.rb:3:in `<module:AWS>'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/fog-aws-0.4.0/lib/fog/aws/auto_scaling.rb:2:in `<module:Fog>'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/fog-aws-0.4.0/lib/fog/aws/auto_scaling.rb:1:in `<top (required)>'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/fog-1.27.0/lib/fog/aws.rb:2:in `require'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/fog-1.27.0/lib/fog/aws.rb:2:in `<top (required)>'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/fog-1.27.0/lib/fog.rb:23:in `require'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/fog-1.27.0/lib/fog.rb:23:in `<top (required)>'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/bosh_openstack_cpi-1.2977.0/lib/cloud/openstack.rb:8:in `require'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/bosh_openstack_cpi-1.2977.0/lib/cloud/openstack.rb:8:in `<top (required)>'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/bosh_openstack_cpi-1.2977.0/lib/bosh_openstack_cpi.rb:4:in `require'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/bosh_openstack_cpi-1.2977.0/lib/bosh_openstack_cpi.rb:4:in `<top (required)>'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/bosh_openstack_cpi-1.2977.0/bin/openstack_cpi:4:in `require'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/gem_home/ruby/1.9.1/gems/bosh_openstack_cpi-1.2977.0/bin/openstack_cpi:4:in `<top (required)>'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/bin/openstack_cpi:16:in `load'
from /home/ubuntu/.bosh_init/installations/7209d838-7e85-40ae-7a26-d7cc46c51afc/packages/bosh_openstack_cpi/bin/openstack_cpi:16:in `<main>'
':
```

The same issue is relevant to `bosh_cli` gem. [Here is a stackoverflow](http://stackoverflow.com/questions/29627590/bosh-deploy-get-uninitialized-constant-fogawscredentialfetcher-nameerror) question about it.

### Problem description

When you look at `fog.rb` file from fog v1.27.0, you'll see that it requires all fog components including `fog-aws` ([link to the source](https://github.com/fog/fog/blob/v1.27.0/lib/fog.rb#L23)). In the same time fog [gemspec file](https://github.com/fog/fog/blob/v1.27.0/fog.gemspec#L57) has does not specify version of `fog-aws` gem, setting it to be `>=0`. This means that when you run `bundle install` you can easily get the latest version of `fog-aws`. Services that are inside of updated `fog-aws` are not required in old `fog` version. This causes the error.

You can find discussion of similar error in this issue https://github.com/fog/fog-aws/issues/83.

Using the latest `fog-aws` (0.4) I needed to add this require statements in order to require `fog` without errors:
```
require "fog/aws/credential_fetcher"
require "fog/aws/region_methods"
```

### The solution

I used the same solution as is described in [this comment](https://github.com/fog/fog-aws/issues/83#issuecomment-93828222). I freezed `fog-aws` version in gemspec files to be equel or less than `0.1.1`. This worked for me.

This problem is solved in the next versions of fog, still the solution where you freeze fog-aws gem version is the easiest way to fix this problem and help users avoid this issue in the future.
