### PR TITLE
Update misleading description for bosh stop hard command

### DIFF
--- a/bosh_cli/lib/cli/commands/job_management.rb
+++ b/bosh_cli/lib/cli/commands/job_management.rb
@@ -19,7 +19,7 @@ module Bosh::Cli
       usage 'stop'
       desc 'Stop all jobs/job/instance'
       option '--soft', 'Stop process only'
-      option '--hard', 'Power off VM'
+      option '--hard', 'Delete the VM'
       option '--force', FORCE
       option '--skip-drain', SKIP_DRAIN
       def stop_job(job = '*', index_or_id = nil)


### PR DESCRIPTION
``` Bosh stop job --hard ``` deletes the VM instead of power off . 