### PR TITLE
/etc/gshadow must be owned by root:root and has mode 0

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -213,6 +213,7 @@ module Bosh::Stemcell
      [
         :base_centos,
         :base_centos_packages,
+        :base_file_permission,
         :base_ssh,
         :system_kernel_modules,
         :system_ixgbevf,
@@ -229,6 +230,7 @@ module Bosh::Stemcell
       [
         :base_rhel,
         :base_centos_packages,
+        :base_file_permission,
         :base_ssh,
         :system_kernel_modules,
         bosh_steps,
@@ -247,6 +249,7 @@ module Bosh::Stemcell
         :base_apt,
         :base_ubuntu_build_essential,
         :base_ubuntu_packages,
+        :base_file_permission,
         :base_ssh,
         :bosh_sysstat,
         :system_kernel,

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -28,6 +28,7 @@ module Bosh::Stemcell
               :base_apt,
               :base_ubuntu_build_essential,
               :base_ubuntu_packages,
+              :base_file_permission,
               :base_ssh,
               :bosh_sysstat,
               :system_kernel,
@@ -57,6 +58,7 @@ module Bosh::Stemcell
             [
               :base_centos,
               :base_centos_packages,
+              :base_file_permission,
               :base_ssh,
               :system_kernel_modules,
               :system_ixgbevf,
@@ -83,6 +85,7 @@ module Bosh::Stemcell
             [
               :base_rhel,
               :base_centos_packages,
+              :base_file_permission,
               :base_ssh,
               :system_kernel_modules,
               :bosh_sysctl,

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -190,4 +190,15 @@ shared_examples_for 'every OS image' do
       end
     end
   end
+
+  context '/etc/gshadow file' do
+    describe file('/etc/gshadow') do
+      # should be owned by root user (stig: V-38443)
+      it { should be_owned_by('root') }
+      # should be owned by root group (stig: V-38448)
+      it { should be_grouped_into('root') }
+      # should have mode 0 (stig: V-38449)
+      it { should be_mode('0') }
+    end
+  end
 end

--- a/stemcell_builder/stages/base_file_permission/apply.sh
+++ b/stemcell_builder/stages/base_file_permission/apply.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+base_dir=$(readlink -nf $(dirname $0)/../..)
+source $base_dir/lib/prelude_apply.bash
+
+chmod 0000 $chroot/etc/gshadow
+chown root:root $chroot/etc/gshadow


### PR DESCRIPTION
[#98978112](https://www.pivotaltracker.com/story/show/98978112)
[#98978238](https://www.pivotaltracker.com/story/show/98978238)
[#98978236](https://www.pivotaltracker.com/story/show/98978236)

Signed-off-by: Hua Zhang <zhuadl@cn.ibm.com>