### PR TITLE
Allow CPI gem to handle badly encoded UTF-8 data in CPI response

### DIFF
--- a/bosh_cpi/lib/bosh/cpi/cli.rb
+++ b/bosh_cpi/lib/bosh/cpi/cli.rb
@@ -100,7 +100,7 @@ class Bosh::Cpi::Cli
         message: message,
         ok_to_retry: ok_to_retry,
       },
-      log: @logs_string_io.string.force_encoding(Encoding::UTF_8),
+      log: @logs_string_io.string.encode(Encoding::UTF_8, undef: :replace, invalid: :replace),
     }
     @result_io.print(JSON.dump(hash)); nil
   end
@@ -109,7 +109,7 @@ class Bosh::Cpi::Cli
     hash = {
       result: result,
       error: nil,
-      log: @logs_string_io.string.force_encoding(Encoding::UTF_8),
+      log: @logs_string_io.string.encode(Encoding::UTF_8, undef: :replace, invalid: :replace),
     }
     @result_io.print(JSON.dump(hash)); nil
   end

--- a/bosh_cpi/lib/bosh/cpi/cli.rb
+++ b/bosh_cpi/lib/bosh/cpi/cli.rb
@@ -100,7 +100,7 @@ class Bosh::Cpi::Cli
         message: message,
         ok_to_retry: ok_to_retry,
       },
-      log: @logs_string_io.string.encode(Encoding::UTF_8, undef: :replace, invalid: :replace),
+      log: encode_string_as_utf8(@logs_string_io.string)
     }
     @result_io.print(JSON.dump(hash)); nil
   end
@@ -109,12 +109,21 @@ class Bosh::Cpi::Cli
     hash = {
       result: result,
       error: nil,
-      log: @logs_string_io.string.encode(Encoding::UTF_8, undef: :replace, invalid: :replace),
+      log: encode_string_as_utf8(@logs_string_io.string)
     }
     @result_io.print(JSON.dump(hash)); nil
   end
 
   def error_name(error)
     error.class.name
+  end
+
+  def encode_string_as_utf8(src)
+    log = @logs_string_io.string.force_encoding(Encoding::UTF_8)
+    unless log.valid_encoding?
+      # the src encoding hint of Encoding::BINARY is only required for ruby 1.9.3
+      log = @logs_string_io.string.encode(Encoding::UTF_8, Encoding::BINARY, undef: :replace, invalid: :replace)
+    end
+    log
   end
 end

--- a/bosh_cpi/spec/unit/cpi/cli_spec.rb
+++ b/bosh_cpi/spec/unit/cpi/cli_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'spec_helper'
 
 describe Bosh::Cpi::Cli do

--- a/bosh_cpi/spec/unit/cpi/cli_spec.rb
+++ b/bosh_cpi/spec/unit/cpi/cli_spec.rb
@@ -466,6 +466,37 @@ describe Bosh::Cpi::Cli do
       end
     end
 
+    context 'when logger has invalid utf-8 characters in the message string' do
+      class ErrorClass4 < Exception; end
+
+      it 'writes the result response to the provided logger' do
+        expect(cpi).to receive(:has_disk?).with('fake-disk-cid') do
+          bad_encoding = "\255"
+          expect(bad_encoding.valid_encoding?).to be(false)
+          logs_io.print(bad_encoding)
+
+          true
+        end
+
+        subject.run('{"method":"has_disk","arguments":["fake-disk-cid"],"context":{"director_uuid":"abc"}}')
+        expect(result_io.string).to include('�')
+      end
+
+      it 'writes the error response to the provided logger' do
+        expect(cpi).to receive(:has_disk?).with('fake-disk-cid') do
+          bad_encoding = "\255"
+          expect(bad_encoding.valid_encoding?).to be(false)
+          logs_io.print(bad_encoding)
+
+          raise ErrorClass4.new('fäke-error')
+        end
+
+        subject.run('{"method":"has_disk","arguments":["fake-disk-cid"],"context":{"director_uuid":"abc"}}')
+        expect(result_io.string).to include('�', 'fäke-error')
+        expect(result_io.string).to include_the_backtrace
+      end
+    end
+
     context 'when error class name contains sequential uppercase letters' do
       class ERRClass5 < Bosh::Clouds::CpiError; end
 


### PR DESCRIPTION
- Now works with Ruby 1.9.3, End of Life February 23, 2015 :)
- `force_encoding` tells ruby to treat a string as if it were UTF-8 encoded, but passing a badly encoded string will cause functions like JSON.dump to panic with "Invalid byte sequence"
- `encode` will instead replace invalid byte sequences with '�' instead of panicking