### PR TITLE
Allow use of env vars/direnv to specify .bosh_deployer_config location via

### DIFF
--- a/bosh_cli_plugin_micro/lib/bosh/cli/commands/micro.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/cli/commands/micro.rb
@@ -12,7 +12,9 @@ module Bosh::Cli::Command
 
     def initialize(runner)
       super(runner)
-      options[:config] ||= DEFAULT_CONFIG_PATH # hijack Cli::Config
+      # Handle the environment variable being set to the empty string.
+      env_bosh_config = ENV['BOSH_DEPLOYER_CONFIG'].to_s.empty? ? nil : ENV['BOSH_DEPLOYER_CONFIG']
+      options[:config] ||= env_bosh_config || DEFAULT_CONFIG_PATH # hijack Cli::Config
     end
 
     usage 'micro'


### PR DESCRIPTION
Demo:

```
$ cd /data/drnic-workspace/deployments/microbosh-deployments/r5
direnv: error .envrc is blocked. Run `direnv allow` to approve its content.                                                                                                                                                                                  
$ direnv allow
direnv: loading .envrc                                                                                                                                                                                                                                       
direnv: export +BOSH_DEPLOYER_CONFIG
$ bosh micro deployment micro-bosh.yml          
WARNING! Your target has been changed to `https://10.202.75.102:25555'!
Deployment set to '/data/drnic-workspace/deployments/microbosh-deployments/r5/micro-bosh.yml'
$ cat .bosh_deployer_config 
---
target: https://10.202.75.102:25555
target_name: 
target_version: 
target_uuid: 
deployment:
  https://10.202.75.102:25555: "/data/drnic-workspace/deployments/microbosh-deployments/r5/micro-bosh.yml"
```

This now allows for the target micro bosh config file to be relative to the folder you are in; rather than globally.