### PR TITLE
Switching to use s3cli binary in bosh-release for the director

### DIFF
--- a/blobstore_client/lib/blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client.rb
@@ -11,3 +11,4 @@ Bosh::Blobstore.autoload(:S3BlobstoreClient, 'blobstore_client/s3_blobstore_clie
 Bosh::Blobstore.autoload(:SimpleBlobstoreClient, 'blobstore_client/simple_blobstore_client')
 Bosh::Blobstore.autoload(:LocalClient, 'blobstore_client/local_client')
 Bosh::Blobstore.autoload(:DavBlobstoreClient, 'blobstore_client/dav_blobstore_client')
+Bosh::Blobstore.autoload(:S3cliBlobstoreClient, 'blobstore_client/s3cli_blobstore_client')

--- a/blobstore_client/lib/blobstore_client/client.rb
+++ b/blobstore_client/lib/blobstore_client/client.rb
@@ -1,7 +1,7 @@
 module Bosh
   module Blobstore
     class Client
-      PROVIDER_NAMES = %w[dav simple s3 local]
+      PROVIDER_NAMES = %w[dav simple s3 local s3cli]
 
       def self.create(blobstore_provider, options = {})
         unless PROVIDER_NAMES.include?(blobstore_provider)

--- a/blobstore_client/lib/blobstore_client/s3cli_blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client/s3cli_blobstore_client.rb
@@ -1,0 +1,133 @@
+require 'openssl'
+require 'digest/sha1'
+require 'base64'
+require 'securerandom'
+require 'open3'
+require 'json'
+
+module Bosh
+  module Blobstore
+    class S3cliBlobstoreClient < BaseClient
+
+      # Blobstore client for S3, using s3cli Go version
+      # @param [Hash] options S3connection options
+      # @option options [Symbol] bucket_name
+      #   key that is applied before the object is sent to S3
+      # @option options [Symbol, optional] access_key_id
+      # @option options [Symbol, optional] secret_access_key
+      # @option options [Symbol] s3cli_path
+      #   path to s3cli binary
+      # @option options [Symbol, optional] s3cli_config_path
+      #   path to store configuration files
+      # @note If access_key_id and secret_access_key are not present, the
+      #   blobstore client operates in read only mode
+      def initialize(options)
+        super(options)
+
+        @s3cli_path = @options.fetch(:s3cli_path)
+        unless Kernel.system("#{@s3cli_path} --v", out: "/dev/null", err: "/dev/null")
+          raise BlobstoreError, "Cannot find s3cli executable. Please specify s3cli_path parameter"
+        end
+
+        @s3cli_options = {
+          bucket_name: @options[:bucket_name],
+          use_ssl: @options.fetch(:use_ssl, true),
+          host: @options[:host],
+          port: @options[:port],
+          region: @options[:region],
+          ssl_verify_peer:  @options.fetch(:ssl_verify_peer, true),
+          credentials_source: @options.fetch(:credentials_source, 'none'),
+          access_key_id: @options[:access_key_id],
+          secret_access_key: @options[:secret_access_key],
+          signature_version: @options[:signature_version]
+        }
+
+        @s3cli_options.reject! {|k,v| v.nil?}
+
+        if  @options[:access_key_id].nil? &&
+            @options[:secret_access_key].nil?
+              @options[:credentials_source] = 'none'
+        end
+
+        @config_file = write_config_file(@options.fetch(:s3cli_config_path, nil))
+      end
+
+      # @param [File] file file to store in S3
+      def create_file(object_id, file)
+        object_id ||= generate_object_id
+        # in Ruby 1.8 File doesn't respond to :path
+        path = file.respond_to?(:path) ? file.path : file
+
+        store_in_s3(path, full_oid_path(object_id))
+
+        object_id
+      end
+
+      # @param [String] object_id object id to retrieve
+      # @param [File] file file to store the retrived object in
+      def get_file(object_id, file)
+        begin
+        out, err, status = Open3.capture3("#{@s3cli_path} -c #{@config_file} get #{object_id} #{file.path}")
+        rescue Exception => e
+          raise BlobstoreError, e.inspect
+        end
+        raise BlobstoreError, "Failed to download S3 object, code #{status.exitstatus}, output: '#{out}', error: '#{err}'" unless status.success?
+      end
+
+      # @param [String] object_id object id to delete
+      def delete_object(object_id)
+        begin
+          out, err, status = Open3.capture3("#{@s3cli_path} -c #{@config_file} delete #{object_id}")
+        rescue Exception => e
+          raise BlobstoreError, e.inspect
+        end
+        raise BlobstoreError, "Failed to delete S3 object, code #{status.exitstatus}, output: '#{out}', error: '#{err}'" unless status.success?
+      end
+
+      def object_exists?(object_id)
+        begin
+          out, err, status = Open3.capture3("#{@s3cli_path} -c #{@config_file} exists #{object_id}")
+          if status.exitstatus == 0
+            return true
+          end
+          if status.exitstatus == 3
+            return false
+          end
+        rescue Exception => e
+          raise BlobstoreError, e.inspect
+        end
+        raise BlobstoreError, "Failed to check existence of S3 object, code #{status.exitstatus}, output: '#{out}', error: '#{err}'" unless status.success?
+      end
+
+      protected
+
+      # @param [String] path path to file which will be stored in S3
+      # @param [String] oid object id
+      # @return [void]
+      def store_in_s3(path, oid)
+        begin
+        out, err, status = Open3.capture3("#{@s3cli_path} -c #{@config_file} put #{path} #{oid}")
+        rescue Exception => e
+          raise BlobstoreError, e.inspect
+        end
+        raise BlobstoreError, "Failed to create S3 object, code #{status.exitstatus}, output: '#{out}', error: '#{err}'" unless status.success?
+      end
+
+      def full_oid_path(object_id)
+         @options[:folder] ?  @options[:folder] + '/' + object_id : object_id
+      end
+
+      def write_config_file(config_file_dir = nil)
+        config_file_dir = Dir::tmpdir unless config_file_dir
+        Dir.mkdir(config_file_dir) unless File.exists?(config_file_dir)
+        random_name = "s3_blobstore_config-#{SecureRandom.uuid}"
+        config_file = File.join(config_file_dir, random_name)
+        config_data = JSON.dump(@s3cli_options)
+
+        File.write(config_file, config_data)
+        config_file
+      end
+
+    end
+  end
+end

--- a/blobstore_client/spec/unit/client_spec.rb
+++ b/blobstore_client/spec/unit/client_spec.rb
@@ -24,6 +24,15 @@ module Bosh::Blobstore
           })).to be_instance_of(S3BlobstoreClient)
         end
 
