### PR TITLE
Make PowerDNS local-address and query-local-address configurable via …

### DIFF
--- a/release/jobs/powerdns/spec
+++ b/release/jobs/powerdns/spec
@@ -35,6 +35,10 @@ properties:
     default: 2
   dns.recursor:
     description: If recursion is desired, IP address of a recursing nameserver (optional)
+  dns.local_address:
+    description: IP address to which to bind to (optional; useful with multiple IP addresses)
+  dns.query_local_address:
+    description: IP address to use as a source address for sending queries (optional; useful with multiple IP addresses)
   dns.address:
     description: Address of the primary PowerDNS instance
 

--- a/release/jobs/powerdns/templates/pdns.conf.erb
+++ b/release/jobs/powerdns/templates/pdns.conf.erb
@@ -25,6 +25,12 @@ module-dir=/usr/local/lib
 <% if_p('dns.recursor') do |recursor| %>
 recursor=<%= recursor %>
 <% end %>
+<% if_p('dns.local_address') do |local_address| %>
+local-address=<%= local_address %>
+<% end %>
+<% if_p('dns.query_local_address') do |query_local_address| %>
+query-local-address=<%= query_local_address %>
+<% end %>
 setgid=vcap
 setuid=vcap
 version-string=anonymous


### PR DESCRIPTION
#### Purpose
Make PowerDNS settings ```local-address``` and ```query-local-address``` configurable.

#### Motivation
When the MicroBosh is having multiple IPs (e.g. an additional dynamic/elastic IP) and a DNS recursor is configured, PowerDNS may run the query to the recursor with the wrong IP and/or return the response with the wrong IP, which makes the client reject the response with "reply from unexpected source".

#### Proposal
PowerDNS has settings to control this behavior, but they are not exposed as job properties, so the proposal is to expose them as optional job properties.

#### Changes
* Add two new properties to spec (```local-address``` and ```query-local-address```)
* Apply them in configuration template if set (optionally)

#### Steps to Test or Reproduce
Define PowerDNS recursor, let the MicroBosh have multiple IPs, make a DNS query from a different machine (e.g. with dig @<microbosh> <something>) using not the primary IP of the MicroBosh (e.g. if multiple network adapters are defined not the primary network adapter IP or if a dynamic/elastic IP is defined that instead of the primary network adapter IP).

#### Issues
https://github.com/cloudfoundry/bosh/issues/836

#### CC
@holgerkoser @voelzmo