### PR TITLE
`bosh cck` will find problems for instances without VMs

### DIFF
--- a/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -246,7 +246,7 @@ module Bosh::Director
           redirect "/tasks/#{task.id}"
         else
           instances = @instance_manager.find_instances_by_deployment(deployment)
-          JSON.generate(create_instances_response(instances))
+          JSON.generate(create_instances_response_with_vm_expected(instances))
         end
       end
 
@@ -466,14 +466,24 @@ module Bosh::Director
 
       def create_instances_response(instances)
         instances.map do |instance|
-          {
-              'agent_id' => instance.agent_id,
-              'cid' => instance.vm_cid,
-              'job' => instance.job,
-              'index' => instance.index,
-              'id' => instance.uuid
-          }
+          create_instance_response(instance)
         end
+      end
+
+      def create_instances_response_with_vm_expected(instances)
+        instances.map do |instance|
+          create_instance_response(instance).merge('expects_vm' => instance.expects_vm?)
+        end
+      end
+
+      def create_instance_response(instance)
+        {
+            'agent_id' => instance.agent_id,
+            'cid' => instance.vm_cid,
+            'job' => instance.job,
+            'index' => instance.index,
+            'id' => instance.uuid
+        }
       end
     end
   end

--- a/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -590,41 +590,144 @@ module Bosh::Director
         end
 
         describe 'getting deployment instances' do
-          before { basic_authorize 'reader', 'reader' }
+          before do
+            basic_authorize 'reader', 'reader'
+            release = Models::Release.create(:name => 'test_release')
+            version = Models::ReleaseVersion.create(:release => release, :version => 1)
+            version.add_template(Models::Template.make(name: 'job_using_pkg_1', release: release))
+          end
+          let(:deployment) { Models::Deployment.create(:name => 'test_deployment', :manifest => manifest) }
+          let(:default_manifest) { Bosh::Spec::Deployments.remote_stemcell_manifest('stemcell_url', 'stemcell_sha1') }
 
-          it 'returns a list of all instances' do
-            deployment = Models::Deployment.
-                create(:name => 'test_deployment',
-                       :manifest => YAML.dump({'foo' => 'bar'}))
+          context 'multiple instances' do
+            let(:manifest) {
+              jobs = []
+              15.times do |i|
+                jobs << {
+                    'name' => "job-#{i}",
+                    'templates' => [{ 'name' => 'job_using_pkg_1' }],
+                    'instances' => 1,
+                    'resource_pool' => 'a',
+                    'networks' => [{ 'name' => 'a' }]
+                }
+              end
+              YAML.dump(default_manifest.merge({'jobs' => jobs}))
+            }
 
+            it 'returns all' do
+              15.times do |i|
+                instance_params = {
+                    'deployment_id' => deployment.id,
+                    'job' => "job-#{i}",
+                    'index' => i,
+                    'state' => 'started',
+                    'uuid' => "instance-#{i}",
+                    'agent_id' => "agent-#{i}",
+                }
 
-            15.times do |i|
-              instance_params = {
-                'deployment_id' => deployment.id,
-                'job' => "job-#{i}",
-                'index' => i,
-                'state' => 'started',
-                'uuid' => "instance-#{i}",
-                'agent_id' => "agent-#{i}",
-              }
+                Models::Instance.create(instance_params)
+              end
 
-              Models::Instance.create(instance_params)
+              get '/test_deployment/instances'
+
+              expect(last_response.status).to eq(200)
+              body = JSON.parse(last_response.body)
+              expect(body.size).to eq(15)
+
+              body.each_with_index do |instance, i|
+                expect(instance).to eq(
+                                        'agent_id' => "agent-#{i}",
+                                        'cid' => nil,
+                                        'job' => "job-#{i}",
+                                        'index' => i,
+                                        'id' => "instance-#{i}",
+                                        'expects_vm' => true
+                                    )
+              end
+            end
+          end
+
+          context 'instance lifecycle' do
+            let(:job_state) { 'started' }
+            before do
+              Models::Instance.create({
+                                          'deployment_id' => deployment.id,
+                                          'job' => 'job',
+                                          'index' => 1,
+                                          'state' => job_state,
+                                          'uuid' => 'instance-1',
+                                          'agent_id' => 'agent-1',
+                                      })
             end
 
