### PR TITLE
Raise meaningful error if non-existant vm_extension is requested

### DIFF
--- a/bosh-dev/lib/bosh/dev/tasks/fly.rake
+++ b/bosh-dev/lib/bosh/dev/tasks/fly.rake
@@ -12,7 +12,7 @@ namespace :fly do
   desc 'Fly integration specs'
   task :integration do
     env(DB: (ENV['DB'] || 'postgresql'), SPEC_PATH: (ENV['SPEC_PATH'] || nil))
-    execute('test-integration', '-p --tag=fly-integration')
+    execute('test-integration', '-p')
   end
 
   # bundle exec rake fly:run["pwd ; ls -al"]
@@ -22,6 +22,11 @@ namespace :fly do
   end
 
   private
+
+  def concourse_tag
+    tag = ENV.fetch('CONCOURSE_TAG', 'fly-integration')
+    "--tag=#{tag}" unless tag.empty?
+  end
 
   def concourse_target
     "-t #{ENV['CONCOURSE_TARGET']}" if ENV.has_key?('CONCOURSE_TARGET')
@@ -38,7 +43,7 @@ namespace :fly do
 
   def execute(task, command_options = nil)
     sh("#{env} fly #{concourse_target} sync")
-    sh("#{env} fly #{concourse_target} execute #{command_options} -x -c ci/tasks/#{task}.yml -i bosh-src=$PWD")
+    sh("#{env} fly #{concourse_target} execute #{concourse_tag} #{command_options} -x -c ci/tasks/#{task}.yml -i bosh-src=$PWD")
   end
 end
 

--- a/bosh-director/lib/bosh/director/deployment_plan/planner.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/planner.rb
@@ -353,6 +353,10 @@ module Bosh::Director
       end
 
       def vm_extension(name)
+        unless @vm_extensions.has_key?(name)
+          raise "The vm_extension '#{name}' has not been configured in cloud-config."
+        end
+
         @vm_extensions[name]
       end
 

--- a/bosh-director/spec/unit/deployment_plan/planner_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/planner_spec.rb
@@ -2,6 +2,41 @@ require 'spec_helper'
 
 module Bosh::Director
   module DeploymentPlan
+    describe CloudPlanner do
+      subject { described_class.new({
+        :networks => {},
+        :global_network_resolver => [],
+        :resource_pools => [],
+        :disk_types => [],
+        :availability_zones_list => [],
+        :compilation => {},
+        :vm_extensions => vm_extensions,
+        :ip_provider_factory => nil,
+        :logger => nil,
+      }) }
+
+      context '#vm_extension' do
+        let(:vm_extensions) do
+          [
+            VmExtension.new({
+              'name' => 'test1',
+              'cloud_properties' => {
+                'fake-property' => 'fake-value',
+              }
+            })
+          ]
+        end
+
+        it 'returns a defined vm_extension' do
+          expect(subject.vm_extension('test1').cloud_properties['fake-property']).to eq('fake-value')
+        end
+
+        it 'raises for an undefined vm_extension' do
+          expect{ subject.vm_extension('non-existant') }.to raise_error("The vm_extension 'non-existant' has not been configured in cloud-config.")
+        end
+      end
+    end
+
     describe Planner do
       subject(:planner) { described_class.new(planner_attributes, minimal_manifest, cloud_config, runtime_config, deployment_model) }
 


### PR DESCRIPTION
I ran into [this error](https://github.com/cloudfoundry/bosh/issues/1267) again and was briefly confused before recognizing it. Here's a fix so I don't have to think about it next time. Instead of failing with the following during deployment...

    Error 100: undefined method `cloud_properties' for nil:NilClass

It now shows...

    Error 100: The vm_extension 'wrongname' has not been configured in cloud-config.

Also a commit to allow using the `fly:*` tasks with a Concourse that doesn't have a `fly-integration`-tagged worker. Pre-existing behavior is still default.