### PR TITLE
Bump s3cli to 0.0.24

### DIFF
--- a/stemcell_builder/stages/aws_cli/config.sh
+++ b/stemcell_builder/stages/aws_cli/config.sh
@@ -9,6 +9,6 @@ source $base_dir/lib/prelude_config.bash
 cd $assets_dir
 rm -rf s3cli
 mkdir s3cli
-current_version=0.0.21
+current_version=0.0.24
 curl -L -o s3cli/s3cli https://s3.amazonaws.com/s3cli-artifacts/s3cli-${current_version}-linux-amd64
-echo "7a9db1342d8b8e4cb6e5282e26fceb6ad6e3bf2c s3cli/s3cli" | sha1sum -c -
+echo "a1035806703d7909f278e5c9e6d975289067c8c8 s3cli/s3cli" | sha1sum -c -


### PR DESCRIPTION
- Can be configured using AWS region, host, or both
- Smarter defaults when selecting whether to use signing version 2 or 4
  based on hostname

[#111994203](https://www.pivotaltracker.com/story/show/111994203)