### PR TITLE
Use security-group ID in addition to using security-group NAME

### DIFF
--- a/bosh_aws_cpi/README.md
+++ b/bosh_aws_cpi/README.md
@@ -16,7 +16,7 @@ These options are passed to the AWS CPI when it is instantiated.
 * `default_key_name` (required)
   default AWS ssh key name to assign to created virtual machines
 * `default_security_groups` (required)
-  list of AWS security group to assign to created virtual machines
+  list of AWS security group names or ids to assign to created virtual machines, note that name and id can not be used together in this attribute.
 * `ec2_private_key` (required)
   local path to the ssh private key, must match `default_key_name`
 * `region` (required)
@@ -65,6 +65,9 @@ These options are specified under `cloud_options` in the `networks` section of a
 * `type` (required)
   can be either `dynamic` for a DHCP assigned IP by AWS, or `vip` to use an Elastic IP (which needs to be already
   allocated)
+
+* `security_groups` (optional)
+  the AWS security group names or ids to assign to VMs. If not specified, it'll use the default security groups set at the AWS options. Note that name and id can not be used together in this attribute.
 
 ## Example
 

--- a/bosh_aws_cpi/lib/cloud/aws/cloud.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/cloud.rb
@@ -398,7 +398,7 @@ module Bosh::AwsCloud
     # we need to send the InstanceUpdater a request to do it for us
     def compare_security_groups(instance, network_spec)
       actual_group_names = instance.security_groups.collect { |sg| sg.name }
-      specified_group_names = extract_security_group_names(network_spec)
+      specified_group_names = extract_security_groups(network_spec)
       if specified_group_names.empty?
         new_group_names = Array(aws_properties["default_security_groups"])
       else

--- a/bosh_aws_cpi/lib/cloud/aws/helpers.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/helpers.rb
@@ -17,7 +17,7 @@ module Bosh::AwsCloud
       raise Bosh::Clouds::CloudError, message
     end
 
-    def extract_security_group_names(networks_spec)
+    def extract_security_groups(networks_spec)
       networks_spec.
           values.
           select { |network_spec| network_spec.has_key? "cloud_properties" }.

--- a/bosh_aws_cpi/spec/unit/helpers_spec.rb
+++ b/bosh_aws_cpi/spec/unit/helpers_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Bosh::AwsCloud::Helpers do
 
 
-  describe "#extract_security_group_names" do
+  describe "#extract_security_groups" do
     let(:networks_spec) do
       {
           "vip" => {"cloud_properties" => {}},
@@ -20,7 +20,7 @@ describe Bosh::AwsCloud::Helpers do
       end
 
       helpers_tester = HelpersTester.new
-      expect(helpers_tester.extract_security_group_names(networks_spec)).to match_array(["numero uno", "two to tango"])
+      expect(helpers_tester.extract_security_groups(networks_spec)).to match_array(["numero uno", "two to tango"])
     end
   end
 end


### PR DESCRIPTION
In this patch, we provide the following changes for aws cpi:

- Support new deployment optional option 'default_security_group_ids'
- Support new deployment optional option 'security_group_ids'
- Usage document changes for these two new options

[#94035130]

Signed-off-by: Zhang Hua <zhuadl@cn.ibm.com>