### PR TITLE
Aws spot ondemand fallback

### DIFF
--- a/bosh-director/lib/bosh/director/config.rb
+++ b/bosh-director/lib/bosh/director/config.rb
@@ -171,7 +171,12 @@ module Bosh::Director
         db_config = db_config.merge(connection_options)
 
         db = Sequel.connect(db_config)
-        db.extension :connection_validator
+
+        Bosh::Common.retryable(sleep: 0.5, tries: 20, on: [Exception]) do
+          db.extension :connection_validator
+          true
+        end
+
         db.pool.connection_validation_timeout = -1
         if logger
           db.logger = logger

--- a/bosh_aws_cpi/README.md
+++ b/bosh_aws_cpi/README.md
@@ -57,6 +57,8 @@ These options are specified under `cloud_options` in the `resource_pools` sectio
   which [type of instance](http://aws.amazon.com/ec2/instance-types/) the VMs should belong to
 * `spot_bid_price` (optional)
   the [AWS spot instance](http://aws.amazon.com/ec2/purchasing-options/spot-instances/) bid price to use.  When specified spot instances are started rather than on demand instances.  _NB: this will dramatically slow down resource pool creation._
+* `spot_ondemand_fallback` (optional)
+  set to `true` to use an on demand instance if a spot instance is not available during VM creation (defaults to `false`)
 
 ### Network options
 

--- a/bosh_aws_cpi/lib/cloud/aws/helpers.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/helpers.rb
@@ -4,7 +4,12 @@ module Bosh::AwsCloud
 
   module Helpers
     def default_ephemeral_disk_mapping
-       { '/dev/sdb' => 'ephemeral0' }
+       [
+         {
+           :device_name => '/dev/sdb',
+           :virtual_name => 'ephemeral0',
+         },
+       ]
     end
 
     def ebs_ephemeral_disk_mapping(volume_size_in_gb, volume_type)

--- a/bosh_aws_cpi/lib/cloud/aws/spot_manager.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/spot_manager.rb
@@ -85,6 +85,10 @@ module Bosh::AwsCloud
         spec[:launch_specification][:network_interfaces][0][:groups] = security_groups
       end
 
+      if instance_params[:block_device_mappings]
+        spec[:launch_specification][:block_device_mappings] = instance_params[:block_device_mappings]
+      end
+
       spec
     end
 

--- a/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -38,7 +38,12 @@ describe Bosh::AwsCloud::InstanceManager do
         security_groups: ['baz'],
         private_ip_address: '1.2.3.4',
         availability_zone: 'us-east-1a',
-        block_device_mappings: { '/dev/sdb' => 'ephemeral0' }
+        block_device_mappings: [
+          {
+            :device_name => '/dev/sdb',
+            :virtual_name => 'ephemeral0',
+          },
+        ]
       }
     end
 
@@ -132,7 +137,13 @@ describe Bosh::AwsCloud::InstanceManager do
               :groups=>['sg-baz-1234'],
               :device_index=>0,
               :private_ip_address=>'1.2.3.4'
-            }]
+            }],
+            :block_device_mappings => [
+              {
+                :device_name => '/dev/sdb',
+                :virtual_name => 'ephemeral0',
+              },
+            ],
           })
 
           # return
@@ -302,7 +313,7 @@ describe Bosh::AwsCloud::InstanceManager do
               create_instance
 
               expect(aws_instances).to have_received(:create) do |instance_params|
-                expect(instance_params[:block_device_mappings]).to eq({ '/dev/sdb' => 'ephemeral0' })
+                expect(instance_params[:block_device_mappings]).to eq([{:device_name=>"/dev/sdb", :virtual_name=>"ephemeral0"}])
               end
             end
           end
@@ -340,7 +351,14 @@ describe Bosh::AwsCloud::InstanceManager do
             create_instance
 
             expect(aws_instances).to have_received(:create) do |instance_params|
-              expect(instance_params[:block_device_mappings]).to eq({ '/dev/sdb' => 'ephemeral0' })
+              expect(instance_params[:block_device_mappings]).to eq(
+                [
+                  {
+                    :device_name => '/dev/sdb',
+                    :virtual_name => 'ephemeral0',
+                  },
+                ]
+              )
             end
           end
         end

--- a/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
+++ b/bosh_aws_cpi/spec/unit/instance_manager_spec.rb
@@ -164,6 +164,33 @@ describe Bosh::AwsCloud::InstanceManager do
         # Trigger spot instance request
         create_instance
       end
