### PR TITLE
Add http_proxy configuration options to registry

### DIFF
--- a/release/jobs/registry/spec
+++ b/release/jobs/registry/spec
@@ -2,7 +2,7 @@
 name: registry
 
 templates:
-  registry_ctl:     bin/registry_ctl
+  registry_ctl.erb: bin/registry_ctl
   registry.yml.erb: config/registry.yml
 
 packages:
@@ -19,6 +19,13 @@ properties:
     description: Username clients must use to access Registry via HTTP Basic Auth
   registry.http.password:
     description: Password clients must use to access Registry via HTTP Basic Auth
+
+  env.http_proxy:
+    description: HTTP proxy that the registry should use
+  env.https_proxy:
+    description: HTTPS proxy that the registry should use
+  env.no_proxy:
+    description: List of comma-separated hosts that should skip connecting to the proxy in the registry
 
   # Registry Database
   registry.db.adapter:

--- a/release/jobs/registry/templates/registry_ctl.erb
+++ b/release/jobs/registry/templates/registry_ctl.erb
@@ -9,6 +9,19 @@ export PATH=/var/vcap/packages/ruby/bin:$PATH
 export BUNDLE_GEMFILE=/var/vcap/packages/registry/Gemfile
 export GEM_HOME=/var/vcap/packages/registry/gem_home/ruby/2.1.0
 
+<% if_p('env.http_proxy') do |http_proxy| %>
+export HTTP_PROXY=<%= http_proxy %>
+export http_proxy=<%= http_proxy %>
+<% end %>
+<% if_p('env.https_proxy') do |https_proxy| %>
+export HTTPS_PROXY=<%= https_proxy %>
+export https_proxy=<%= https_proxy %>
+<% end %>
+<% if_p('env.no_proxy') do |no_proxy| %>
+export NO_PROXY=<%= no_proxy %>
+export no_proxy=<%= no_proxy %>
+<% end %>
+
 function pid_exists() {
   ps -p $1 &> /dev/null
 }


### PR DESCRIPTION
- Allows bosh to be deployed behind an http proxy

[#113560739](https://www.pivotaltracker.com/story/show/113560739)

Signed-off-by: Edwin Xie <exie@pivotal.io>