### PR TITLE
Make sure the progress bar goes to 100%

### DIFF
--- a/bosh_cli/lib/cli/file_with_progress_bar.rb
+++ b/bosh_cli/lib/cli/file_with_progress_bar.rb
@@ -32,6 +32,7 @@ module Bosh
         if result && result.size > 0
           progress_bar.inc(result.size)
         else
+          progress_bar.set(size)
           progress_bar.finish
         end
 
@@ -43,6 +44,7 @@ module Bosh
         if count
           progress_bar.inc(count)
         else
+          progress_bar.set(size)
           progress_bar.finish
         end
         count


### PR DESCRIPTION
No one likes it when an operation ends and the progress bar never went all the way to 100%. @zachgersh was showing me some concourseci output and the progress bars always ended at 96%. Rather than sort out exactly why the chunks never match up exactly, just set the progress bar to 100% when we're done.