### PR TITLE
Add Ephemeral EBS Support to AWS Spot Instances

### DIFF
--- a/bosh_aws_cpi/lib/cloud/aws/helpers.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/helpers.rb
@@ -4,7 +4,12 @@ module Bosh::AwsCloud
 
   module Helpers
     def default_ephemeral_disk_mapping
-       { '/dev/sdb' => 'ephemeral0' }
+       [
+         {
+           :device_name => '/dev/sdb',
+           :virtual_name => 'ephemeral0',
+         },
+       ]
     end
 
     def ebs_ephemeral_disk_mapping(volume_size_in_gb, volume_type)

--- a/bosh_aws_cpi/lib/cloud/aws/spot_manager.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/spot_manager.rb
@@ -85,6 +85,10 @@ module Bosh::AwsCloud
         spec[:launch_specification][:network_interfaces][0][:groups] = security_groups
       end
 
+      if instance_params[:block_device_mappings]
+        spec[:launch_specification][:block_device_mappings] = instance_params[:block_device_mappings]
+      end
+
       spec
     end
 

--- a/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -38,7 +38,12 @@ describe Bosh::AwsCloud::InstanceManager do
         security_groups: ['baz'],
         private_ip_address: '1.2.3.4',
         availability_zone: 'us-east-1a',
-        block_device_mappings: { '/dev/sdb' => 'ephemeral0' }
+        block_device_mappings: [
+          {
+            :device_name => '/dev/sdb',
+            :virtual_name => 'ephemeral0',
+          },
+        ]
       }
     end
 
@@ -132,7 +137,13 @@ describe Bosh::AwsCloud::InstanceManager do
               :groups=>['sg-baz-1234'],
               :device_index=>0,
               :private_ip_address=>'1.2.3.4'
-            }]
+            }],
+            :block_device_mappings => [
+              {
+                :device_name => '/dev/sdb',
+                :virtual_name => 'ephemeral0',
+              },
+            ],
           })
 
           # return
@@ -302,7 +313,7 @@ describe Bosh::AwsCloud::InstanceManager do
               create_instance
 
               expect(aws_instances).to have_received(:create) do |instance_params|
-                expect(instance_params[:block_device_mappings]).to eq({ '/dev/sdb' => 'ephemeral0' })
+                expect(instance_params[:block_device_mappings]).to eq([{:device_name=>"/dev/sdb", :virtual_name=>"ephemeral0"}])
               end
             end
           end
@@ -340,7 +351,14 @@ describe Bosh::AwsCloud::InstanceManager do
             create_instance
 
             expect(aws_instances).to have_received(:create) do |instance_params|
-              expect(instance_params[:block_device_mappings]).to eq({ '/dev/sdb' => 'ephemeral0' })
+              expect(instance_params[:block_device_mappings]).to eq(
+                [
+                  {
+                    :device_name => '/dev/sdb',
+                    :virtual_name => 'ephemeral0',
+                  },
+                ]
+              )
             end
           end
         end

--- a/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
+++ b/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
@@ -75,10 +75,18 @@ describe Bosh::AwsCloud::StemcellCreator do
         expect(params[:description]).to eq("stemcell-name 0.7.0")
         expect(params[:kernel_id]).to eq("aki-xxxxxxxx")
         expect(params[:root_device_name]).to eq("/dev/sda1")
-        expect(params[:block_device_mappings]).to eq({
-          "/dev/sda"=>{:snapshot_id=>"id"},
-          "/dev/sdb"=>"ephemeral0"
-        })
+        expect(params[:block_device_mappings]).to eq([
+          {
+            :device_name => "/dev/sda",
+            :ebs => {
+              :snapshot_id => "id",
+            },
+          },
+          {
+            :device_name => "/dev/sdb",
+            :virtual_name => "ephemeral0",
+          },
+        ])
       end
     end
 
@@ -93,10 +101,18 @@ describe Bosh::AwsCloud::StemcellCreator do
         expect(params).not_to have_key(:kernel_id)
         expect(params[:root_device_name]).to eq("/dev/xvda")
         expect(params[:sriov_net_support]).to eq("simple")
