### PR TITLE
Event ids should be timestamp instead of Integer

### DIFF
--- a/bosh-dev/assets/sandbox/director_test.yml.erb
+++ b/bosh-dev/assets/sandbox/director_test.yml.erb
@@ -32,6 +32,9 @@ db: &bosh_db
     max_connections: 32
     pool_timeout: 10
     reconnect: <%= database.adapter == 'mysql2' ? true : false %>
+    <% if database.adapter == 'mysql2' %>
+    fractional_seconds: true
+    <% end %>
 
 dns:
   db: *bosh_db

--- a/bosh-director/db/migrations/director/20160606184338_change_events.rb
+++ b/bosh-director/db/migrations/director/20160606184338_change_events.rb
@@ -1,0 +1,19 @@
+Sequel.migration do
+  change do
+    drop_table(:events)
+
+    create_table :events do
+      Time :id, :index => true, unique: true, primary_key: true, :null => false
+      Time :parent_id
+      String :user, :null => false
+      String :action, :null => false
+      String :object_type, :null => false
+      String :object_name
+      String :error, :text => true
+      String :task
+      String :deployment
+      String :instance
+      String :context_json, :text => true
+    end
+  end
+end

--- a/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
+++ b/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
@@ -12,8 +12,8 @@ module Bosh::Director
         events = Models::Event.order_by(Sequel.desc(:id))
 
         if params['before_id']
-          before_id = params['before_id'].to_i
-          events = events.filter("id < ?", before_id)
+          before_id = params['before_id'].to_f
+          events = events.filter("id < ?", Time.at(before_id))
         end
 
         if params['before_time']
@@ -24,7 +24,7 @@ module Bosh::Director
             body("Invalid before parameter: '#{params['before_time']}' ")
             return
           end
-          events = events.filter("timestamp < ?", before_datetime)
+          events = events.filter("id < ?", before_datetime)
         end
 
         if params['after_time']
@@ -35,7 +35,7 @@ module Bosh::Director
             body("Invalid after parameter: '#{params['after_time']}' ")
             return
           end
-          events = events.filter("timestamp >= ?", after_datetime)
+          events = events.filter("id >= ?", after_datetime)
         end
 
         if params['task']

--- a/bosh-director/lib/bosh/director/models/event.rb
+++ b/bosh-director/lib/bosh/director/models/event.rb
@@ -2,8 +2,15 @@
 
 module Bosh::Director::Models
   class Event < Sequel::Model(Bosh::Director::Config.db)
+    unrestrict_primary_key
+
+    def before_create
+      self.id ||= Time.now
+      super
+    end
+
     def validate
-      validates_presence [:timestamp, :action, :object_type]
+      validates_presence [:action, :object_type]
     end
 
     def context

--- a/bosh-director/spec/blueprints.rb
+++ b/bosh-director/spec/blueprints.rb
@@ -192,7 +192,6 @@ module Bosh::Director::Models
     object_type {'deployment' }
     object_name { Sham.object_name }
     user        { Sham.username }
-    timestamp   { Time.now }
   end
 
   Team.blueprint do

--- a/bosh-director/spec/db_spec_helper.rb
+++ b/bosh-director/spec/db_spec_helper.rb
@@ -38,6 +38,7 @@ module DBSpecHelper
       @db_helper.create_db
 
       db_opts = {:max_connections => 32, :pool_timeout => 10}
+      db_opts[:fractional_seconds] = true if ENV.fetch('DB', 'sqlite') == 'mysql'
 
       @db = Sequel.connect(@db_helper.connection_string, db_opts)
     end

--- a/bosh-director/spec/spec_helper.rb
+++ b/bosh-director/spec/spec_helper.rb
@@ -110,6 +110,7 @@ module SpecHelper
 
     def connect_database
       db_opts = {:max_connections => 32, :pool_timeout => 10}
+      db_opts[:fractional_seconds] = true if @director_db_helper.adapter == 'mysql2'
 
       Sequel.default_timezone = :utc
       @director_db = Sequel.connect(@director_db_helper.connection_string, db_opts)

--- a/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
+++ b/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
@@ -9,7 +9,14 @@ module Bosh::Director
 
       subject(:app) { described_class.new(config) }
       let(:config) { Config.load_hash(SpecHelper.spec_get_director_config) }
-      let(:timestamp) { Time.now }
+      let(:timestamp) { Time.at(1465372161.629570) }
+      let (:all_expected_ids) do
+        expected_ids = []
+        (1..270).each do |i|
+          expected_ids << (timestamp + i).to_f.to_s
+        end
+        expected_ids
+      end
 
       before do
         App.new(config)
