### PR TITLE
/etc/passwd should be owned by root:root and should not contain passw…

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -162,4 +162,19 @@ shared_examples_for 'every OS image' do
       it { should_not be_installed }
     end
   end
+
+  context '/etc/passwd file' do
+    describe file('/etc/passwd') do
+      # should be owned by root user (stig: V-38450)
+      it { should be_owned_by('root') }
+      # should be group-owned by root group (stig: V-38451)
+      it { should be_grouped_into('root') }
+    end
+
+    context 'should not contain password hash (stig: V-38499)' do
+      describe command('grep -v "^#" /etc/passwd | awk -F: \'($2 != "x") {print}\'') do
+        its (:stdout) { should eq('') }
+      end
+    end
+  end
 end


### PR DESCRIPTION
…ord hash

[#98978092](https://www.pivotaltracker.com/story/show/98978092)
[#98978096](https://www.pivotaltracker.com/story/show/98978096)
[#98978090](https://www.pivotaltracker.com/story/show/98978090)

Signed-off-by: Hua Zhang <zhuadl@cn.ibm.com>