+        it 'returns s3cli client' do
+          allow(Kernel).to receive(:system).with("/path --v", {:out => "/dev/null", :err => "/dev/null"}).and_return(true)
+          expect(Client.create('s3cli', {
+              access_key_id: 'foo',
+              secret_access_key: 'bar',
+              s3cli_path: '/path'
+          })).to be_instance_of(S3cliBlobstoreClient)
+        end
+
         it 'should pick S3 provider when S3 is used without credentials' do
           expect(Client.create('s3', bucket_name: 'foo')).to be_instance_of(S3BlobstoreClient)
         end

--- a/blobstore_client/spec/unit/s3cli_blobstore_client_spec.rb
+++ b/blobstore_client/spec/unit/s3cli_blobstore_client_spec.rb
@@ -1,0 +1,166 @@
+require 'spec_helper'
+require 'json'
+
+module Bosh::Blobstore
+  describe S3cliBlobstoreClient do
+    subject(:client) { described_class.new(options) }
+    let!(:base_dir) { Dir.mktmpdir }
+    before do
+      allow(Dir).to receive(:tmpdir).and_return(base_dir)
+      allow(SecureRandom).to receive_messages(uuid: 'FAKE_UUID')
+      allow(Kernel).to receive(:system).with("/var/vcap/packages/s3cli/bin/s3cli --v", {:out => "/dev/null", :err => "/dev/null"}).and_return(true)
+    end
+
+    let(:options) do
+      {
+          bucket_name:       'test',
+          access_key_id:     'KEY',
+          secret_access_key: 'SECRET',
+          s3cli_path:        '/var/vcap/packages/s3cli/bin/s3cli'
+      }
+    end
+
+    let(:expected_config_file) { File.join(base_dir, 's3_blobstore_config-FAKE_UUID') }
+    let(:success_exit_status) { instance_double('Process::Status', exitstatus: 0, success?: true) }
+    let(:not_existed_exit_status) { instance_double('Process::Status', exitstatus: 3, success?: true) }
+    let(:failure_exit_status) { instance_double('Process::Status', exitstatus: 1, success?: false) }
+    let(:object_id) { 'fo1' }
+    let(:file_path) { File.join(base_dir, "temp-path-FAKE_UUID") }
+
+    after { FileUtils.rm_rf(base_dir) }
+
+    describe 'interface' do
+      it_implements_base_client_interface
+    end
+
+    describe 'options' do
+      let(:expected_options) do
+        options.merge(
+            {
+                use_ssl:            true,
+                ssl_verify_peer:    true,
+                credentials_source: 'none'
+            }
+        ).reject { |k, v| k == :s3cli_path }
+      end
+      let (:stored_config_file) { File.new(expected_config_file).readlines }
+
+      context 'when there is no s3cli' do
+        it 'raises an error' do
+          allow(Kernel).to receive(:system).with("/var/vcap/packages/s3cli/bin/s3cli --v", {:out => "/dev/null", :err => "/dev/null"}).and_return(false)
+          expect { described_class.new(options) }.to raise_error(
+              Bosh::Blobstore::BlobstoreError, 'Cannot find s3cli executable. Please specify s3cli_path parameter')
+        end
+      end
+
+      context 'when s3cli exists' do
+        before { described_class.new(options) }
+
+        it 'should set default values to config file' do
+          expect(File.exist?(expected_config_file)).to eq(true)
+          expect(JSON.parse(stored_config_file[0], {:symbolize_names => true})).to eq(expected_options)
+        end
+
+        it 'should set `none` as credentials_source' do
+          expect(JSON.parse(stored_config_file[0])["credentials_source"]).to eq("none")
+        end
+      end
+
+      context 'when s3cli_config_path option is provided' do
+        let (:s3cli_config_path) { Dir::tmpdir }
+        let (:config_file_options) do
+          options.merge (
+              {
+                  s3cli_config_path: s3cli_config_path
+              })
+        end
+
+        it 'creates config file with provided path' do
+          described_class.new(config_file_options)
+          expect(File.exist?(File.join(s3cli_config_path, 's3_blobstore_config-FAKE_UUID'))).to eq(true)
+        end
+      end
+    end
+
+    describe '#delete' do
+      it 'should delete an object' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, success_exit_status])
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/s3cli/bin/s3cli -c #{expected_config_file} delete #{object_id}")
+        client.delete(object_id)
+      end
+
+      it 'should show an error from s3cli' do
+        allow(Open3).to receive(:capture3).and_return([nil, 'error', failure_exit_status])
+        expect { client.delete(object_id) }.to raise_error(
+            BlobstoreError, /error: 'error'/)
+      end
+    end
+
+    describe '#exists?' do
+      it 'should return true if s3cli reported so' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, success_exit_status])
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/s3cli/bin/s3cli -c #{expected_config_file} exists #{object_id}")
+        expect(client.exists?(object_id)).to eq(true)
+      end
+
+      it 'should return false if s3cli reported so' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, not_existed_exit_status])
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/s3cli/bin/s3cli -c #{expected_config_file} exists #{object_id}")
+        expect(client.exists?(object_id)).to eq(false)
+      end
+
+      it 'should show an error from s3cli' do
+        allow(Open3).to receive(:capture3).and_return([nil, 'error', failure_exit_status])
+        expect { client.create(object_id) }.to raise_error(
+            BlobstoreError, /error: 'error'/)
+      end
+    end
+
+    describe '#get' do
+
+      it 'should have correct parameters' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, success_exit_status])
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/s3cli/bin/s3cli -c #{expected_config_file} get #{object_id} #{file_path}")
+        client.get(object_id)
+      end
+
+      it 'should show an error from s3cli' do
+        allow(Open3).to receive(:capture3).and_return([nil, 'error', failure_exit_status])
+        expect { client.get(object_id) }.to raise_error(
+            BlobstoreError, /Failed to download S3 object/)
+      end
+    end
+
+    describe '#create' do
+      it 'should take a string as argument' do
+        expect(client).to receive(:store_in_s3)
+        client.create('foobar')
+      end
+
+      it 'should take a file as argument' do
+        expect(client).to receive(:store_in_s3)
+        file = File.open(asset('file'))
+        client.create(file)
+      end
+
+      it 'should have correct parameters' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, success_exit_status])
+        file = File.open(asset('file'))
+        expect(Open3).to receive(:capture3).with("/var/vcap/packages/s3cli/bin/s3cli -c #{expected_config_file} put #{file.path} FAKE_UUID")
+        client.create(file)
+      end
+
+      it 'should show an error ' do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, failure_exit_status])
+        expect { client.create(object_id) }.to raise_error(
+            BlobstoreError, /Failed to create S3 object/)
+      end
+
+      it 'should show an error from s3cli' do
+        allow(Open3).to receive(:capture3).and_return([nil, 'error', failure_exit_status])
+        expect { client.create(object_id) }.to raise_error(
+            BlobstoreError, /error: 'error'/)
+      end
+    end
+  end
+end

