### PR TITLE
Pass encryption options to s3cli.

### DIFF
--- a/blobstore_client/lib/blobstore_client/s3cli_blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client/s3cli_blobstore_client.rb
@@ -39,7 +39,9 @@ module Bosh
           credentials_source: @options.fetch(:credentials_source, 'none'),
           access_key_id: @options[:access_key_id],
           secret_access_key: @options[:secret_access_key],
-          signature_version: @options[:signature_version]
+          signature_version: @options[:signature_version],
+          server_side_encryption: @options[:server_side_encryption],
+          sse_kms_key_id: @options[:sse_kms_key_id]
         }
 
         @s3cli_options.reject! {|k,v| v.nil?}

--- a/release/jobs/director/spec
+++ b/release/jobs/director/spec
@@ -259,6 +259,10 @@ properties:
     default: 16777216
   blobstore.s3_signature_version:
     description: Signature version of the blobstore used by s3 blobstore plugin (optional, if not provided the s3 client decides which version to use)
+  blobstore.server_side_encryption:
+    description: Specifies server-side encryption of the object in S3. Valid values are AES256 and aws:kms (optional; if not provided, server side encryption is not used)
+  blobstore.sse_kms_key_id:
+    description: The AWS KMS key ID that should be used to server-side encrypt the object in S3 (optional; if not provided, AWS KMS is not used)
   blobstore.director.user:
     description: Username director uses to connect to blobstore used by simple blobstore plugin
   blobstore.director.password:

--- a/release/jobs/director/templates/director.yml.erb.erb
+++ b/release/jobs/director/templates/director.yml.erb.erb
@@ -135,6 +135,14 @@ if p('blobstore.provider') == 's3'
   if_p('blobstore.s3_signature_version') do |s3_signature_version|
      blobstore_options['s3_signature_version'] = s3_signature_version
   end
+
+  if_p('blobstore.server_side_encryption') do |server_side_encryption|
+     blobstore_options['server_side_encryption'] = server_side_encryption
+  end
+
+  if_p('blobstore.sse_kms_key_id') do |sse_kms_key_id|
+     blobstore_options['sse_kms_key_id'] = sse_kms_key_id
+  end
 else
   blobstore_options = {
     'endpoint' => "http://#{p('blobstore.address')}:#{p('blobstore.port')}",

--- a/release/packages/s3cli/packaging
+++ b/release/packages/s3cli/packaging
@@ -1,5 +1,5 @@
 set -e
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-mv s3cli/s3cli-0.0.31-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
+mv s3cli/s3cli-0.0.42-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
 chmod +x ${BOSH_INSTALL_TARGET}/bin/s3cli

--- a/release/packages/s3cli/spec
+++ b/release/packages/s3cli/spec
@@ -1,4 +1,4 @@
 ---
 name: s3cli
 files:
-- s3cli/s3cli-0.0.31-linux-amd64
+- s3cli/s3cli-0.0.42-linux-amd64

--- a/stemcell_builder/stages/aws_cli/config.sh
+++ b/stemcell_builder/stages/aws_cli/config.sh
@@ -9,6 +9,6 @@ source $base_dir/lib/prelude_config.bash
 cd $assets_dir
 rm -rf s3cli
 mkdir s3cli
-current_version=0.0.31
+current_version=0.0.42
 curl -L -o s3cli/s3cli https://s3.amazonaws.com/s3cli-artifacts/s3cli-${current_version}-linux-amd64
 echo "32130fe8d775c33695dc83ec21ae41c97d804023 s3cli/s3cli" | sha1sum -c -


### PR DESCRIPTION
Note: these options won't have any effect unless s3cli is bumped to
>=0.0.34.

Replaces #1278.