### PR TITLE
Provide manual network type to external cpi

### DIFF
--- a/bosh-director/lib/bosh/director/deployment_plan/manual_network.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/manual_network.rb
@@ -51,6 +51,7 @@ module Bosh::Director
         end
 
         config = {
+          "type" => "manual",
           "ip" => ip.ip,
           "netmask" => subnet.netmask,
           "cloud_properties" => subnet.cloud_properties

--- a/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
@@ -102,6 +102,7 @@ module Bosh::Director::DeploymentPlan
               'dns' => '10.0.0.1',
             },
             'a' =>{
+              'type' => 'manual',
               'ip' => '192.168.1.3',
               'netmask' => '255.255.255.0',
               'cloud_properties' =>{},
@@ -453,6 +454,7 @@ module Bosh::Director::DeploymentPlan
       it 'generates network settings from the job and desired reservations' do
         expect(instance_plan.network_settings_hash).to eq({
               'a' => {
+                'type' => 'manual',
                 'ip' => '192.168.1.3',
                 'netmask' => '255.255.255.0',
                 'cloud_properties' => {},

--- a/bosh-director/spec/unit/deployment_plan/manual_network_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/manual_network_spec.rb
@@ -67,6 +67,7 @@ describe Bosh::Director::DeploymentPlan::ManualNetwork do
       reservation = BD::DesiredNetworkReservation.new_static(instance_model, manual_network, '192.168.1.2')
 
       expect(manual_network.network_settings(reservation, [])).to eq({
+            'type' => 'manual',
             'ip' => '192.168.1.2',
             'netmask' => '255.255.255.0',
             'cloud_properties' => {},
@@ -80,6 +81,7 @@ describe Bosh::Director::DeploymentPlan::ManualNetwork do
       reservation = BD::DesiredNetworkReservation.new_static(instance_model, manual_network, '192.168.1.2')
 
       expect(manual_network.network_settings(reservation)).to eq({
+            'type' => 'manual',
             'ip' => '192.168.1.2',
             'netmask' => '255.255.255.0',
             'cloud_properties' => {},

--- a/spec/integration/cpi_spec.rb
+++ b/spec/integration/cpi_spec.rb
@@ -27,6 +27,7 @@ describe 'CPI calls', type: :integration do
         'cloud_properties' => {},
         'networks' => {
           'a' => {
+            'type' => 'manual',
             'ip' => '192.168.1.3',
             'netmask' => '255.255.255.0',
             'cloud_properties' => {},
@@ -80,6 +81,7 @@ describe 'CPI calls', type: :integration do
         'cloud_properties' => {},
         'networks' => {
           'a' => {
+            'type' => 'manual',
             'ip' => '192.168.1.3',
             'netmask' => '255.255.255.0',
             'cloud_properties' => {},
@@ -134,6 +136,7 @@ describe 'CPI calls', type: :integration do
         'cloud_properties' =>{},
         'networks' => {
           'a' => {
+            'type' => 'manual',
             'ip' => '192.168.1.2',
             'netmask' => '255.255.255.0',
             'default' => ['dns', 'gateway'],
@@ -198,6 +201,7 @@ describe 'CPI calls', type: :integration do
           'cloud_properties' => {},
           'networks' => {
             'a' => {
+              'type' => 'manual',
               'ip' => '192.168.1.10',
               'netmask' => '255.255.255.0',
               'cloud_properties' => {},
@@ -270,6 +274,7 @@ describe 'CPI calls', type: :integration do
           'cloud_properties' => {},
           'networks' => {
             'a' => {
+              'type' => 'manual',
               'ip' => '192.168.1.11',
               'netmask' => '255.255.255.0',
               'cloud_properties' => {},


### PR DESCRIPTION
Looks like bosh-init provides the network type to the e-CPI but the bosh director does not. Seems both should do the same thing.

Per quick chat with @cppforlife on slack, opening a PR.

Units and integration were run but I did not execute the BATS.
