### PR TITLE
Allow job and index in cli

### DIFF
--- a/bosh_cli/lib/cli/commands/disks.rb
+++ b/bosh_cli/lib/cli/commands/disks.rb
@@ -43,9 +43,12 @@ module Bosh::Cli::Command
 
     usage 'attach disk'
     desc 'Attaches an disk to an instance and replaces the current disk'
-    def attach(job_name, id, disk_cid)
+    def attach(job_name, id, disk_cid = nil)
       auth_required
       manifest = prepare_deployment_manifest
+
+      job_name, id, disk_cid = split_job⁄id(job_name, id, disk_cid)
+
       status, result = director.attach_disk(manifest.name, job_name, id, disk_cid)
 
       task_report(status, result, "Attached disk #{disk_cid} to #{job_name}/#{id}")
@@ -67,6 +70,20 @@ module Bosh::Cli::Command
       disks.sort do |a, b|
         Time.parse(b['orphaned_at']).to_i <=> Time.parse(a['orphaned_at']).to_i
       end
+    end
+
+    def split_job⁄id(job_name, id, disk_cid)
+      if disk_cid.nil?
+        disk_cid = id
+
+        job_name, id = job_name.split('/', 2)
+
+        if id.nil?
+          raise ArgumentError, 'wrong number of arguments'
+        end
+      end
+
+      [job_name, id, disk_cid]
     end
   end
 end

--- a/bosh_cli/lib/cli/commands/disks.rb
+++ b/bosh_cli/lib/cli/commands/disks.rb
@@ -47,7 +47,7 @@ module Bosh::Cli::Command
       auth_required
       manifest = prepare_deployment_manifest
 
-      job_name, id, disk_cid = split_job⁄id(job_name, id, disk_cid)
+      job_name, id, disk_cid = split_job_and_index(job_name, id, disk_cid)
 
       status, result = director.attach_disk(manifest.name, job_name, id, disk_cid)
 
@@ -72,7 +72,7 @@ module Bosh::Cli::Command
       end
     end
 
-    def split_job⁄id(job_name, id, disk_cid)
+    def split_job_and_index(job_name, id, disk_cid)
       if disk_cid.nil?
         disk_cid = id
 

--- a/bosh_cli/lib/cli/commands/log_management.rb
+++ b/bosh_cli/lib/cli/commands/log_management.rb
@@ -1,3 +1,5 @@
+require 'cli/job_command_args'
+
 module Bosh::Cli
   module Command
     class LogManagement < Base
@@ -12,7 +14,7 @@ module Bosh::Cli
       option '--dir destination_directory', String, 'download directory'
       option '--all', 'deprecated'
 
-      def fetch_logs(job, index_or_id)
+      def fetch_logs(job, index_or_id = nil)
         auth_required
 
         manifest = prepare_deployment_manifest(show_state: true)
@@ -20,6 +22,7 @@ module Bosh::Cli
 
         logs_downloader = LogsDownloader.new(director, self)
 
+        job, index_or_id, _ = JobCommandArgs.new([job, index_or_id]).to_a
         resource_id = fetch_log_resource_id(manifest.name, index_or_id, job)
         logs_path = logs_downloader.build_destination_path(job, index_or_id, options[:dir] || Dir.pwd)
         logs_downloader.download(resource_id, logs_path)

--- a/bosh_cli/lib/cli/commands/log_management.rb
+++ b/bosh_cli/lib/cli/commands/log_management.rb
@@ -1,75 +1,77 @@
-module Bosh::Cli::Command
-  class LogManagement < Base
-    # bosh logs
-    usage 'logs'
-    desc 'Fetch job or agent logs from a BOSH-managed VM'
-    option '--agent', 'fetch agent logs'
-    option '--job', 'fetch job logs'
-    option '--only filter1,filter2,...', Array,
-           'only fetch logs that satisfy',
-           'given filters (defined in job spec)'
-    option '--dir destination_directory', String, 'download directory'
-    option '--all', 'deprecated'
+module Bosh::Cli
+  module Command
+    class LogManagement < Base
+      # bosh logs
+      usage 'logs'
+      desc 'Fetch job or agent logs from a BOSH-managed VM'
+      option '--agent', 'fetch agent logs'
+      option '--job', 'fetch job logs'
+      option '--only filter1,filter2,...', Array,
+             'only fetch logs that satisfy',
+             'given filters (defined in job spec)'
+      option '--dir destination_directory', String, 'download directory'
+      option '--all', 'deprecated'
 
-    def fetch_logs(job, index_or_id)
-      auth_required
+      def fetch_logs(job, index_or_id)
+        auth_required
 
-      manifest = prepare_deployment_manifest(show_state: true)
-      check_arguments
+        manifest = prepare_deployment_manifest(show_state: true)
+        check_arguments
 