--- a/release/config/blobs.yml
+++ b/release/config/blobs.yml
@@ -91,3 +91,7 @@ postgres/postgresql-9.4.6.tar.gz:
   object_id: 5e7c0628-e8b4-46c4-933e-6e6bd388f5db
   sha: bd031beebd86bf149c497525dccf57eebe5a6add
   size: 23249307
+#director/s3cli-0.0.24-linux-amd64:
+#  object_id:
+#  sha:
+#  size:

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -25,6 +25,7 @@ packages:
 - postgres
 - mysql
 - ruby
+- s3cli
 
 properties:
   env.http_proxy:

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -147,6 +147,12 @@ params['blobstore'] = {
   'options' => blobstore_options
 }
 
+if p('blobstore.provider') == "s3"
+   params['blobstore']['provider'] = "s3cli"
+   params['blobstore']['options']['s3cli_config_path'] = "/var/vcap/data/tmp/director"
+   params['blobstore']['options']['s3cli_path'] = "/var/vcap/packages/s3cli/bin/s3cli"
+end
+
 user_management = {
     'provider' => p('director.user_management.provider')
 }
@@ -176,13 +182,15 @@ params['trusted_certs'] = p('director.trusted_certs')
 
 if_p('compiled_package_cache.options.bucket_name') do |bucket_name|
   params['compiled_package_cache'] = {
-    'provider' => 's3',
+    'provider' => 's3cli',
     'options' => {
       'bucket_name' => bucket_name,
       'credentials_source' => p('compiled_package_cache.options.credentials_source', 'static'),
       'access_key_id' => p('compiled_package_cache.options.access_key_id', nil),
       'secret_access_key' => p('compiled_package_cache.options.secret_access_key', nil),
-      'region' => p('blobstore.s3_region', nil)
+      'region' => p('blobstore.s3_region', nil),
+      's3cli_config_path' => "/var/vcap/data/tmp/director",
+      's3cli_path' => "/var/vcap/packages/s3cli/bin/s3cli",
     }
   }
 

