### PR TITLE
'apply_resolutions' reports error at the end if any resolution failed

### DIFF
--- a/bosh-director/lib/bosh/director/jobs/cloud_check/apply_resolutions.rb
+++ b/bosh-director/lib/bosh/director/jobs/cloud_check/apply_resolutions.rb
@@ -35,7 +35,12 @@ module Bosh::Director
 
         def perform
           with_deployment_lock(@deployment) do
-            count = @problem_resolver.apply_resolutions(@resolutions)
+            count, error_message = @problem_resolver.apply_resolutions(@resolutions)
+
+            if error_message
+              raise Bosh::Director::ProblemHandlerError, error_message
+            end
+
             "#{count} resolved"
           end
         end

--- a/bosh-director/lib/bosh/director/problem_resolver.rb
+++ b/bosh-director/lib/bosh/director/problem_resolver.rb
@@ -6,6 +6,7 @@ module Bosh::Director
     def initialize(deployment)
       @deployment = deployment
       @resolved_count = 0
+      @resolution_error_logs = StringIO.new
 
       #temp
       @event_log = Config.event_log
@@ -42,7 +43,10 @@ module Bosh::Director
           apply_resolution(problem)
         end
       end
-      @resolved_count
+
+      error_message = @resolution_error_logs.string.empty? ? nil : @resolution_error_logs.string.chomp
+
+      [@resolved_count, error_message]
     end
 
     private
@@ -75,8 +79,10 @@ module Bosh::Director
     private
 
     def log_resolution_error(problem, error)
-      logger.error("Error resolving problem `#{problem.id}': #{error}")
+      error_message = "Error resolving problem `#{problem.id}': #{error}"
+      logger.error(error_message)
       logger.error(error.backtrace.join("\n"))
+      @resolution_error_logs.puts(error_message)
     end
   end
 end

--- a/bosh-director/spec/unit/jobs/cloud_check/apply_resolutions_spec.rb
+++ b/bosh-director/spec/unit/jobs/cloud_check/apply_resolutions_spec.rb
@@ -20,28 +20,44 @@ module Bosh::Director
     let(:resolver) { instance_double('Bosh::Director::ProblemResolver') }
     let(:deployment) { Models::Deployment[1] }
 
-    it 'should normalize the problem ids' do
-      allow(job).to receive(:with_deployment_lock).and_yield
+    describe '#perform' do
+      context 'when resolution succeeds' do
+        it 'should normalize the problem ids' do
+          allow(job).to receive(:with_deployment_lock).and_yield
 
-      expect(resolver).to receive(:apply_resolutions).with(normalized_resolutions)
+          expect(resolver).to receive(:apply_resolutions).with(normalized_resolutions)
 
-      job.perform
-    end
+          job.perform
+        end
 
-    it 'obtains a deployment lock' do
-      expect(job).to receive(:with_deployment_lock).with(deployment).and_yield
+        it 'obtains a deployment lock' do
+          expect(job).to receive(:with_deployment_lock).with(deployment).and_yield
 
-      allow(resolver).to receive(:apply_resolutions)
+          allow(resolver).to receive(:apply_resolutions)
 
-      job.perform
-    end
+          job.perform
+        end
 
-    it 'applies the resolutions' do
-      allow(job).to receive(:with_deployment_lock).and_yield
+        it 'applies the resolutions' do
+          allow(job).to receive(:with_deployment_lock).and_yield
 
-      expect(resolver).to receive(:apply_resolutions).and_return(1)
+          expect(resolver).to receive(:apply_resolutions).and_return(1)
 
-      expect(job.perform).to eq('1 resolved')
+          expect(job.perform).to eq('1 resolved')
+        end
+      end
+
+      context 'when resolution fails' do
+        it 'raises an error' do
+          allow(job).to receive(:with_deployment_lock).and_yield
+
+          expect(resolver).to receive(:apply_resolutions).and_return([1, 'error message'])
+
+          expect{
+            job.perform
+          }.to raise_error(Bosh::Director::ProblemHandlerError)
+        end
+      end
     end
   end
 end

--- a/bosh-director/spec/unit/problem_resolver_spec.rb
+++ b/bosh-director/spec/unit/problem_resolver_spec.rb
@@ -21,76 +21,104 @@ module Bosh::Director
                                      state: 'open')
     end
 
-    it 'applies resolutions' do
-      disks = []
-      problems = []
+    describe '#apply_resolutions' do
+      context 'when execution succeeds' do
+        it 'applies all resolutions' do
+          disks = []
+          problems = []
 
-      agent = double('agent')
-      expect(agent).to receive(:list_disk).and_return([])
+          agent = double('agent')
+          expect(agent).to receive(:list_disk).and_return([])
 
-      expect(@cloud).to receive(:detach_disk).exactly(1).times
+          expect(@cloud).to receive(:detach_disk).exactly(1).times
 
-      allow(AgentClient).to receive(:with_vm_credentials_and_agent_id).and_return(agent)
+          allow(AgentClient).to receive(:with_vm_credentials_and_agent_id).and_return(agent)
 
