### PR TITLE
Add check if task was cancelled to AgentClient.wait_until_ready

### DIFF
--- a/bosh-director/lib/bosh/director/agent_client.rb
+++ b/bosh-director/lib/bosh/director/agent_client.rb
@@ -168,7 +168,11 @@ module Bosh::Director
       @deadline = Time.now.to_i + deadline
 
       begin
+        Config.job_cancelled?
         ping
+      rescue TaskCancelled => e
+        @logger.debug("Task was cancelled. Stop waiting response from vm")
+        raise e
       rescue RpcTimeout
         retry if @deadline - Time.now.to_i > 0
         raise RpcTimeout, "Timed out pinging to #{@client_id} after #{deadline} seconds"

--- a/bosh-director/lib/bosh/director/cloudcheck_helper.rb
+++ b/bosh-director/lib/bosh/director/cloudcheck_helper.rb
@@ -51,6 +51,8 @@ module Bosh::Director
         agent_client(vm).wait_until_ready
       rescue Bosh::Director::RpcTimeout
         handler_error("Agent still unresponsive after reboot")
+      rescue Bosh::Director::TaskCancelled
+        handler_error("Task was cancelled")
       end
     end
 

--- a/bosh-director/lib/bosh/director/deployment_plan/steps/package_compile_step.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/steps/package_compile_step.rb
@@ -166,8 +166,8 @@ module Bosh::Director
             configure_vm(vm, agent, network_settings)
             vm_data.agent = agent
             yield vm_data
-          rescue RpcTimeout => e
-            # if we time out waiting for the agent, we should clean up the the VM
+          rescue RpcTimeout, TaskCancelled => e
+            # if we time out waiting for the agent or task was cancelled, we should clean up the the VM
             # as it will leave us in an unrecoverable state otherwise
             @vm_reuser.remove_vm(vm_data)
             tear_down_vm(vm_data)

--- a/bosh-director/lib/bosh/director/jobs/base_job.rb
+++ b/bosh-director/lib/bosh/director/jobs/base_job.rb
@@ -28,7 +28,7 @@ module Bosh::Director
       def task_cancelled?
         return false if task_id.nil?
         task = task_manager.find_task(task_id)
-        task && (task.state == 'cancelling' || task.state == 'timeout')
+        task && (task.state == 'cancelling' || task.state == 'timeout' || task.state == 'cancelled')
       end
 
       def task_checkpoint

--- a/bosh-director/lib/bosh/director/resource_pool_updater.rb
+++ b/bosh-director/lib/bosh/director/resource_pool_updater.rb
@@ -50,7 +50,6 @@ module Bosh::Director
 
       vm_model = VmCreator.new.create(deployment, stemcell, @resource_pool.cloud_properties,
                                 vm.network_settings, nil, @resource_pool.env)
-
       agent = AgentClient.with_defaults(vm_model.agent_id)
       agent.wait_until_ready
       agent.update_settings(Config.trusted_certs)

--- a/bosh-director/spec/unit/agent_client_spec.rb
+++ b/bosh-director/spec/unit/agent_client_spec.rb
@@ -402,6 +402,21 @@ module Bosh::Director
 
           expect { client.wait_until_ready }.to raise_error(Bosh::Director::RpcRemoteException)
         end
+
+        it 'should raise an exception if task was cancelled' do
+          testjob_class = Class.new(Jobs::BaseJob) do
+            define_method :perform do
+              'foo'
+            end
+          end
+          task_id = 1
+          tasks_dir = Dir.mktmpdir
+          allow(Config).to receive(:base_dir).and_return(tasks_dir)
+          allow(Config).to receive(:cloud_options).and_return({})
+          task = Models::Task.make(:id => task_id, :state => 'cancelling')
+          testjob_class.perform(task_id)
+          expect { client.wait_until_ready }.to raise_error(Bosh::Director::TaskCancelled)
+        end
       end
     end
 


### PR DESCRIPTION
If task was cancelled TaskCancelled exception will be raised.
For some case it leads to vm deletion (just as RpcTimeout).

[#106641948](https://www.pivotaltracker.com/story/show/106641948)

Signed-off-by: Alexey Miroshkin <alexey.miroshkin@ru.ibm.com>