### PR TITLE
bosh events should only return last 200 events by default

### DIFF
--- a/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
+++ b/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
@@ -12,10 +12,10 @@ module Bosh::Director
 
         if params['before_id']
           before_id = params['before_id'].to_i
-          events = events.filter("id < ?", before_id).limit(EVENT_LIMIT)
+          events = events.filter("id < ?", before_id)
         end
 
-        events = events.map do |event|
+        events = events.limit(EVENT_LIMIT).map do |event|
           @event_manager.event_to_hash(event)
         end
         json_encode(events)

--- a/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
+++ b/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
@@ -78,6 +78,21 @@ module Bosh::Director
           ]
           expect(Yajl::Parser.parse(last_response.body)).to eq(expected)
         end
+
+        it 'returns 200 events' do
+          basic_authorize 'admin', 'admin'
+          (1..250).each do |i|
+            Models::Event.make
+          end
+
+          get '/'
+          body = Yajl::Parser.parse(last_response.body)
+
+          expect(body.size).to eq(200)
+          response_ids = body.map { |e| e['id'].to_i }
+          expected_ids = *(53..252)
+          expect(response_ids).to eq(expected_ids.reverse)
+        end
       end
 
       context 'when before_id is specified' do


### PR DESCRIPTION
[#116793839](https://www.pivotaltracker.com/story/show/116793839)

Signed-off-by: Peter Kalambet <peter.kalambet@ru.ibm.com>