### PR TITLE
update s3_blobstore_client to support use AWS China S3 bucket

### DIFF
--- a/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
@@ -31,7 +31,7 @@ module Bosh
         aws_options = {
           use_ssl: @options.fetch(:use_ssl, true),
           s3_port: @options.fetch(:port, 443),
-          s3_endpoint: @options.fetch(:host, URI.parse(S3BlobstoreClient::ENDPOINT).host),
+          s3_endpoint: @options.fetch(:host, URI.parse(@options[:s3_endpoint] || S3BlobstoreClient::ENDPOINT).host),
           s3_force_path_style: @options.fetch(:s3_force_path_style, false),
           ssl_verify_peer: @options.fetch(:ssl_verify_peer, true),
           s3_multipart_threshold: @options.fetch(:s3_multipart_threshold, 16_777_216),
@@ -51,7 +51,8 @@ module Bosh
           end
 
           @options[:bucket] ||= @options[:bucket_name]
-          @options[:endpoint] ||= S3BlobstoreClient::ENDPOINT
+          endpoint = @options[:s3_endpoint] || S3BlobstoreClient::ENDPOINT
+          @options[:endpoint] ||= endpoint
           @simple = SimpleBlobstoreClient.new(@options)
         else
           @s3 = AWS::S3.new(aws_options)


### PR DESCRIPTION
As you know, network speed is very low to access s3 blobstore based on US region from AWS China region, so it's a nightmare when uploading release in AWS China.

We suggest to use AWS China S3 buckets as the blobstores when doing bosh deployments in AWS China, which will speed up a lot. 

So we make a PR to make s3_blobstore_client support China S3 bucket, when uploading bosh release, we just make below change in config/final.yml: 
```
---
final_name: test
blobstore:
  provider: s3
  options:
    bucket_name: S3_BUCKET_IN_CHINA
    s3_endpoint: https://s3.cn-north-1.amazonaws.com.cn
```

Signed-off-by: Ning Fu <nfu@pivotal.io>