### PR TITLE
Allow more AWS credential sources

### DIFF
--- a/blobstore_client/README.md
+++ b/blobstore_client/README.md
@@ -19,7 +19,7 @@ $ blobstore_client_console -p local -c config/local.yml.example
 => Welcome to BOSH blobstore client console
 You can use 'bsc' to access blobstore client methods
 > bsc.create("this is a test blob")
-=> "ef00746b-21ec-4473-a888-bf257cb7ea21" 
+=> "ef00746b-21ec-4473-a888-bf257cb7ea21"
 > bsc.get("ef00746b-21ec-4473-a888-bf257cb7ea21")
 => "this is a test blob"
 > bsc.exists?("ef00746b-21ec-4473-a888-bf257cb7ea21")
@@ -62,9 +62,11 @@ These are the options for the Blobstore client when provider is `s3`:
   Name of the S3 bucket
 * `encryption_key` (optional)
   Encryption_key that is applied before the object is sent to S3
-* `access_key_id` (optional, if not present, the blobstore client operates in read only mode)
+* `credentials_source` (optional)
+  Where to get AWS credentials. This can be set to `static` for to use an `access_key_id` and `secret_access_key` or `env_or_profile` to get the credentials from environment variables or an EC2 instance profile. Defaults to `static` if not set.
+* `access_key_id` (optional, if not present and `credentials_source` is `static`, the blobstore client operates in read only mode)
   S3 Access Key
-* `secret_access_key` (optional, if not present, the blobstore client operates in read only mode)
+* `secret_access_key` (optional, if not present and `credentials_source` is `static`, the blobstore client operates in read only mode)
   S3 Secret Access Key
 
 ### OpenStack Swift provider

--- a/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
+++ b/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
@@ -416,5 +416,37 @@ module Bosh::Blobstore
         end
       end
     end
+    
+    describe 'credentials_source' do
+      
+      context 'when credentials_source is invalid' do
+        before do
+	  options.merge!('credentials_source' => 'NotACredentialsSource')
+	end
+
+	it 'raises an error' do
+	  expect {
+	    client
+	  }.to raise_error(BlobstoreError, "invalid credentials_source")
+	end
+      end
+
+      context 'when access_key_id and secret_access_key are provided with the env_or_profile credentials_source' do
+        
+        before do
+	  options.merge!(
+	    'credentials_source' => 'env_or_profile',
+            'access_key_id' => 'KEY',
+            'secret_access_key' => 'SECRET'
+	  )
+	end
+
+	it 'raises an error' do
+	  expect {
+	    client
+	  }.to raise_error(BlobstoreError, "can't use access_key_id or secret_access_key with env_or_profile credentials_source")
+	end
+      end
+    end
   end
 end

--- a/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
+++ b/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
@@ -233,7 +233,7 @@ module Bosh::Blobstore
         end
 
         before do
-          allow(client).to receive(:get_object_from_s3).and_return(blob)          
+          allow(client).to receive(:get_object_from_s3).and_return(blob)
         end
 
         it 'uses a proper content-type' do
@@ -416,36 +416,36 @@ module Bosh::Blobstore
         end
       end
     end
-    
+
     describe 'credentials_source' do
-      
+
       context 'when credentials_source is invalid' do
         before do
-	  options.merge!('credentials_source' => 'NotACredentialsSource')
-	end
+          options.merge!('credentials_source' => 'NotACredentialsSource')
+        end
 
-	it 'raises an error' do
-	  expect {
-	    client
-	  }.to raise_error(BlobstoreError, "invalid credentials_source")
-	end
+        it 'raises an error' do
+          expect {
+            client
+          }.to raise_error(BlobstoreError, "invalid credentials_source")
+        end
       end
-
+      
       context 'when access_key_id and secret_access_key are provided with the env_or_profile credentials_source' do
-        
-        before do
-	  options.merge!(
-	    'credentials_source' => 'env_or_profile',
-            'access_key_id' => 'KEY',
-            'secret_access_key' => 'SECRET'
-	  )
-	end
 
