### PR TITLE
[Power Support] Add blobs that need updated config.guess file to S3 blobstore.

### DIFF
--- a/release/config/blobs.yml
+++ b/release/config/blobs.yml
@@ -8,9 +8,9 @@ postgres/postgres-9.0.3-1.i386.tar.gz:
   sha: b2bde31e720eb219bfdc9f1b784f985ecca2cbfb
   size: 15111387
 postgres/postgresql-9.0.3.tar.gz:
-  object_id: rest/objects/4e4e78bca61e121004e4e7d51d950e04fbd4f2ca2d89
-  sha: c8fb5d1d7930e78211e554bb5751183a8148d0ee
-  size: 18335858
+  object_id: 1ab87cef-91b0-4c37-be96-51f5a97758c6
+  sha: 8044cd5af9ea27075ecfbd9a7f5a866b272e344c
+  size: 19028865
 mysql/server-5.1.62-rel13.3-435-Linux-x86_64.tar.gz:
   object_id: rest/objects/4e4e78bca31e121004e4e7d514745f04fb68b2898dd0
   sha: 2bfd575545fe78729c56bb832aa69d8d9fc8630d
@@ -20,9 +20,9 @@ genisoimage/cdrkit-1.1.11.tar.gz:
   sha: 3f7ddc06db0272942e1a4cd98c3c96462df77387
   size: 1445133
 ruby/yaml-0.1.5.tar.gz:
-  object_id: db07c821-62f8-4fd1-a99a-ff1c88b2474b
-  sha: 8b78cb9f759c7d80db8a7328c0ebecfe34fde737
-  size: 504897
+  object_id: 45299e5f-2f25-4d6e-89e7-6cfe82e60928
+  sha: cc17aae943055c1c197e3d957bff22aae2cd1f95
+  size: 505553
 powerdns/pdns-static_3.3.1-1_amd64.deb:
   object_id: 6e861aa6-2e83-4027-a1e8-0ebec995c274
   sha: 22bb46aa0b3e7671e0ee9aa30ed95c38841106ab
@@ -84,6 +84,6 @@ ruby/rubygems-2.3.0.tgz:
   sha: 6902fff7749fa264b8f9020f33daf92170375f75
   size: 431240
 ruby/ruby-2.1.4.tar.gz:
-  object_id: 00b50c34-f264-4245-9a90-b56c7385694e
-  sha: 29e9cfdd9e989b7621d7696ef3f970262a08dbc3
-  size: 15127418
+  object_id: 0d772db0-1acb-48aa-93a4-55c09cb44912
+  sha: 0073ae1c5242b61b08611ae9f11965b88572ba53
+  size: 15132948

--- a/release/config/final.yml
+++ b/release/config/final.yml
@@ -3,4 +3,4 @@ final_name: bosh
 blobstore:
   provider: s3
   options: 
-    bucket_name: blob.cfblob.com
+    bucket_name: power-blobs-with-updated-build-config


### PR DESCRIPTION
Hey, all.

I work on porting BOSH to Power microprocessor architectures. The most common problem here is that some components that are compiled during deployment don’t have correct build configuration support for Power. 

This problem is solved easily by updating [config.guess](http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD) files to such packages. You can find out how I generated this blobs using [this script](https://github.com/Altoros/power-bosh-jumpbox-bootstrap/blob/config-updater/roles/binaries-builder/files/scripts/update-configs.sh) (this script uses this [helpers script](https://github.com/Altoros/power-bosh-jumpbox-bootstrap/blob/config-updater/roles/binaries-builder/files/scripts/helpers.sh) for some functions), inputs for this scripts you can find in [this yaml file](https://github.com/Altoros/power-bosh-jumpbox-bootstrap/blob/config-updater/group_vars/config-updater#L7).

Following [this answer in cf-dev](http://lists.cloudfoundry.org/pipermail/cf-dev/2015-July/000642.html) I need to put this blobs to S3 blobstore and post output of `bosh blobs` to this PR. I tried to run `bosh blobs` command and it shows `No blobs to upload` now. But I guess that contents of `release/config/blobs.yml` can demonstrate you updated blobs.

Thank you,
Alex L.