### PR TITLE
Add instructions for using tags to skip tests in BATs

### DIFF
--- a/docs/running_tests.md
+++ b/docs/running_tests.md
@@ -46,6 +46,25 @@ You can also use `./quick-integration-tests.sh` to run all integration tests aga
 
 BATs describe BOSH behavior at the highest level. They often cover infrastructure-specific behavior that is not easily tested at lower levels. BATs verify integration between all BOSH components and infrastructures. They run against a deployed Director and use the CLI to perform tasks. They exercise different BOSH workflows (e.g. deploying for the first time, updating existing deployments, handling broken deployments). The assertions are made against CLI commands exit status, output and state of VMs after performing the command. Since BATs run on real infrastructures, they help verify that specific combinations of the Director and stemcell works.
 
+Some tests in BATs may not be applicable to a given IaaS and can be skipped using tags.
+BATs currently supports the following tags:
+  - `core`: basic BOSH functionality which all CPIs should implement
+  - `persistent_disk`: persistent disk lifecycle tests
+  - `vip_networking`: static public address handling
+  - `dynamic_networking`: IaaS provided address handling
+  - `manual_networking`: BOSH Director specified address handling
+  - `root_partition`: BOSH agent repartitioning of unused storage on root volume
+  - `multiple_manual_networks`: support for creating machines with multiple network interfaces
+  - `raw_ephemeral_storage`: BOSH agent exposes all attached instance storage to deployed jobs
+  - `changing_static_ip`: `configure_networks` CPI method support [deprecated]
+  - `network_reconfiguration`: `configure_networks` CPI method support [deprecated]
+
+Here is an example of running BATs on vSphere, skipping tests that are not applicable:
+
+```
+bundle exec rspec spec --tag ~vip_networking --tag ~dynamic_networking --tag ~root_partition --tag ~raw_ephemeral_storage
+```
+
 There are two ways to run BATs - [using rake tasks](running_bats_using_rake_tasks.md) and [manually](running_bats_manually.md).
 
 


### PR DESCRIPTION
- It is necessary to skip certain tests when running on an IaaS that
  does not support a given feature.
- This lists the supported tags with an explanation for each

[#115464187](https://www.pivotaltracker.com/story/show/115464187)

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>