### PR TITLE
Ignore snapshot when VM is missing.

### DIFF
--- a/bosh-director/lib/bosh/director/jobs/snapshot_deployment.rb
+++ b/bosh-director/lib/bosh/director/jobs/snapshot_deployment.rb
@@ -31,6 +31,10 @@ module Bosh::Director
       end
 
       def snapshot(instance)
+        if instance.vm_cid.nil?
+          logger.info('No vm attached to this instance, no snapshot; skipping')
+          return
+        end
         logger.info("taking snapshot of: #{instance.job}/#{instance.index} (#{instance.vm_cid})")
         Bosh::Director::Api::SnapshotManager.take_snapshot(instance, @options)
       rescue Bosh::Clouds::CloudError => e
@@ -54,4 +58,3 @@ module Bosh::Director
     end
   end
 end
-

--- a/bosh-director/spec/unit/jobs/snapshot_deployment_spec.rb
+++ b/bosh-director/spec/unit/jobs/snapshot_deployment_spec.rb
@@ -10,6 +10,7 @@ module Bosh::Director
     let!(:instance2) { Models::Instance.make(deployment: deployment) }
     let!(:instance3) { Models::Instance.make(deployment: deployment) }
     let!(:instance4) { Models::Instance.make }
+    let!(:instance5) { Models::Instance.make(deployment: deployment, vm_cid: nil) }
 
     subject { described_class.new(deployment_name) }
 
@@ -31,6 +32,18 @@ module Bosh::Director
           expect(Api::SnapshotManager).to receive(:take_snapshot).with(instance2, {})
           expect(Api::SnapshotManager).to receive(:take_snapshot).with(instance3, {})
           expect(Api::SnapshotManager).not_to receive(:take_snapshot).with(instance4, {})
+
+          expect(subject.perform).to eq "snapshots of deployment 'deployment' created"
+        end
+      end
+
+      context 'when vm is not attached' do
+        it 'should snapshot all instance that have a vms attached' do
+          expect(subject).to receive(:snapshot).with(instance1)
+          expect(subject).to receive(:snapshot).with(instance2)
+          expect(subject).to receive(:snapshot).with(instance3)
+          expect(subject).to receive(:snapshot).with(instance5).and_return(nil)
+          expect(Api::SnapshotManager).not_to receive(:take_snapshot).with(instance5, {})
 
           expect(subject.perform).to eq "snapshots of deployment 'deployment' created"
         end


### PR DESCRIPTION
Due to a missing cck execution there might be no vm attached. In this
case we ignore the snapshot to prevent polluting the logs.

Fixes #901