### PR TITLE
Fix failing Google stemcell spec

### DIFF
--- a/bosh-stemcell/spec/stemcells/ubuntu_trusty_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_trusty_spec.rb
@@ -189,7 +189,7 @@ HERE
   } do
     describe file('/var/vcap/bosh/agent.json') do
       it { should be_valid_json_file }
-      it { should contain('"Type": "HTTP"') }
+      it { should contain('"Type": "InstanceMetadata"') }
     end
   end
 


### PR DESCRIPTION
- GCE CPI recently switched to using a custom InstanceMetadata endpoint
  rather than the registry, but this test was not updated