### PR TITLE
Updates for Bracket Computing

### DIFF
--- a/bosh-director/lib/bosh/director/disk_manager.rb
+++ b/bosh-director/lib/bosh/director/disk_manager.rb
@@ -19,6 +19,7 @@ module Bosh::Director
       disk = nil
       if instance_plan.needs_disk?
         disk = create_and_attach_disk(instance_plan)
+        sleep(30)
         mount_and_migrate_disk(instance, disk, old_disk)
       end
 
@@ -142,6 +143,7 @@ module Bosh::Director
 
       begin
         @cloud.attach_disk(instance_model.vm_cid, disk_cid)
+        sleep(30)
         agent_client(instance_model).mount_disk(disk_cid)
       rescue => e
         @logger.warn("Failed to attach disk to new VM: #{e.inspect}")

--- a/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager.rb
+++ b/bosh_cli_plugin_micro/lib/bosh/deployer/instance_manager.rb
@@ -314,6 +314,7 @@ module Bosh::Deployer
       return unless disk_cid
 
       cloud.attach_disk(state.vm_cid, disk_cid)
+      sleep(30)
       mount_disk(disk_cid)
     end
 
@@ -346,6 +347,7 @@ module Bosh::Deployer
 
     def update_persistent_disk
       attach_missing_disk
+      sleep(60)
       check_persistent_disk
 
       if state.disk_cid.nil?

--- a/stemcell_builder/stages/base_centos_packages/apply.sh
+++ b/stemcell_builder/stages/base_centos_packages/apply.sh
@@ -33,7 +33,7 @@ nfs-common flex psmisc apparmor-utils iptables sysstat \
 rsync openssh-server traceroute libncurses5-dev quota \
 libaio1 gdb libcap2-bin libcap-devel bzip2-devel \
 cmake sudo libuuid-devel parted NetworkManager e2fsprogs cloud-utils-growpart \
-xfsprogs"
+xfsprogs disk cloud-init"
 pkg_mgr install ${packages} ${version_specific_packages}
 
 # Install runit

--- a/stemcell_builder/stages/base_ubuntu_packages/apply.sh
+++ b/stemcell_builder/stages/base_ubuntu_packages/apply.sh
@@ -14,7 +14,7 @@ libaio1 gdb libcap2-bin libcap2-dev libbz2-dev \
 cmake uuid-dev libgcrypt-dev ca-certificates \
 scsitools mg htop module-assistant debhelper runit parted \
 cloud-guest-utils anacron software-properties-common \
-xfsprogs"
+xfsprogs gdisk cloud-init"
 
 if is_ppc64le; then
   debs="$debs \


### PR DESCRIPTION
The main changes are:
1. Adding a sleep statement to workaround the aggressive disk attach timeout
2. Add gdisk package to support GPT paritioned root volumes
3. Add cloud-init to support cloud package automation