### PR TITLE
Support BOSH_COLOR env var for implicit --no-color

### DIFF
--- a/bosh_cli/lib/cli/runner.rb
+++ b/bosh_cli/lib/cli/runner.rb
@@ -25,8 +25,8 @@ module Bosh::Cli
       @option_parser = OptionParser.new(banner)
 
       Config.colorize = nil
-      if ENV.has_key? "BOSH_COLOR"
-        Config.colorize = ENV["BOSH_COLOR"] == "false"
+      if ENV.has_key?("BOSH_COLOR") && ENV["BOSH_COLOR"] == "false"
+        Config.colorize = false
       end
       Config.output ||= STDOUT
 

--- a/bosh_cli/lib/cli/runner.rb
+++ b/bosh_cli/lib/cli/runner.rb
@@ -25,6 +25,9 @@ module Bosh::Cli
       @option_parser = OptionParser.new(banner)
 
       Config.colorize = nil
+      if ENV.has_key? "BOSH_COLOR"
+        Config.colorize = ENV["BOSH_COLOR"] == "false"
+      end
       Config.output ||= STDOUT
 
       parse_global_options


### PR DESCRIPTION
If BOSH_COLOR is set to the string "false", then the `bosh' utility will
behave as if the `--no-color` option has been set.  This behavior can be
overridden by also passing `--color` (which takes precedence)

If BOSH_COLOR is not set, or has any other value, the previous default
behavior holds (only do color if we are hooked up to a terminal)