### PR TITLE
No longer create `pre_packaging` file when running `generate package`

### DIFF
--- a/bosh_cli/lib/cli/commands/package.rb
+++ b/bosh_cli/lib/cli/commands/package.rb
@@ -26,11 +26,6 @@ module Bosh::Cli::Command
         "with a non zero value\nset -e\n"
       end
 
-      generate_file(package_dir, "pre_packaging") do
-        "# abort script on any command that exits " +
-        "with a non zero value\nset -e\n"
-      end
-
       generate_file(package_dir, "spec") do
         "---\nname: #{name}\n\ndependencies:\n\nfiles:\n"
       end

--- a/bosh_cli/spec/unit/commands/job_spec.rb
+++ b/bosh_cli/spec/unit/commands/job_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+module Bosh::Cli
+  describe Command::Job do
+    let(:command) { Command::Job.new }
+    let(:director) { instance_double('Bosh::Cli::Client::Director') }
+
+    let(:release_source) { Support::FileHelpers::ReleaseDirectory.new }
+
+    before do
+      release_source.add_dir('jobs')
+      release_source.add_dir('packages')
+      release_source.add_dir('src')
+
+      allow(command).to receive(:director).and_return(director)
+      allow(command).to receive(:say)
+
+      command.options = { dir: release_source.path }
+    end
+
+    describe 'generate' do
+      before { Dir.chdir(release_source.path) }
+
+      context 'empty string is passed for job name' do
+        let(:job_name) { '' }
+
+        it 'raises error' do
+          expect{ command.generate(job_name) }.to raise_error
+        end
+      end
+
+      context 'nil is passed for job name' do
+        let(:job_name) { nil }
+
+        it 'raises error' do
+          expect{ command.generate(job_name) }.to raise_error
+        end
+      end
+
+      context 'when job does not already exist' do
+        let(:job_name) { 'non-existent-job' }
+        let(:job_dir) { "jobs/#{job_name}" }
+
+        it 'generates monit and spec files and empty templates directory' do
+          command.generate(job_name)
+
+          expect(Dir.entries(File.join(job_dir))).to match_array(['.','..','monit','spec','templates'])
+          expect(Dir.entries(File.join(job_dir, 'templates'))).to match_array(['.', '..'])
+        end
+
+        it 'echoes success message' do
+          expect(command).to receive(:say).with("\nGenerated skeleton for '#{job_name}' job in '#{job_dir}'")
+
+          command.generate(job_name)
+        end
+      end
+
+      context 'when job already exists' do
+        let(:job_name) { 'existent-job' }
+        let(:job_dir) { "jobs/#{job_name}" }
+
+        before { FileUtils.touch(job_dir) }
+
+        it 'raises error saying that job already exists' do
+          expect { command.generate(job_name) }.to raise_error("Job '#{job_name}' already exists, please pick another name")
+        end
+      end
+    end
+  end
+end

--- a/bosh_cli/spec/unit/commands/package_spec.rb
+++ b/bosh_cli/spec/unit/commands/package_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+module Bosh::Cli
+  describe Command::Package do
+    let(:command) { Command::Package.new }
+    let(:director) { instance_double('Bosh::Cli::Client::Director') }
+
+    let(:release_source) { Support::FileHelpers::ReleaseDirectory.new }
+
+    before do
+      release_source.add_dir('jobs')
+      release_source.add_dir('packages')
+      release_source.add_dir('src')
+
+      allow(command).to receive(:director).and_return(director)
+      allow(command).to receive(:say)
+
+      command.options = { dir: release_source.path }
+    end
+
+    describe 'generate' do
+      before { Dir.chdir(release_source.path) }
+
+      context 'empty string is passed for package name' do
+        let(:package_name) { '' }
+
+        it 'raises error' do
+          expect{ command.generate(package_name) }.to raise_error
+        end
+      end
+
+      context 'nil is passed for package name' do
+        let(:package_name) { nil }
+
+        it 'raises error' do
+          expect{ command.generate(package_name) }.to raise_error
+        end
+      end
+
+      context 'when package does not already exist' do
+        let(:package_name) { 'non-existent-package' }
+        let(:package_dir) { "packages/#{package_name}" }
+
+        it 'generates packaging, pre_packaging, and spec files' do
+          command.generate(package_name)
+
+          expect(Dir.entries(package_dir)).to match_array(['.','..','packaging','pre_packaging','spec'])
+        end
+
+        it 'echoes success message' do
+          expect(command).to receive(:say).with("\nGenerated skeleton for '#{package_name}' package in '#{package_dir}'")
+
+          command.generate(package_name)
+        end
+      end
+
+      context 'when package already exists' do
+        let(:package_name) { 'existent-package' }
+        let(:package_dir) { "packages/#{package_name}" }
+
+        before { FileUtils.touch(package_dir) }
+
+        it 'raises error saying that package already exists' do
+          expect { command.generate(package_name) }.to raise_error("Package '#{package_name}' already exists, please pick another name")
+        end
+      end
+    end
+  end
+end

--- a/bosh_cli/spec/unit/commands/package_spec.rb
+++ b/bosh_cli/spec/unit/commands/package_spec.rb
@@ -41,10 +41,10 @@ module Bosh::Cli
         let(:package_name) { 'non-existent-package' }
         let(:package_dir) { "packages/#{package_name}" }
 
-        it 'generates packaging, pre_packaging, and spec files' do
+        it 'generates packaging and spec files' do
           command.generate(package_name)
 
-          expect(Dir.entries(package_dir)).to match_array(['.','..','packaging','pre_packaging','spec'])
+          expect(Dir.entries(package_dir)).to match_array(['.','..','packaging','spec'])
         end
 
         it 'echoes success message' do


### PR DESCRIPTION
`pre_packaging` file functionality is no longer a suggested workflow, so running `bosh generate package` should no longer create the `pre_packaging` file