@@ -18,7 +25,7 @@ module Bosh::Director
       context 'events' do
         before do
           Models::Event.make(
-            'timestamp' => timestamp,
+            'id' => timestamp,
             'user' => 'test',
             'action' => 'create',
             'object_type' => 'deployment',
@@ -26,8 +33,8 @@ module Bosh::Director
             'task' => '1'
           )
           Models::Event.make(
-            'parent_id' => 1,
-            'timestamp' => timestamp,
+            'id' => timestamp + 1,
+            'parent_id' => timestamp,
             'user' => 'test',
             'action' => 'create',
             'object_type' => 'deployment',
@@ -52,9 +59,9 @@ module Bosh::Director
           expect(body.size).to eq(2)
 
           expected = [
-            { 'id' => '2',
-              'parent_id' => '1',
-              'timestamp' => timestamp.to_i,
+            { 'id' => (timestamp + 1).to_f.to_s,
+              'parent_id' => timestamp.to_f.to_s,
+              'timestamp' => (timestamp + 1).to_i,
               'user' => 'test',
               'action' => 'create',
               'object_type' => 'deployment',
@@ -63,7 +70,7 @@ module Bosh::Director
               'context' => {}
             },
             {
-              'id' => '1',
+              'id' => timestamp.to_f.to_s,
               'timestamp' => timestamp.to_i,
               'user' => 'test',
               'action' => 'create',
@@ -79,15 +86,14 @@ module Bosh::Director
         it 'returns 200 events' do
           basic_authorize 'admin', 'admin'
           (1..250).each do |i|
-            Models::Event.make
+            Models::Event.make('id' => timestamp + i + 2)
           end
 
           get '/'
           body = Yajl::Parser.parse(last_response.body)
-
           expect(body.size).to eq(200)
-          response_ids = body.map { |e| e['id'].to_i }
-          expected_ids = *(53..252)
+          response_ids = body.map { |e| e['id'] }
+          expected_ids = all_expected_ids.slice(52, 200)
           expect(response_ids).to eq(expected_ids.reverse)
         end
       end
@@ -150,8 +156,8 @@ module Bosh::Director
             Models::Event.make('deployment' => 'not the droid we are looking for')
           end
 
-          it 'returns the anded results' do
-            get '?instance=job/5&task=4&deployment=name&before_id=3'
+          it 'returns the ended results' do
+            get "?instance=job/5&task=4&deployment=name&before_id=#{Models::Event.all[3].id.to_f}"
             events = Yajl::Parser.parse(last_response.body)
             expect(events.size).to eq(1)
             expect(events[0]['instance']).to eq('job/5')
@@ -163,30 +169,30 @@ module Bosh::Director
         context 'when before and after are specified' do
           before do
             (1..20).each do |i|
-              Models::Event.make(:timestamp => timestamp + i)
+              Models::Event.make(:id => timestamp + i)
             end
           end
 
           it 'returns the correct results' do
-            get "?before_time=#{URI.encode(Models::Event.all[16].timestamp.to_s)}&after_time=#{URI.encode(Models::Event.all[14].timestamp.to_s)}"
+            get "?before_time=#{URI.encode(Models::Event.all[16].id.to_i.to_s)}&after_time=#{URI.encode(Models::Event.all[14].id.to_i.to_s)}"
             events = Yajl::Parser.parse(last_response.body)
             expect(events.size).to eq(1)
-            expect(events.first['id']).to eq('16')
+            expect(events.first['id']).to eq(Models::Event.all[15].id.to_f.to_s)
           end
         end
 
         context 'when after and before_id are specified' do
           before do
             (1..20).each do |i|
-              Models::Event.make(:timestamp => timestamp+i)
+              Models::Event.make(:id => timestamp + i)
             end
           end
 
           it 'returns the correct result' do
-            get "?before_id=15&after_time=#{URI.encode(Models::Event.all[12].timestamp.to_s)}"
+            get "?before_id=#{Models::Event.all[14].id.to_f}&after_time=#{URI.encode(Models::Event.all[12].id.to_s)}"
             events = Yajl::Parser.parse(last_response.body)
             expect(events.size).to eq(1)
-            expect(events.first['id']).to eq('14')
+            expect(events.first['id']).to eq(Models::Event.all[13].id.to_f.to_s)
           end
         end
       end
@@ -204,37 +210,37 @@ module Bosh::Director
 
         it 'returns a list of events' do
           (1..210).each do |i|
-            Models::Event.make(:timestamp => timestamp+i)
+            Models::Event.make(:id => timestamp + i)
           end
-          get "?before_time=#{URI.encode(Models::Event.all[201].timestamp.to_s)}"
+          get "?before_time=#{URI.encode(Time.at(Models::Event.all[201].id).to_s)}"
           events = Yajl::Parser.parse(last_response.body)
 
           expect(events.size).to eq(200) # 200 limit
-          response_ids = events.map { |e| e['id'].to_i }
-          expected_ids = *(2..201) # exclusive
+          response_ids = events.map { |e| e['id'] }
+          expected_ids = all_expected_ids.slice(1, 200)
           expect(response_ids).to eq(expected_ids.reverse)
         end
 
         it 'supports date as Integer' do
           (1..10).each do |i|
-            Models::Event.make(:timestamp => timestamp+i)
+            Models::Event.make(:id => timestamp + i)
           end
-          get "?before_time=#{Models::Event.all[1].timestamp.to_i}"
+          get "?before_time=#{Models::Event.all[1].id.to_i}"
           events = Yajl::Parser.parse(last_response.body)
 
           expect(events.size).to eq(1)
-          expect(events.first['id']).to eq('1')
+          expect(events.first['id']).to eq(Models::Event.first.id.to_f.to_s)
         end
 
         it 'supports date as specified in the event table' do
           (1..10).each do |i|
-            Models::Event.make(:timestamp => timestamp+i)
+            Models::Event.make(:id => timestamp + i)
           end
-          get "?before_time=#{URI.encode(Models::Event.all[1].timestamp.utc.strftime('%a %b %d %H:%M:%S %Z %Y'))}"
+          get "?before_time=#{URI.encode(Models::Event.all[1].id.utc.strftime('%a %b %d %H:%M:%S %Z %Y'))}"
           events = Yajl::Parser.parse(last_response.body)
 
           expect(events.size).to eq(1)
-          expect(events.first['id']).to eq('1')
+          expect(events.first['id']).to eq(Models::Event.first.id.to_f.to_s)
         end
       end
 
@@ -251,37 +257,37 @@ module Bosh::Director
 
         it 'returns a list of events' do
           (1..210).each do |i|
-            Models::Event.make(:timestamp => timestamp+i)
+            Models::Event.make(:id => timestamp + i)
           end
-          get "?after_time=#{URI.encode(Models::Event.all[9].timestamp.to_s)}"
+          get "?after_time=#{URI.encode(Models::Event.all[9].id.to_s)}"
           events = Yajl::Parser.parse(last_response.body)
 
           expect(events.size).to eq(200)
-          response_ids = events.map { |e| e['id'].to_i }
-          expected_ids = *(11..210)
+          response_ids = events.map { |e| e['id'] }
+          expected_ids = all_expected_ids.slice(10, 200)
           expect(response_ids).to eq(expected_ids.reverse)
         end
 
         it 'supports date as Integer' do
           (1..10).each do |i|
-            Models::Event.make(:timestamp => timestamp+i)
+            Models::Event.make(:id => timestamp + i)
           end
-          get "?after_time=#{Models::Event.all[8].timestamp.to_i}"
+          get "?after_time=#{Models::Event.all[8].id.to_i}"
           events = Yajl::Parser.parse(last_response.body)
 
           expect(events.size).to eq(1)
-          expect(events.first['id']).to eq('10')
+          expect(events.first['id']).to eq(Models::Event.all[9].id.to_f.to_s)
         end
 
         it 'supports date as specified in the event table' do
           (1..10).each do |i|
-            Models::Event.make(:timestamp => timestamp+i)
+            Models::Event.make(:id => timestamp + i)
           end
-          get "?after_time=#{URI.encode(Models::Event.all[8].timestamp.utc.strftime('%a %b %d %H:%M:%S %Z %Y'))}"
+          get "?after_time=#{URI.encode(Models::Event.all[8].id.utc.strftime('%a %b %d %H:%M:%S %Z %Y'))}"
           events = Yajl::Parser.parse(last_response.body)
 
           expect(events.size).to eq(1)
-          expect(events.first['id']).to eq('10')
+          expect(events.first['id']).to eq(Models::Event.all[9].id.to_f.to_s)
         end
       end
 
@@ -292,34 +298,33 @@ module Bosh::Director
 
         it 'returns a list of events' do
           (1..250).each do |i|
-            Models::Event.make
+            Models::Event.make(:id => timestamp + i)
           end
-
-          get '?before_id=230'
+          get "?before_id=#{Models::Event.all[230].id.to_f}"
           events = Yajl::Parser.parse(last_response.body)
 
           expect(events.size).to eq(200)
-          response_ids = events.map { |e| e['id'].to_i }
-          expected_ids = *(30..229)
+          response_ids = events.map { |e| e['id'] }
+          expected_ids = all_expected_ids.slice(30, 200)
           expect(response_ids).to eq(expected_ids.reverse)
         end
 
         it 'returns correct number of events' do
           (1..250).each do |i|
-            Models::Event.make
+            Models::Event.make(:id => timestamp + i)
           end
-          Models::Event.filter("id > ?", 200).delete
+          Models::Event.filter("id > ?", Time.at(Models::Event.all[200].id)).delete
 
           (1..50).each do |i|
-            Models::Event.make
+            Models::Event.make(:id => timestamp + 250 + i)
           end
 
-          get '?before_id=270'
+          get "?before_id=#{Models::Event.all[220].id.to_f}"
           body = Yajl::Parser.parse(last_response.body)
 
           expect(body.size).to eq(200)
-          response_ids = body.map { |e| e['id'].to_i }
-          expected_ids = [*20..200, *251..269]
+          response_ids = body.map { |e| e['id'] }
+          expected_ids =  all_expected_ids.slice(20..200) + all_expected_ids.slice(250..268)
           expect(response_ids).to eq(expected_ids.reverse)
         end
 
@@ -328,8 +333,9 @@ module Bosh::Director
             (1..10).each do |i|
               Models::Event.make
             end
-            Models::Event.filter("id <  ?", 5).delete
-            get '?before_id=4'
+            before_id = Models::Event.all[4].id.to_f
+            Models::Event.filter("id < ?", Time.at(Models::Event.all[5].id)).delete
+            get "?before_id=#{before_id}"
             body = Yajl::Parser.parse(last_response.body)
 
             expect(last_response.status).to eq(200)
@@ -340,14 +346,14 @@ module Bosh::Director
             (1..10).each do |i|
               Models::Event.make
             end
-            get '?before_id=3'
+            get "?before_id=#{Models::Event.all[2].id.to_f}"
 
             body         = Yajl::Parser.parse(last_response.body)
             response_ids = body.map { |e| e['id'] }
 
             expect(last_response.status).to eq(200)
             expect(body.size).to eq(2)
-            expect(response_ids).to eq(['2', '1'])
+            expect(response_ids).to eq([Models::Event.all[1].id.to_f.to_s, Models::Event.all[0].id.to_f.to_s])
           end
         end
       end

--- a/bosh-director/spec/unit/api/event_manager_spec.rb
+++ b/bosh-director/spec/unit/api/event_manager_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'timecop'
 
 describe Bosh::Director::Api::EventManager do
   let(:manager) { described_class.new(true) }
@@ -10,6 +11,27 @@ describe Bosh::Director::Api::EventManager do
       }.to change {
         Bosh::Director::Models::Event.count
       }.from(0).to(1)
+    end
+
+    it 'should take care about duplicates' do
+      expect {
+        Timecop.freeze do
+          2.times do
+            manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment', :object_name => 'dep'})
+          end
+        end
+      }.not_to raise_error
+      expect(Bosh::Director::Models::Event.count).to eq(2)
+    end
+
+    it 'should not be deadlocked' do
+      expect {
+        Timecop.freeze do
+          3.times do
+            manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment', :object_name => 'dep'})
+          end
+        end
+      }.to raise_error
     end
   end
 
@@ -31,13 +53,13 @@ describe Bosh::Director::Api::EventManager do
 
     it 'should pass ids as String' do
       Bosh::Director::Models::Event.make(
-          'parent_id' => 2,
+          'parent_id' => Time.new,
           'user' => 'test',
           'action' => 'create',
           'object_type' => 'deployment',
           'object_name' => 'depl1',
       )
-      expect(manager.event_to_hash(Bosh::Director::Models::Event.first)).to include('id' => '1', 'parent_id' => '2')
+      expect(manager.event_to_hash(Bosh::Director::Models::Event.first)).to include('id' => String, 'parent_id' => String)
     end
   end
 
@@ -102,31 +124,25 @@ describe Bosh::Director::Api::EventManager do
           Bosh::Director::Models::Event.filter.count
         }.from(13).to(3)
       end
-
-      it 'does not duplicate ids (no reuse of deleted ids)' do
-        manager.remove_old_events(3)
-        manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment', :object_name => 'dep'})
-        expect(Bosh::Director::Models::Event.order{Sequel.asc(:id)}.last.id).to eq(14)
-      end
     end
 
     context 'when there is `parent_id` from dataset to remove' do
       before {
         make_n_events(10)
-        Bosh::Director::Models::Event.make(parent_id: 5, action: 'action', object_type: 'type')
+        Bosh::Director::Models::Event.make(parent_id: Time.at(Bosh::Director::Models::Event.all[5].id), action: 'action', object_type: 'type')
+        Bosh::Director::Models::Event.make(parent_id: Time.at(Bosh::Director::Models::Event.all[3].id), action: 'action', object_type: 'type')
         make_n_events(2)
       }
 
       it 'keeps the events started from `parent_id` in the database' do
+        first_id = Bosh::Director::Models::Event.all[3].id
         expect {
-          manager.remove_old_events(3)
+          manager.remove_old_events(4)
         }.to change {
           Bosh::Director::Models::Event.count
-        }.from(13).to(9)
-        expect(Bosh::Director::Models::Event.order{Sequel.desc(:id)}.last.id).to eq(5)
+        }.from(14).to(11)
+        expect(Bosh::Director::Models::Event.order { Sequel.asc(:id) }.first.id).to eq(first_id)
       end
     end
-
-
   end
 end

--- a/bosh-director/spec/unit/api/event_manager_spec.rb
+++ b/bosh-director/spec/unit/api/event_manager_spec.rb
@@ -16,18 +16,18 @@ describe Bosh::Director::Api::EventManager do
     it 'should take care about duplicates' do
       expect {
         Timecop.freeze do
-          2.times do
+          9.times do
             manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment', :object_name => 'dep'})
           end
         end
       }.not_to raise_error
-      expect(Bosh::Director::Models::Event.count).to eq(2)
+      expect(Bosh::Director::Models::Event.count).to eq(9)
     end
 
     it 'should not be deadlocked' do
       expect {
         Timecop.freeze do
-          3.times do
+          11.times do
             manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment', :object_name => 'dep'})
           end
         end

--- a/bosh-director/spec/unit/deployment_plan/compilation_instance_pool_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/compilation_instance_pool_spec.rb
@@ -164,7 +164,7 @@ module Bosh::Director
         expect(event_1.instance).to eq('compilation-deadbeef/instance-uuid-1')
 
         event_2 = Bosh::Director::Models::Event.order(:id).last
-        expect(event_2.parent_id).to eq(1)
+        expect(event_2.parent_id).to eq(Bosh::Director::Models::Event.first.id)
         expect(event_2.user).to eq('user')
         expect(event_2.action).to eq('create')
         expect(event_2.object_type).to eq('instance')

--- a/bosh-director/spec/unit/disk_manager_spec.rb
+++ b/bosh-director/spec/unit/disk_manager_spec.rb
@@ -144,8 +144,8 @@ module Bosh::Director
           expect(event_1.deployment).to eq(instance_model.deployment.name)
           expect(event_1.instance).to eq(instance_model.name)
 
-          event_2 = Bosh::Director::Models::Event.order(:id)[2]
-          expect(event_2.parent_id).to eq(1)
+          event_2 = Bosh::Director::Models::Event.all[1]
+          expect(event_2.parent_id).to eq(Bosh::Director::Models::Event.first.id)
           expect(event_2.user).to eq('user')
           expect(event_2.action).to eq('create')
           expect(event_2.object_type).to eq('disk')
@@ -161,7 +161,7 @@ module Bosh::Director
             disk_manager.update_persistent_disk(instance_plan)
           }.to raise_error Exception, 'error'
 
-          event_2 = Bosh::Director::Models::Event.order(:id)[2]
+          event_2 = Bosh::Director::Models::Event.all[1]
           expect(event_2.error).to eq('error')
         end
 
@@ -387,7 +387,7 @@ module Bosh::Director
         expect(event_1.instance).to eq(instance_model.name)
 
         event_2 = Bosh::Director::Models::Event.order(:id).last
-        expect(event_2.parent_id).to eq(1)
+        expect(event_2.parent_id).to eq(Bosh::Director::Models::Event.first.id)
         expect(event_2.user).to eq('user')
         expect(event_2.action).to eq('delete')
         expect(event_2.object_type).to eq('disk')

--- a/bosh-director/spec/unit/instance_deleter_spec.rb
+++ b/bosh-director/spec/unit/instance_deleter_spec.rb
@@ -134,7 +134,7 @@ module Bosh::Director
           expect(event_1.instance).to eq('fake-job-name/my-uuid-1')
 
           event_2 = Bosh::Director::Models::Event.order(:id).last
-          expect(event_2.parent_id).to eq(1)
+          expect(event_2.parent_id).to eq(Bosh::Director::Models::Event.first.id)
           expect(event_2.user).to eq(task.username)
           expect(event_2.action).to eq('delete')
           expect(event_2.object_type).to eq('instance')

--- a/bosh-director/spec/unit/jobs/delete_deployment_spec.rb
+++ b/bosh-director/spec/unit/jobs/delete_deployment_spec.rb
@@ -13,7 +13,6 @@ module Bosh::Director
       allow(Bosh::Director::Config).to receive(:record_events).and_return(true)
       allow(App).to receive_message_chain(:instance, :blobstores, :blobstore).and_return(blobstore)
       allow(job).to receive(:task_id).and_return(task.id)
-      allow(Time).to receive_messages(now: Time.parse('2016-02-15T09:55:40+00:00'))
     end
 
     let(:cloud) { instance_double('Bosh::Cloud') }
@@ -50,17 +49,15 @@ module Bosh::Director
       expect(event_1.object_name).to eq('test_deployment')
       expect(event_1.deployment).to eq('test_deployment')
       expect(event_1.task).to eq("#{task.id}")
-      expect(event_1.timestamp).to eq(Time.now)
 
       event_2 = Bosh::Director::Models::Event.order(:id).last
-      expect(event_2.parent_id).to eq(1)
+      expect(event_2.parent_id).to eq(Bosh::Director::Models::Event.first.id)
       expect(event_2.user).to eq(task.username)
       expect(event_2.action).to eq('delete')
       expect(event_2.object_type).to eq('deployment')
       expect(event_2.object_name).to eq('test_deployment')
       expect(event_2.deployment).to eq('test_deployment')
       expect(event_2.task).to eq("#{task.id}")
-      expect(event_2.timestamp).to eq(Time.now)
     end
   end
 end

--- a/bosh-director/spec/unit/jobs/ssh_spec.rb
+++ b/bosh-director/spec/unit/jobs/ssh_spec.rb
@@ -30,7 +30,6 @@ module Bosh::Director
       allow(agent).to receive(:ssh).and_return({})
       allow(job).to receive(:task_id).and_return(task.id)
       allow(Config).to receive(:record_events).and_return(true)
-      allow(Time).to receive_messages(now: Time.parse('2016-02-15T09:55:40Z'))
       Config.default_ssh_options = {'gateway_host' => 'fake-host', 'gateway_user' => 'vcap'}
       Config.result = result_file
     end
@@ -58,7 +57,6 @@ module Bosh::Director
       expect(event.instance).to eq('fake-job/fake-uuid-1')
       expect(event.task).to eq("#{task.id}")
       expect(event.context).to eq({'user' => 'user-ssh'})
-      expect(event.timestamp).to eq(Time.now)
     end
 
     it 'should store event with error' do

--- a/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -18,7 +18,6 @@ module Bosh::Director::Jobs
       allow(Bosh::Director::Config).to receive(:cloud) { instance_double(Bosh::Cloud) }
       Bosh::Director::App.new(config)
       allow(job).to receive(:task_id).and_return(task.id)
-      allow(Time).to receive_messages(now: Time.parse('2016-02-15T09:55:40Z'))
     end
 
     describe '#perform' do
@@ -127,16 +126,14 @@ module Bosh::Director::Jobs
           expect(event_1.deployment).to eq('deployment-name')
           expect(event_1.object_name).to eq('deployment-name')
           expect(event_1.task).to eq("#{task.id}")
-          expect(event_1.timestamp).to eq(Time.now)
 
           event_2 = Bosh::Director::Models::Event.order(:id).last
-          expect(event_2.parent_id).to eq(1)
+          expect(event_2.parent_id).to eq(Bosh::Director::Models::Event.first.id)
           expect(event_2.user).to eq(task.username)
           expect(event_2.object_type).to eq('deployment')
           expect(event_2.deployment).to eq('deployment-name')
           expect(event_2.object_name).to eq('deployment-name')
           expect(event_2.task).to eq("#{task.id}")
-          expect(event_2.timestamp).to eq(Time.now)
         end
 
         context 'when there are releases and stemcells' do

--- a/bosh-director/spec/unit/vm_creator_spec.rb
+++ b/bosh-director/spec/unit/vm_creator_spec.rb
@@ -141,8 +141,8 @@ describe Bosh::Director::VmCreator do
     expect(event_1.deployment).to eq(instance_model.deployment.name)
     expect(event_1.instance).to eq(instance_model.name)
 
-    event_2 = Bosh::Director::Models::Event.order(:id)[2]
-    expect(event_2.parent_id).to eq(1)
+    event_2 = Bosh::Director::Models::Event.all[1]
+    expect(event_2.parent_id).to eq(Bosh::Director::Models::Event.first.id)
     expect(event_2.user).to eq('user')
     expect(event_2.action).to eq('create')
     expect(event_2.object_type).to eq('vm')
@@ -158,7 +158,7 @@ describe Bosh::Director::VmCreator do
       subject.create_for_instance_plan(instance_plan, ['fake-disk-cid'])
     }.to raise_error Bosh::Clouds::VMCreationFailed
 
