### PR TITLE
Show error message if static ip is not found.

### DIFF
--- a/bosh-director/lib/bosh/director/errors.rb
+++ b/bosh-director/lib/bosh/director/errors.rb
@@ -145,6 +145,7 @@ module Bosh::Director
   NetworkReservationWrongType = err(130009)
   NetworkReservationError = err(130010)
   NetworkReservationNotEnoughCapacity = err(130010)
+  NetworksReservationNotInSubnet = err(130012)
 
   # Manifest parsing: job section
   JobMissingRelease = err(140001)

--- a/bosh-director/lib/bosh/director/network_reservation.rb
+++ b/bosh-director/lib/bosh/director/network_reservation.rb
@@ -12,6 +12,7 @@ module Bosh::Director
     USED = :used
     CAPACITY = :capacity
     WRONG_TYPE = :wrong_type
+    NOT_IN_SUBNET = :not_in_subnet
 
     # @return [Integer, nil] ip
     attr_accessor :ip
@@ -98,6 +99,10 @@ module Bosh::Director
             raise NetworkReservationWrongType,
                   "#{origin} asked for a static IP #{formatted_ip} " +
                   "but it's in the dynamic pool"
+          when NetworkReservation::NOT_IN_SUBNET
+            raise NetworksReservationNotInSubnet,
+                  "#{origin} asked for a static IP #{formatted_ip}" +
+                  "but it's not in the network's subnet range"
           else
             raise NetworkReservationError,
                   "#{origin} failed to reserve static IP " +

--- a/bosh-director/spec/unit/deployment_plan/manual_network_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/manual_network_spec.rb
@@ -121,6 +121,13 @@ describe Bosh::Director::DeploymentPlan::ManualNetwork do
       expect(reservation.reserved).to eq(false)
       expect(reservation.error).to eq(BD::NetworkReservation::CAPACITY)
     end
+
+    it 'it raises an error when the selected static ip is not in subnet range' do
+      reservation = BD::NetworkReservation.new(
+          :ip => '0.0.1.1', :type => BD::NetworkReservation::DYNAMIC)
+      @network.reserve(reservation)
+      expect(reservation.error).to eq(BD::NetworkReservation::NOT_IN_SUBNET)
+    end
   end
 
   describe :release do

--- a/bosh-director/spec/unit/network_reservation_spec.rb
+++ b/bosh-director/spec/unit/network_reservation_spec.rb
@@ -74,6 +74,14 @@ module Bosh::Director
           }.to raise_error(NetworkReservationWrongType)
         end
 
+        it 'handles not in subnet range errors' do
+          reservation.error = NetworkReservation::NOT_IN_SUBNET
+
+          expect{
+            reservation.handle_error('fake-origin')
+          }.to raise_error(NetworksReservationNotInSubnet)
+        end
+
         it 'handles other reservation errors' do
           reservation.error = StandardError.new
 


### PR DESCRIPTION
When a use selects a static ip that is not within the network's subnets
we show an error message.