### PR TITLE
Require 'bosh/stemcell/archive' to build light stemcells.

### DIFF
--- a/bosh-dev/lib/bosh/dev/tasks/stemcell.rake
+++ b/bosh-dev/lib/bosh/dev/tasks/stemcell.rake
@@ -5,6 +5,7 @@ namespace :stemcell do
   task :build_light, [:stemcell_path, :virtualization_type] do |_, args|
     begin
       require 'bosh/stemcell/aws/light_stemcell'
+      require 'bosh/stemcell/archive'
       stemcell = Bosh::Stemcell::Archive.new(args.stemcell_path)
       regions = Array(ENV.fetch('BOSH_AWS_REGION', Bosh::Stemcell::Aws::Region::REGIONS))
       light_stemcell = Bosh::Stemcell::Aws::LightStemcell.new(stemcell, args.virtualization_type, regions)


### PR DESCRIPTION
`bundle exec rake stemcell:build_light` was  failing for me without this...