### PR TITLE
Parallel Stemcell Uploads

### DIFF
--- a/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
+++ b/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
@@ -77,10 +77,12 @@ module Bosh::Director
         end
 
         stemcell = nil
+	      stemcell_exists = false
         track_and_log("Checking if this stemcell already exists") do
           begin
             stemcell = @stemcell_manager.find_by_name_and_version @name, @version
-            raise StemcellAlreadyExists, "Stemcell '#{@name}/#{@version}' already exists" unless @fix
+            #raise StemcellAlreadyExists, "Stemcell `#{@name}/#{@version}' already exists" unless @fix
+            stemcell_exists = true
           rescue StemcellNotFound => e
             stemcell = Models::Stemcell.new
             stemcell.name = @name
@@ -90,13 +92,15 @@ module Bosh::Director
           end
         end
 
-        track_and_log("Uploading stemcell #{@name}/#{@version} to the cloud") do
-          stemcell.cid = @cloud.create_stemcell(@stemcell_image, @cloud_properties)
-          logger.info("Cloud created stemcell: #{stemcell.cid}")
-        end
+        unless stemcell_exists
+          track_and_log("Uploading stemcell #{@name}/#{@version} to the cloud") do
+            stemcell.cid = @cloud.create_stemcell(@stemcell_image, @cloud_properties)
+            logger.info("Cloud created stemcell: #{stemcell.cid}")
+          end
 
-        track_and_log("Save stemcell #{@name}/#{@version} (#{stemcell.cid})") do
-          stemcell.save
+          track_and_log("Save stemcell #{@name}/#{@version} (#{stemcell.cid})") do
+            stemcell.save
+          end
         end
 
         "/stemcells/#{stemcell.name}/#{stemcell.version}"

--- a/bosh_cli/lib/cli/commands/stemcell.rb
+++ b/bosh_cli/lib/cli/commands/stemcell.rb
@@ -75,7 +75,8 @@ If --name & --version are provided, they will be used for checking if stemcell e
             say("Stemcell '#{name}/#{version}' already exists. Skipping upload.")
             return
           else
-            err("Stemcell '#{name}/#{version}' already exists. Increment the version if it has changed.")
+            say("Stemcell `#{name}/#{version}' already exists. Increment the version if it has changed.")
+            return
           end
         end
 


### PR DESCRIPTION
These commits should allow the client and director to receive duplicate stemcells, but ignore them without throwing exceptions and stopping the execution's flow. See [this issue](https://github.com/cloudfoundry/bosh/issues/1169) for more details.