### PR TITLE
openstack cpi should wait for the server to be deleted

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -305,6 +305,12 @@ module Bosh::OpenStackCloud
 
           with_openstack { server.destroy }
 
+          begin
+            wait_resource(server, [:terminated, :deleted], :state, true)
+          rescue Bosh::Clouds::CloudError => delete_server_error
+            @logger.warn("Failed to destroy server: #{delete_server_error.inspect}\n#{delete_server_error.backtrace.join('\n')}")
+          end
+
           raise Bosh::Clouds::VMCreationFailed.new(true), e.message
         end
 

--- a/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
+++ b/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
@@ -427,21 +427,28 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
   end
 
   context "when cannot create an OpenStack server" do
+    let(:logger) { double }
+
     let(:cloud) do
-      c = mock_cloud do |openstack|
+      allow(Bosh::Clouds::Config).to receive(:logger).and_return(logger)
+      allow(logger).to receive(:debug)
+      allow(logger).to receive(:info)
+
+      mock_cloud do |openstack|
         expect(openstack.servers).to receive(:create).and_return(server)
         expect(openstack.security_groups).to receive(:collect).and_return(%w[default])
         expect(openstack.images).to receive(:find).and_return(image)
         expect(openstack.flavors).to receive(:find).and_return(flavor)
         expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
       end
-
-      allow(c).to receive(:wait_resource).with(server, :active, :state).and_raise(Bosh::Clouds::CloudError)
-      c
     end
 
-    it "raises a Retryable Error" do
-      allow(server).to receive(:destroy)
+    it "destroys the server successfully and raises a Retryable Error" do
+      allow(logger).to receive(:warn)
+
+      expect(server).to receive(:destroy)
+      expect(cloud).to receive(:wait_resource).with(server, :active, :state).and_raise(Bosh::Clouds::CloudError)
+      expect(cloud).to receive(:wait_resource).with(server, [:terminated, :deleted], :state, true)
 
       expect {
         vm_id = cloud.create_vm("agent-id", "sc-id",
@@ -451,13 +458,20 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
       }.to raise_error(Bosh::Clouds::VMCreationFailed)
     end
 
-    it "destroys the server" do
-      expect(server).to receive(:destroy)
+    it "raises a Retryable Error and logs correct failure message when failed to destroy the server" do
+      allow(server).to receive(:destroy)
+      allow(cloud).to receive(:wait_resource).with(server, :active, :state).and_raise(Bosh::Clouds::CloudError)
+      allow(cloud).to receive(:wait_resource).with(server, [:terminated, :deleted], :state, true).and_raise(Bosh::Clouds::CloudError)
 
-      cloud.create_vm("agent-id", "sc-id",
-                      resource_pool_spec,
-                      {"network_a" => dynamic_network_spec},
-                      nil, {"test_env" => "value"}) rescue nil
+      expect(logger).to receive(:warn).with('Failed to create server: Bosh::Clouds::CloudError')
+      expect(logger).to receive(:warn).with(/Failed to destroy server:.*/)
+
+      expect {
+        vm_id = cloud.create_vm("agent-id", "sc-id",
+                                resource_pool_spec,
+                                { "network_a" => dynamic_network_spec },
+                                nil, { "test_env" => "value" })
+      }.to raise_error(Bosh::Clouds::VMCreationFailed)
     end
   end
 


### PR DESCRIPTION
In the patch, we added the following things:
- wait_resource call when destroying the vm instance
- log error messages during deleting the vm instance
- one new unit test for the code changes

[#95584442]

Signed-off-by: Zhang Hua <zhuadl@cn.ibm.com>