### PR TITLE
Fix the issue that /etc/sudoers.d is not included correctly.

### DIFF
--- a/stemcell_builder/stages/bosh_sudoers/apply.sh
+++ b/stemcell_builder/stages/bosh_sudoers/apply.sh
@@ -10,6 +10,7 @@ source $base_dir/lib/prelude_bosh.bash
 
 # setup sudoers to use includedir, and make sure we don't break anything
 cp -p $chroot/etc/sudoers $chroot/etc/sudoers.save
+echo '' >> $chroot/etc/sudoers
 echo '#includedir /etc/sudoers.d' >> $chroot/etc/sudoers
 run_in_bosh_chroot $chroot "visudo -c"
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Correct one issue which is introduced in this commit: https://github.com/cloudfoundry/bosh/commit/650ef135c85bb8b0e1a51eb5d5a413980de217f9

No blank line as the last line in /etc/sudoers so that the last line will be as below.
%bosh_sudoers ALL=(ALL) NOPASSWD: ALL#includedir /etc/sudoers.d