+
+      it 'should raise an exception when spot creation fails' do
+        expect(instance_manager).to receive(:create_aws_spot_instance).and_raise(Bosh::Clouds::VMCreationFailed.new(false))
+
+        expect {
+          create_instance
+        }.to raise_error(Bosh::Clouds::VMCreationFailed)
+      end
+
+      context 'when spot_ondemand_fallback is configured' do
+        let(:resource_pool) do
+          {
+            'spot_bid_price' => 0.15,
+            'spot_ondemand_fallback' => true,
+            'instance_type' => 'm1.small',
+            'key_name' => 'bar',
+          }
+        end
+
+        it 'should create an on demand instance when spot creation fails AND we have enabled spot_ondemand_fallback' do
+          expect(instance_manager).to receive(:create_aws_spot_instance).and_raise(Bosh::Clouds::VMCreationFailed.new(false))
+
+          expect(aws_instances).to receive(:create).and_return(aws_instance)
+
+          create_instance
+        end
+      end
     end
 
     it 'should retry creating the VM when AWS::EC2::Errors::InvalidIPAddress::InUse raised' do

--- a/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
+++ b/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
@@ -75,10 +75,18 @@ describe Bosh::AwsCloud::StemcellCreator do
         expect(params[:description]).to eq("stemcell-name 0.7.0")
         expect(params[:kernel_id]).to eq("aki-xxxxxxxx")
         expect(params[:root_device_name]).to eq("/dev/sda1")
-        expect(params[:block_device_mappings]).to eq({
-          "/dev/sda"=>{:snapshot_id=>"id"},
-          "/dev/sdb"=>"ephemeral0"
-        })
+        expect(params[:block_device_mappings]).to eq([
+          {
+            :device_name => "/dev/sda",
+            :ebs => {
+              :snapshot_id => "id",
+            },
+          },
+          {
+            :device_name => "/dev/sdb",
+            :virtual_name => "ephemeral0",
+          },
+        ])
       end
     end
 
@@ -93,10 +101,18 @@ describe Bosh::AwsCloud::StemcellCreator do
         expect(params).not_to have_key(:kernel_id)
         expect(params[:root_device_name]).to eq("/dev/xvda")
         expect(params[:sriov_net_support]).to eq("simple")
-        expect(params[:block_device_mappings]).to eq({
-          "/dev/xvda"=>{:snapshot_id=>"id"},
-          "/dev/sdb"=>"ephemeral0"
-        })
+        expect(params[:block_device_mappings]).to eq([
+          {
+            :device_name => "/dev/xvda",
+            :ebs => {
+              :snapshot_id => "id",
+            },
+          },
+          {
+            :device_name => "/dev/sdb",
+            :virtual_name => "ephemeral0",
+          },
+        ])
         expect(params[:virtualization_type]).to eq("hvm")
       end
     end

--- a/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
+++ b/bosh_aws_cpi/spec/unit/stemcell_creator_spec.rb
@@ -23,7 +23,8 @@ describe Bosh::AwsCloud::StemcellCreator do
   context "real" do
     let(:volume) { double("volume") }
     let(:snapshot) { double("snapshot", :id => "snap-xxxxxxxx") }
-    let(:image) { double("image") }
+    let(:image_id) { "ami-a1b2c3d4" }
+    let(:image) { double("image", :id => image_id) }
     let(:ebs_volume) { double("ebs_volume") }
 
     it "should create a real stemcell" do
@@ -31,7 +32,10 @@ describe Bosh::AwsCloud::StemcellCreator do
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_snapshot).with(snapshot: snapshot, state: :completed)
       allow(Bosh::AwsCloud::ResourceWait).to receive(:for_image).with(image: image, state: :available)
       allow(SecureRandom).to receive(:uuid).and_return("fake-uuid")
-      allow(region).to receive_message_chain(:images, :create).and_return(image)
+      allow(region).to receive(:images).and_return({
+        image_id => image,
+      })
+      allow(region).to receive_message_chain(:client, :register_image).and_return(double("object", :image_id => image_id))
 
       expect(creator).to receive(:copy_root_image)
       expect(volume).to receive(:create_snapshot).and_return(snapshot)


### PR DESCRIPTION
This PR is a WIP, and should only be considered for merging after https://github.com/cloudfoundry/bosh/pull/888

------

Occasionally the AWS spot price will spike for a number of hours, causing the resurrection of BOSH deployed spot jobs to fail.

The PR implements a simple but effective way to favor uptime over cost savings - have BOSH "fallback" to creating a regular on-demand instance when spot creation failed AND the `spot_ondemand_fallback` manifest property is set to `true`.

This enables resurrection to succeed during the spot price spike.  At the end of the spot price spike, the operator can manually terminate the on-demand nodes, and the BOSH's will resurrect them as spot instances again.

<img width="316" alt="screen shot 2015-08-10 at 12 20 43" src="https://cloud.githubusercontent.com/assets/227505/9170440/baa08f8a-3f5a-11e5-92f6-c0d5ab85fc5a.png">
