### PR TITLE
Remove obsolete :os_image_version argument from stemcell:build

### DIFF
--- a/bosh-dev/lib/bosh/dev/tasks/stemcell.rake
+++ b/bosh-dev/lib/bosh/dev/tasks/stemcell.rake
@@ -61,7 +61,7 @@ namespace :stemcell do
   end
 
   desc 'Build a stemcell with a remote pre-built base OS image'
-  task :build, [:infrastructure_name, :hypervisor_name, :operating_system_name, :operating_system_version, :agent_name, :os_image_s3_bucket_name, :os_image_key, :os_image_version] do |_, args|
+  task :build, [:infrastructure_name, :hypervisor_name, :operating_system_name, :operating_system_version, :agent_name, :os_image_s3_bucket_name, :os_image_key] do |_, args|
     require 'uri'
     require 'tempfile'
     require 'bosh/dev/download_adapter'


### PR DESCRIPTION
Originally introduced in change 02d7e67,
and reverted in change f6f9c8f,
it came back in change 2754b45

Seems like this is obsolete (at least for now), so let's remove it.
[#84810910](https://www.pivotaltracker.com/story/show/84810910)