### PR TITLE
Replace metadata hostname with IP in google packages

### DIFF
--- a/stemcell_builder/stages/system_google_packages/apply.sh
+++ b/stemcell_builder/stages/system_google_packages/apply.sh
@@ -27,3 +27,6 @@ else
   echo "Unknown OS '${os_type}', exiting"
   exit 2
 fi
+
+# Hack: replace google metadata hostname with ip address (bosh agent might set a dns that it's unable to resolve the hostname)
+run_in_chroot $chroot "find /usr/share/google -type f -exec sed -i 's/metadata.google.internal/169.254.169.254/g' {} +"


### PR DESCRIPTION
The google daemons currently depend on a separate
`google-startup-scripts` package to block until the metadata server
hostname can be resolved.
However, these startup packages do other work that interferes with
stemcell / agent changes.
This seems like the most simple change to have the metadata server
available as soon as networking is available.

[#116463189](https://www.pivotaltracker.com/story/show/116463189)