### PR TITLE
Blob_manager was opening files in text mode instead of binary mode.  …

### DIFF
--- a/bosh_cli/lib/cli/blob_manager.rb
+++ b/bosh_cli/lib/cli/blob_manager.rb
@@ -266,7 +266,7 @@ module Bosh::Cli
       checksum = file_checksum(blob_path)
 
       @progress_renderer.start(path, "uploading...")
-      object_id = @blobstore.create(File.open(blob_path, "r"))
+      object_id = @blobstore.create(File.open(blob_path, "rb"))
       @progress_renderer.finish(path, "uploaded")
 
       @index[path] = {
@@ -294,7 +294,7 @@ module Bosh::Cli
       blob = @index[path]
       size = blob["size"].to_i
       blob_path = path.gsub(File::SEPARATOR, '-')
-      tmp_file = File.open(File.join(Dir.mktmpdir, blob_path), "w")
+      tmp_file = File.open(File.join(Dir.mktmpdir, blob_path), "wb")
 
       download_label = "downloading"
       if size > 0


### PR DESCRIPTION
…This leads to blob's file corruption when blobs are retrieve when using bosh-cli from windows.

A fix that allowed by to use bosh create release from Windows.

I couldn't download blobs from S3 as blob_manager was corrupting the files by treating them as text file.  These files are binaries, hence, they should be opened as such.
