### PR TITLE
fix the bug of not using $chroot/etc/group to check permission

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -184,10 +184,8 @@ shared_examples_for 'every OS image' do
       it { should be_owned_by('root') }
       # should be owned by root group (stig: V-38459)
       it { should be_grouped_into('root') }
-      it "should have mode 0644 or less permissive (stig: V-38461)" do
-        mode = File.stat('/etc/group').mode.to_s(8)[-4..-1].to_i(8)
-        expect(mode & '0644'.to_i(8)).to equal(mode)
-      end
+      # should have mode 0644 (stig: V-38461)
+      it { should be_mode('644') }
     end
   end
 


### PR DESCRIPTION
we occasionally found this bug of not checking /etc/group file
permission under chroot after os image was built. The reason is
File.stat method won't get the chroot context in Rspec setup by
os_image.rb. It will use the /etc/group file of stemcell build
machine's OS, not the stemcell's. But because both of the files
has the same mode value 0644, the problem does not come out in
this case. it will fail the other cases when the files in
$chroot and OS have different mode value.

Signed-off-by: Hua Zhang <zhuadl@cn.ibm.com>