### PR TITLE
Update rsyslog_logrotate.conf

### DIFF
--- a/stemcell_builder/stages/rsyslog_config/assets/rsyslog_logrotate.conf
+++ b/stemcell_builder/stages/rsyslog_config/assets/rsyslog_logrotate.conf
@@ -1,6 +1,7 @@
 /var/log/syslog
 {
 	rotate 7
+	hourly
 	size 5M
 	missingok
 	notifempty
@@ -24,7 +25,8 @@
 /var/log/debug
 /var/log/messages
 {
-	rotate 4
+	rotate 6
+	hourly
 	size 5M
 	missingok
 	notifempty


### PR DESCRIPTION
turn rotation of syslog and messages really hourly.
on heavy load system , ha-proxy and other component will generate huge logs , only true hourly rotated syslog can avoid big disk usage.