-        expect(params[:block_device_mappings]).to eq({
-          "/dev/xvda"=>{:snapshot_id=>"id"},
-          "/dev/sdb"=>"ephemeral0"
-        })
+        expect(params[:block_device_mappings]).to eq([
+          {
+            :device_name => "/dev/xvda",
+            :ebs => {
+              :snapshot_id => "id",
+            },
+          },
+          {
+            :device_name => "/dev/sdb",
+            :virtual_name => "ephemeral0",
+          },
+        ])
         expect(params[:virtualization_type]).to eq("hvm")
       end
     end

--- a/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
+++ b/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
@@ -23,7 +23,8 @@ describe Bosh::AwsCloud::StemcellCreator do
   context "real" do
     let(:volume) { double("volume") }
     let(:snapshot) { double("snapshot", :id => "snap-xxxxxxxx") }
-    let(:image) { double("image") }
+    let(:image_id) { "ami-a1b2c3d4" }
+    let(:image) { double("image", :id => image_id) }
     let(:ebs_volume) { double("ebs_volume") }
 
     it "should create a real stemcell" do
@@ -31,7 +32,10 @@ describe Bosh::AwsCloud::StemcellCreator do
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot).with(snapshot: snapshot, state: :completed)
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_image).with(image: image, state: :available)
       allow(SecureRandom).to receive(:uuid).and_return("fake-uuid")
-      allow(region).to receive_message_chain(:images, :create).and_return(image)
+      allow(region).to receive(:images).and_return({
+        image_id => image,
+      })
+      allow(region).to receive_message_chain(:client, :register_image).and_return(double("object", :image_id => image_id))
 
       expect(creator).to receive(:copy_root_image)
       expect(volume).to receive(:create_snapshot).and_return(snapshot)


### PR DESCRIPTION
Currently, spot instances cannot use newer instance families (e.g. `m4`, `c4`) because they do not have Instance Storage. The `ephemeral_disk` BOSH option provides the capability for On Demand instances, but the `RequestSpotInstances` call does not provide the equivalent `LaunchSpecification.BlockDeviceMappings` parameter.

This PR makes two code changes:

0. As a prerequisite, `default_ephemeral_disk_mapping`, which was returning a plain hash, is now returning a list of values of type [`BlockDeviceMapping`](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html) as recommended by the AWS specifications. The inconsistency of formats between `{'sdb':'ephemeral0'}` and `[{device:'sdb',virtual:'ephemeral0'}]` was causing issues when reusing values between different API calls when adding the spot ephemeral support. This also affected the stemcell builder which used the value for the default block device mappings of the image.
0. Second, forward the `block_device_mappings` from the regular instance parameters to the spot request.