-	it 'raises an error' do
-	  expect {
-	    client
-	  }.to raise_error(BlobstoreError, "can't use access_key_id or secret_access_key with env_or_profile credentials_source")
-	end
+        before do
+          options.merge!(
+          'credentials_source' => 'env_or_profile',
+          'access_key_id' => 'KEY',
+          'secret_access_key' => 'SECRET'
+          )
+        end
+
+        it 'raises an error' do
+          expect {
+            client
+          }.to raise_error(BlobstoreError, "can't use access_key_id or secret_access_key with env_or_profile credentials_source")
+        end
       end
     end
   end

--- a/bosh-registry/README.md
+++ b/bosh-registry/README.md
@@ -52,12 +52,14 @@ the IP addresses belonging to a instances:
 
 These are the credentials to connect to AWS services:
 
-* `access_key_id` (required)
-  IAM Access Key ID
-* `secret_access_key` (required)
-  AWS IAM Secret Access Key
 * `region` (required)
   AWS EC2 Region
+* `credentials_source` (optional)
+  Where to get AWS credentials. This can be set to `static` for to use an `access_key_id` and `secret_access_key` or `env_or_profile` to get the credentials from environment variables or an EC2 instance profile. Defaults to `static` if not set.
+* `access_key_id` (optional, required when `credentials_source` is `static`)
+  AWS IAM user access key
+* `secret_access_key` (optional, required when `credentials_source` is `static`)
+  AWS IAM secret access key
 * `max_retries` (optional, defaults to 2)
   Max number of retries to connect to AWS
 

--- a/bosh-registry/lib/bosh/registry/instance_manager/aws.rb
+++ b/bosh-registry/lib/bosh/registry/instance_manager/aws.rb
@@ -15,19 +15,29 @@ module Bosh::Registry
 
         @aws_properties = cloud_config["aws"]
         @aws_options = {
-          :access_key_id => @aws_properties["access_key_id"],
-          :secret_access_key => @aws_properties["secret_access_key"],
           :max_retries => @aws_properties["max_retries"] || AWS_MAX_RETRIES,
           :ec2_endpoint => @aws_properties['ec2_endpoint'] || "ec2.#{@aws_properties['region']}.amazonaws.com",
           :logger => @logger
         }
         # configure optional parameters
         %w(
+          access_key_id
+          secret_access_key
           ssl_verify_peer
           ssl_ca_file
           ssl_ca_path
         ).each do |k|
           @aws_options[k.to_sym] = @aws_properties[k] unless @aws_properties[k].nil?
+        end
+
+        # credentials_source could be static (default) or env_or_profile
+        # static credentials must be included in aws_properties
+        # env_or_profile credentials will use the AWS DefaultCredentialsProvider
+        # to find AWS credentials in environment variables or EC2 instance profiles
+
+        if cloud_config['aws']['credentials_source'] == 'static' || cloud_config['aws']['credentials_source'].nil?
+          @aws_options[:access_key_id] = cloud_config['aws']['access_key_id']
+          @aws_options[:secret_access_key] = cloud_config['aws']['secret_access_key']
         end
 
         @ec2 = AWS::EC2.new(@aws_options)
@@ -36,11 +46,29 @@ module Bosh::Registry
       def validate_options(cloud_config)
         unless cloud_config.has_key?("aws") &&
             cloud_config["aws"].is_a?(Hash) &&
-            cloud_config["aws"]["access_key_id"] &&
-            cloud_config["aws"]["secret_access_key"] &&
             cloud_config["aws"]["region"]
           raise ConfigError, "Invalid AWS configuration parameters"
         end