-            get '/test_deployment/instances'
+            context 'is "service"' do
+              let(:manifest) { YAML.dump(default_manifest.merge(Bosh::Spec::Deployments.test_release_job)) }
+              context 'and state is either "started" or "stopped"' do
 
-            expect(last_response.status).to eq(200)
-            body = JSON.parse(last_response.body)
-            expect(body.size).to eq(15)
+                it 'sets "expects_vm" to "true"' do
 
-            body.each_with_index do |instance, i|
-              expect(instance).to eq(
-                  'agent_id' => "agent-#{i}",
-                  'job' => "job-#{i}",
-                  'index' => i,
-                  'cid' => nil,
-                  'id' => "instance-#{i}"
-              )
+                  get '/test_deployment/instances'
+
+                  expect(last_response.status).to eq(200)
+                  body = JSON.parse(last_response.body)
+                  expect(body.size).to eq(1)
+
+                  expect(body[0]).to eq(
+                                         'agent_id' => 'agent-1',
+                                         'cid' => nil,
+                                         'job' => 'job',
+                                         'index' => 1,
+                                         'id' => 'instance-1',
+                                         'expects_vm' => true
+                                     )
+                end
+              end
+
+              context 'and state is "detached"' do
+                let(:job_state) { 'detached'}
+                it 'sets "expects_vm" to "false"' do
+
+                  get '/test_deployment/instances'
+
+                  expect(last_response.status).to eq(200)
+                  body = JSON.parse(last_response.body)
+                  expect(body.size).to eq(1)
+
+                  expect(body[0]).to eq(
+                                         'agent_id' => 'agent-1',
+                                         'cid' => nil,
+                                         'job' => 'job',
+                                         'index' => 1,
+                                         'id' => 'instance-1',
+                                         'expects_vm' => false
+                                     )
+                end
+              end
+            end
+
+            context 'is "errand"' do
+              let(:manifest) {
+                manifest = default_manifest.merge(Bosh::Spec::Deployments.test_release_job)
+                manifest['jobs'][0]['lifecycle'] = 'errand'
+                YAML.dump(manifest)
+              }
+
+              it 'sets "expects_vm" to "false"' do
+                get '/test_deployment/instances'
+
+                expect(last_response.status).to eq(200)
+                body = JSON.parse(last_response.body)
+                expect(body.size).to eq(1)
+
+                expect(body[0]).to eq(
+                                       'agent_id' => 'agent-1',
+                                       'cid' => nil,
+                                       'job' => 'job',
+                                       'index' => 1,
+                                       'id' => 'instance-1',
+                                       'expects_vm' => false
+                                   )
+              end
             end
           end
         end

--- a/bosh-director/spec/unit/models/instance_spec.rb
+++ b/bosh-director/spec/unit/models/instance_spec.rb
@@ -324,5 +324,118 @@ module Bosh::Director::Models
         end
       end
     end
