### PR TITLE
The sudo command must require authentication.

### DIFF
--- a/bosh-stemcell/spec/stemcells/stig_spec.rb
+++ b/bosh-stemcell/spec/stemcells/stig_spec.rb
@@ -53,6 +53,7 @@ describe 'Stig test case verification', { stemcell_image: true, stig_check: true
       V-38466
       V-38469
       V-38472
+      V-58901
     }
 
     expected_stig_test_cases = expected_base_stig_test_cases

--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -19,6 +19,12 @@ shared_examples_for 'every OS image' do
     end
   end
 
+  context 'The sudo command must require authentication (stig: V-58901)' do
+    describe command("egrep -sh 'NOPASSWD|!authenticate' /etc/sudoers /etc/sudoers.d/* | egrep -v '^#|%bosh_sudoers' --") do
+      its (:stdout) { should eq('') }
+    end
+  end
+
   context 'installed by bosh_users' do
     describe command("grep -q 'export PATH=/var/vcap/bosh/bin:$PATH\n' /root/.bashrc") do
       it { should return_exit_status(0) }


### PR DESCRIPTION
bosh_sudoers group should not be required.

[#98978184]

Signed-off-by: Zhou Xing <xingzhou@cn.ibm.com>