### PR TITLE
Allow bosh_cli to use IAM profiles

### DIFF
--- a/bosh_cli/lib/cli/release.rb
+++ b/bosh_cli/lib/cli/release.rb
@@ -128,6 +128,7 @@ module Bosh::Cli
     def has_blobstore_secrets?(blobstore, name, *keys)
       return false unless blobstore
       return false unless blobstore[name]
+      return true if blobstore["s3"]["credentials_source"] == "env_or_profile"
       keys.each {|key| return false unless blobstore[name][key]}
       true
     end


### PR DESCRIPTION
### What
Currently it is not possible to use IAM roles for `bosh create release --final` command to allow it to upload blobs using temporary security credentials. 

If no AWS keys are specified, blobstore type is S3 and `credentials_source` is set to
`env_or_profile` bosh cli should try to use IAM profile.

### How to test
Use this `private.yml`:

```
---
blobstore:
  s3:
    credentials_source: env_or_profile
```

And execute `bosh create release --final` from a VM that has IAM role assigned and check if blobs are uploaded to your S3 bucket.