+
+        credentials_source = cloud_config['aws']['credentials_source'] || 'static'
+
+        if credentials_source != 'env_or_profile' && credentials_source != 'static'
+          raise ConfigError, "Unknown credentials_source #{credentials_source}"
+        end
+
+        if credentials_source == 'static'
+          if !cloud_config["aws"].has_key?("access_key_id") || !cloud_config["aws"].has_key?("secret_access_key")
+              raise ConfigError, "Must use access_key_id and secret_access_key with static credentials_source"
+          end
+        end
+
+        if credentials_source == 'env_or_profile'
+          if cloud_config["aws"].has_key?("access_key_id") || cloud_config["aws"].has_key?("secret_access_key")
+              raise ConfigError, "Can't use access_key_id and secret_access_key with env_or_profile credentials_source"
+          end
+        end
+
+
       end
 
       # Get the list of IPs belonging to this instance

--- a/bosh-registry/spec/unit/bosh/registry/aws/config_spec.rb
+++ b/bosh-registry/spec/unit/bosh/registry/aws/config_spec.rb
@@ -11,8 +11,6 @@ describe Bosh::Registry::InstanceManager do
       @config["cloud"] = {
         "plugin" => "aws",
         "aws" => {
-          "access_key_id" => "foo",
-          "secret_access_key" => "bar",
           "region" => "foobar",
           "max_retries" => 5
         }
@@ -33,20 +31,6 @@ describe Bosh::Registry::InstanceManager do
       }.to raise_error(Bosh::Registry::ConfigError, /Invalid AWS configuration parameters/)
     end
 