+
+
+    context 'with deployment_plan' do
+      subject { described_class.make(deployment: deployment, job: 'job-1') }
+
+      let(:instance_groups) {
+        [{
+             'name' => 'job-1',
+             'lifecycle' => lifecycle,
+             'instances' => 1,
+             'jobs' => [],
+             'vm_type' => 'm1.small',
+             'stemcell' => 'stemcell',
+             'networks' => [{'name' => 'network'}]
+         }]
+      }
+
+      let(:manifest) {
+        {
+            'name' => 'something',
+            'releases' => [],'instance_groups' => instance_groups,
+            'update' => {
+                'canaries' => 1,
+                'max_in_flight' => 1,
+                'canary_watch_time' => 20,
+                'update_watch_time' => 20
+            },
+            'stemcells' => [{
+                                'name' => 'stemcell',
+                                'alias' => 'stemcell'
+                            }]
+        }
+      }
+
+      let(:cloud_config_hash) {
+        {
+            'compilation' => {
+                'network' => 'network',
+                'workers' => 1
+            },
+            'networks' => [{
+                               'name' => 'network',
+                               'subnets' => []
+
+                           }],
+            'vm_types' => [{
+                               'name' => 'm1.small'
+                           }]
+
+        }
+      }
+      let(:manifest_text) { manifest.to_yaml }
+      let(:cloud_config) { CloudConfig.make(manifest: cloud_config_hash) }
+      let(:deployment) { Deployment.make(name: 'deployment', manifest: manifest_text, cloud_config: cloud_config) }
+
+      describe '#lifecycle' do
+        context "when lifecycle is 'service'" do
+          let(:lifecycle) { 'service' }
+          it "returns 'service'" do
+            expect(subject.lifecycle).to eq('service')
+          end
+        end
+
+        context "when lifecycle is 'errand'" do
+          let(:lifecycle) { 'errand' }
+          it "returns 'errand'" do
+            expect(subject.lifecycle).to eq('errand')
+          end
+        end
+
+        context 'when no manifest is stored in the database' do
+          let(:manifest_text) { nil }
+          it "returns 'nil'" do
+            expect(subject.lifecycle).to be_nil
+          end
+        end
+      end
+
+      describe '#expects_vm?' do
+
+        context "when lifecycle is 'errand'" do
+          let(:lifecycle) { 'errand' }
+
+          it "doesn't expect vm" do
+            expect(subject.expects_vm?).to eq(false)
+          end
+        end
+
+        context "when lifecycle is 'service'" do
+          let(:lifecycle) { 'service' }
+
+          ['started', 'stopped'].each do |state|
+
+            context "when state is '#{state}'" do
+              subject { described_class.make(deployment: deployment, job: 'job-1', state: "#{state}") }
+
+              it 'expects a vm' do
+                expect(subject.expects_vm?).to eq(true)
+              end
+            end
+          end
+
+          context "when state is 'detached'" do
+            subject { described_class.make(deployment: deployment, job: 'job-1', state: 'detached') }
+
+            it "doesn't expect vm" do
+              expect(subject.expects_vm?).to eq(false)
+            end
+          end
+
+        end
+      end
+    end
   end
 end

--- a/bosh-director/spec/unit/problem_scanner/vm_scan_stage_spec.rb
+++ b/bosh-director/spec/unit/problem_scanner/vm_scan_stage_spec.rb
@@ -13,6 +13,23 @@ module Bosh::Director
       )
     end
 
+    def create_vm(i, state: 'started', lifecycle: 'service', ignore: false, vm_cid: "vm-cid-#{i}")
+      job_name = "job-#{i}"
+      instance = Models::Instance.make(vm_cid: vm_cid, agent_id: "agent-#{i}", deployment: deployment, job: job_name, index: i, state: state, ignore: ignore)
+      instance_groups[job_name] = double(name: job_name, lifecycle: lifecycle)
+      instance
+    end
+
+    let(:instance_groups) {
+      {}
+    }
+
+    before(:each) do
+      deployment_plan = instance_double(Bosh::Director::DeploymentPlan::Planner)
+      allow_any_instance_of(Bosh::Director::DeploymentPlan::PlannerFactory).to receive(:create_from_model).and_return(deployment_plan)
+      allow(deployment_plan).to receive(:instance_group) { |name| instance_groups[name] }
+    end
+
     let(:instance_manager) { instance_double(Api::InstanceManager) }
     let(:problem_register) { ProblemScanner::ProblemRegister.new(deployment, logger) }
     before do
@@ -30,7 +47,7 @@ module Bosh::Director
     describe '#scan' do
       it 'scans a subset of vms' do
         instances = (1..3).collect do |i|
-          Models::Instance.make(agent_id: "agent-#{i}", deployment: deployment, job: "job-#{i}", index: i)
+          create_vm(i)
         end
 
         allow(instance_manager).to receive(:find_by_name).with(deployment, 'job-1', 1).and_return(instances[0])
