### PR TITLE
Initial support for db migration unit tests

### DIFF
--- a/bosh-director/spec/spec_helper.rb
+++ b/bosh-director/spec/spec_helper.rb
@@ -233,6 +233,12 @@ module Migrations
         model.set_dataset model.dataset
       end
     end
+
+    def reset_models(*models)
+      models.each do |model|
+        model.set_dataset model.dataset
+      end
+    end
   end
 
   def during_migration(namespace, &blk)

--- a/bosh-director/spec/unit/db_migrations/20151031001039_add_spec_to_instance_spec.rb
+++ b/bosh-director/spec/unit/db_migrations/20151031001039_add_spec_to_instance_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe '20151031001039_add_spec_to_instance' do
+  include Migrations
+
+  before do
+    during_migration('director') do |migration, db|
+      migration.stop_before('20151031001039_add_spec_to_instance')
+
+      db['INSERT INTO deployments (id, name) VALUES (789, "deployment")'].insert
+      db["INSERT INTO vms (id, cid, agent_id, deployment_id, apply_spec_json) VALUES (1, 123, 456, 789, #{JSON.dump("{'empty' : 'value'}")})"].insert
+      db['INSERT INTO instances (vm_id, job, "index", deployment_id, state) VALUES (1, "job", 1, 789, "started")'].insert
+
+      migration.stop_after('20151031001039_add_spec_to_instance')
+    end
+  end
+
+  it 'moves "Vm.apply_spec_json" to "Instance.spec_json"' do
+    assert { |db|
+      expect(db.fetch('SELECT * FROM vms').first[:cid]).to eq('123')
+      expect(db.fetch('SELECT * FROM vms').first.has_key?(:apply_spec_json)).to eq(false)
+      expect(db.fetch('SELECT * FROM instances').first[:spec_json]).to eq("{'empty' : 'value'}")
+    }
+  end
+end

--- a/bosh-director/spec/unit/db_migrations/20151031001039_add_spec_to_instance_spec.rb
+++ b/bosh-director/spec/unit/db_migrations/20151031001039_add_spec_to_instance_spec.rb
@@ -7,19 +7,45 @@ describe '20151031001039_add_spec_to_instance' do
     during_migration('director') do |migration, db|
       migration.stop_before('20151031001039_add_spec_to_instance')
 
-      db['INSERT INTO deployments (id, name) VALUES (789, "deployment")'].insert
-      db["INSERT INTO vms (id, cid, agent_id, deployment_id, apply_spec_json) VALUES (1, 123, 456, 789, #{JSON.dump("{'empty' : 'value'}")})"].insert
-      db['INSERT INTO instances (vm_id, job, "index", deployment_id, state) VALUES (1, "job", 1, 789, "started")'].insert
+      # Why do we have to 'bind' Bosh::Director::Models::Deployment
+      migration.reset_models(Bosh::Director::Models::Vm, Bosh::Director::Models::Instance, Bosh::Director::Models::Deployment)
+
+      deployment = Bosh::Director::Models::Deployment.create({
+          name: 'deployment'
+        })
+
+      vm = Bosh::Director::Models::Vm.create({
+          cid: 123,
+          deployment: deployment,
+          agent_id: SecureRandom.uuid,
+          apply_spec_json: Yajl::Encoder.encode({
+              'empty' => 'value'
+            })
+        })
+      @vm_id = vm.id
+
+      @instance_id = Bosh::Director::Models::Instance.create({
+          deployment: deployment,
+          job: 'job',
+          index: 0,
+          state: 'started',
+          vm: vm
+        }).id
 
       migration.stop_after('20151031001039_add_spec_to_instance')
+
+      migration.reset_models(Bosh::Director::Models::Vm, Bosh::Director::Models::Instance, Bosh::Director::Models::Deployment)
     end
   end
 
   it 'moves "Vm.apply_spec_json" to "Instance.spec_json"' do
-    assert { |db|
-      expect(db.fetch('SELECT * FROM vms').first[:cid]).to eq('123')
-      expect(db.fetch('SELECT * FROM vms').first.has_key?(:apply_spec_json)).to eq(false)
-      expect(db.fetch('SELECT * FROM instances').first[:spec_json]).to eq("{'empty' : 'value'}")
-    }
+    vm = Bosh::Director::Models::Vm.where(id: @vm_id).first
+    instance = Bosh::Director::Models::Instance.where(id: @instance_id).first
+
+    expect(Yajl::Parser.parse(instance.spec_json)).to eq({
+          'empty' => 'value'
+        })
+
+    expect(vm.apply_spec_json).to eq(nil)
   end
 end


### PR DESCRIPTION
With this a test has fine grained control over Sequel migrations.

Just do

```ruby
during_migration(<namespace> (1)) do | migration, db |
    stop_before <migration name>

   # prepare the database

   stop_after <migration name>

   # assert migration result (2)
end
```

You can see a running example at https://github.com/loewenstein/bosh/blob/db-migration-unit-tests/bosh-director/spec/unit/db_migrations/20151031001039_add_spec_to_instance_spec.rb

Assertions can be made either using Sequel::Models. You have to ```reset_models``` the model classes though to make them compliant to the current version (the current migration step) of the database schema.
Alternatively you can use raw Sequel expressions like the following (details are in the history of https://github.com/loewenstein/bosh/blob/db-migration-unit-tests/bosh-director/spec/unit/db_migrations/20151031001039_add_spec_to_instance_spec.rb)

```ruby
#preparation
db['INSERT INTO deployments (id, name) VALUES (789, "deployment")'].insert

#assertions
expect(db.fetch('SELECT * FROM vms').first[:cid]).to eq('123')
```

Use ```assert { | db | # assertions }``` to get access to the ```db``` object from outside of ```during_migration```.

(1) Currently only the namespace 'director' is supported.
(2) You can run ```during_migration``` in a ```before``` block and put your expectations in separate ```it``` blocks