### PR TITLE
Bump s3cli to 0.0.21

### DIFF
--- a/stemcell_builder/stages/aws_cli/config.sh
+++ b/stemcell_builder/stages/aws_cli/config.sh
@@ -9,6 +9,6 @@ source $base_dir/lib/prelude_config.bash
 cd $assets_dir
 rm -rf s3cli
 mkdir s3cli
-current_version=0.0.20
+current_version=0.0.21
 curl -L -o s3cli/s3cli https://s3.amazonaws.com/s3cli-artifacts/s3cli-${current_version}-linux-amd64
-echo "b168931ed916e1c86563986d3ec06ac6fd613fa0 s3cli/s3cli" | sha1sum -c -
+echo "7a9db1342d8b8e4cb6e5282e26fceb6ad6e3bf2c s3cli/s3cli" | sha1sum -c -


### PR DESCRIPTION
This version of s3cli allows the ability to specify both the host and the region in the blobstore configuration.