### PR TITLE
events can be filtered via --before and/or --after by the timestamp

### DIFF
--- a/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
+++ b/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
@@ -1,4 +1,5 @@
 require 'bosh/director/api/controllers/base_controller'
+require 'time'
 
 module Bosh::Director
   module Api::Controllers
@@ -13,6 +14,28 @@ module Bosh::Director
         if params['before_id']
           before_id = params['before_id'].to_i
           events = events.filter("id < ?", before_id)
+        end
+
+        if params['before_time']
+          begin
+            before_datetime = timestamp_filter_value(params['before_time']) + 1
+          rescue ArgumentError
+            status(400)
+            body("Invalid before parameter: '#{params['before_time']}' ")
+            return
+          end
+          events = events.filter("timestamp < ?", before_datetime)
+        end
+
+        if params['after_time']
+          begin
+            after_datetime = timestamp_filter_value(params['after_time']) + 1
+          rescue ArgumentError
+            status(400)
+            body("Invalid after parameter: '#{params['after_time']}' ")
+            return
+          end
+          events = events.filter("timestamp >= ?", after_datetime)
         end
 
         if params['task']
@@ -31,6 +54,17 @@ module Bosh::Director
           @event_manager.event_to_hash(event)
         end
         json_encode(events)
+      end
+
+      private
+
+      def timestamp_filter_value(value)
+        return Time.at(value.to_i).utc if integer?(value)
+        Time.parse(value)
+      end
+
+      def integer?(string)
+        string =~ /\A[-+]?\d+\z/
       end
     end
   end

--- a/bosh_cli/lib/cli/client/director.rb
+++ b/bosh_cli/lib/cli/client/director.rb
@@ -127,7 +127,9 @@ module Bosh
         def list_events(options={})
           query_string = "/events"
           delimeter = "?"
-          [:before_id, :deployment, :instance, :task].each do |param|
+          options[:before_time] = URI.encode(options.delete(:before)) if options[:before]
+          options[:after_time] = URI.encode(options.delete(:after)) if options[:after]
+          [:before_id, :deployment, :instance, :task, :before_time, :after_time].each do |param|
             if options[param]
               query_string += "#{delimeter}#{ param.to_s}=#{options[param]}"
               delimeter = "&"

--- a/bosh_cli/lib/cli/commands/events.rb
+++ b/bosh_cli/lib/cli/commands/events.rb
@@ -3,10 +3,11 @@ module Bosh::Cli::Command
     usage 'events'
     desc 'Show all deployment events'
     option '--before-id id', Integer, 'Show all events with id less or equal to given id'
-    option '--deployment name', String, 'filter all events by the Deployment Name'
-    option '--task id', String, 'filter all events by the task id'
-    option '--instance job_name/id', String, 'filter all events by the instance job_name/id'
-
+    option '--before timestamp', String, 'Show all events by the given timestamp (ex: 2016-05-08 17:26:32)'
+    option '--after timestamp', String, 'Show all events after the given timestamp (ex: 2016-05-08 17:26:32)'
+    option '--deployment name', String, 'Filter all events by the Deployment Name'
+    option '--task id', String, 'Filter all events by the task id'
+    option '--instance job_name/id', String, 'Filter all events by the instance job_name/id'
 
     def list
       auth_required

--- a/bosh_cli/spec/unit/commands/events_spec.rb
+++ b/bosh_cli/spec/unit/commands/events_spec.rb
@@ -90,6 +90,24 @@ describe Bosh::Cli::Command::Events do
       end
     end
 
+    context 'when filtering events by before timestamp' do
+      before { expect(director).to receive(:list_events).with({target: target, before: 'Tue Feb 16 15:15:08 UTC 2016'}) { [] } }
+
+      it 'should invoke the director with the right options' do
+        command.options = {before: 'Tue Feb 16 15:15:08 UTC 2016', target: target}
+        command.list
+      end
+    end
+
+    context 'when filtering events by after timestamp' do
+      before { expect(director).to receive(:list_events).with({target: target, after: 'Tue Feb 16 15:15:08 UTC 2016'}) { [] } }
+
+      it 'should invoke the director with the right options' do
+        command.options = {after: 'Tue Feb 16 15:15:08 UTC 2016', target: target}
+        command.list
+      end
+    end
+
     context 'when filtering events by instance jobname/id' do
       before { expect(director).to receive(:list_events).with({target: target, instance: 'job/1'}) { [] } }
 


### PR DESCRIPTION
Timestamp can be integer or formatted string.

[#118294801](https://www.pivotaltracker.com/story/show/118294801)

Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>