### PR TITLE
add support for em threadpool_size property

### DIFF
--- a/bosh-monitor/lib/bosh/monitor/config.rb
+++ b/bosh-monitor/lib/bosh/monitor/config.rb
@@ -6,6 +6,7 @@ module Bosh::Monitor
     attr_accessor :director
     attr_accessor :intervals
     attr_accessor :mbus
+    attr_accessor :em_threadpool_size
     attr_accessor :event_mbus
     attr_accessor :agent_manager
     attr_accessor :event_processor
@@ -22,6 +23,8 @@ module Bosh::Monitor
       @intervals = OpenStruct.new(config["intervals"])
       @director = Director.new(config["director"], @logger)
       @mbus = OpenStruct.new(config["mbus"])
+
+      @em_threadpool_size = config["em_threadpool_size"]
 
       @event_processor = EventProcessor.new
       @agent_manager = AgentManager.new(event_processor)

--- a/bosh-monitor/lib/bosh/monitor/runner.rb
+++ b/bosh-monitor/lib/bosh/monitor/runner.rb
@@ -14,6 +14,7 @@ module Bosh::Monitor
       @intervals     = Bhm.intervals
       @mbus          = Bhm.mbus
       @agent_manager = Bhm.agent_manager
+      EM.threadpool_size = Bhm.em_threadpool_size
     end
 
     def run

--- a/bosh-monitor/spec/unit/bosh/monitor/config_spec.rb
+++ b/bosh-monitor/spec/unit/bosh/monitor/config_spec.rb
@@ -8,6 +8,7 @@ describe Bosh::Monitor do
       'director' => {},
       'http' => http_config,
       'loglevel' => 'debug',
+      'em_threadpool_size' => 20,
       'plugins' => %w(plugin1 plugin2)
     } }
 
@@ -53,6 +54,11 @@ describe Bosh::Monitor do
         it 'should set a default for rogue_agent_alert' do
           expect(Bosh::Monitor.intervals.rogue_agent_alert).to eq(120)
         end
+
+        it 'should set a default for em_threadpool_size' do
+          expect(Bosh::Monitor.em_threadpool_size).to eq(20)
+        end
+
       end
 
       context 'with http config' do

--- a/release/jobs/health_monitor/spec
+++ b/release/jobs/health_monitor/spec
@@ -45,6 +45,10 @@ properties:
     description: Level of log messages (fatal, error, warn, info, debug)
     default: info
 
+  hm.em_threadpool_size:
+    description: EM thread pool size
+    default: 20
+
   #
   # NATS options (to get alerts from agents)
   #

--- a/release/jobs/health_monitor/templates/health_monitor.yml.erb
+++ b/release/jobs/health_monitor/templates/health_monitor.yml.erb
@@ -31,6 +31,7 @@ params = {
   },
   'logfile' => '/var/vcap/sys/log/health_monitor/health_monitor.log',
   'loglevel' => p('hm.loglevel'),
+  'em_threadpool_size' => p('hm.em_threadpool_size'),
   'plugins' => [
     {
       'name' => 'logger',

--- a/release/spec/health_monitor.yml.erb_spec.rb
+++ b/release/spec/health_monitor.yml.erb_spec.rb
@@ -27,6 +27,7 @@ describe 'health_monitor.yml.erb' do
             'rogue_agent_alert' => 66,
           },
           'loglevel' => 'INFO',
+          'em_threadpool_size' => 20,
           # plugins
           'email_notifications' => false,
           'tsdb_enabled' => false,
@@ -81,6 +82,7 @@ describe 'health_monitor.yml.erb' do
       expect(parsed_yaml['intervals']['rogue_agent_alert']).to eq(66)
       expect(parsed_yaml['logfile']).to be_a(String)
       expect(parsed_yaml['loglevel']).to eq('INFO')
+      expect(parsed_yaml['em_threadpool_size']).to eq(20)
 
       expect(parsed_yaml['plugins'].length).to eq(1)
       expect(parsed_yaml['plugins'].first['name']).to eq('logger')


### PR DESCRIPTION
This is the pull request for the issue #1098

The changes will allow a configurable EM threadpool_size so that users can set large value to increase throughput.

Signed-off-by: Simon Gao <sgao@pivotal.io>