### PR TITLE
Allow bosh_cli to use IAM profiles

### DIFF
--- a/bosh_cli/lib/cli/release.rb
+++ b/bosh_cli/lib/cli/release.rb
@@ -73,7 +73,8 @@ module Bosh::Cli
       has_legacy_secret? ||
         has_blobstore_secrets?(bs, "simple", "user", "password") ||
         has_blobstore_secrets?(bs, "dav", "user", "password") ||
-        has_blobstore_secrets?(bs, "s3", "access_key_id", "secret_access_key")
+        has_blobstore_secrets?(bs, "s3", "access_key_id", "secret_access_key") ||
+        has_blobstore_secrets?(bs, "s3", "credentials_source")
     end
 
     # final.yml


### PR DESCRIPTION
### What
Currently it is not possible to use IAM roles for `bosh create release --final` command to allow it to upload blobs using temporary security credentials. 

If no AWS keys are specified, blobstore type is S3 and `credentials_source` is set to
`env_or_profile` bosh cli should try to use IAM profile.

### How to test
Use this `private.yml`:

```
---
blobstore:
  s3:
    credentials_source: env_or_profile
```

And execute `bosh create release --final` from a VM that has IAM role assigned and check if blobs are uploaded to your S3 bucket.