### PR TITLE
Update bundler configuration in bosh-release build for `nokogiri` build for `ppc64le`

### DIFF
--- a/release/packages/director/packaging
+++ b/release/packages/director/packaging
@@ -20,6 +20,10 @@ EOF
 
 bundle_cmd="/var/vcap/packages/ruby/bin/bundle"
 
+if [ "`uname -m`" == "ppc64le" ]; then
+    $bundle_cmd config build.nokogiri '--use-system-libraries'
+fi
+
 $bundle_cmd config build.mysql2 \
   --with-mysql-config=$mysqlclient_dir/bin/mariadb_config \
 

--- a/release/packages/health_monitor/packaging
+++ b/release/packages/health_monitor/packaging
@@ -11,6 +11,10 @@ gem 'json', '1.8.3'
 gem 'bosh-monitor'
 EOF
 
+if [ "`uname -m`" == "ppc64le" ]; then
+    /var/vcap/packages/ruby/bin/bundle config build.nokogiri '--use-system-libraries'
+fi
+
 /var/vcap/packages/ruby/bin/bundle install \
   --local \
   --no-prune \

--- a/release/packages/postgres/packaging
+++ b/release/packages/postgres/packaging
@@ -3,6 +3,13 @@ set -e -x
 tar xzf postgres/postgresql-9.0.23.tar.gz
 cd postgresql-9.0.23
 
+if [ "`uname -m`" == "ppc64le" ]; then
+ cd config
+ curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" > config.guess
+ curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" > config.sub
+ cd ../
+fi
+
 ./configure --prefix=$BOSH_INSTALL_TARGET
 
 pushd src/bin/pg_config

--- a/release/packages/postgres/packaging
+++ b/release/packages/postgres/packaging
@@ -4,10 +4,7 @@ tar xzf postgres/postgresql-9.0.23.tar.gz
 cd postgresql-9.0.23
 
 if [ "`uname -m`" == "ppc64le" ]; then
- cd config
- curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD" > config.guess
- curl "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD" > config.sub
- cd ../
+  cp ${BOSH_COMPILE_TARGET}/config/config.{guess,sub} ./config
 fi
 
 ./configure --prefix=$BOSH_INSTALL_TARGET

--- a/release/packages/postgres/spec
+++ b/release/packages/postgres/spec
@@ -2,3 +2,5 @@
 name: postgres
 files:
 - postgres/postgresql-9.0.23.tar.gz
+- config/config.guess
+- config/config.sub

--- a/release/packages/registry/packaging
+++ b/release/packages/registry/packaging
@@ -17,6 +17,10 @@ gem 'mysql2'
 gem 'pg'
 EOF
 
+if [ "`uname -m`" == "ppc64le" ]; then
+    $bundle_cmd config build.nokogiri '--use-system-libraries'
+fi
+
 $bundle_cmd config build.mysql2 \
 --with-mysql-config=$mysqlclient_dir/bin/mariadb_config \
 


### PR DESCRIPTION
Update bundler configuration in bosh-release build for `nokogiri` build for `ppc64le`
Update postgresql config with the new `config.guess` and `config.sub` for `ppc64le` support

Signed-off-by: Yulia Gaponenko <yulia.gaponenko@ru.ibm.com>