### PR TITLE
Add AWS Asia Pacific (Seoul) region

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/aws/region.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/aws/region.rb
@@ -7,7 +7,8 @@ module Bosh
         DEFAULT = 'us-east-1'
         REGIONS = %w{
           us-east-1 us-west-1 us-west-2 eu-west-1 eu-central-1
-          ap-southeast-1 ap-southeast-2 ap-northeast-1 sa-east-1
+          ap-southeast-1 ap-southeast-2 ap-northeast-1 ap-northeast-2
+          sa-east-1
         }
       end
     end


### PR DESCRIPTION
This PR adds `ap-northeast-2` Asia Pacific (Seoul) region to the AWS region list. 

However, since it fails to find an AMI ID for the stemcell, `bosh deploy` still fails. I created a separate issue(https://github.com/cloudfoundry/bosh/issues/1110) for this.