### PR TITLE
stemcell/google: Disable SSH set host keys by Google agent

### DIFF
--- a/stemcell_builder/stages/system_google_packages/apply.sh
+++ b/stemcell_builder/stages/system_google_packages/apply.sh
@@ -10,6 +10,10 @@ source $base_dir/lib/prelude_apply.bash
 # Copy google daemon packages into chroot
 cp -R $assets_dir/usr $chroot/
 
+# Configure the Google guest environment
+# https://github.com/GoogleCloudPlatform/compute-image-packages#configuration
+cp $assets_dir/instance_configs.cfg.template $chroot/etc/default/
+
 os_type="$(get_os_type)"
 if [ "${os_type}" == "ubuntu" ]
 then

--- a/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
+++ b/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
@@ -1,0 +1,3 @@
+'InstanceSetup': {
+    'set_host_keys': 'false',
+},


### PR DESCRIPTION
A Google system package in Google stemcells is, by default, configured to configure SSH host keys on boot. This is known to race with BOSH's own host key behavior. This change disables the Google system package's behavior.