### PR TITLE
Refine replace_blob method to raise error while deleting missing blob,

### DIFF
--- a/bosh-director/lib/bosh/director/blob_util.rb
+++ b/bosh-director/lib/bosh/director/blob_util.rb
@@ -22,9 +22,8 @@ module Bosh::Director
       blobstore_id
     end
 
-    def self.replace_blob(old_blobstore_id, path)
-      blobstore.delete(old_blobstore_id) if blobstore.exists?(old_blobstore_id)
-      return create_blob path
+    def self.delete_blob(blobstore_id)
+      blobstore.delete(blobstore_id)
     end
 
     def self.save_to_global_cache(compiled_package, cache_key)

--- a/bosh-director/spec/unit/blob_util_spec.rb
+++ b/bosh-director/spec/unit/blob_util_spec.rb
@@ -82,23 +82,15 @@ module Bosh::Director
       end
     end
 
-    describe '#replace_blob' do
+    describe '#delete_blob' do
       let(:fake_local_blobstore) { instance_double('Bosh::Blobstore::LocalClient') }
       before do
         allow(App).to receive_message_chain(:instance, :blobstores, :blobstore).and_return(fake_local_blobstore)
       end
 
-      it 'replaces existing blob and returns new blobstore id when blob exists' do
-        expect(fake_local_blobstore).to receive(:exists?).with('fake-blobstore-id').and_return true
+      it 'deletes blob' do
         expect(fake_local_blobstore).to receive(:delete).with('fake-blobstore-id')
-        expect(BlobUtil).to receive(:create_blob).with('path-to-package').and_return 'new-blobstore-id'
-        expect(BlobUtil.replace_blob('fake-blobstore-id', 'path-to-package')).to eq 'new-blobstore-id'
-      end
-
-      it 'uploads blob and returns new blobstore id when blob is missing' do
-        expect(fake_local_blobstore).to receive(:exists?).with('fake-blobstore-id').and_return false
-        expect(BlobUtil).to receive(:create_blob).with('path-to-package').and_return 'new-blobstore-id'
-        expect(BlobUtil.replace_blob('fake-blobstore-id', 'path-to-package')).to eq 'new-blobstore-id'
+        expect{ BlobUtil.delete_blob('fake-blobstore-id') }.to_not raise_error
       end
     end
   end

--- a/bosh-director/spec/unit/jobs/update_release_spec.rb
+++ b/bosh-director/spec/unit/jobs/update_release_spec.rb
@@ -812,7 +812,8 @@ module Bosh::Director
         end
 
         it 'verifies and fixes package' do
-          expect(BlobUtil).to receive(:replace_blob).with('fake-blobstore-id-1', File.join(release_dir, 'packages', 'fake-name-1.tgz')).and_return('new-blobstore-id')
+          expect(BlobUtil).to receive(:delete_blob).with('fake-blobstore-id-1')
+          expect(BlobUtil).to receive(:create_blob).with(File.join(release_dir, 'packages', 'fake-name-1.tgz')).and_return('new-blobstore-id-after-fix')
           job.perform
         end
       end
@@ -843,7 +844,8 @@ module Bosh::Director
         end
 
         it 'fixes existing package and copy blob' do
-          expect(BlobUtil).to receive(:replace_blob).with('fake-blobstore-id-1', File.join(release_dir, 'packages', 'fake-name-1.tgz')).and_return('new-blobstore-id-after-fix')
+          expect(BlobUtil).to receive(:delete_blob).with('fake-blobstore-id-1')
+          expect(BlobUtil).to receive(:create_blob).with(File.join(release_dir, 'packages', 'fake-name-1.tgz')).and_return('new-blobstore-id-after-fix')
           expect(BlobUtil).to receive(:copy_blob).with('new-blobstore-id-after-fix').and_return('new-blobstore-id')
           job.perform
         end

--- a/spec/integration/release/upload_release_spec.rb
+++ b/spec/integration/release/upload_release_spec.rb
@@ -559,12 +559,6 @@ describe 'upload release', type: :integration do
 
       out = bosh_runner.run("upload release #{release_filename} --fix")
 
-      expect(out).to match /Started fixing package \'pkg_1.*Done/
-      expect(out).to match /Started fixing package \'pkg_2.*Done/
-      expect(out).to match /Started fixing package \'pkg_3_depends_on_2.*Done/
-      expect(out).to match /Started fixing package \'pkg_4_depends_on_3.*Done/
-      expect(out).to match /Started fixing package \'pkg_5_depends_on_4_and_1.*Done/
-
       inspect2 = bosh_runner.run('inspect release test_release/1')
       new_pkg_inspect = Bosh::Dev::TableParser.new(inspect2.split(/\n\n/)[1]).to_a
 


### PR DESCRIPTION
rather than doing extra existence check.

[#101003512](https://www.pivotaltracker.com/story/show/101003512)

Signed-off-by: Xing Zhou <xingzhou@cn.ibm.com>