### PR TITLE
optional check for openstack volume service

### DIFF
--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -47,7 +47,7 @@ module Bosh::OpenStackCloud
       @boot_from_volume = @openstack_properties["boot_from_volume"]
       @boot_volume_cloud_properties = @openstack_properties["boot_volume_cloud_properties"] || {}
       @use_dhcp = @openstack_properties.fetch('use_dhcp', true)
-      @use_openstack_volume_service = @openstack_properties["use_openstack_volume_service"]
+      @use_openstack_volume_service = @openstack_properties.fetch('use_openstack_volume_service', true)
 
       unless @openstack_properties['auth_url'].match(/\/tokens$/)
         @openstack_properties['auth_url'] = @openstack_properties['auth_url'] + '/tokens'

--- a/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -47,6 +47,7 @@ module Bosh::OpenStackCloud
       @boot_from_volume = @openstack_properties["boot_from_volume"]
       @boot_volume_cloud_properties = @openstack_properties["boot_volume_cloud_properties"] || {}
       @use_dhcp = @openstack_properties.fetch('use_dhcp', true)
+      @use_openstack_volume_service = @openstack_properties["use_openstack_volume_service"]
 
       unless @openstack_properties['auth_url'].match(/\/tokens$/)
         @openstack_properties['auth_url'] = @openstack_properties['auth_url'] + '/tokens'
@@ -118,14 +119,16 @@ module Bosh::OpenStackCloud
         :openstack_endpoint_type => @openstack_properties['endpoint_type'],
         :connection_options => @openstack_properties['connection_options'].merge(extra_connection_options)
       }
-
-      begin
-        Bosh::Common.retryable(connect_retry_options) do |tries, error|
-          @logger.error("Failed #{tries} times, last failure due to: #{error.inspect}") unless error.nil?
-          @volume = Fog::Volume.new(volume_params)
+      
+      if @use_openstack_volume_service
+        begin
+          Bosh::Common.retryable(connect_retry_options) do |tries, error|
+            @logger.error("Failed #{tries} times, last failure due to: #{error.inspect}") unless error.nil?
+            @volume = Fog::Volume.new(volume_params)
+          end
+        rescue Bosh::Common::RetryCountExceeded, Excon::Errors::ClientError, Excon::Errors::ServerError
+          cloud_error('Unable to connect to the OpenStack Volume API. Check task debug log for details.')
         end
-      rescue Bosh::Common::RetryCountExceeded, Excon::Errors::ClientError, Excon::Errors::ServerError
-        cloud_error('Unable to connect to the OpenStack Volume API. Check task debug log for details.')
       end
 
       @metadata_lock = Mutex.new

--- a/bosh_openstack_cpi/spec/spec_helper.rb
+++ b/bosh_openstack_cpi/spec/spec_helper.rb
@@ -18,7 +18,8 @@ def mock_cloud_options
         'tenant' => 'admin',
         'region' => 'RegionOne',
         'state_timeout' => 1,
-        'wait_resource_poll_interval' => 3
+        'wait_resource_poll_interval' => 3,
+        'use_openstack_volume_service' => 'true'
       },
       'registry' => {
         'endpoint' => 'localhost:42288',

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -407,6 +407,9 @@ properties:
   openstack.ignore_server_availability_zone:
     description: When creating disks do not use the servers AZ, default to openstack default
     default: false
+  openstack.use_openstack_volume_service
+    description: Option to disable cpi volume endpoint check (by default true so it won't affect cpi initialization)
+    default: true
   vcenter.address:
     description: Address of vCenter server used by vsphere cpi
   vcenter.user:

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -407,7 +407,7 @@ properties:
   openstack.ignore_server_availability_zone:
     description: When creating disks do not use the servers AZ, default to openstack default
     default: false
-  openstack.use_openstack_volume_service
+  openstack.use_openstack_volume_service:
     description: Option to disable cpi volume endpoint check (by default true so it won't affect cpi initialization)
     default: true
   vcenter.address:


### PR DESCRIPTION
Just a optional openstack volume service check , the requirement for this is because openstack deployment sometimes is without shared storage . 

So if there is no volume endpoint on openstack , bosh openstack cpi initialization will fail after retrying . 
By default this value is true so it won't affect normal openstack deployments with volume endpoint.