### PR TITLE
/etc/group should be owned by root:root with 644 mode or less permissive

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -162,4 +162,17 @@ shared_examples_for 'every OS image' do
       it { should_not be_installed }
     end
   end
+
+  context '/etc/group file' do
+    describe file('/etc/group') do
+      # should be owned by root user (stig: V-38458)
+      it { should be_owned_by('root') }
+      # should be owned by root group (stig: V-38459)
+      it { should be_grouped_into('root') }
+      it "should have mode 0644 or less permissive (stig: V-38461)" do
+        mode = File.stat('/etc/group').mode.to_s(8)[-4..-1].to_i(8)
+        expect(mode & '0644'.to_i(8)).to equal(mode)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[#98978098](https://www.pivotaltracker.com/story/show/98978098)
[#98978082](https://www.pivotaltracker.com/story/show/98978082)
[#98978150](https://www.pivotaltracker.com/story/show/98978150)

Signed-off-by: Hua Zhang <zhuadl@cn.ibm.com>