-    event_2 = Bosh::Director::Models::Event.order(:id)[2]
+    event_2 = Bosh::Director::Models::Event.all[1]
     expect(event_2.error).to eq('Bosh::Clouds::VMCreationFailed')
   end
 

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -31,6 +31,10 @@ params = {
   'flush_arp' => p('director.flush_arp'),
 }
 
+if params['db']['adapter']  == 'mysql2'
+  params['db']['connection_options']['fractional_seconds'] = true
+end
+
 params['scheduled_jobs'] = []
 
 if_p('director.snapshot_schedule') do |snapshot_schedule|

--- a/release/spec/director.yml.erb.erb_spec.rb
+++ b/release/spec/director.yml.erb.erb_spec.rb
@@ -108,6 +108,20 @@ describe 'director.yml.erb.erb' do
       expect(parsed_yaml['logging']['file']).to eq("/var/vcap/sys/log/director/<%= ENV['COMPONENT'] %>.debug.log")
     end
 
+    describe 'db settings' do
+      context 'when db adapter is mysql2' do
+        it 'sets fractional_seconds to true' do
+          expect(parsed_yaml['db']['connection_options']['fractional_seconds']).to eq(true)
+        end
+      end
+      context 'when db adapter is not mysql2' do
+        before { deployment_manifest_fragment['properties']['director']['db']['adapter'] = 'postgres' }
+        it 'does not set fractional_seconds parameter' do
+          expect(parsed_yaml['db']['connection_options']['fractional_seconds']).to be_nil
+        end
+      end
+    end
+
     context 'when domain name specified without all other dns properties' do
       before do
         deployment_manifest_fragment['properties']['dns'] = {

--- a/spec/integration/cli_events_spec.rb
+++ b/spec/integration/cli_events_spec.rb
@@ -28,7 +28,7 @@ describe 'cli: events', type: :integration do
     expect(stable_data).to all(include('Time' => /xxx xxx xx xx:xx:xx UTC xxxx|^$/))
     expect(stable_data).to all(include('User' => /test|^$/))
     expect(stable_data).to all(include('Task' => /[0-9]{1,3}|-|^$/))
-    expect(stable_data).to all(include('ID' => /[0-9]{1,3} <- [0-9]{1,3}|[0-9]{1,3}|^$/))
+    expect(stable_data).to all(include('ID' => /[0-9]{10}\.[0-9]{1,6} <- [0-9]{10}\.[0-9]{1,6}|[0-9]{10}\.[0-9]{1,6}|^$/))
 
     expect(flexible_data).to contain_exactly(
       {'Action' => 'delete', 'Object type' => 'deployment', 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => '-'},

--- a/spec/integration/cli_recreate_spec.rb
+++ b/spec/integration/cli_recreate_spec.rb
@@ -33,11 +33,11 @@ describe 'recreate job', type: :integration do
 
     parser = Support::TableHelpers::Parser.new(scrub_event_time(scrub_random_cids(scrub_random_ids(output))))
     expect(parser.data).to include(
-      {'ID' => /[0-9]{1,3} <- [0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => 'before: {"releases"=>["bosh-release/0+dev.1"], "stemcells"=>["ubuntu-stemcell/1"]},'},
+      {'ID' => /[0-9]{10}\.[0-9]{1,6} <- [0-9]{10}\.[0-9]{1,6}|[0-9]{10}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => 'before: {"releases"=>["bosh-release/0+dev.1"], "stemcells"=>["ubuntu-stemcell/1"]},'},
       {'ID' => '', 'Time' => '', 'User' => '', 'Action' => '', 'Object type' => '', 'Task' => '', 'Object ID' => '', 'Dep' => '', 'Inst' => '', 'Context' => 'after: {"releases"=>["bosh-release/0+dev.1"], "stemcells"=>["ubuntu-stemcell/1"]}'},
-      {'ID' => /[0-9]{1,3} <- [0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'recreate', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
-      {'ID' => /[0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'recreate', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
-      {'ID' => /[0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => '-'}
+      {'ID' => /[0-9]{10}\.[0-9]{1,6} <- [0-9]{10}\.[0-9]{1,6}|[0-9]{10}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'recreate', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
+      {'ID' => /[0-9]{10}\.[0-9]{1,6}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'recreate', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
+      {'ID' => /[0-9]{10}\.[0-9]{1,6}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => '-'}
 )
   end
 

--- a/spec/integration/cli_restart_spec.rb
+++ b/spec/integration/cli_restart_spec.rb
@@ -17,11 +17,11 @@ describe 'restart job', type: :integration do
     output = bosh_runner.run('events')
     parser = Support::TableHelpers::Parser.new(scrub_event_time(scrub_random_cids(scrub_random_ids(output))))
     expect(parser.data).to include(
-      {'ID' => /[0-9]{1,3} <- [0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => 'before: {"releases"=>["bosh-release/0+dev.1"], "stemcells"=>["ubuntu-stemcell/1"]},'},
+      {'ID' => /[0-9]{10}\.[0-9]{1,6} <- [0-9]{10}\.[0-9]{1,6}|[0-9]{10}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => 'before: {"releases"=>["bosh-release/0+dev.1"], "stemcells"=>["ubuntu-stemcell/1"]},'},
       {'ID' => '', 'Time' => '', 'User' => '', 'Action' => '', 'Object type' => '', 'Task' => '', 'Object ID' => '', 'Dep' => '', 'Inst' => '', 'Context' => 'after: {"releases"=>["bosh-release/0+dev.1"], "stemcells"=>["ubuntu-stemcell/1"]}'},
-      {'ID' => /[0-9]{1,3} <- [0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'restart', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
-      {'ID' => /[0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'restart', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
-      {'ID' => /[0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => '-'},
+      {'ID' => /[0-9]{10}\.[0-9]{1,6} <- [0-9]{10}\.[0-9]{1,6}|[0-9]{10}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'restart', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
+      {'ID' => /[0-9]{10}\.[0-9]{1,6}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'restart', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
+      {'ID' => /[0-9]{10}\.[0-9]{1,6}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => '-'},
     )
   end
 end

--- a/spec/integration/cli_stop_spec.rb
+++ b/spec/integration/cli_stop_spec.rb
@@ -62,11 +62,11 @@ describe 'stop command', type: :integration do
         output = bosh_runner.run('events')
         parser = Support::TableHelpers::Parser.new(scrub_event_time(scrub_random_cids(scrub_random_ids(output))))
         expect(parser.data).to include(
-          {'ID' => /[0-9]{1,3} <- [0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => 'before: {"releases"=>["bosh-release/0+dev.1"], "stemcells"=>["ubuntu-stemcell/1"]},'},
+          {'ID' => /[0-9]{10}\.[0-9]{1,6} <- [0-9]{10}\.[0-9]{1,6}|[0-9]{10}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => 'before: {"releases"=>["bosh-release/0+dev.1"], "stemcells"=>["ubuntu-stemcell/1"]},'},
           {'ID' => '', 'Time' => '', 'User' => '', 'Action' => '', 'Object type' => '', 'Task' => '', 'Object ID' => '', 'Dep' => '', 'Inst' => '', 'Context' => 'after: {"releases"=>["bosh-release/0+dev.1"], "stemcells"=>["ubuntu-stemcell/1"]}'},
-          {'ID' => /[0-9]{1,3} <- [0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'stop', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
-          {'ID' => /[0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'stop', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
-          {'ID' => /[0-9]{1,3}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => '-'}
+          {'ID' => /[0-9]{10}\.[0-9]{1,6} <- [0-9]{10}\.[0-9]{1,6}|[0-9]{10}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'stop', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
+          {'ID' => /[0-9]{10}\.[0-9]{1,6}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'stop', 'Object type' => 'instance', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Dep' => 'simple', 'Inst' => 'foobar/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'Context' => '-'},
+          {'ID' => /[0-9]{10}\.[0-9]{1,6}/, 'Time' => 'xxx xxx xx xx:xx:xx UTC xxxx', 'User' => 'test', 'Action' => 'update', 'Object type' => 'deployment', 'Task' => /[0-9]{1,3}/, 'Object ID' => 'simple', 'Dep' => 'simple', 'Inst' => '-', 'Context' => '-'}
         )
       end
     end


### PR DESCRIPTION
- id and parent_id have Time type
- timestamp column is removed
- fractional_seconds connection option is added for mysql2
- if duplicate/unique db error for event id appears, timestamp id should be slightly increased
- previous information from event table is deleted

[#116887061](https://www.pivotaltracker.com/story/show/116887061)

Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>