### PR TITLE
Correct number of events with before_id parameter should be displayed

### DIFF
--- a/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
+++ b/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
@@ -11,9 +11,8 @@ module Bosh::Director
         events = Models::Event.order_by(Sequel.desc(:id))
 
         if params['before_id']
-          fetch_until = params['before_id'].to_i
-          start_from = fetch_until > EVENT_LIMIT ? (fetch_until - (EVENT_LIMIT-1)) : 1
-          events = events.where(:id => start_from..fetch_until)
+          before_id = params['before_id'].to_i
+          events = events.filter("id < ?", before_id).limit(EVENT_LIMIT)
         end
 
         events = events.map do |event|

--- a/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
+++ b/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
@@ -55,15 +55,15 @@ module Bosh::Director
           expect(body.size).to eq(2)
 
           expected = [
-            {'id' => '2',
-             'parent_id' => '1',
-             'timestamp' => timestamp.to_i,
-             'user' => 'test',
-             'action' => 'create',
-             'object_type' => 'deployment',
-             'object_name' => 'depl1',
-             'task' => '2',
-             'context' => {}
+            { 'id' => '2',
+              'parent_id' => '1',
+              'timestamp' => timestamp.to_i,
+              'user' => 'test',
+              'action' => 'create',
+              'object_type' => 'deployment',
+              'object_name' => 'depl1',
+              'task' => '2',
+              'context' => {}
             },
             {
               'id' => '1',
@@ -75,42 +75,75 @@ module Bosh::Director
               'task' => '1',
               'context' => {}
             }
-
           ]
           expect(Yajl::Parser.parse(last_response.body)).to eq(expected)
         end
-
-        it 'returns a list of events before_id' do
-          Models::Event.make
-
-          basic_authorize 'admin', 'admin'
-          get '?before_id=2'
-
-          body = Yajl::Parser.parse(last_response.body)
-          response_ids = body.map { |e| e['id'] }
-
-          expect(last_response.status).to eq(200)
-          expect(body.size).to eq(2)
-          expect(response_ids).to eq(['2', '1'])
-        end
       end
 
-      context '200 events' do
+      context 'when before_id is specified' do
         before do
+          basic_authorize 'admin', 'admin'
+        end
+
+        it 'returns a list of events' do
           (1..250).each do |i|
             Models::Event.make
           end
-        end
 
-        it 'returns a list of events before_id' do
-          basic_authorize 'admin', 'admin'
           get '?before_id=230'
           body = Yajl::Parser.parse(last_response.body)
 
           expect(body.size).to eq(200)
           response_ids = body.map { |e| e['id'].to_i }
-          expected_ids = *(31..230)
+          expected_ids = *(30..229)
           expect(response_ids).to eq(expected_ids.reverse)
+        end
+
+        it 'returns correct number of events' do
+          (1..250).each do |i|
+            Models::Event.make
+          end
+          Models::Event.filter("id > ?", 200).delete
+
+          (1..50).each do |i|
+            Models::Event.make
+          end
+
+          get '?before_id=270'
+          body = Yajl::Parser.parse(last_response.body)
+
+          expect(body.size).to eq(200)
+          response_ids = body.map { |e| e['id'].to_i }
+          expected_ids = [*20..200, *251..269]
+          expect(response_ids).to eq(expected_ids.reverse)
+        end
+
+        context 'when number of returned events is less than EVENT_LIMIT' do
+          it 'returns empty list if before_id < minimal id' do
+            (1..10).each do |i|
+              Models::Event.make
+            end
+            Models::Event.filter("id <  ?", 5).delete
+            get '?before_id=4'
+            body = Yajl::Parser.parse(last_response.body)
+
+            expect(last_response.status).to eq(200)
+            expect(body.size).to eq(0)
+          end
+
+          it 'returns a list of events before_id' do
+            (1..10).each do |i|
+              Models::Event.make
+            end
+            get '?before_id=3'
+
+            body         = Yajl::Parser.parse(last_response.body)
+            response_ids = body.map { |e| e['id'] }
+
+            expect(last_response.status).to eq(200)
+            expect(body.size).to eq(2)
+            expect(response_ids).to eq(['2', '1'])
+          end
         end
       end
     end


### PR DESCRIPTION
even if there are gaps in event ids.

[#114655221](https://www.pivotaltracker.com/story/show/114655221)

Signed-off-by: Peter Kalambet <peter.kalambet@ru.ibm.com>