@@ -64,14 +81,50 @@ module Bosh::Director
         vm_scanner.scan([['job-1', 1], ['job-2', 2]])
       end
 
+      context 'when service instance is detached' do
+        let!(:detached_instance) { create_vm(0, state: 'detached', vm_cid: nil) }
+
+        before(:each) do
+          unresponsive_agent = double(AgentClient)
+          agent_options = { timeout: 10, retry_methods: { get_state: 0}}
+          allow(AgentClient).to receive(:with_vm_credentials_and_agent_id).with(detached_instance.credentials, detached_instance.agent_id, agent_options).and_return(unresponsive_agent)
+          allow(unresponsive_agent).to receive(:get_state).and_raise(RpcTimeout)
+        end
+
+        it 'does not report any problem' do
+          expect(event_logger).to receive(:track_and_log).with('Checking VM states')
+          expect(event_logger).to receive(:track_and_log).with('0 OK, 0 unresponsive, 0 missing, 0 unbound')
+
+          expect(problem_register).to_not receive(:problem_found)
+
+          vm_scanner.scan
+        end
+      end
+
+      context "when instance lifecycle is 'errand'" do
+        let!(:errand_vm) { create_vm(0, lifecycle: 'errand', vm_cid: nil) }
+
+        before(:each) do
+          unresponsive_agent = double(AgentClient)
+          agent_options = { timeout: 10, retry_methods: { get_state: 0}}
+          allow(AgentClient).to receive(:with_vm_credentials_and_agent_id).with(errand_vm.credentials, errand_vm.agent_id, agent_options).and_return(unresponsive_agent)
+          allow(unresponsive_agent).to receive(:get_state).and_raise(RpcTimeout)
+        end
+
+        it 'does not report any problem' do
+          expect(event_logger).to receive(:track_and_log).with('Checking VM states')
+          expect(event_logger).to receive(:track_and_log).with('0 OK, 0 unresponsive, 0 missing, 0 unbound')
+
+          expect(problem_register).to_not receive(:problem_found)
+
+          vm_scanner.scan
+        end
+      end
+
       context 'when agent on a VM did not respond in time' do
         let!(:unresponsive_vm1) { create_vm(0) }
         let!(:unresponsive_vm2) { create_vm(1) }
         let!(:responsive_vm) { create_vm(2) }
-
-        def create_vm(i)
-          Models::Instance.make(vm_cid: "vm-cid-#{i}", agent_id: "agent-#{i}", deployment: deployment, job: "job-#{i}", index: i)
-        end
 
         before do
           unresponsive_agent1 = double(AgentClient)
@@ -95,6 +148,41 @@ module Bosh::Director
           }
           allow(responsive_agent).to receive(:get_state).and_return(good_state)
           allow(responsive_agent).to receive(:list_disk).and_return([])
+        end
+
+        context 'when instance has no VM assigned' do
+          let!(:instance_without_vm) {create_vm(4, vm_cid: nil)}
+
+          before(:each) {
+            unresponsive_agent = double(AgentClient)
+            agent_options = { timeout: 10, retry_methods: { get_state: 0}}
+            allow(AgentClient).to receive(:with_vm_credentials_and_agent_id).with(instance_without_vm.credentials, instance_without_vm.agent_id, agent_options).and_return(unresponsive_agent)
+            allow(unresponsive_agent).to receive(:get_state).and_raise(RpcTimeout)
+            allow(cloud).to receive(:has_vm?).with('vm-cid-0').and_return(true)
+            allow(cloud).to receive(:has_vm?).with('vm-cid-1').and_return(true)
+          }
+
+          it 'registers missing VM problem' do
+            expect(event_logger).to receive(:track_and_log).with('Checking VM states')
+            expect(event_logger).to receive(:track_and_log).with('1 OK, 2 unresponsive, 1 missing, 0 unbound')
+
+            expect(problem_register).to receive(:problem_found).with(
+                :unresponsive_agent,
+                unresponsive_vm1
+            )
+
+            expect(problem_register).to receive(:problem_found).with(
+                :unresponsive_agent,
+                unresponsive_vm2
+            )
+
+            expect(problem_register).to receive(:problem_found).with(
+                :missing_vm,
+                instance_without_vm
+            )
+
+            vm_scanner.scan
+          end
         end
 
         context 'when cloud implements has_vm?' do
