### PR TITLE
Director, scheduler and workers should die after 10 secs

### DIFF
--- a/release/jobs/director/templates/director_ctl.erb
+++ b/release/jobs/director/templates/director_ctl.erb
@@ -83,7 +83,15 @@ case $1 in
     if [ ! -z $PID ] && pid_exists $PID; then
       kill $PID
     fi
-    while [ -e /proc/$PID ]; do sleep 0.1; done
+    TRIES=0
+    while [ -e /proc/$PID ]
+    do
+      TRIES=$(( $TRIES + 1 ))
+      if [ $TRIES -gt 100 ]; then
+        kill -9 $PID
+      fi
+      sleep 0.1
+    done
     rm -f $PIDFILE
     ;;
 

--- a/release/jobs/director/templates/scheduler_ctl.erb
+++ b/release/jobs/director/templates/scheduler_ctl.erb
@@ -55,7 +55,15 @@ case $1 in
     if [ ! -z $PID ] && pid_exists $PID; then
       kill $PID
     fi
-    while [ -e /proc/$PID ]; do sleep 0.1; done
+    TRIES=0
+    while [ -e /proc/$PID ]
+    do
+      TRIES=$(( $TRIES + 1 ))
+      if [ $TRIES -gt 100 ]; then
+        kill -9 $PID
+      fi
+      sleep 0.1
+    done
     rm -f $PIDFILE
     ;;
 

--- a/release/jobs/director/templates/worker_ctl.erb
+++ b/release/jobs/director/templates/worker_ctl.erb
@@ -66,7 +66,15 @@ case $1 in
     if [ ! -z $PID ] && pid_exists $PID; then
      kill $PID
     fi
-    while [ -e /proc/$PID ]; do sleep 0.1; done
+    TRIES=0
+    while [ -e /proc/$PID ]
+    do
+      TRIES=$(( $TRIES + 1 ))
+      if [ $TRIES -gt 100 ]; then
+        kill -9 $PID
+      fi
+      sleep 0.1
+    done
     rm -f $PIDFILE
     ;;
 


### PR DESCRIPTION
We currently wait indefinitely for pid to die which will not happen in
some cases. This fix makes scripts to send `kill -9` after 10 seconds
of waiting.

Here is some code for manual test we did https://gist.github.com/hashmap/046c0efb6abe21702a5b

[#108987020] (https://www.pivotaltracker.com/story/show/108987020)

Signed-off-by: Yulia Gaponenko <yulia.gaponenko@ru.ibm.com>