### PR TITLE
Force utf-8 when JSON-encoding CPI results / errors

### DIFF
--- a/bosh_cpi/lib/bosh/cpi/cli.rb
+++ b/bosh_cpi/lib/bosh/cpi/cli.rb
@@ -99,7 +99,7 @@ class Bosh::Cpi::Cli
         message: message,
         ok_to_retry: ok_to_retry,
       },
-      log: @logs_string_io.string,
+      log: @logs_string_io.string.force_encoding(Encoding::UTF_8),
     }
     @result_io.print(JSON.dump(hash)); nil
   end
@@ -108,7 +108,7 @@ class Bosh::Cpi::Cli
     hash = {
       result: result,
       error: nil,
-      log: @logs_string_io.string,
+      log: @logs_string_io.string.force_encoding(Encoding::UTF_8),
     }
     @result_io.print(JSON.dump(hash)); nil
   end


### PR DESCRIPTION
This fixes a problem noticed in a production vSphere environment where
snapshot tasks were being met with HTTP responses including some sort of
arbitrary binary (believed to be Unicode) data.

See https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/issues/5