### PR TITLE
Fix the bug of using same shared example of 'every OS image'

### DIFF
--- a/bosh-stemcell/spec/os_image/centos_7_spec.rb
+++ b/bosh-stemcell/spec/os_image/centos_7_spec.rb
@@ -5,6 +5,7 @@ describe 'CentOS 7 OS image', os_image: true do
   it_behaves_like 'a CentOS or RHEL based OS image'
   it_behaves_like 'a systemd-based OS image'
   it_behaves_like 'a Linux kernel 3.x based OS image'
+  it_behaves_like 'a Linux kernel module configured OS image'
 
   context 'installed by base_centos' do
     describe file('/etc/locale.conf') do

--- a/bosh-stemcell/spec/os_image/rhel_7_spec.rb
+++ b/bosh-stemcell/spec/os_image/rhel_7_spec.rb
@@ -5,6 +5,7 @@ describe 'RHEL 7 OS image', os_image: true do
   it_behaves_like 'a CentOS or RHEL based OS image'
   it_behaves_like 'a systemd-based OS image'
   it_behaves_like 'a Linux kernel 3.x based OS image'
+  it_behaves_like 'a Linux kernel module configured OS image'
 
   context 'installed by base_rhel' do
     describe command('rct cat-cert /etc/pki/product/69.pem') do

--- a/bosh-stemcell/spec/os_image/ubuntu_trusty_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_trusty_spec.rb
@@ -4,6 +4,7 @@ describe 'Ubuntu 14.04 OS image', os_image: true do
   it_behaves_like 'every OS image'
   it_behaves_like 'an upstart-based OS image'
   it_behaves_like 'a Linux kernel 3.x based OS image'
+  it_behaves_like 'a Linux kernel module configured OS image'
 
   describe package('apt') do
     it { should be_installed }

--- a/bosh-stemcell/spec/support/os_image_linux_kernel_modules_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_linux_kernel_modules_shared_examples.rb
@@ -1,4 +1,4 @@
-shared_examples_for 'every OS image' do
+shared_examples_for 'a Linux kernel module configured OS image' do
   context 'prevent bluetooth module to be loaded (stig: V-38682)' do
     describe file('/etc/modprobe.d/blacklist.conf') do
       it { should be_file }


### PR DESCRIPTION
This bug was introduced by PR [#897](https://github.com/cloudfoundry/bosh/pull/897)
in which the new tests override the shared examples 'every OS image' used in
'os_image_shared_examples.rb'. we rename it to 'a Linux kernel module configured OS image'
to avoid skipping the other tests.

Signed-off-by: Hua Zhang <zhuadl@cn.ibm.com>