### PR TITLE
Changes for proper support `micro_bosh_eanbled` variable for `ppc64le`

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -37,7 +37,7 @@ module Bosh::Stemcell
         :aws_cli,
         :logrotate_config,
         :dev_tools_config,
-      ].reject{ |s| Bosh::Stemcell::Arch.ppc64le? and [:bosh_ruby, :bosh_micro_go].include?(s) }
+      ]
     end
 
     def build_stemcell_image_stages

--- a/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
+++ b/bosh-stemcell/spec/bosh/stemcell/stage_collection_spec.rb
@@ -121,7 +121,7 @@ module Bosh::Stemcell
           :aws_cli,
           :logrotate_config,
           :dev_tools_config,
-        ].reject{ |s| Bosh::Stemcell::Arch.ppc64le? and [:bosh_ruby, :bosh_micro_go].include?(s) }
+        ]
       end
 
       it 'returns the correct stages' do

--- a/release/packages/director/packaging
+++ b/release/packages/director/packaging
@@ -20,6 +20,10 @@ EOF
 
 bundle_cmd="/var/vcap/packages/ruby/bin/bundle"
 
+if [ "`uname -m`" == "ppc64le" ]; then
+    $bundle_cmd config build.nokogiri '--use-system-libraries'
+fi
+
 $bundle_cmd config build.mysql2 \
   --with-mysql-config=$mysqlclient_dir/bin/mariadb_config \
 

--- a/release/packages/health_monitor/packaging
+++ b/release/packages/health_monitor/packaging
@@ -11,6 +11,10 @@ gem 'json', '1.8.3'
 gem 'bosh-monitor'
 EOF
 
+if [ "`uname -m`" == "ppc64le" ]; then
+    /var/vcap/packages/ruby/bin/bundle config build.nokogiri '--use-system-libraries'
+fi
+
 /var/vcap/packages/ruby/bin/bundle install \
   --local \
   --no-prune \

--- a/release/packages/postgres/packaging
+++ b/release/packages/postgres/packaging
@@ -3,6 +3,13 @@ set -e -x
 tar xzf postgres/postgresql-9.0.23.tar.gz
 cd postgresql-9.0.23
 
+if [ "`uname -m`" == "ppc64le" ]; then
+ cd config
+ curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" > config.guess
+ curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" > config.sub
+ cd ../
+fi
+
 ./configure --prefix=$BOSH_INSTALL_TARGET
 
 pushd src/bin/pg_config

--- a/release/packages/registry/packaging
+++ b/release/packages/registry/packaging
@@ -17,6 +17,10 @@ gem 'mysql2'
 gem 'pg'
 EOF
 
+if [ "`uname -m`" == "ppc64le" ]; then
+    $bundle_cmd config build.nokogiri '--use-system-libraries'
+fi
+
 $bundle_cmd config build.mysql2 \
 --with-mysql-config=$mysqlclient_dir/bin/mariadb_config \
 

--- a/stemcell_builder/stages/bosh_micro_go/apply.sh
+++ b/stemcell_builder/stages/bosh_micro_go/apply.sh
@@ -7,7 +7,10 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 source $base_dir/lib/prelude_bosh.bash
 
-[ "$bosh_micro_enabled" == "yes" ] || exit 0
+if [ "$bosh_micro_enabled" == "no" ]; then
+  mkdir -p $chroot/$bosh_dir/../micro_bosh/data/cache
+  exit 0
+fi
 
 mkdir -p $chroot/$bosh_dir/src/micro_bosh/bosh-release
 if [ -z "${agent_gem_src_url:-}" ]; then


### PR DESCRIPTION
This PR contains two types of changes separated in two commits.

The first one related to stemcell build process. Disabling the `micro_bosh` in stemcell build leads to problem with local blobstore because proper path does not exist in resulting stemcell so the `micro_bosh_go` stage just creates the path explicitly. Plus previously added excluding of `bosh_micro_go` and `bosh_ruby` build stages reverted back in favour of using `bosh_micro_enabled` environment variable.

The second commit contain changes in `bosh-release` build process. It update configuration for old PostgreSQL sources to support `ppc64le` architecture and also update bundler configuration for using system `xslt` and `xml2` libs in case of `ppc64le` build.