### PR TITLE
Avoid quoting listed, sub-error messages

### DIFF
--- a/bosh-director/lib/bosh/director/deployment_plan/planner_factory.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/planner_factory.rb
@@ -130,7 +130,7 @@ module Bosh
             message = 'Unable to process links for deployment. Errors are:'
 
             errors.each do |e|
-              message = "#{message}\n   - \"#{e.message.gsub(/\n/, "\n  ")}\""
+              message = "#{message}\n   - #{e.message.gsub(/\n/, "\n     ")}"
             end
 
             raise message

--- a/bosh-director/spec/unit/deployment_plan/links/links_resolver_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/links/links_resolver_spec.rb
@@ -242,7 +242,7 @@ describe Bosh::Director::DeploymentPlan::LinksResolver do
           expect {
             links_resolver.resolve(api_server_job)
           }.to raise_error("Unable to process links for deployment. Errors are:
-   - \"Can't find deployment non-existent\"")
+   - Can't find deployment non-existent")
         end
       end
     end
@@ -316,7 +316,7 @@ describe Bosh::Director::DeploymentPlan::LinksResolver do
         expect {
           links_resolver.resolve(api_server_job)
         }.to raise_error("Unable to process links for deployment. Errors are:
-   - \"Can't find deployment non-existant\"")
+   - Can't find deployment non-existant")
       end
     end
 
@@ -328,7 +328,7 @@ describe Bosh::Director::DeploymentPlan::LinksResolver do
         expect {
           links_resolver.resolve(api_server_job)
         }.to raise_error("Unable to process links for deployment. Errors are:
-   - \"Can't resolve link 'c' in instance group 'api-server' on job 'api-server-template' in deployment 'fake-deployment'.\"")
+   - Can't resolve link 'c' in instance group 'api-server' on job 'api-server-template' in deployment 'fake-deployment'.")
       end
     end
 

--- a/spec/integration/links_spec.rb
+++ b/spec/integration/links_spec.rb
@@ -439,9 +439,9 @@ Error 100: Unable to render instance groups for deployment. Errors are:
           expect(exit_code).not_to eq(0)
           expect(output).to include <<-EOF
 Error 100: Unable to process links for deployment. Errors are:
-   - "Multiple instance groups provide links of type 'db'. Cannot decide which one to use for instance group 'optional_db'.
-     simple.mysql.database.db
-     simple.postgres.backup_database.backup_db"
+   - Multiple instance groups provide links of type 'db'. Cannot decide which one to use for instance group 'optional_db'.
+        simple.mysql.database.db
+        simple.postgres.backup_database.backup_db
           EOF
         end
       end
@@ -1481,9 +1481,9 @@ Error 100: Unable to process links for deployment. Errors are:
 
       expect(exit_code).not_to eq(0)
       expect(out).to include("Error 100: Unable to process links for deployment. Errors are:")
-      expect(out).to include("- \"Can't find link with type 'bad_link' for job 'api_server_with_bad_link_types' in deployment 'simple'\"")
-      expect(out).to include("- \"Can't find link with type 'bad_link_2' for job 'api_server_with_bad_link_types' in deployment 'simple'\"")
-      expect(out).to include("- \"Can't find link with type 'bad_link_3' for job 'api_server_with_bad_link_types' in deployment 'simple'\"")
+      expect(out).to include("- Can't find link with type 'bad_link' for job 'api_server_with_bad_link_types' in deployment 'simple'")
+      expect(out).to include("- Can't find link with type 'bad_link_2' for job 'api_server_with_bad_link_types' in deployment 'simple'")
+      expect(out).to include("- Can't find link with type 'bad_link_3' for job 'api_server_with_bad_link_types' in deployment 'simple'")
     end
   end
 end


### PR DESCRIPTION
Seems like error messages don't need to be quoted if they're already in list form where each item is going to be an actual error message. The extra quotes just add noise in the deployment output.