### PR TITLE
Bump s3cli to v0.0.31

### DIFF
--- a/release/config/blobs.yml
+++ b/release/config/blobs.yml
@@ -91,7 +91,7 @@ postgres/postgresql-9.4.6.tar.gz:
   object_id: 5e7c0628-e8b4-46c4-933e-6e6bd388f5db
   sha: bd031beebd86bf149c497525dccf57eebe5a6add
   size: 23249307
-s3cli/s3cli-0.0.28-linux-amd64:
-  object_id: fcec1341-c5ec-41a0-a6fc-c7115e3cc812
-  sha: 6dde380bf7d9e29e5c9ad47ba8860561e031c864
-  size: 11465472
+s3cli/s3cli-0.0.31-linux-amd64:
+  object_id: a691b107-af1b-4087-b1cb-3ee0b7fd1045
+  sha: 32130fe8d775c33695dc83ec21ae41c97d804023
+  size: 11465536

--- a/release/packages/s3cli/packaging
+++ b/release/packages/s3cli/packaging
@@ -1,5 +1,5 @@
 set -e
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-mv s3cli/s3cli-0.0.28-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
+mv s3cli/s3cli-0.0.31-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
 chmod +x ${BOSH_INSTALL_TARGET}/bin/s3cli

--- a/release/packages/s3cli/spec
+++ b/release/packages/s3cli/spec
@@ -1,4 +1,4 @@
 ---
 name: s3cli
 files:
-- s3cli/s3cli-0.0.28-linux-amd64
+- s3cli/s3cli-0.0.31-linux-amd64


### PR DESCRIPTION
- Rebuilt binary with golang 1.6.1 to include security fixes

[#117551911](https://www.pivotaltracker.com/story/show/117551911)

Signed-off-by: Felix Riegger <felix.riegger@sap.com>