### PR TITLE
Quote all proxy environment variables to account for spaces

### DIFF
--- a/release/jobs/director/templates/director_ctl.erb
+++ b/release/jobs/director/templates/director_ctl.erb
@@ -30,16 +30,16 @@ export C_INCLUDE_PATH=/var/vcap/packages/sqlite/include:/var/vcap/packages/libpq
 export LIBRARY_PATH=/var/vcap/packages/sqlite/lib:/var/vcap/packages/libpq/lib:/var/vcap/packages/mysqlclient/lib:$LIBRARY_PATH
 
 <% if_p('env.http_proxy') do |http_proxy| %>
-export HTTP_PROXY=<%= http_proxy %>
-export http_proxy=<%= http_proxy %>
+export HTTP_PROXY="<%= http_proxy %>"
+export http_proxy="<%= http_proxy %>"
 <% end %>
 <% if_p('env.https_proxy') do |https_proxy| %>
-export HTTPS_PROXY=<%= https_proxy %>
-export https_proxy=<%= https_proxy %>
+export HTTPS_PROXY="<%= https_proxy %>"
+export https_proxy="<%= https_proxy %>"
 <% end %>
 <% if_p('env.no_proxy') do |no_proxy| %>
-export NO_PROXY=<%= no_proxy %>
-export no_proxy=<%= no_proxy %>
+export NO_PROXY="<%= no_proxy %>"
+export no_proxy="<%= no_proxy %>"
 <% end %>
 
 function pid_exists() {

--- a/release/jobs/director/templates/scheduler_ctl.erb
+++ b/release/jobs/director/templates/scheduler_ctl.erb
@@ -17,16 +17,16 @@ export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/2.3.0
 export TMPDIR=/var/vcap/data/tmp/director
 
 <% if_p('env.http_proxy') do |http_proxy| %>
-export HTTP_PROXY=<%= http_proxy %>
-export http_proxy=<%= http_proxy %>
+export HTTP_PROXY="<%= http_proxy %>"
+export http_proxy="<%= http_proxy %>"
 <% end %>
 <% if_p('env.https_proxy') do |https_proxy| %>
-export HTTPS_PROXY=<%= https_proxy %>
-export https_proxy=<%= https_proxy %>
+export HTTPS_PROXY="<%= https_proxy %>"
+export https_proxy="<%= https_proxy %>"
 <% end %>
 <% if_p('env.no_proxy') do |no_proxy| %>
-export NO_PROXY=<%= no_proxy %>
-export no_proxy=<%= no_proxy %>
+export NO_PROXY="<%= no_proxy %>"
+export no_proxy="<%= no_proxy %>"
 <% end %>
 
 function pid_exists() {

--- a/release/jobs/director/templates/worker_ctl.erb
+++ b/release/jobs/director/templates/worker_ctl.erb
@@ -33,16 +33,16 @@ fi
 <% end %>
 
 <% if_p('env.http_proxy') do |http_proxy| %>
-export HTTP_PROXY=<%= http_proxy %>
-export http_proxy=<%= http_proxy %>
+export HTTP_PROXY="<%= http_proxy %>"
+export http_proxy="<%= http_proxy %>"
 <% end %>
 <% if_p('env.https_proxy') do |https_proxy| %>
-export HTTPS_PROXY=<%= https_proxy %>
-export https_proxy=<%= https_proxy %>
+export HTTPS_PROXY="<%= https_proxy %>"
+export https_proxy="<%= https_proxy %>"
 <% end %>
 <% if_p('env.no_proxy') do |no_proxy| %>
-export NO_PROXY=<%= no_proxy %>
-export no_proxy=<%= no_proxy %>
+export NO_PROXY="<%= no_proxy %>"
+export no_proxy="<%= no_proxy %>"
 <% end %>
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/release/jobs/health_monitor/templates/health_monitor_ctl.erb
+++ b/release/jobs/health_monitor/templates/health_monitor_ctl.erb
@@ -12,16 +12,16 @@ export GEM_HOME=/var/vcap/packages/health_monitor/gem_home/ruby/2.3.0
 export BUNDLE_GEMFILE=/var/vcap/packages/health_monitor/Gemfile
 
 <% if_p('env.http_proxy') do |http_proxy| %>
-export HTTP_PROXY=<%= http_proxy %>
-export http_proxy=<%= http_proxy %>
+export HTTP_PROXY="<%= http_proxy %>"
+export http_proxy="<%= http_proxy %>"
 <% end %>
 <% if_p('env.https_proxy') do |https_proxy| %>
-export HTTPS_PROXY=<%= https_proxy %>
-export https_proxy=<%= https_proxy %>
+export HTTPS_PROXY="<%= https_proxy %>"
+export https_proxy="<%= https_proxy %>"
 <% end %>
 <% if_p('env.no_proxy') do |no_proxy| %>
-export NO_PROXY=<%= no_proxy %>
-export no_proxy=<%= no_proxy %>
+export NO_PROXY="<%= no_proxy %>"
+export no_proxy="<%= no_proxy %>"
 <% end %>
 
 function pid_exists() {

--- a/release/jobs/registry/templates/registry_ctl.erb
+++ b/release/jobs/registry/templates/registry_ctl.erb
@@ -10,16 +10,16 @@ export BUNDLE_GEMFILE=/var/vcap/packages/registry/Gemfile
 export GEM_HOME=/var/vcap/packages/registry/gem_home/ruby/2.3.0
 
 <% if_p('env.http_proxy') do |http_proxy| %>
-export HTTP_PROXY=<%= http_proxy %>
-export http_proxy=<%= http_proxy %>
+export HTTP_PROXY="<%= http_proxy %>"
+export http_proxy="<%= http_proxy %>"
 <% end %>
 <% if_p('env.https_proxy') do |https_proxy| %>
-export HTTPS_PROXY=<%= https_proxy %>
-export https_proxy=<%= https_proxy %>
+export HTTPS_PROXY="<%= https_proxy %>"
+export https_proxy="<%= https_proxy %>"
 <% end %>
 <% if_p('env.no_proxy') do |no_proxy| %>
-export NO_PROXY=<%= no_proxy %>
-export no_proxy=<%= no_proxy %>
+export NO_PROXY="<%= no_proxy %>"
+export no_proxy="<%= no_proxy %>"
 <% end %>
 
 function pid_exists() {


### PR DESCRIPTION
- Prior to this fix, if a user entered spaces under `no_proxy`, only the first address would
  be set due to missing quotes around bash values

[#128111241](https://www.pivotaltracker.com/story/show/128111241)

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>