### PR TITLE
Customize BOSH agent settings for GCE stemcell

### DIFF
--- a/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
+++ b/stemcell_builder/stages/bosh_google_agent_settings/apply.sh
@@ -16,9 +16,9 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
     "Settings": {
       "Sources": [
         {
-          "Type": "HTTP",
+          "Type": "InstanceMetadata",
           "URI": "http://169.254.169.254",
-          "UserDataPath": "/computeMetadata/v1/instance/attributes/user_data",
+          "SettingsPath": "/computeMetadata/v1/instance/attributes/bosh_settings",
           "Headers": {
             "Metadata-Flavor": "Google"
           }
@@ -26,7 +26,7 @@ cat > $chroot/var/vcap/bosh/agent.json <<JSON
       ],
 
       "UseServerName": true,
-      "UseRegistry": true
+      "UseRegistry": false
     }
   }
 }


### PR DESCRIPTION
**Important**: This PR depends on https://github.com/cloudfoundry/bosh-agent/pull/73 and should not be merged until that `bosh-agent` PR is merged to master.

This customizes *agent.json* on Google Compute Engine stemcells to use GCE instance metadata to retrieve BOSH settings, eliminating the need for the BOSH registry. `UseRegistry` is set to false, `UserDataPath` is removed (no need to bootstrap the registry connection info), and a default `SettingsPath` is provided where the agent can expect to find BOSH settings JSON.