-      2.times do
-        disk = Models::PersistentDisk.make(:active => false)
-        disks << disk
-        problems << inactive_disk(disk.id)
+          2.times do
+            disk = Models::PersistentDisk.make(:active => false)
+            disks << disk
+            problems << inactive_disk(disk.id)
+          end
+
+          resolver = make_resolver(@deployment)
+
+          expect(resolver.apply_resolutions({ problems[0].id.to_s => 'delete_disk', problems[1].id.to_s => 'ignore' })).to eq([2, nil])
+
+          expect(Models::PersistentDisk.find(id: disks[0].id)).to be_nil
+          expect(Models::PersistentDisk.find(id: disks[1].id)).not_to be_nil
+
+          expect(Models::DeploymentProblem.filter(state: 'open').count).to eq(0)
+        end
+
+        it 'notices and logs extra resolutions' do
+          disks = (1..3).map { |_| Models::PersistentDisk.make(:active => false) }
+
+          problems = [
+              inactive_disk(disks[0].id),
+              inactive_disk(disks[1].id),
+              inactive_disk(disks[2].id, @other_deployment.id)
+          ]
+
+          resolver1 = make_resolver(@deployment)
+          expect(resolver1.apply_resolutions({ problems[0].id.to_s => 'ignore', problems[1].id.to_s => 'ignore' })).to eq([2, nil])
+
+          resolver2 = make_resolver(@deployment)
+
+          messages = []
+          expect(resolver2).to receive(:track_and_log).exactly(3).times { |message| messages << message }
+          resolver2.apply_resolutions({
+                                          problems[0].id.to_s => 'ignore',
+                                          problems[1].id.to_s => 'ignore',
+                                          problems[2].id.to_s => 'ignore',
+                                          'foobar' => 'ignore',
+                                          '318' => 'do_stuff'
+                                      })
+
+          expect(messages).to match_array([
+                                              "Ignoring problem #{problems[0].id} (state is 'resolved')",
+                                              "Ignoring problem #{problems[1].id} (state is 'resolved')",
+                                              "Ignoring problem #{problems[2].id} (not a part of this deployment)",
+                                          ])
+        end
       end
 
-      resolver = make_resolver(@deployment)
+      context 'when execution fails' do
+        it 'raises error and logs' do
+          backtrace = anything
+          disk = Models::PersistentDisk.make(:active => false)
+          problem = inactive_disk(disk.id)
+          resolver = make_resolver(@deployment)
 
-      expect(resolver.apply_resolutions({ problems[0].id.to_s => 'delete_disk', problems[1].id.to_s => 'ignore' })).to eq(2)
+          expect(resolver).to receive(:track_and_log)
+                                  .and_raise(Bosh::Director::ProblemHandlerError.new('Resolution failed'))
+          expect(logger).to receive(:error).with("Error resolving problem `1': Resolution failed")
+          expect(logger).to receive(:error).with(backtrace)
 
-      expect(Models::PersistentDisk.find(id: disks[0].id)).to be_nil
-      expect(Models::PersistentDisk.find(id: disks[1].id)).not_to be_nil
+          count, error_message = resolver.apply_resolutions({ problem.id.to_s => 'ignore' })
 
-      expect(Models::DeploymentProblem.filter(state: 'open').count).to eq(0)
-    end
+          expect(error_message).to eq("Error resolving problem `1': Resolution failed")
+          expect(count).to eq(1)
+        end
+      end
 
-    it 'notices and logs extra resolutions' do
-      disks = (1..3).map { |_| Models::PersistentDisk.make(:active => false) }
+      context 'when execution fails because of other errors' do
+        it 'raises error and logs' do
+          backtrace = anything
+          disk = Models::PersistentDisk.make(:active => false)
+          problem = inactive_disk(disk.id)
+          resolver = make_resolver(@deployment)
 
-      problems = [
-        inactive_disk(disks[0].id),
-        inactive_disk(disks[1].id),
-        inactive_disk(disks[2].id, @other_deployment.id)
-      ]
+          expect(ProblemHandlers::Base).to receive(:create_from_model)
+                                               .and_raise(StandardError.new('Model creation failed'))
+          expect(logger).to receive(:error).with("Error resolving problem `1': Model creation failed")
+          expect(logger).to receive(:error).with(backtrace)
 
-      resolver1 = make_resolver(@deployment)
-      expect(resolver1.apply_resolutions({ problems[0].id.to_s => 'ignore', problems[1].id.to_s => 'ignore' })).to eq(2)
+          count, error_message = resolver.apply_resolutions({ problem.id.to_s => 'ignore' })
 
-      resolver2 = make_resolver(@deployment)
-
-      messages = []
-      expect(resolver2).to receive(:track_and_log).exactly(3).times { |message| messages << message }
-      resolver2.apply_resolutions({
-                               problems[0].id.to_s => 'ignore',
-                               problems[1].id.to_s => 'ignore',
-                               problems[2].id.to_s => 'ignore',
-                               'foobar' => 'ignore',
-                               '318' => 'do_stuff'
-                             })
-
-      expect(messages).to match_array([
-        "Ignoring problem #{problems[0].id} (state is 'resolved')",
-        "Ignoring problem #{problems[1].id} (state is 'resolved')",
-        "Ignoring problem #{problems[2].id} (not a part of this deployment)",
-      ])
-    end
-
-    it 'receives error logs' do
-      backtrace = anything
-      disk = Models::PersistentDisk.make(:active => false)
-      problem = inactive_disk(disk.id)
-      resolver = make_resolver(@deployment)
-
-      expect(resolver).to receive(:track_and_log)
-        .and_raise(Bosh::Director::ProblemHandlerError)
-      expect(logger).to receive(:error).with("Error resolving problem `1': Bosh::Director::ProblemHandlerError")
-      expect(logger).to receive(:error).with(backtrace)
-
-      expect(resolver.apply_resolutions({ problem.id.to_s => 'ignore' })).to eq(1)
+          expect(error_message).to eq("Error resolving problem `1': Model creation failed")
+          expect(count).to eq(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Before this change, 'apply_resolutions' always succeeded.
- This changes behaviour of job 'scan_and_fix' and 'apply_resolutions'.
  They will finish with error now in case of any resolution error.

[#114092983](https://www.pivotaltracker.com/story/show/114092983)

Signed-off-by: Tom Kiemes <tom.kiemes@sap.com>