### PR TITLE
Bump s3cli to 0.0.33 to fix bug interacting with Ceph

### DIFF
--- a/release/packages/s3cli/packaging
+++ b/release/packages/s3cli/packaging
@@ -1,5 +1,5 @@
 set -e
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-mv s3cli/s3cli-0.0.31-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
+mv s3cli/s3cli-0.0.40-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
 chmod +x ${BOSH_INSTALL_TARGET}/bin/s3cli

--- a/release/packages/s3cli/spec
+++ b/release/packages/s3cli/spec
@@ -1,4 +1,4 @@
 ---
 name: s3cli
 files:
-- s3cli/s3cli-0.0.31-linux-amd64
+- s3cli/s3cli-0.0.40-linux-amd64

--- a/stemcell_builder/stages/aws_cli/config.sh
+++ b/stemcell_builder/stages/aws_cli/config.sh
@@ -9,6 +9,6 @@ source $base_dir/lib/prelude_config.bash
 cd $assets_dir
 rm -rf s3cli
 mkdir s3cli
-current_version=0.0.31
+current_version=0.0.40
 curl -L -o s3cli/s3cli https://s3.amazonaws.com/s3cli-artifacts/s3cli-${current_version}-linux-amd64
-echo "32130fe8d775c33695dc83ec21ae41c97d804023 s3cli/s3cli" | sha1sum -c -
+echo "c6472e3a522ac3a047a404a6865a97b6377cf3a8 s3cli/s3cli" | sha1sum -c -


### PR DESCRIPTION
WARNING: be sure to add + upload the new blob for s3cli-0.0.40

[#121159041](https://www.pivotaltracker.com/story/show/121159041)

Signed-off-by: Corey Innis <cinnis@pivotal.io>