### PR TITLE
Support trim characters when rendering templates

### DIFF
--- a/bosh-template/lib/bosh/template/renderer.rb
+++ b/bosh-template/lib/bosh/template/renderer.rb
@@ -12,7 +12,7 @@ module Bosh
       def render(template_name)
         spec = JSON.parse(@context)
         evaluation_context = EvaluationContext.new(spec)
-        template = ERB.new(File.read(template_name))
+        template = ERB.new(File.read(template_name), nil, "-")
         template.result(evaluation_context.get_binding)
       end
     end

--- a/bosh-template/spec/assets/nats.conf
+++ b/bosh-template/spec/assets/nats.conf
@@ -1,4 +1,3 @@
-
 net: "127.0.0.1"
 port: 1234
 prof_port: 4321
@@ -27,12 +26,8 @@ timeout: 0
 }
 
 routes = [
-
     nats-route://user:password@127.0.0.2:1235
-
     nats-route://user:password@127.0.0.3:1235
-
     nats-route://user:password@127.0.0.4:1235
-
 ]
 }

--- a/bosh-template/spec/assets/nats.conf.erb
+++ b/bosh-template/spec/assets/nats.conf.erb
@@ -1,4 +1,4 @@
-<% self_ip = spec.networks.send(properties.networks.apps).ip %>
+<% self_ip = spec.networks.send(properties.networks.apps).ip -%>
 net: "<%= self_ip %>"
 port: <%= p("nats.port") %>
 prof_port: <%= p("nats.prof_port") %>
@@ -27,8 +27,8 @@ timeout: <%= p("nats.authorization_timeout") %>
 }
 
 routes = [
-<% (p("nats.machines") - [self_ip]).each do |address| %>
+<% (p("nats.machines") - [self_ip]).each do |address| -%>
     nats-route://<%= p("nats.user") %>:<%= p("nats.password") %>@<%= address %>:<%= p("nats.port") + 1 %>
-<% end %>
+<% end -%>
 ]
 }


### PR DESCRIPTION
BOSH job templates now support using the '-' character
to specify trimming  of newlines in the rendered ERB
templates.

Fixes #1086