I updated and added spec tests. For the stemcell builder change, I went through the process of creating a stemcell and reviewed the resultant AMI. I also manually tested the following scenarios (test job utilized a regular, persistent disk and ran from stemcell [`bosh-aws-xen-hvm-ubuntu-trusty-go_agent/sriov20150630a`](https://github.com/cloudfoundry/bosh/pull/860))...

**spot + ebs**

    # resource pool
    $ cat bosh.yml
        cloud_properties:
          availability_zone: "us-west-2b"
          instance_type: "c4.xlarge"
          spot_bid_price: 0.05
          ephemeral_disk:
            size: 8192

    # verify ephemeral
    $ aws ec2 describe-spot-instance-requests --spot-instance-request-ids=sir-03hqa00c | jq -c '.SpotInstanceRequests[] | ( .InstanceId , .LaunchSpecification.BlockDeviceMappings )'
    "i-d6ef0e20"
    [{"DeviceName":"/dev/sdb","Ebs":{"DeleteOnTermination":true,"VolumeSize":8,"VolumeType":"standard"}}]

    # ebs volumes
    $ aws ec2 describe-instances --instance-ids i-d6ef0e20 | jq -c '.Reservations[].Instances[].BlockDeviceMappings[] | .'
    {"DeviceName":"/dev/xvda","Ebs":{"Status":"attached","DeleteOnTermination":true,"VolumeId":"vol-f9a9f20c","AttachTime":"2015-07-20T00:16:31.000Z"}}
    {"DeviceName":"/dev/sdb","Ebs":{"Status":"attached","DeleteOnTermination":true,"VolumeId":"vol-d2a9f227","AttachTime":"2015-07-20T00:16:31.000Z"}}
    {"DeviceName":"/dev/sdf","Ebs":{"Status":"attached","DeleteOnTermination":false,"VolumeId":"vol-9f149a8e","AttachTime":"2015-07-20T00:19:20.000Z"}}

    # system volumes
    vm$ df -h | grep /dev/
    /dev/xvda1      2.8G  1.3G  1.4G  49% /
    /dev/xvdb2      3.9G  1.3G  2.5G  33% /var/vcap/data
    /dev/loop0      120M  1.6M  115M   2% /tmp
    /dev/xvdf1       32G   28G  1.9G  94% /var/vcap/store

**spot + ephemeral0**

    $ cat bosh.yml
        cloud_properties:
          availability_zone: "us-west-2b"
          instance_type: "c3.xlarge"
          spot_bid_price: 0.04
    
    $ aws ec2 describe-spot-instance-requests --spot-instance-request-ids=sir-03hl94lq | jq -c '.SpotInstanceRequests[] | ( .InstanceId , .LaunchSpecification.BlockDeviceMappings )'
    "i-f0ca2b06"
    [{"DeviceName":"/dev/sdb","VirtualName":"ephemeral0"}]
    
    $ aws ec2 describe-instances --instance-ids i-f0ca2b06 | jq -c '.Reservations[].Instances[].BlockDeviceMappings[] | .'
    {"DeviceName":"/dev/xvda","Ebs":{"Status":"attached","DeleteOnTermination":true,"VolumeId":"vol-f2d28907","AttachTime":"2015-07-20T01:21:15.000Z"}}
    {"DeviceName":"/dev/sdf","Ebs":{"Status":"attached","DeleteOnTermination":false,"VolumeId":"vol-9f149a8e","AttachTime":"2015-07-20T01:23:39.000Z"}}

    vm$ df -h | grep /dev/
    /dev/xvda1      2.8G  1.3G  1.4G  49% /
    /dev/xvdb2       33G  1.7G   29G   6% /var/vcap/data
    /dev/loop0      120M  1.7M  115M   2% /tmp
    /dev/xvdf1       32G   28G  1.9G  94% /var/vcap/store

**on demand + ebs**

    $ cat bosh.yml
        cloud_properties:
          instance_type: "c4.xlarge"
          ephemeral_disk:
           size: 8192
        
    $ aws ec2 describe-instances --instance-ids i-b7d33241 | jq -c '.Reservations[].Instances[].BlockDeviceMappings[] | .'
    {"DeviceName":"/dev/xvda","Ebs":{"Status":"attached","DeleteOnTermination":true,"VolumeId":"vol-86cb9073","AttachTime":"2015-07-20T01:42:31.000Z"}}
    {"DeviceName":"/dev/sdb","Ebs":{"Status":"attached","DeleteOnTermination":true,"VolumeId":"vol-53cb90a6","AttachTime":"2015-07-20T01:42:31.000Z"}}
    {"DeviceName":"/dev/sdf","Ebs":{"Status":"attached","DeleteOnTermination":false,"VolumeId":"vol-9f149a8e","AttachTime":"2015-07-20T01:44:18.000Z"}}

    vm$ df -h | grep /dev/
    /dev/xvda1      2.8G  1.3G  1.4G  49% /
    /dev/xvdb2      3.9G  1.4G  2.3G  38% /var/vcap/data
    /dev/loop0      120M  1.6M  115M   2% /tmp
    /dev/xvdf1       32G   28G  1.9G  94% /var/vcap/store

**on demand + ephemeral0**

    $ cat bosh.yml
        cloud_properties:
          availability_zone: "us-west-2b"
          instance_type: "c3.xlarge"
        
    $ aws ec2 describe-instances --instance-ids i-1cce2fea | jq -c '.Reservations[].Instances[].BlockDeviceMappings[] | .'
    {"DeviceName":"/dev/xvda","Ebs":{"Status":"attached","DeleteOnTermination":true,"VolumeId":"vol-a3d68d56","AttachTime":"2015-07-20T01:34:11.000Z"}}
    {"DeviceName":"/dev/sdf","Ebs":{"Status":"attached","DeleteOnTermination":false,"VolumeId":"vol-9f149a8e","AttachTime":"2015-07-20T01:36:00.000Z"}}

    vm$ df -h | grep /dev/
    /dev/xvda1      2.8G  1.3G  1.4G  49% /
    /dev/xvdb2       33G  1.6G   29G   6% /var/vcap/data
    /dev/loop0      120M  1.7M  115M   2% /tmp
    /dev/xvdf1       32G   28G  1.9G  94% /var/vcap/store
