### PR TITLE
Normalise stemcell versions for v2 manifests

### DIFF
--- a/bosh_cli/lib/cli/deployment_manifest.rb
+++ b/bosh_cli/lib/cli/deployment_manifest.rb
@@ -10,6 +10,12 @@ module Bosh::Cli
       normalized = Bosh::Common::DeepCopy.copy(manifest_hash)
 
       # for backwards compatibility, new directors always convert stemcell and release versions to string
+      if normalized['stemcells']
+        normalized['stemcells'].each do |stemcell|
+          stemcell['version'] = stemcell['version'].to_s
+        end
+      end
+
       if normalized['resource_pools']
         normalized['resource_pools'].each do |rp|
           rp['stemcell']['version'] = rp['stemcell']['version'].to_s

--- a/bosh_cli/spec/unit/deployment_manifest_spec.rb
+++ b/bosh_cli/spec/unit/deployment_manifest_spec.rb
@@ -4,6 +4,12 @@ require 'cli/deployment_manifest'
 describe Bosh::Cli::DeploymentManifest do
   let(:manifest_hash) do
     {
+      'stemcells' => [
+        {
+          'name' => 'fake-stemcell-v2-manifest',
+          'version' => 12321
+        }
+      ],
       'releases' => [
         {
           'name' => 'fake-release',
@@ -24,7 +30,7 @@ describe Bosh::Cli::DeploymentManifest do
         {
           'name' => 'fake-resource-pool',
           'stemcell' => {
-            'name' => 'fake-stemcell',
+            'name' => 'fake-stemcell-v1-manifest',
             'version' => 12321
           }
         }
@@ -42,7 +48,14 @@ describe Bosh::Cli::DeploymentManifest do
     }.not_to change { manifest_hash['networks'].first['subnets'] }
   end
 
-  context 'when stemcell version is an integer' do
+  context 'when stemcell version is an integer in a v2 manifest' do
+    it 'converts it to string' do
+      normalized = subject.normalize
+      expect(normalized['stemcells'].first['version']).to eq('12321')
+    end
+  end
+
+  context 'when stemcell version is an integer in a v1 manifest' do
     it 'converts it to string' do
       normalized = subject.normalize
       expect(normalized['resource_pools']['fake-resource-pool']['stemcell']['version']).to eq('12321')


### PR DESCRIPTION
This was already done for v1 manifests where stemcells are specified/merged
into the `resource_pools` block. But not for v2 manifests where a top-level
`stemcells` block is used:
- https://bosh.io/docs/manifest-v2.html#stemcells

The result of this was that commands such as `bosh recreate` would warn that
there are deployment changes present without listing any such changes:

```
/tmp/build/e55deab7 # bosh recreate api/1
Acting as user 'admin' on deployment 'dcarley' on 'my-bosh'
You are about to recreate api/1

Detecting deployment changes
----------------------------
Releases
No changes

…

Stemcells
No changes

Cannot perform job management when other deployment changes are present. Please use '--force' to override.
```

Adding a breakpoint and printing `diff#summary` revealed the cause:

```
From: /usr/local/bundle/gems/bosh_cli-1.3232.0/lib/cli/deployment_helper.rb @ line 119 Bosh::Cli::DeploymentHelper#inspect_deployment_changes:

    114:           nl
    115:         end
    116:       end
    117:
    118: require 'pry'
 => 119: binding.pry
    120:
    121:       diff.changed?
    122:     rescue Bosh::Cli::ResourceNotFound
    123:       say('Cannot get current deployment information from director, possibly a new deployment'.make_red)
    124:       true

[1] pry(#<Bosh::Cli::Command::JobManagement>)> puts diff.summary
± stemcells:
  - {"alias"=>"default", "name"=>"bosh-aws-xen-hvm-ubuntu-trusty-go_agent", "version"=>"3232.11"}
  + {"alias"=>"default", "name"=>"bosh-aws-xen-hvm-ubuntu-trusty-go_agent", "version"=>3232.11}
```