--- a/release/jobs/director/templates/director_ctl.erb
+++ b/release/jobs/director/templates/director_ctl.erb
@@ -102,6 +102,9 @@ case $1 in
       fi
       sleep 0.1
     done
+  <%if p('blobstore.provider') == "s3" %>
+    rm -f $TMPDIR/s3_blobstore_config*
+  <%end%>
     rm -f $PIDFILE
     ;;
 

--- a/release/packages/director/spec
+++ b/release/packages/director/spec
@@ -4,5 +4,6 @@ dependencies:
 - libpq
 - mysql
 - ruby
+- s3cli
 files:
 - bosh/bosh-director/vendor/cache/*

--- a/release/packages/s3cli/packaging
+++ b/release/packages/s3cli/packaging
@@ -1,0 +1,5 @@
+set -e
+
+mkdir -p ${BOSH_INSTALL_TARGET}/bin
+mv s3cli/s3cli-0.0.24-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
+chmod +x ${BOSH_INSTALL_TARGET}/bin/s3cli

--- a/release/packages/s3cli/spec
+++ b/release/packages/s3cli/spec
@@ -1,0 +1,4 @@
+---
+name: s3cli
+files:
+- s3cli/s3cli-0.0.24-linux-amd64

--- a/release/spec/director.yml.erb.erb_spec.rb
+++ b/release/spec/director.yml.erb.erb_spec.rb
@@ -630,7 +630,7 @@ describe 'director.yml.erb.erb' do
         end
 
         it 'sets the blobstore fields appropriately' do
-          expect(parsed_yaml['blobstore']['options']).to eq({
+          expect(parsed_yaml['blobstore']['options']).to include({
             'bucket_name' => 'mybucket',
             'credentials_source' => 'env_or_profile',
             'access_key_id' => nil,
@@ -652,13 +652,19 @@ describe 'director.yml.erb.erb' do
           }
         end
 
+        it 'set provider as s3cli' do
+          expect(parsed_yaml['blobstore']['provider']).to eq("s3cli")
+        end
+
         it 'sets the blobstore fields appropriately' do
           expect(parsed_yaml['blobstore']['options']).to eq({
             'bucket_name' => 'mybucket',
             'credentials_source' => 'static',
             'access_key_id' => 'key',
             'secret_access_key' => 'secret',
-            'region' => 'region'
+            'region' => 'region',
+            's3cli_config_path' => '/var/vcap/data/tmp/director',
+            's3cli_path' => '/var/vcap/packages/s3cli/bin/s3cli'
           })
         end
 
@@ -752,7 +758,7 @@ describe 'director.yml.erb.erb' do
           end
 
           it 'sets the blobstore fields appropriately' do
-            expect(parsed_yaml['blobstore']['options']).to eq({
+            expect(parsed_yaml['blobstore']['options']).to include({
               'bucket_name' => 'mybucket',
               'credentials_source' => 'static',
               'access_key_id' => 'key',
@@ -767,7 +773,7 @@ describe 'director.yml.erb.erb' do
               'region' => 'region'
             })
 
-            expect(parsed_yaml['compiled_package_cache']['options']).to eq({
+            expect(parsed_yaml['compiled_package_cache']['options']).to include({
               'bucket_name' => 'mybucket',
               'credentials_source' => 'static',
               'access_key_id' => 'key',
@@ -786,7 +792,7 @@ describe 'director.yml.erb.erb' do
           it 'sets endpoint protocol appropriately when use_ssl is true' do
             deployment_manifest_fragment['properties']['blobstore']['use_ssl'] = true
 
-            expect(parsed_yaml['blobstore']['options']).to eq({
+            expect(parsed_yaml['blobstore']['options']).to include({
               'bucket_name' => 'mybucket',
               'credentials_source' => 'static',
               'access_key_id' => 'key',


### PR DESCRIPTION
- new s3cli blobstore client is provided
- `s3cli_config_path` and `s3cli_path` parameters are used as options for s3cli blobstore client
- new s3cli package for bosh release

[#110879584](https://www.pivotaltracker.com/story/show/110879584)

Signed-off-by: Peter Kalambet <peter.kalambet@ru.ibm.com>