### PR TITLE
Configure custom shell prompt via stemcell

### DIFF
--- a/bosh-stemcell/spec/support/os_image_shared_examples.rb
+++ b/bosh-stemcell/spec/support/os_image_shared_examples.rb
@@ -34,6 +34,25 @@ shared_examples_for 'every OS image' do
       it { should return_exit_status(0) }
     end
 
+    describe file('/root/.bashrc') do
+      it { should be_file }
+      it { should contain 'source /etc/profile.d/00-bosh-ps1' }
+    end
+
+    describe file('/home/vcap/.bashrc') do
+      it { should be_file }
+      it { should contain 'source /etc/profile.d/00-bosh-ps1' }
+    end
+
+    describe file('/etc/skel/.bashrc') do
+      it { should be_file }
+      it { should contain 'source /etc/profile.d/00-bosh-ps1' }
+    end
+
+    describe file('/etc/profile.d/00-bosh-ps1') do
+      it { should be_file }
+    end
+
     describe command("grep -q .bashrc /root/.profile") do
       it { should return_exit_status(0) }
     end

--- a/stemcell_builder/stages/bosh_users/apply.sh
+++ b/stemcell_builder/stages/bosh_users/apply.sh
@@ -41,3 +41,10 @@ if [ "\$BASH" ]; then
 fi
 EOS
 fi
+
+# install custom command prompt
+# due to differences in ordering between OSes, explicitly source it last
+cp $assets_dir/ps1.sh $chroot/etc/profile.d/00-bosh-ps1
+echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/root/.bashrc
+echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/home/vcap/.bashrc
+echo "source /etc/profile.d/00-bosh-ps1" >> $chroot/etc/skel/.bashrc

--- a/stemcell_builder/stages/bosh_users/assets/ps1.sh
+++ b/stemcell_builder/stages/bosh_users/assets/ps1.sh
@@ -3,31 +3,8 @@
 # only if interactive
 [ ! -z "$PS1" ] || return
 
-case "${TERM:-}" in
-  xterm-color)
-    color_prompt=yes
-    ;;
-  *)
-    # fallback to term capabilities check
-    ! tput setaf 1 >&/dev/null || color_prompt=yes
-    ;;
-esac
+bosh_instance="$( cat /var/vcap/instance/name )/$( cat /var/vcap/instance/id )"
 
-bosh_instance=$( cat /var/vcap/instance/name )/$( cat /var/vcap/instance/id )
-
-if [ "${color_prompt:-}" = yes ]; then
-    PS1="\\[\\033[01;32m\\]$bosh_instance\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\\$ "
-else
-    PS1="$bosh_instance:\\w\\\$ "
-fi
-
-unset color_prompt
-
-case "${TERM:-}" in
-  xterm*|rxvt*)
-    # hinting the window title with instance and working directory
-    PS1="\\[\\e]0;$bosh_instance:\\w\\a\\]$PS1"
-    ;;
-esac
+PS1="$bosh_instance:\\w\\\$ "
 
 unset bosh_instance

--- a/stemcell_builder/stages/bosh_users/assets/ps1.sh
+++ b/stemcell_builder/stages/bosh_users/assets/ps1.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# only if interactive
+[ ! -z "$PS1" ] || return
+
+case "${TERM:-}" in
+  xterm-color)
+    color_prompt=yes
+    ;;
+  *)
+    # fallback to term capabilities check
+    ! tput setaf 1 >&/dev/null || color_prompt=yes
+    ;;
+esac
+
+bosh_instance=$( cat /var/vcap/instance/name )/$( cat /var/vcap/instance/id )
+
+if [ "${color_prompt:-}" = yes ]; then
+    PS1="\\[\\033[01;32m\\]$bosh_instance\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\\$ "
+else
+    PS1="$bosh_instance:\\w\\\$ "
+fi
+
+unset color_prompt
+
+case "${TERM:-}" in
+  xterm*|rxvt*)
+    # hinting the window title with instance and working directory
+    PS1="\\[\\e]0;$bosh_instance:\\w\\a\\]$PS1"
+    ;;
+esac
+
+unset bosh_instance


### PR DESCRIPTION
Show `{instance.name}/{instance.id}:{pwd}$` (instead of `{username}@{hostname}:{pwd}$`) based on `/var/vcap/instance/*` files. The `instance/*` files are read only once when the shell first loads.

This no longer shows the user in the prompt. It felt like clutter and not really useful since it's usually random `bosh_*` names. Still shows `#` when root instead of `$`.

This no longer shows chroot names as a prompt prefix in Ubuntu environments (which I doubt was actually a used feature). Excluding it keeps the shell script simpler and avoids Ubuntu-specific logic.

The individual `.bashrc` user file is where `PS1` is normally defined. Just using regular `/etc/profile.d/*.sh` files doesn't work since Ubuntu loads them before `~/.bashrc` (and `~/.bashrc` overrides `PS1`). Instead, it always sources the PS1-modifying script at the end of `~/.bashrc`. The `/etc/skel/.bashrc` was updated for agent-managed users.

Created an Ubuntu and CentOS OS image; tested both via Docker imports. Didn't create a full stemcell; instead manually patched a running VM with relevant snippets. Tested with...

    $ os_name=ubuntu ; os_version=trusty
    $ bundle exec rake stemcell:build_os_image[$os_version,$os_version,$PWD/tmp/bosh-$os_name-$os_version-os-image.tgz]
    $ docker import - bosh/$os_name-$os_version-os-image < tmp/bosh-$os_name-$os_version-os-image.tgz

    $ mkdir tmp/instance
    $ echo -n test-name > tmp/instance/name
    $ echo -n test-id > tmp/instance/id

    $ docker run -i --rm -t -u vcap -v $PWD/tmp/instance:/var/vcap/instance bosh/$os_name-$os_version-os-image /bin/bash
    test-name/test-id:/$ sudo -i
    [sudo] password for vcap: 
    test-name/test-id:~# cd /var/vcap
    test-name/test-id:/var/vcap# true
