### PR TITLE
User can cancel while drain action is running

### DIFF
--- a/bosh-director/lib/bosh/director/agent_client.rb
+++ b/bosh-director/lib/bosh/director/agent_client.rb
@@ -95,7 +95,7 @@ module Bosh::Director
     end
 
     def drain(*args)
-      send_message(:drain, *args)
+      send_cancellable_message(:drain, *args)
     end
 
     def fetch_logs(*args)
@@ -305,6 +305,22 @@ module Bosh::Director
         task['value']
       end
     end
+
+    def send_cancellable_message(method_name, *args)
+      task = start_task(method_name, *args)
+      cancel_blk = lambda {Config.job_cancelled?}
+      if task['agent_task_id']
+        begin
+          wait_for_task(task['agent_task_id'], &cancel_blk)
+        rescue TaskCancelled => e
+          cancel_task(task['agent_task_id'])
+          raise e
+        end
+      else
+        task['value']
+      end
+    end
+
 
     def start_task(method_name, *args)
       AgentMessageConverter.convert_old_message_to_new(handle_message_with_retry(method_name, *args))

--- a/bosh-director/lib/bosh/director/instance_deleter.rb
+++ b/bosh-director/lib/bosh/director/instance_deleter.rb
@@ -56,7 +56,6 @@ module Bosh::Director
       while drain_time < 0
         drain_time = drain_time.abs
         begin
-          Config.job_cancelled?
           @logger.info("Drain - check back in #{drain_time} seconds")
           sleep(drain_time)
           drain_time = agent.drain("status")

--- a/bosh-director/lib/bosh/director/instance_updater/stopper.rb
+++ b/bosh-director/lib/bosh/director/instance_updater/stopper.rb
@@ -48,9 +48,6 @@ module Bosh::Director
       drain_time = initial_drain_time
 
       loop do
-        # This could go on forever if drain script is broken, canceling the task is a way out.
-        @config.task_checkpoint
-
         wait_time = drain_time.abs
         if wait_time > 0
           @logger.info("`#{@instance}' is draining: checking back in #{wait_time}s")

--- a/bosh-director/spec/unit/instance_deleter_spec.rb
+++ b/bosh-director/spec/unit/instance_deleter_spec.rb
@@ -129,8 +129,8 @@ module Bosh::Director
       it 'should stop vm-drain if task is cancelled' do
         agent = double('agent')
         allow(AgentClient).to receive(:with_defaults).with('some_agent_id').and_return(agent)
-        allow(Config).to receive(:job_cancelled?).and_raise(TaskCancelled.new(1))
         expect(agent).to receive(:drain).with('shutdown').and_return(-2)
+        expect(agent).to receive(:drain).with('status').and_raise(TaskCancelled.new(1))
         expect { @deleter.drain('some_agent_id') }.to raise_error(TaskCancelled)
       end
     end

--- a/bosh-director/spec/unit/instance_updater/stopper_spec.rb
+++ b/bosh-director/spec/unit/instance_updater/stopper_spec.rb
@@ -41,6 +41,11 @@ module Bosh::Director
             expect(agent_client).to receive(:stop).with(no_args).ordered
             subject.stop
           end
+
+          it 'should stop task if task was cancelled' do
+             allow(agent_client).to receive(:drain).and_raise(TaskCancelled)
+             expect{ subject.stop }.to raise_error(TaskCancelled)
+          end
         end
 
         context 'with dynamic drain' do
@@ -80,7 +85,7 @@ module Bosh::Director
       before { allow(subject).to receive(:sleep) }
 
       it 'can be canceled' do
-        expect(Config).to receive(:task_checkpoint).and_raise(TaskCancelled)
+        expect(agent_client).to receive(:drain).with("status").and_raise(TaskCancelled)
         expect {
           subject.send(:wait_for_dynamic_drain, -1)
         }.to raise_error TaskCancelled


### PR DESCRIPTION
This change makes drain action cancellable in bosh. There is a separate
change for bosh-agent.

[#106642152] (https://www.pivotaltracker.com/story/show/106642152)

Signed-off-by: Yulia Gaponenko <yulia.gaponenko@ru.ibm.com>