### PR TITLE
Changed job_state for not existing VMs

### DIFF
--- a/bosh-director/lib/bosh/director/jobs/vm_state.rb
+++ b/bosh-director/lib/bosh/director/jobs/vm_state.rb
@@ -87,8 +87,6 @@ module Bosh::Director
           rescue Bosh::Director::RpcTimeout
             job_state = 'unresponsive agent'
           end
-        else
-          job_state = 'missing vm'
         end
 
         return job_state, job_vitals, processes, ips

--- a/bosh-director/spec/unit/jobs/vm_state_spec.rb
+++ b/bosh-director/spec/unit/jobs/vm_state_spec.rb
@@ -236,7 +236,7 @@ module Bosh::Director
 
           expect(@result_file).to receive(:write) do |agent_status|
             status = JSON.parse(agent_status)
-            expect(status['job_state']).to eq('missing vm')
+            expect(status['job_state']).to eq(nil)
           end
 
           expect(AgentClient).to_not receive(:with_vm_credentials_and_agent_id)


### PR DESCRIPTION
- job_state actually reflects agent_state,
  therefore null instead of 'missing vm' is
  more appropriate

[#114100869](https://www.pivotaltracker.com/story/show/114100869)

Signed-off-by: Tom Kiemes <tom.kiemes@sap.com>