-    it "validates presence of access_key_id cloud option" do
-      @config["cloud"]["aws"].delete("access_key_id")
-      expect {
-        Bosh::Registry.configure(@config)
-      }.to raise_error(Bosh::Registry::ConfigError, /Invalid AWS configuration parameters/)
-    end
-
-    it "validates presence of secret_access_key cloud option" do
-      @config["cloud"]["aws"].delete("secret_access_key")
-      expect {
-        Bosh::Registry.configure(@config)
-      }.to raise_error(Bosh::Registry::ConfigError, /Invalid AWS configuration parameters/)
-    end
-
     it "validates presence of region cloud option" do
       @config["cloud"]["aws"].delete("region")
       expect {
@@ -55,12 +39,16 @@ describe Bosh::Registry::InstanceManager do
     end
 
     it "passes optional parameters to EC2" do
+      @config["cloud"]["aws"]["access_key_id"] = "foo"
+      @config["cloud"]["aws"]["secret_access_key"] = "bar"
       @config["cloud"]["aws"]["ssl_verify_peer"] = false
       @config["cloud"]["aws"]["ssl_ca_file"] = '/custom/cert/ca-certificates'
       @config["cloud"]["aws"]["ssl_ca_path"] = '/custom/cert/'
 
       instance_double('AWS::EC2')
       expect(AWS::EC2).to receive(:new) do |config|
+        expect(config[:access_key_id]).to eq('foo')
+        expect(config[:secret_access_key]).to eq('bar')
         expect(config[:ssl_verify_peer]).to be false
         expect(config[:ssl_ca_file]).to eq('/custom/cert/ca-certificates')
         expect(config[:ssl_ca_path]).to eq('/custom/cert/')
@@ -69,6 +57,8 @@ describe Bosh::Registry::InstanceManager do
     end
 
     it "uses default ec2_endpoint if none specified" do
+      @config["cloud"]["aws"]["access_key_id"] = "foo"
+      @config["cloud"]["aws"]["secret_access_key"] = "bar"
       instance_double('AWS::EC2')
       expect(AWS::EC2).to receive(:new) do |config|
         expect(config[:ec2_endpoint]).to eq("ec2.#{@config['cloud']['aws']['region']}.amazonaws.com")
@@ -77,6 +67,8 @@ describe Bosh::Registry::InstanceManager do
     end
 
     it "uses specified ec2_endpoint" do
+      @config["cloud"]["aws"]["access_key_id"] = "foo"
+      @config["cloud"]["aws"]["secret_access_key"] = "bar"
       @config["cloud"]["aws"]["ec2_endpoint"] = "ec2endpoint.websites.com"
       instance_double('AWS::EC2')
       expect(AWS::EC2).to receive(:new) do |config|
@@ -84,5 +76,34 @@ describe Bosh::Registry::InstanceManager do
       end
       Bosh::Registry.configure(@config)
     end
+
+    it "raises an error when using an invalid credentials_source" do
+      @config["cloud"]["aws"]["credentials_source"] = "NotACredentialsSource"
+      instance_double('AWS::EC2')
+      expect {
+        Bosh::Registry.configure(@config)
+      }.to raise_error(Bosh::Registry::ConfigError, "Unknown credentials_source NotACredentialsSource")
+    end
+
+    it "validates the env_or_profile credentials_source" do
+      @config["cloud"]["aws"]["credentials_source"] = "env_or_profile"
+      instance_double('AWS::EC2')
+      expect(AWS::EC2).to receive(:new) do |config|
+        expect(config[:access_key_id]).to be nil
+        expect(config[:secret_access_key]).to be nil
+      end
+      Bosh::Registry.configure(@config)
+    end
+
+    it "raises an error when access keys are used with the env_or_profile credentials_source" do
+      @config["cloud"]["aws"]["credentials_source"] = "env_or_profile"
+      @config["cloud"]["aws"]["access_key_id"] = "foo"
+      @config["cloud"]["aws"]["secret_access_key"] = "bar"
+      instance_double('AWS::EC2')
+      expect {
+        Bosh::Registry.configure(@config)
+      }.to raise_error(Bosh::Registry::ConfigError, "Can't use access_key_id and secret_access_key with env_or_profile credentials_source")
+    end
+
   end
 end

--- a/bosh_aws_cpi/README.md
+++ b/bosh_aws_cpi/README.md
@@ -9,10 +9,6 @@ These options are passed to the AWS CPI when it is instantiated.
 
 ### AWS options
 
-* `access_key_id` (required)
-  AWS IAM user access key
-* `secret_access_key` (required)
-  AWS IAM secret access key
 * `default_key_name` (required)
   default AWS ssh key name to assign to created virtual machines
 * `default_security_groups` (required)
@@ -21,6 +17,12 @@ These options are passed to the AWS CPI when it is instantiated.
   local path to the ssh private key, must match `default_key_name`
 * `region` (required)
   EC2 region
+* `credentials_source` (optional)
+  Where to get AWS credentials. This can be set to `static` for to use an `access_key_id` and `secret_access_key` or `env_or_profile` to get the credentials from environment variables or an EC2 instance profile. Defaults to `static` if not set
+* `access_key_id` (optional, required when `credentials_source` is `static`)
+  AWS IAM user access key
+* `secret_access_key` (optional, required when `credentials_source` is `static`)
+  AWS IAM secret access key
 * `ec2_endpoint` (optional)
   URL of the EC2 endpoint to connect to, defaults to the endpoint corresponding to the selected region,
   or `default_ec2_endpoint` if no region has been selected
@@ -57,7 +59,9 @@ These options are specified under `cloud_options` in the `resource_pools` sectio
   which [type of instance](http://aws.amazon.com/ec2/instance-types/) the VMs should belong to
 * `spot_bid_price` (optional)
   the [AWS spot instance](http://aws.amazon.com/ec2/purchasing-options/spot-instances/) bid price to use.  When specified spot instances are started rather than on demand instances.  _NB: this will dramatically slow down resource pool creation._
-
+* `iam_instance_profile` (optional)
+   the [IAM Instance Profile](http://docs.aws.amazon.com/IAM/latest/UserGuide/roles-usingrole-instanceprofile.html) to use for the instance. This allows EC2 instances to use [IAM Roles](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) when working with AWS APIs.
+    
 ### Network options
 
 These options are specified under `cloud_options` in the `networks` section of a BOSH deployment manifest.

--- a/bosh_aws_cpi/lib/cloud/aws/cloud.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/cloud.rb
@@ -718,27 +718,23 @@ module Bosh::AwsCloud
     # will be able to authenticate to AWS.
     #
     def validate_credentials_source
-      validation_errors = []
-
       credentials_source = options['aws']['credentials_source'] || 'static'
 
       if credentials_source != 'env_or_profile' && credentials_source != 'static'
-        validation_errors << "Unknown credentials_source #{credentials_source}"
+        raise ArgumentError, "Unknown credentials_source #{credentials_source}"
       end
 
       if credentials_source == 'static'
         if !options["aws"].has_key?("access_key_id") || !options["aws"].has_key?("secret_access_key")
-            validation_errors << "Must use access_key_id and secret_access_key with static credentials_source"
+            raise ArgumentError, "Must use access_key_id and secret_access_key with static credentials_source"
         end
       end
 
       if credentials_source == 'env_or_profile'
         if options["aws"].has_key?("access_key_id") || options["aws"].has_key?("secret_access_key")
-            validation_errors << "Can't use access_key_id and secret_access_key with env_or_profile credentials_source"
+            raise ArgumentError, "Can't use access_key_id and secret_access_key with env_or_profile credentials_source"
         end
       end
-
-      raise ArgumentError, "Invalid credentials_source: #{validation_errors.join(', ')}" unless validation_errors.empty?
     end
 
     # Generates initial agent settings. These settings will be read by agent

--- a/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
+++ b/bosh_aws_cpi/lib/cloud/aws/instance_manager.rb
@@ -118,7 +118,7 @@ module Bosh::AwsCloud
       set_key_name_parameter(instance_params, resource_pool["key_name"], options["aws"]["default_key_name"])
       set_security_groups_parameter(instance_params, networks_spec, options["aws"]["default_security_groups"])
       set_vpc_parameters(instance_params, networks_spec)
-
+      set_iam_instance_profile_parameter(instance_params, resource_pool["iam_instance_profile"], options["aws"]["default_iam_instance_profile"])
       set_availability_zone_parameter(
         instance_params,
         (disk_locality || []).map { |volume_id| @region.volumes[volume_id].availability_zone.to_s },
@@ -211,6 +211,11 @@ module Bosh::AwsCloud
       user_data[:dns] = {nameserver: spec_with_dns["dns"]} if spec_with_dns
 
       instance_params[:user_data] = Yajl::Encoder.encode(user_data)
+    end
+
+    def set_iam_instance_profile_parameter(instance_params, resource_pool_iam_instance_profile, default_aws_iam_instance_profile)
+      iam_instance_profile = resource_pool_iam_instance_profile || default_aws_iam_instance_profile
+      instance_params[:iam_instance_profile] = iam_instance_profile unless iam_instance_profile.nil?
     end
 
     def validate_and_prepare_security_groups_parameter(instance_params, security_groups)

--- a/bosh_aws_cpi/spec/unit/cloud_spec.rb
+++ b/bosh_aws_cpi/spec/unit/cloud_spec.rb
@@ -277,7 +277,7 @@ describe Bosh::AwsCloud::Cloud do
         it 'raises an error' do
           expect { cloud }.to raise_error(
           ArgumentError,
-          'Invalid credentials_source: Must use access_key_id and secret_access_key with static credentials_source'
+          'Must use access_key_id and secret_access_key with static credentials_source'
           )
         end
       end
@@ -322,7 +322,7 @@ describe Bosh::AwsCloud::Cloud do
       it 'raises an error' do
         expect { cloud }.to raise_error(
         ArgumentError,
-        "Invalid credentials_source: Can't use access_key_id and secret_access_key with env_or_profile credentials_source"
+        "Can't use access_key_id and secret_access_key with env_or_profile credentials_source"
         )
       end
     end
@@ -346,7 +346,7 @@ describe Bosh::AwsCloud::Cloud do
       it 'raises an error' do
         expect { cloud }.to raise_error(
         ArgumentError,
-        'Invalid credentials_source: Unknown credentials_source NotACredentialsSource'
+        'Unknown credentials_source NotACredentialsSource'
         )
       end
     end

--- a/bosh_aws_cpi/spec/unit/cloud_spec.rb
+++ b/bosh_aws_cpi/spec/unit/cloud_spec.rb
@@ -255,4 +255,100 @@ describe Bosh::AwsCloud::Cloud do
       end
     end
   end
+
+  describe 'validating credentials_source' do
+    context 'when credentials_source is set to static' do
+
+      context 'when access_key_id and secret_access_key are omitted' do
+        let(:options) do
+          {
+            'aws' => {
+              'credentials_source' => 'static',
+              'region' => 'fake-region',
+              'default_key_name' => 'sesame'
+            },
+            'registry' => {
+              'user' => 'abuser',
+              'password' => 'hard2gess',
+              'endpoint' => 'http://websites.com'
+            }
+          }
+        end
+        it 'raises an error' do
+          expect { cloud }.to raise_error(
+          ArgumentError,
+          'Invalid credentials_source: Must use access_key_id and secret_access_key with static credentials_source'
+          )
+        end
+      end
+    end
+
+    context 'when credentials_source is set to env_or_profile' do
+      let(:options) do
+        {
+          'aws' => {
+            'credentials_source' => 'env_or_profile',
+            'region' => 'fake-region',
+            'default_key_name' => 'sesame'
+          },
+          'registry' => {
+            'user' => 'abuser',
+            'password' => 'hard2gess',
+            'endpoint' => 'http://websites.com'
+          }
+        }
+      end
+      it 'does not raise an error ' do
+        expect { cloud }.to_not raise_error
+      end
+    end
+
+    context 'when credentials_source is set to env_or_profile and access_key_id is provided' do
+      let(:options) do
+        {
+          'aws' => {
+            'credentials_source' => 'env_or_profile',
+            'access_key_id' => 'some access key',
+            'region' => 'fake-region',
+            'default_key_name' => 'sesame'
+          },
+          'registry' => {
+            'user' => 'abuser',
+            'password' => 'hard2gess',
+            'endpoint' => 'http://websites.com'
+          }
+        }
+      end
+      it 'raises an error' do
+        expect { cloud }.to raise_error(
+        ArgumentError,
+        "Invalid credentials_source: Can't use access_key_id and secret_access_key with env_or_profile credentials_source"
+        )
+      end
+    end
+
+    context 'when an unknown credentails_source is set' do
+      let(:options) do
+        {
+          'aws' => {
+            'credentials_source' => 'NotACredentialsSource',
+            'region' => 'fake-region',
+            'default_key_name' => 'sesame'
+          },
+          'registry' => {
+            'user' => 'abuser',
+            'password' => 'hard2gess',
+            'endpoint' => 'http://websites.com'
+          }
+        }
+      end
+
+      it 'raises an error' do
+        expect { cloud }.to raise_error(
+        ArgumentError,
+        'Invalid credentials_source: Unknown credentials_source NotACredentialsSource'
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR contains changes that allow BOSH to be configured to get AWS credentials from different places. The primary driver for this is to allow BOSH to use IAM Roles via EC2 instance profiles so it includes a change that enables BOSH users to set IAM instance profiles for their resource pools.

BOSH users can set different credential sources in their configuration. This is how it changes BOSH configuration:

* `credentials_source` (optional)
  Where to get AWS credentials. This can be set to `static` for to use an `access_key_id` and `secret_access_key` or `env_or_profile` to get the credentials from environment variables or an EC2 instance profile. Defaults to `static` if not set
* `access_key_id` (optional, required when `credentials_source` is `static`)
  AWS IAM user access key
* `secret_access_key` (optional, required when `credentials_source` is `static`)
  AWS IAM secret access key

The default behavior matches what BOSH does today. 