-      logs_downloader = Bosh::Cli::LogsDownloader.new(director, self)
+        logs_downloader = LogsDownloader.new(director, self)
 
-      resource_id = fetch_log_resource_id(manifest.name, index_or_id, job)
-      logs_path = logs_downloader.build_destination_path(job, index_or_id, options[:dir] || Dir.pwd)
-      logs_downloader.download(resource_id, logs_path)
-    end
-
-    private
-
-    def fetch_log_resource_id(deployment_name, index_or_id, job)
-      resource_id = director.fetch_logs(deployment_name, job, index_or_id, log_type, filters)
-      err('Error retrieving logs') if resource_id.nil?
-
-      resource_id
-    end
-
-    def agent_logs_wanted?
-      options[:agent]
-    end
-
-    def job_logs_wanted?
-      options[:job]
-    end
-
-    def check_arguments
-      no_track_unsupported
-
-      if agent_logs_wanted? && options[:only]
-        err('Custom filtering is not supported for agent logs')
+        resource_id = fetch_log_resource_id(manifest.name, index_or_id, job)
+        logs_path = logs_downloader.build_destination_path(job, index_or_id, options[:dir] || Dir.pwd)
+        logs_downloader.download(resource_id, logs_path)
       end
-    end
 
-    def log_type
-      err("You can't use --job and --agent together") if job_logs_wanted? && agent_logs_wanted?
+      private
 
-      if agent_logs_wanted?
-        'agent'
-      else
-        'job'
+      def fetch_log_resource_id(deployment_name, index_or_id, job)
+        resource_id = director.fetch_logs(deployment_name, job, index_or_id, log_type, filters)
+        err('Error retrieving logs') if resource_id.nil?
+
+        resource_id
       end
-    end
 
-    def filters
-      if options[:only]
-        err("You can't use --only and --all together") if options[:all]
-        filter = options[:only].join(',')
-      elsif options[:all]
-        filter = nil
-        say("Warning: --all flag is deprecated and has no effect.".make_red)
-      else
-        filter = nil
+      def agent_logs_wanted?
+        options[:agent]
       end
-      filter
+
+      def job_logs_wanted?
+        options[:job]
+      end
+
+      def check_arguments
+        no_track_unsupported
+
+        if agent_logs_wanted? && options[:only]
+          err('Custom filtering is not supported for agent logs')
+        end
+      end
+
+      def log_type
+        err("You can't use --job and --agent together") if job_logs_wanted? && agent_logs_wanted?
+
+        if agent_logs_wanted?
+          'agent'
+        else
+          'job'
+        end
+      end
+
+      def filters
+        if options[:only]
+          err("You can't use --only and --all together") if options[:all]
+          filter = options[:only].join(',')
+        elsif options[:all]
+          filter = nil
+          say("Warning: --all flag is deprecated and has no effect.".make_red)
+        else
+          filter = nil
+        end
+        filter
+      end
     end
   end
 end

--- a/bosh_cli/lib/cli/commands/snapshot.rb
+++ b/bosh_cli/lib/cli/commands/snapshot.rb
@@ -7,7 +7,7 @@ module Bosh::Cli::Command
 
       deployment_name = prepare_deployment_manifest(show_state: true).name
 
-      job, index = split_job⁄index(job, index)
+      job, index = split_job_and_index(job, index)
 
       snapshots = director.list_snapshots(deployment_name, job, index)
 
@@ -51,7 +51,7 @@ module Bosh::Cli::Command
 
       deployment_name = prepare_deployment_manifest(show_state: true).name
 
-      job, index = split_job⁄index(job, index)
+      job, index = split_job_and_index(job, index)
 
       unless job && index
         unless confirmed?("Are you sure you want to take a snapshot of all deployment '#{deployment_name}'?")
@@ -101,7 +101,7 @@ module Bosh::Cli::Command
 
     private
 
-    def split_job⁄index(job, index)
+    def split_job_and_index(job, index)
       if job && !index
         job.split('/', 2)
       else

--- a/bosh_cli/lib/cli/commands/snapshot.rb
+++ b/bosh_cli/lib/cli/commands/snapshot.rb
@@ -7,6 +7,8 @@ module Bosh::Cli::Command
 
       deployment_name = prepare_deployment_manifest(show_state: true).name
 
+      job, index = split_job⁄index(job, index)
+
       snapshots = director.list_snapshots(deployment_name, job, index)
 
       if snapshots.empty?
@@ -48,6 +50,8 @@ module Bosh::Cli::Command
       auth_required
 
       deployment_name = prepare_deployment_manifest(show_state: true).name
+
+      job, index = split_job⁄index(job, index)
 
       unless job && index
         unless confirmed?("Are you sure you want to take a snapshot of all deployment '#{deployment_name}'?")
