### PR TITLE
stemcell_builder: force-remove SSH host keys

### DIFF
--- a/stemcell_builder/stages/base_ubuntu_firstboot/assets/root/firstboot.sh
+++ b/stemcell_builder/stages/base_ubuntu_firstboot/assets/root/firstboot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-rm /etc/ssh/ssh_host*key*
+rm -f /etc/ssh/ssh_host*key*
 
 dpkg-reconfigure -fnoninteractive -pcritical openssh-server
 dpkg-reconfigure -fnoninteractive sysstat


### PR DESCRIPTION
If no host keys exist in /etc/ssh, the `rm` command  will return 1 and the
remaining commands will not be executed in an exit-on-error shell. This will
result in no host keys being configured, thus disabling SSH.