### PR TITLE
Add SettingsPath in OpenStack stemcell builder

### DIFF
--- a/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_openstack_agent_settings/apply.sh
@@ -19,6 +19,10 @@ if [ "${stemcell_operating_system}" == "rhel" ]; then
     "Settings": {
       "Sources": [
         {
+          "Type": "File",
+          "SettingsPath": "/var/vcap/bosh/agent-bootstrap-env.json"
+        },
+        {
           "Type": "ConfigDrive",
           "DiskPaths": [
             "/dev/disk/by-label/CONFIG-2",
@@ -53,6 +57,10 @@ else
   "Infrastructure": {
     "Settings": {
       "Sources": [
+        {
+          "Type": "File",
+          "SettingsPath": "/var/vcap/bosh/agent-bootstrap-env.json"
+        },
         {
           "Type": "ConfigDrive",
           "DiskPaths": [


### PR DESCRIPTION
we will look for this file before looking for settings from config drive or
the http registry, when the stemcell is used on onrack.

[#102600956](https://www.pivotaltracker.com/story/show/102600956)