@@ -93,6 +97,16 @@ module Bosh::Cli::Command
       status, task_id = director.delete_all_snapshots(deployment_name)
 
       task_report(status, task_id, "Deleted all snapshots of deployment '#{deployment_name}'")
+    end
+
+    private
+
+    def split_job⁄index(job, index)
+      if job && !index
+        job.split('/', 2)
+      else
+        [job, index]
+      end
     end
   end
 end

--- a/bosh_cli/spec/unit/commands/log_management_spec.rb
+++ b/bosh_cli/spec/unit/commands/log_management_spec.rb
@@ -7,6 +7,7 @@ describe Bosh::Cli::Command::LogManagement do
   let(:deployment) { 'mycloud' }
   let(:job) { 'dea' }
   let(:index) { '6' }
+  let(:job_and_index) { 'dea/6' }
   let(:id) { 'jobId123' }
   let(:instance_count) { 5 }
 
@@ -104,6 +105,11 @@ describe Bosh::Cli::Command::LogManagement do
           it 'successfully retrieves the log resource id when fetching logs by job id' do
             expect(director).to receive(:fetch_logs).with(deployment, job, id, 'job', nil).and_return('resource_id')
             command.fetch_logs(job, id)
+          end
+
+          it 'successfully retrieves the log resource id when fetching logs by job/index' do
+            expect(director).to receive(:fetch_logs).with(deployment, job, index, 'job', nil).and_return('resource_id')
+            command.fetch_logs(job_and_index)
           end
 
           it 'successfully retrieves the log resource id when fetching logs by job index' do

--- a/bosh_cli/spec/unit/commands/snapshot_spec.rb
+++ b/bosh_cli/spec/unit/commands/snapshot_spec.rb
@@ -61,6 +61,22 @@ describe Bosh::Cli::Command::Snapshot do
           command.list
         end
 
+        it 'list all snapshots for a job/index' do
+          expect(director).to receive(:list_snapshots).with('bosh', 'foo', '0').and_return([snapshots[0]])
+          expect(command).to receive(:say) do |display_output|
+            expect(display_output.to_s).to match_output '
+               +-------------------+--------------+---------------------------+-------+
+               | Job/ID            | Snapshot CID | Created at                | Clean |
+               +-------------------+--------------+---------------------------+-------+
+               | job/12xyz4561 (0) | snap0a       | 2015-12-21 14:53:28 -0800 | true  |
+               +-------------------+--------------+---------------------------+-------+
+              '
+          end
+          expect(command).to receive(:say).with('Snapshots total: 1')
+
+          command.list('foo/0')
+        end
+
         it 'list all snapshots for a job and index' do
           expect(director).to receive(:list_snapshots).with('bosh', 'foo', '0').and_return([snapshots[0]])
           expect(command).to receive(:say) do |display_output|
@@ -147,6 +163,14 @@ describe Bosh::Cli::Command::Snapshot do
           expect(director).to receive(:take_snapshot).with('bosh', 'foo', '0')
 
           command.take('foo', '0')
+        end
+      end
+
+      context 'for a job/index' do
+        it 'takes the snapshot' do
+          expect(director).to receive(:take_snapshot).with('bosh', 'foo', '0')
+
+          command.take('foo/0')
         end
       end
 

--- a/bosh_cli/spec/unit/commands/snapshot_spec.rb
+++ b/bosh_cli/spec/unit/commands/snapshot_spec.rb
@@ -107,7 +107,7 @@ describe Bosh::Cli::Command::Snapshot do
           end
 
           context 'when the user confirms taking the snapshot' do
-            it 'deletes the snapshot' do
+            it 'takes the snapshot' do
               allow(command).to receive(:prepare_deployment_manifest).and_return(double(:manifest, name: 'bosh'))
               expect(command).to receive(:confirmed?).with("Are you sure you want to take a snapshot of all deployment 'bosh'?").and_return(true)
 
@@ -118,7 +118,7 @@ describe Bosh::Cli::Command::Snapshot do
           end
 
           context 'when the user does not confirms taking the snapshot' do
-            it 'does not delete the snapshot' do
+            it 'does not take the snapshot' do
               allow(command).to receive(:prepare_deployment_manifest).and_return(double(:manifest, name: 'bosh'))
               expect(command).to receive(:confirmed?).with("Are you sure you want to take a snapshot of all deployment 'bosh'?").and_return(false)
 


### PR DESCRIPTION
Most of the other bosh cli commands allow for either of the two formats:

```
bosh command job 0
bosh command job/0
```

This PR makes the rest of the commands support both formats:

```
bosh attach disk
bosh logs
bosh take snapshot
bosh snapshots
```

Paired with @mkenyon