### PR TITLE
Expose `calculate_vm_cloud_properties` in BOSH CPI

### DIFF
--- a/bosh_cpi/lib/bosh/cpi/cli.rb
+++ b/bosh_cpi/lib/bosh/cpi/cli.rb
@@ -19,6 +19,7 @@ class Bosh::Cpi::Cli
     delete_snapshot
     get_disks
     ping
+    calculate_vm_cloud_properties
   ).freeze
 
   RPC_METHOD_TO_RUBY_METHOD = {

--- a/bosh_cpi/lib/cloud.rb
+++ b/bosh_cpi/lib/cloud.rb
@@ -210,6 +210,14 @@ module Bosh
       not_implemented(:get_disks)
     end
 
+    # Specify VM's hardware resources
+    # @param [Hash] vm_properties (typically cpu, ram, ephemeral_disk_size)
+    # @return [Hash] opaque description of the VM's configuration that
+    # can be used with {#create_vm}
+    def calculate_vm_cloud_properties(vm_properties)
+      not_implemented(:calculate_vm_cloud_properties)
+    end
+
     private
 
     def not_implemented(method)

--- a/bosh_cpi/spec/unit/cpi/cli_spec.rb
+++ b/bosh_cpi/spec/unit/cpi/cli_spec.rb
@@ -323,6 +323,24 @@ describe Bosh::Cpi::Cli do
       end
     end
 
+    describe 'calculate_vm_cloud_properties' do
+      it 'takes json and calls specified method on the cpi' do
+        expect(cpi).to(receive(:calculate_vm_cloud_properties).
+          with({ 'ram' => 1024, 'cpu' => 2, 'ephemeral_disk_size' => 2048 })) { logs_io.write('fake-log') }.
+          and_return('fake-vm-type')
+
+        subject.run <<-JSON
+          {
+            "method": "calculate_vm_cloud_properties",
+            "arguments": [{ "ram": 1024, "cpu": 2, "ephemeral_disk_size": 2048 }],
+            "context" : { "director_uuid" : "abc" }
+          }
+        JSON
+
+        expect(result_io.string).to eq('{"result":"fake-vm-type","error":null,"log":"fake-log"}')
+      end
+    end
+
     describe 'configure cloud' do
       it 'configures cloud with the director uuid' do
         allow(cpi).to receive(:get_disks)


### PR DESCRIPTION
Allows users to specify VM resources (cpu, ram, ephemeral_disk_size) in an
IaaS-agnostic manner in their manifests

For example, instead of specifying `m3.large` in the manifest, one could
have the following `cloud_properties` stanza:

```yml
{
  "ram": 4096,
  "cpu": 4,
  "ephemeral_disk_size": 2048
}
```

[#126023253](https://www.pivotaltracker.com/story/show/126023253)

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>