### PR TITLE
Fix: Issue #845

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -25,6 +25,10 @@ shared_examples_for 'every OS image' do
       it { should return_exit_status(0) }
     end
 
+    describe command("grep -q 'source /root/.bashrc\n' /root/.bash_profile") do
+      it { should return_exit_status(0) }
+    end
+
     describe command("stat -c %a ~vcap") do
       it { should return_stdout("755") }
     end

--- a/stemcell_builder/stages/bosh_users/apply.sh
+++ b/stemcell_builder/stages/bosh_users/apply.sh
@@ -32,3 +32,4 @@ cp $assets_dir/sudoers $chroot/etc/sudoers
 # Add $bosh_dir/bin to $PATH
 echo "export PATH=$bosh_dir/bin:\$PATH" >> $chroot/root/.bashrc
 echo "export PATH=$bosh_dir/bin:\$PATH" >> $chroot/home/vcap/.bashrc
+echo "source /root/.bashrc" >> $chroot/root/.bash_profile


### PR DESCRIPTION
@drnic @cppforlife in regards to issue #845 ::

If you sudo to root as using a login shell:
```sh
sudo su -
```
or
```sh
sudo su -l
```
then monit was not in the path.

If you sudo to root using a non-login shell:
```sh
sudo su
```
then monit was in the path.

The reason for this is that in bash for a login shell it only loads `$HOME/.bash_profile` and for a non-login shell it only loads `$HOME/.bashrc`.  The code only wrote a `/root/.bashrc` and not a `/root/.bash_profile`.

This patch adds the `/root/.bash_profile` file which sources `/root/.bashrc` which adds `$bosh-dir/bin` to `$PATH` and thus `monit` will now be in a root login shell's path.

  ~Wayne