@@ -170,8 +258,8 @@ module Bosh::Director
 
         context 'when a VM is ignored' do
           before do
-            ignored_unresponsive_vm = Models::Instance.make(vm_cid: "vm-cid-smurf", agent_id: "agent-smurf", deployment: deployment, job: "job-smurf", index: 0, ignore: true)
-            ignored_responsive_vm = Models::Instance.make(vm_cid: "vm-cid-gargamel", agent_id: "agent-gargamel", deployment: deployment, job: "job-gargamel", index: 0, ignore: true)
+            ignored_unresponsive_vm = create_vm(4, ignore: true)
+            ignored_responsive_vm = create_vm(5, ignore: true)
 
             ignored_unresponsive_agent = double(AgentClient)
             ignored_responsive_agent =   double(AgentClient)
@@ -185,7 +273,7 @@ module Bosh::Director
             # Working agent
             good_state = {
                 'deployment' => 'fake-deployment',
-                'job' => {'name' => 'job-gargamel'},
+                'job' => {'name' => 'job-1'},
                 'index' => 0
             }
             allow(ignored_responsive_agent).to receive(:get_state).and_return(good_state)
@@ -205,7 +293,7 @@ module Bosh::Director
     end
 
     describe 'agent_disks' do
-      let(:instance) { Models::Instance.make(vm_cid: 'vm-cid', agent_id: 'agent-1', deployment: deployment, job: 'job-1', index: 0) }
+      let(:instance) { create_vm(0) }
       before { allow(cloud).to receive(:has_vm?).and_return(true) }
 
       let(:agent) { double('Bosh::Director::AgentClient') }
@@ -233,7 +321,7 @@ module Bosh::Director
         it 'returns disk cid registered on vm' do
           expect(problem_register).to receive(:problem_found).with(:unresponsive_agent, instance)
           vm_scanner.scan
-          expect(vm_scanner.agent_disks['fake-disk-cid']).to eq(['vm-cid'])
+          expect(vm_scanner.agent_disks['fake-disk-cid']).to eq(['vm-cid-0'])
         end
       end
 
@@ -263,7 +351,7 @@ module Bosh::Director
 
       context 'when disk is mounted twice' do
         before do
-          second_instance = Models::Instance.make(vm_cid: 'vm-cid-2', agent_id: 'agent-2', deployment: deployment, job: 'job-2', index: 2)
+          second_instance = create_vm(1)
 
           agent_2 = double('agent-2')
           allow(AgentClient).to receive(:with_vm_credentials_and_agent_id).with(second_instance.credentials, second_instance.agent_id, anything).and_return(agent_2)
@@ -282,7 +370,7 @@ module Bosh::Director
         it 'returns all owners' do
           expect(problem_register).to_not receive(:problem_found)
           vm_scanner.scan
-          expect(vm_scanner.agent_disks['fake-disk-cid']).to eq(['vm-cid', 'vm-cid-2'])
+          expect(vm_scanner.agent_disks['fake-disk-cid']).to eq(['vm-cid-0', 'vm-cid-1'])
         end
       end
 
@@ -295,7 +383,7 @@ module Bosh::Director
           expect(problem_register).to_not receive(:problem_found)
           vm_scanner.scan
           expect(vm_scanner.agent_disks['fake-disk-cid']).to be_nil
-          expect(vm_scanner.agent_disks['fake-disk-cid-2']).to eq(['vm-cid'])
+          expect(vm_scanner.agent_disks['fake-disk-cid-2']).to eq(['vm-cid-0'])
         end
       end
     end

