### PR TITLE
Bump s3cli to 0.0.45

### DIFF
--- a/release/packages/s3cli/packaging
+++ b/release/packages/s3cli/packaging
@@ -1,5 +1,5 @@
 set -e
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-mv s3cli/s3cli-0.0.44-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
+mv s3cli/s3cli-0.0.45-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
 chmod +x ${BOSH_INSTALL_TARGET}/bin/s3cli

--- a/release/packages/s3cli/spec
+++ b/release/packages/s3cli/spec
@@ -1,4 +1,4 @@
 ---
 name: s3cli
 files:
-- s3cli/s3cli-0.0.44-linux-amd64
+- s3cli/s3cli-0.0.45-linux-amd64

--- a/stemcell_builder/stages/aws_cli/config.sh
+++ b/stemcell_builder/stages/aws_cli/config.sh
@@ -9,6 +9,6 @@ source $base_dir/lib/prelude_config.bash
 cd $assets_dir
 rm -rf s3cli
 mkdir s3cli
-current_version=0.0.44
+current_version=0.0.45
 curl -L -o s3cli/s3cli https://s3.amazonaws.com/s3cli-artifacts/s3cli-${current_version}-linux-amd64
-echo "885a8d95354978f1f6126aef6b161515efaac221 s3cli/s3cli" | sha1sum -c -
+echo "dd0bad17c31d215189c6ad25daf80cd00226a940 s3cli/s3cli" | sha1sum -c -


### PR DESCRIPTION
- Includes fix for Region being silently overridden if it didn't
  match the provided AWS Hostname

[#127485941](https://www.pivotaltracker.com/story/show/127485941)