### PR TITLE
BOSH vSphere stemcells should not have floppy drives

### DIFF
--- a/bosh-stemcell/spec/stemcells/vsphere_spec.rb
+++ b/bosh-stemcell/spec/stemcells/vsphere_spec.rb
@@ -16,3 +16,13 @@ describe 'vSphere Stemcell', stemcell_image: true do
     end
   end
 end
+
+describe 'vSphere stemcell tarball', stemcell_tarball: true do
+  context 'disables the floppy drive' do
+    describe file("#{ENV['STEMCELL_WORKDIR']}/ovf/*.vmx") do
+      its(:content) { should include('floppy0.present = "FALSE"') }
+      its(:content) { should_not include('floppy0.clientDevice') }
+      its(:content) { should_not include('floppy0.startConnected') }
+    end
+  end
+end

--- a/stemcell_builder/stages/image_ovf_vmx/apply.sh
+++ b/stemcell_builder/stages/image_ovf_vmx/apply.sh
@@ -48,7 +48,7 @@ vm_guestos=ubuntu-64
 cat > $ovf/$vm_hostname.vmx <<EOS
 config.version = "8"
 virtualHW.version = 8
-floppy0.present = "true"
+floppy0.present = "FALSE"
 nvram = "nvram"
 deploymentPlatform = "windows"
 virtualHW.productCompatibility = "hosted"
@@ -74,8 +74,6 @@ ide0:0.present = "true"
 ide0:0.clientDevice = "TRUE"
 ide0:0.deviceType = "cdrom-raw"
 ide0:0.startConnected = "FALSE"
-floppy0.startConnected = "false"
-floppy0.clientDevice = "true"
 
 guestOSAltName = "$vm_guestos ($vm_arch)"
 guestOS = "$vm_guestos"


### PR DESCRIPTION
Stemcells do not need and should not have floppy drives (notice there's no floppy drive in the following stemcell that we built *ad hoc* to test our change):

![no_floppy_2](https://cloud.githubusercontent.com/assets/1020675/16933632/2a1c790c-4d04-11e6-82ef-70b1306ba6c3.png)

[#126546965](https://www.pivotaltracker.com/story/show/126546965)