### PR TITLE
Clarify `bosh scp` and `bosh ssh` documentation

### DIFF
--- a/bosh_cli/lib/cli/commands/ssh.rb
+++ b/bosh_cli/lib/cli/commands/ssh.rb
@@ -6,7 +6,7 @@ module Bosh::Cli
     class Ssh < Base
 
       # bosh ssh
-      usage 'ssh'
+      usage 'ssh <job>/<index>'
       desc 'Execute command or start an interactive session'
       option '--gateway_host HOST', 'Gateway host'
       option '--gateway_user USER', 'Gateway user'
@@ -38,11 +38,11 @@ module Bosh::Cli
       end
 
       # bosh scp
-      usage 'scp'
-      desc 'upload/download the source file to the given job. ' +
-             'Note: for download /path/to/destination is a directory'
-      option '--download', 'Download file'
-      option '--upload', 'Upload file'
+      usage 'scp <job>/<index> <source> <destination>'
+      desc "Transfer files to (--upload) or from (--download) a job.\n" +
+             'Note: for --download, <destination> is treated as a directory'
+      option '--download', 'Download <source> file from the job'
+      option '--upload', 'Upload <source> file to the job'
       option '--gateway_host HOST', 'Gateway host'
       option '--gateway_user USER', 'Gateway user'
       option '--gateway_identity_file FILE', 'Gateway identity file'


### PR DESCRIPTION
- Add positional arguments to the usage string
- Be more explicit re: what `scp --upload` and `--download` options do

Fixes #884