--- a/spec/integration/cli_cck_spec.rb
+++ b/spec/integration/cli_cck_spec.rb
@@ -46,13 +46,25 @@ describe 'cli: cloudcheck', type: :integration do
       it 'deletes unresponsive VMs' do
         delete_vm = 5
         bosh_run_cck_with_resolution(3, delete_vm)
-        expect(runner.run('cloudcheck --report')).to match(regexp('No problems found'))
+        expect(runner.run('cloudcheck --report', failure_expected: true)).to match_output %(
+          Found 3 problems
+
+          Problem 1 of 3: VM with cloud ID '' missing.
+          Problem 2 of 3: VM with cloud ID '' missing.
+          Problem 3 of 3: VM with cloud ID '' missing.
+        )
       end
 
       it 'deletes VM reference' do
         delete_vm_reference = 6
         bosh_run_cck_with_resolution(3, delete_vm_reference)
-        expect(runner.run('cloudcheck --report')).to match(regexp('No problems found'))
+        expect(runner.run('cloudcheck --report', failure_expected: true)).to match_output %(
+          Found 3 problems
+
+          Problem 1 of 3: VM with cloud ID '' missing.
+          Problem 2 of 3: VM with cloud ID '' missing.
+          Problem 3 of 3: VM with cloud ID '' missing.
+        )
       end
 
       context 'when there is an ignored vm' do
@@ -105,7 +117,11 @@ describe 'cli: cloudcheck', type: :integration do
       it 'deletes missing VM reference' do
         delete_vm_reference = 4
         bosh_run_cck_with_resolution(1, delete_vm_reference)
-        expect(runner.run('cloudcheck --report')).to match(regexp('No problems found'))
+        expect(runner.run('cloudcheck --report', failure_expected: true)).to match_output %(
+          Found 1 problem
+
+          Problem 1 of 1: VM with cloud ID '' missing.
+        )
       end
     end
 

--- a/spec/support/deployments.rb
+++ b/spec/support/deployments.rb
@@ -455,16 +455,7 @@ module Bosh::Spec
     end
 
     def self.remote_release_manifest(remote_release_url, sha1, version='latest')
-      minimal_manifest.merge({
-          'jobs' => [
-            {
-              'name' => 'job',
-              'templates' => [{ 'name' => 'job_using_pkg_1' }],
-              'instances' => 1,
-              'resource_pool' => 'a',
-              'networks' => [{'name' => 'a'}]
-            }
-          ],
+      minimal_manifest.merge(test_release_job).merge({
           'releases' => [{
               'name'    => 'test_release',
               'version' => version,
@@ -475,22 +466,25 @@ module Bosh::Spec
     end
 
     def self.local_release_manifest(local_release_path, version = 'latest')
-      minimal_manifest.merge({
-          'jobs' => [
-            {
-              'name' => 'job',
-              'templates' => [{ 'name' => 'job_using_pkg_1' }],
-              'instances' => 1,
-              'resource_pool' => 'a',
-              'networks' => [{'name' => 'a'}]
-            }
-          ],
+      minimal_manifest.merge(test_release_job).merge({
           'releases' => [{
               'name'    => 'test_release',
               'version' => version,
               'url' => local_release_path,
             }]
         })
+    end
+
+    def self.test_release_job
+      {
+          'jobs' => [{
+                         'name' => 'job',
+                         'templates' => [{ 'name' => 'job_using_pkg_1' }],
+                         'instances' => 1,
+                         'resource_pool' => 'a',
+                         'networks' => [{ 'name' => 'a' }]
+                     }]
+      }
     end
 
     def self.simple_job(opts = {})


### PR DESCRIPTION
- if an instance has lifecycle type 'service' and is in state
  'started' or 'stopped' but has no VM a :missing_vm problem
  is reported
- errands are excluded
- detached instances are excluded
- ignored instances are excluded

[#114101259](https://www.pivotaltracker.com/story/show/114101259)

Signed-off-by: Tom Kiemes <tom.kiemes@sap.com>