### PR TITLE
Add a --terse option to `bosh stemcells` list view

### DIFF
--- a/bosh_cli/lib/cli/commands/stemcell.rb
+++ b/bosh_cli/lib/cli/commands/stemcell.rb
@@ -84,9 +84,10 @@ module Bosh::Cli
 
     usage 'stemcells'
     desc 'Show the list of available stemcells'
+    option "--terse", "easy to parse output"
     def list
+      terse = options[:terse]
       auth_required
-      show_current_state
 
       stemcells = director.list_stemcells.sort do |sc1, sc2|
         if sc1['name'] == sc2['name']
@@ -96,21 +97,29 @@ module Bosh::Cli
         end
       end
 
-      err('No stemcells') if stemcells.empty?
-
-      stemcells_table = table do |t|
-        t.headings = 'Name', 'OS', 'Version', 'CID'
-        stemcells.each do |sc|
-          t << get_stemcell_table_record(sc)
+      if terse
+        stemcells.each do |sc| 
+          row = get_stemcell_table_record(sc)
+          say(row.join("\t"))
         end
-      end
+      else
+        show_current_state
+        err('No stemcells') if stemcells.empty?
 
-      nl
-      say(stemcells_table)
-      nl
-      say('(*) Currently in-use')
-      nl
-      say('Stemcells total: %d' % stemcells.size)
+        stemcells_table = table do |t|
+          t.headings = 'Name', 'OS', 'Version', 'CID'
+          stemcells.each do |sc|
+            t << get_stemcell_table_record(sc)
+          end
+        end
+
+        nl
+        say(stemcells_table)
+        nl
+        say('(*) Currently in-use')
+        nl
+        say('Stemcells total: %d' % stemcells.size)
+      end
     end
 
     usage 'public stemcells'


### PR DESCRIPTION
The current output of `bosh stemcells` is hard to accurately parse from
scripts that invoke it. This commit implements the `--terse` option
currently only found on `bosh properties`.

One line is outputted per stemcell with zero lines being output if no
stemcells are available. The terse view lacks the total size visible in
the table view.