### PR TITLE
Adding the ability to provide the StrictHostKeyChecking flag to ssh when starting interactive terminals.

### DIFF
--- a/bosh_cli/lib/cli/commands/ssh.rb
+++ b/bosh_cli/lib/cli/commands/ssh.rb
@@ -16,6 +16,8 @@ module Bosh::Cli
       option '--gateway_identity_file FILE', 'Gateway identity file'
       option '--default_password PASSWORD',
              'Use default ssh password (NOT RECOMMENDED)'
+      option '--strict_host_key_checking <yes/no>',
+             'Can use this flag to skip host key checking (NOT RECOMMENDED)'
 
       def shell(*args)
         if args.size > 0
@@ -187,13 +189,16 @@ module Bosh::Cli
 
           say("Starting interactive shell on job #{job}/#{index}")
 
+          skip_strict_host_key_checking = options[:strict_host_key_checking] =~ (/(no|false)$/i) ?
+              '-o StrictHostKeyChecking=no' : '-o StrictHostKeyChecking=yes'
+
           if gateway
             port        = gateway.open(session['ip'], 22)
-            ssh_session = Process.spawn('ssh', "#{user}@localhost", '-p', port.to_s)
+            ssh_session = Process.spawn('ssh', "#{user}@localhost", '-p', port.to_s, skip_strict_host_key_checking)
             Process.waitpid(ssh_session)
             gateway.close(port)
           else
-            ssh_session = Process.spawn('ssh', "#{user}@#{session['ip']}")
+            ssh_session = Process.spawn('ssh', "#{user}@#{session['ip']}", skip_strict_host_key_checking)
             Process.waitpid(ssh_session)
           end
         end

--- a/bosh_cli/spec/unit/commands/ssh_spec.rb
+++ b/bosh_cli/spec/unit/commands/ssh_spec.rb
@@ -163,7 +163,7 @@ describe Bosh::Cli::Command::Ssh do
       end
 
       it 'should setup ssh' do
-        expect(Process).to receive(:spawn).with('ssh', 'testable_user@127.0.0.1')
+        expect(Process).to receive(:spawn).with('ssh', 'testable_user@127.0.0.1', "-o StrictHostKeyChecking=yes")
 
         expect(director).to receive(:setup_ssh).and_return([:done, 42])
         expect(director).to receive(:get_task_result_log).with(42).
@@ -171,6 +171,23 @@ describe Bosh::Cli::Command::Ssh do
         expect(director).to receive(:cleanup_ssh)
 
         command.shell('dea/0')
+      end
+
+      context 'when strict host key checking is overriden to false' do
+        before do
+          command.add_option(:strict_host_key_checking, 'false')
+        end
+
+        it 'should disable strict host key checking' do
+          expect(Process).to receive(:spawn).with('ssh', 'testable_user@127.0.0.1', "-o StrictHostKeyChecking=no")
+
+          allow(director).to receive(:setup_ssh).and_return([:done, 42])
+          allow(director).to receive(:get_task_result_log).with(42).
+                                and_return(JSON.generate([{'status' => 'success', 'ip' => '127.0.0.1'}]))
+          allow(director).to receive(:cleanup_ssh)
+
+          command.shell('dea/0')
+        end
       end
 
       context 'with a gateway host' do
@@ -184,7 +201,7 @@ describe Bosh::Cli::Command::Ssh do
         it 'should setup ssh with gateway host' do
           expect(Net::SSH::Gateway).to receive(:new).with(gateway_host, gateway_user, {}).and_return(net_ssh)
           expect(net_ssh).to receive(:open).with(anything, 22).and_return(2345)
-          expect(Process).to receive(:spawn).with('ssh', 'testable_user@localhost', '-p', '2345')
+          expect(Process).to receive(:spawn).with('ssh', 'testable_user@localhost', '-p', '2345', "-o StrictHostKeyChecking=yes")
 
           expect(director).to receive(:setup_ssh).and_return([:done, 42])
           expect(director).to receive(:get_task_result_log).with(42).
@@ -207,7 +224,7 @@ describe Bosh::Cli::Command::Ssh do
           it 'should setup ssh with gateway host and user' do
             expect(Net::SSH::Gateway).to receive(:new).with(gateway_host, gateway_user, {}).and_return(net_ssh)
             expect(net_ssh).to receive(:open).with(anything, 22).and_return(2345)
-            expect(Process).to receive(:spawn).with('ssh', 'testable_user@localhost', '-p', '2345')
+            expect(Process).to receive(:spawn).with('ssh', 'testable_user@localhost', '-p', '2345', "-o StrictHostKeyChecking=yes")
 
             expect(director).to receive(:setup_ssh).and_return([:done, 42])
             expect(director).to receive(:get_task_result_log).with(42).
@@ -223,7 +240,7 @@ describe Bosh::Cli::Command::Ssh do
           it 'should setup ssh with gateway host and user and identity file' do
             expect(Net::SSH::Gateway).to receive(:new).with(gateway_host, gateway_user, {keys: ['/tmp/private_file']}).and_return(net_ssh)
             expect(net_ssh).to receive(:open).with(anything, 22).and_return(2345)
-            expect(Process).to receive(:spawn).with('ssh', 'testable_user@localhost', '-p', '2345')
+            expect(Process).to receive(:spawn).with('ssh', 'testable_user@localhost', '-p', '2345', "-o StrictHostKeyChecking=yes")
 
             expect(director).to receive(:setup_ssh).and_return([:done, 42])
             expect(director).to receive(:get_task_result_log).with(42).
@@ -249,6 +266,28 @@ describe Bosh::Cli::Command::Ssh do
               command.shell('dea/0')
             }.to raise_error(Bosh::Cli::CliError,
                              "Authentication failed with gateway #{gateway_host} and user #{gateway_user}.")
+          end
+
+          context 'when strict host key checking is overriden to false' do
+            before do
+              command.add_option(:strict_host_key_checking, 'false')
+            end
+
+            it 'should disable strict host key checking' do
+              allow(Net::SSH::Gateway).to receive(:new).with(gateway_host, gateway_user, {}).and_return(net_ssh)
+              allow(net_ssh).to receive(:open).with(anything, 22).and_return(2345)
+              expect(Process).to receive(:spawn).with('ssh', 'testable_user@localhost', '-p', '2345', "-o StrictHostKeyChecking=no")
+
+              allow(director).to receive(:setup_ssh).and_return([:done, 42])
+              allow(director).to receive(:get_task_result_log).with(42).
+                                      and_return(JSON.generate([{'status' => 'success', 'ip' => '127.0.0.1'}]))
+              allow(director).to receive(:cleanup_ssh)
+
+              allow(net_ssh).to receive(:close)
+              allow(net_ssh).to receive(:shutdown!)
+
+              command.shell('dea/0')
+            end
           end
         end
       end


### PR DESCRIPTION
This allows us to ignore the host key when we recreate vms.

Usage:
bosh ssh --strict_host_key_checking no