### PR TITLE
Avoid exception when invalid UTF-8 character is present in CPI Resp

### DIFF
--- a/bosh_cpi/lib/bosh/cpi/cli.rb
+++ b/bosh_cpi/lib/bosh/cpi/cli.rb
@@ -99,7 +99,7 @@ class Bosh::Cpi::Cli
         message: message,
         ok_to_retry: ok_to_retry,
       },
-      log: @logs_string_io.string.force_encoding(Encoding::UTF_8),
+      log: @logs_string_io.string.encode(Encoding::UTF_8, undef: :replace, invalid: :replace),
     }
     @result_io.print(JSON.dump(hash)); nil
   end
@@ -108,7 +108,7 @@ class Bosh::Cpi::Cli
     hash = {
       result: result,
       error: nil,
-      log: @logs_string_io.string.force_encoding(Encoding::UTF_8),
+      log: @logs_string_io.string.encode(Encoding::UTF_8, undef: :replace, invalid: :replace),
     }
     @result_io.print(JSON.dump(hash)); nil
   end


### PR DESCRIPTION
- Using `force_encoding` will throw an exception if an invalid char is present,
  while encode + replace will replace all invalid chars with '�'

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>

[#124949631](https://www.pivotaltracker.com/story/show/124949631)