### PR TITLE
Update stemcell build process for ppc64le support

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stemcell_packager.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stemcell_packager.rb
@@ -48,7 +48,7 @@ module Bosh
       def manifest_cloud_properties(disk_format, infrastructure, stemcell_name)
         architecture = 'x86_64'
         if Bosh::Stemcell::Arch.ppc64le?
-          architecture = 'ppc64le'
+          architecture = 'ppc64'
         end
 
         {

--- a/bosh-stemcell/spec/bosh/stemcell/stemcell_packager_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stemcell_packager_spec.rb
@@ -94,7 +94,7 @@ describe Bosh::Stemcell::StemcellPackager do
 
       architecture = 'x86_64'
       if Bosh::Stemcell::Arch.ppc64le?
-        architecture = 'ppc64le'
+        architecture = 'ppc64'
       end
 
       expect(actual_manifest).to eq({

--- a/bosh-stemcell/spec/os_image/ubuntu_trusty_spec.rb
+++ b/bosh-stemcell/spec/os_image/ubuntu_trusty_spec.rb
@@ -162,7 +162,7 @@ describe 'Ubuntu 14.04 OS image', os_image: true do
       uuid-dev
       wget
       zip
-    ).reject{ |pkg| Bosh::Stemcell::Arch.ppc64le? and pkg == 'rsyslog-mmjsonparse' }.each do |pkg|
+    ).reject{ |pkg| Bosh::Stemcell::Arch.ppc64le? and ( pkg == 'rsyslog-mmjsonparse' or pkg == 'rsyslog-gnutls' or pkg == 'rsyslog-relp') }.each do |pkg|
       describe package(pkg) do
         it { should be_installed }
       end

--- a/bosh-stemcell/spec/stemcells/openstack_spec.rb
+++ b/bosh-stemcell/spec/stemcells/openstack_spec.rb
@@ -8,7 +8,7 @@ describe 'OpenStack Stemcell', stemcell_image: true do
   end
 
   context 'installed by package_qcow2_image stage' do
-    describe 'converts to qcow2 0.10 compat' do
+    describe 'converts to qcow2 0.10(x86) or 1.1(ppc64le) compat' do
       # environment is cleaned up inside rspec context
       stemcell_image = ENV['STEMCELL_IMAGE']
 
@@ -17,7 +17,10 @@ describe 'OpenStack Stemcell', stemcell_image: true do
         `#{cmd}`
       end
 
-      it { should include('compat: 0.10') }
+      it {
+        compat = Bosh::Stemcell::Arch.ppc64le? ? '1.1' : '0.10'
+        should include("compat: #{compat}") 
+      }
     end
   end
 

--- a/stemcell_builder/stages/base_debootstrap/apply.sh
+++ b/stemcell_builder/stages/base_debootstrap/apply.sh
@@ -32,7 +32,11 @@ then
   # https://bugs.launchpad.net/ubuntu/+source/debootstrap/+bug/1182540
   # The issue was fixed in 1.0.52
   downloaded_file=`mktemp`
-  url="http://archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.59_all.deb"
+  if is_ppc64le; then
+    url="http://archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.67_all.deb"
+  else
+    url="http://archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.59_all.deb"
+  fi
   wget $url -qO $downloaded_file
   dpkg -i $downloaded_file
   rm $downloaded_file

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -24,13 +24,40 @@ fi
 
 pkg_mgr install $debs
 
-# we need newer rsyslog; this comes from the upstream project's own repo
-run_in_chroot $chroot "add-apt-repository ppa:adiscon/v8-stable"
-# needed to remove rsyslog-mmjsonparse on ppc64le
-# because of this issue https://gist.github.com/allomov-altoros/cd579aa76f3049bee9c7
-pkg_mgr install "rsyslog rsyslog-relp rsyslog-gnutls"
 if ! is_ppc64le; then
+  # we need newer rsyslog; this comes from the upstream project's own repo
+  run_in_chroot $chroot "add-apt-repository ppa:adiscon/v8-stable"
+  # needed to remove rsyslog-mmjsonparse on ppc64le
+  # because of this issue https://gist.github.com/allomov-altoros/cd579aa76f3049bee9c7
+  pkg_mgr install "rsyslog rsyslog-relp rsyslog-gnutls"
   pkg_mgr install "rsyslog-mmjsonparse"
+else
+  # on ppc64le compile from source as the .deb packages are not available 
+  # from the repo above
+  wget http://download.rsyslog.com/liblogging/liblogging-1.0.5.tar.gz
+  wget http://www.rsyslog.com/download/files/download/rsyslog/rsyslog-8.15.0.tar.gz
+  wget http://download.rsyslog.com/librelp/librelp-1.2.9.tar.gz
+  
+  pkg_mgr install "libsystemd-journal-dev libestr-dev libjson0 libjson0-dev uuid-dev python-docutils libcurl4-openssl-dev" 
+
+  tar xvfz liblogging-1.0.5.tar.gz 
+  cd liblogging-1.0.5
+  ./configure --disable-man-pages
+  make && sudo make install
+  cd ..
+  
+  tar xvfz librelp-1.2.9.tar.gz
+  cd librelp-1.2.9
+  ./configure
+  make && sudo make install
+  cd ..
+
+  tar xvfz rsyslog-8.15.0.tar.gz
+  cd rsyslog-8.15.0
+  ./configure --enable-mmjsonparse --enable-gnutls --enable-relp
+  make && make install
+  cd ..
+
 fi
 
 

--- a/stemcell_builder/stages/image_create/apply.sh
+++ b/stemcell_builder/stages/image_create/apply.sh
@@ -59,3 +59,15 @@ add_on_exit "umount ${image_mount_point}"
 
 # Copy root
 time rsync -aHA $chroot/ ${image_mount_point}
+
+if is_ppc64le; then
+  # Add Xen hypervisor console support
+  cat > ${image_mount_point}/etc/init/hvc0.conf <<HVC_CONF
+
+start on stopped rc RUNLEVEL=[2345]
+stop on runlevel [!2345]
+
+respawn
+exec /sbin/getty -8 38400 hvc0
+HVC_CONF
+fi

--- a/stemcell_builder/stages/image_install_grub/apply.sh
+++ b/stemcell_builder/stages/image_install_grub/apply.sh
@@ -183,7 +183,7 @@ then
   if is_ppc64le; then
     run_in_chroot ${image_mount_point} "
     if [ -f /etc/default/grub ]; then
-      sed -i -e 's/^grub_cmdline_linux=\\\"\\\"/grub_cmdline_linux=\\\"quiet splash selinux=0 cgroup_enable=memory swapaccount=1 \\\"/' /etc/default/grub
+      sed -i -e 's/^GRUB_CMDLINE_LINUX=\\\"\\\"/GRUB_CMDLINE_LINUX=\\\"quiet splash selinux=0 cgroup_enable=memory swapaccount=1 \\\"/' /etc/default/grub
     fi
     grub-mkconfig -o /boot/grub/grub.cfg
     "
@@ -246,4 +246,9 @@ if [ -f ${image_mount_point}/boot/grub2/grub.cfg ];then
 fi
 
 run_in_chroot ${image_mount_point} "rm -f /boot/grub/menu.lst"
-run_in_chroot ${image_mount_point} "ln -s ./grub.conf /boot/grub/menu.lst"
+
+if is_ppc64le; then
+  run_in_chroot ${image_mount_point} "touch /boot/grub/menu.lst"
+else
+  run_in_chroot ${image_mount_point} "ln -s ./grub.conf /boot/grub/menu.lst"
+fi

--- a/stemcell_builder/stages/prepare_qcow2_image_stemcell/apply.sh
+++ b/stemcell_builder/stages/prepare_qcow2_image_stemcell/apply.sh
@@ -6,8 +6,13 @@ set -e
 
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
+if is_ppc64le; then 
+  compat=1.1
+else
+  compat=0.10
+fi
 
-qemu-img convert -c -O qcow2 -o compat=0.10 $work/${stemcell_image_name} $work/root.qcow2
+qemu-img convert -c -O qcow2 -o compat=$compat $work/${stemcell_image_name} $work/root.qcow2
 
 pushd $work
 rm -f root.img


### PR DESCRIPTION
List of changes:

1. Architecture name change from `ppc64le` to `ppc64` for Open Stack compatibility
2. Update `compat` version to 1.1 for Power KVM 2.0 and higher
3. Add steps for manual rsyslog build
4. Deboostrap stage for ppc64le pull package for Ubuntu 14.04.4, Kernel 3.19.53
5. Add hvc console configuration file
6. Update `sed` command that modifies `/etc/default/grub`
7. Fix broken symlink on `/boot/grub/menu.lst`

Signed-off-by: Yulia Gaponenko <yulia.gaponenko@ru.ibm.com>