### PR TITLE
Pass upload options to upload file method.

### DIFF
--- a/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
@@ -128,8 +128,12 @@ module Bosh
         raise BlobstoreError, "object id #{oid} is already in use" if object_exists?(oid)
 
         s3_object = Aws::S3::Object.new({:key => oid}.merge(@aws_options))
-        multipart_threshold = @options.fetch(:s3_multipart_threshold, 16_777_216)
-        s3_object.upload_file(path, {content_type: "application/octet-stream", multipart_threshold: multipart_threshold})
+        options = {
+          content_type: 'application/octet-stream',
+          multipart_threshold: @options.fetch(:s3_multipart_threshold, 16_777_216),
+        }
+        options.merge!(@options.fetch(:upload_options, {}))
+        s3_object.upload_file(path, options)
         nil
       end
 

--- a/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
+++ b/blobstore_client/spec/unit/s3_blobstore_client_spec.rb
@@ -49,6 +49,9 @@ module Bosh::Blobstore
               port: 8080,
               host: 'our.userdefined.com',
               s3_force_path_style: true,
+              upload_options: {
+                server_side_encryption: 'AES256',
+              },
             })
         end
 
@@ -61,6 +64,14 @@ module Bosh::Blobstore
             access_key_id: 'KEY',
             secret_access_key: 'SECRET',
           )).twice.and_return(blob)
+
+          expect(blob).to receive(:upload_file) do |_, options|
+            expect(options).to eq({
+              server_side_encryption: 'AES256',
+              content_type: 'application/octet-stream',
+              multipart_threshold: 33333,
+            })
+          end
 
           client.create_file('foo', 'file')
         end


### PR DESCRIPTION
This allows users to pass upload options to the s3 blobstore client via an `upload_options` key. I'm specifically looking to pass the `server_side_encryption` option for compliance purposes, but any options from http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Object.html#upload_file-instance_method can be passed. This also adds a unit test asserting that the expected arguments are passed to `upload_file`.

cc @sharms @rogeruiz