### PR TITLE
Check no less frequently than 15s during watch_time

### DIFF
--- a/bosh-director/lib/bosh/director/instance_updater/state_applier.rb
+++ b/bosh-director/lib/bosh/director/instance_updater/state_applier.rb
@@ -83,7 +83,7 @@ module Bosh::Director
     # on the [min_watch_time..max_watch_time] interval.
     #
     # Tries to respect intervals but doesn't allow an interval to
-    # fall under 1 second.
+    # fall below 1 second or go over 15 seconds.
     # All times are in milliseconds.
     # @param [Numeric] min_watch_time minimum time to watch the jobs
     # @param [Numeric] max_watch_time maximum time to watch the jobs
@@ -91,7 +91,7 @@ module Bosh::Director
     def watch_schedule(min_watch_time, max_watch_time)
       delta = (max_watch_time - min_watch_time).to_f
       watch_intervals = 10
-      step = [1000, delta / (watch_intervals - 1)].max
+      step = [1000, delta / (watch_intervals - 1), 15000].sort[1]
 
       [min_watch_time] + ([step] * (delta / step).floor)
     end

--- a/bosh-director/spec/unit/instance_updater/state_applier_spec.rb
+++ b/bosh-director/spec/unit/instance_updater/state_applier_spec.rb
@@ -138,6 +138,15 @@ module Bosh::Director
             expect { state_applier.apply(update_config) }.to raise_error
           end
         end
+        
+        context 'when the interval length is longer than 150 seconds' do
+          let(:update_watch_time) { '1000-301000' }
+
+          it 'divides the interval into 15 seconds steps' do
+            expect(state_applier).to receive(:sleep).with(15.0).exactly(20).times
+            expect { state_applier.apply(update_config) }.to raise_error
+          end
+        end
       end
 
       context 'when trying to start a job' do


### PR DESCRIPTION
Especially stateful components require sometimes a pretty high max_*_watch_time (10-20 minutes) causing 1-2 minutes intervals between checks.
This change makes sure that checks are done at most every 15s, regardless of min_watch_time and max_watch_time.