### PR TITLE
Install libgo5 in Ubuntu

### DIFF
--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -13,7 +13,7 @@ rsync openssh-server traceroute libncurses5-dev quota \
 libaio1 gdb libcap2-bin libcap2-dev libbz2-dev \
 cmake uuid-dev libgcrypt-dev ca-certificates \
 scsitools mg htop module-assistant debhelper runit parted \
-anacron software-properties-common"
+anacron software-properties-common libgo5"
 pkg_mgr install $debs
 
 # we need newer rsyslog; this comes from the upstream project's own repo


### PR DESCRIPTION
Closes #868

bosh_micro_go fails to build with the following error:

    /var/vcap/bosh/bin/bosh-agent -P dummy -M dummy -C /var/vcap/bosh/agent.json
    /var/vcap/bosh/bin/bosh-agent: error while loading shared libraries: libgo.so.5: cannot open shared object file: No such file or directory

This commit fixes the issue by installing the dependency needed to run
bosh-agent.