### PR TITLE
[Power Support] Update build configuration files to support IBM Power platform (for ruby and libpq packages)

### DIFF
--- a/release/packages/libpq/pre_packaging
+++ b/release/packages/libpq/pre_packaging
@@ -3,13 +3,6 @@
 # This pre_packaging script runs only for IBM Power platform
 # It updates old versions of build configuration (config.guess and config.sub files)
 
-main(){
-  if [ "`uname -m`" == "ppc64le" ]; then
-    cd ${BUILD_DIR}
-    update_build_config postgres/postgresql-9.0.3.tar.gz
-  fi  
-}
-
 function update_build_config {
   local blob_path=$1
   local archive_file=$(basename $blob_path);
@@ -27,3 +20,8 @@ function update_build_config {
   popd
   tar -czvf $blob_path $folder_with_sources
 }
+
+if [ "`uname -m`" == "ppc64le" ]; then
+  cd ${BUILD_DIR}
+  update_build_config postgres/postgresql-9.0.3.tar.gz
+fi

--- a/release/packages/libpq/pre_packaging
+++ b/release/packages/libpq/pre_packaging
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This pre_packaging script runs only for IBM Power platform
+# It updates old versions of build configuration (config.guess and config.sub files)
+
+main(){
+  if [ "`uname -m`" == "ppc64le" ]; then
+    cd ${BUILD_DIR}
+    update_build_config postgres/postgresql-9.0.3.tar.gz
+  fi  
+}
+
+function update_build_config {
+  local blob_path=$1
+  local archive_file=$(basename $blob_path);
+  local folder_with_sources="${archive_file%.tar.gz}"
+  tar -xzvf $blob_path
+  pushd $folder_with_sources
+    local config_guess_path=`find . -name config.guess`
+    if [ ! -z "$config_guess_path" ]; then
+      curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;hb=HEAD;f=config.guess" > "${config_guess_path}"
+    fi
+    local config_sub_path=`find . -name config.sub`
+    if [ ! -z "$config_sub_path" ]; then
+      curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;hb=HEAD;f=config.sub" > "${config_sub_path}"
+    fi  
+  popd
+  tar -czvf $blob_path $folder_with_sources
+}

--- a/release/packages/ruby/pre_packaging
+++ b/release/packages/ruby/pre_packaging
@@ -3,14 +3,6 @@
 # This pre_packaging script runs only for IBM Power platform
 # It updates old versions of build configuration (config.guess and config.sub files)
 
-main(){
-  if [ "`uname -m`" == "ppc64le" ]; then
-    cd ${BUILD_DIR}
-    update_build_config ruby/yaml-0.1.5.tar.gz
-    update_build_config ruby/ruby-2.1.4.tar.gz
-  fi  
-}
-
 function update_build_config {
   local blob_path=$1
   local archive_file=$(basename $blob_path);
@@ -28,3 +20,9 @@ function update_build_config {
   popd
   tar -czvf $blob_path $folder_with_sources
 }
+
+if [ "`uname -m`" == "ppc64le" ]; then
+  cd ${BUILD_DIR}
+  update_build_config ruby/yaml-0.1.5.tar.gz
+  update_build_config ruby/ruby-2.1.4.tar.gz
+fi

--- a/release/packages/ruby/pre_packaging
+++ b/release/packages/ruby/pre_packaging
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This pre_packaging script runs only for IBM Power platform
+# It updates old versions of build configuration (config.guess and config.sub files)
+
+main(){
+  if [ "`uname -m`" == "ppc64le" ]; then
+    cd ${BUILD_DIR}
+    update_build_config ruby/yaml-0.1.5.tar.gz
+    update_build_config ruby/ruby-2.1.4.tar.gz
+  fi  
+}
+
+function update_build_config {
+  local blob_path=$1
+  local archive_file=$(basename $blob_path);
+  local folder_with_sources="${archive_file%.tar.gz}"
+  tar -xzvf $blob_path
+  pushd $folder_with_sources
+    local config_guess_path=`find . -name config.guess`
+    if [ ! -z "$config_guess_path" ]; then
+      curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;hb=HEAD;f=config.guess" > "${config_guess_path}"
+    fi
+    local config_sub_path=`find . -name config.sub`
+    if [ ! -z "$config_sub_path" ]; then
+      curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;hb=HEAD;f=config.sub" > "${config_sub_path}"
+    fi  
+  popd
+  tar -czvf $blob_path $folder_with_sources
+}


### PR DESCRIPTION
This PR is made to provide IBM Power support to BOSH.

You can find details of the issue in this PR https://github.com/cloudfoundry/bosh/pull/892. I've come to the idea of this changes thanking to Matthew Sykes (and his post in [cf-dev](http://lists.cloudfoundry.org/pipermail/cf-dev/2015-July/000911.html)). 
