### PR TITLE
Add arbitrary metadata tags to deploy manifest.

### DIFF
--- a/bosh-director/lib/bosh/director/vm_metadata_updater.rb
+++ b/bosh-director/lib/bosh/director/vm_metadata_updater.rb
@@ -13,6 +13,12 @@ module Bosh::Director
     def update(instance, metadata)
       if @cloud.respond_to?(:set_vm_metadata)
         metadata = metadata.merge(@director_metadata)
+
+        manifest = Manifest.load_from_model(instance.deployment)
+        if manifest.raw_manifest_hash.is_a?(Hash)
+          metadata = metadata.merge(manifest.to_hash.fetch('tags', {}))
+        end
+
         metadata[:deployment] = instance.deployment.name
 
         metadata[:id] = instance.uuid

--- a/bosh-director/spec/unit/vm_metadata_updater_spec.rb
+++ b/bosh-director/spec/unit/vm_metadata_updater_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'logger'
 require 'timecop'
+require 'yaml'
 
 describe Bosh::Director::VmMetadataUpdater do
   describe '.build' do
@@ -36,6 +37,12 @@ describe Bosh::Director::VmMetadataUpdater do
         expected_vm_metadata = {'fake-director-key1' => 'fake-director-value1'}
         director_metadata.merge!(expected_vm_metadata)
         expect(cloud).to receive(:set_vm_metadata).with('fake-vm-cid', hash_including(expected_vm_metadata))
+        vm_metadata_updater.update(instance, {})
+      end
+
+      it 'updates vm metadata with instance tags' do
+        instance.deployment.manifest = YAML.dump({'tags' => {'my-tag' => 'my-value'}})
+        expect(cloud).to receive(:set_vm_metadata).with('fake-vm-cid', hash_including({'my-tag' => 'my-value'}))
         vm_metadata_updater.update(instance, {})
       end
 


### PR DESCRIPTION
This is a first pass at the interface described by @cppforlife in https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/issues/33#issuecomment-223487970. I'm not very familiar with the bosh internals, so let me know if there's a better way to do this, and I'll be happy to revise.

[Resolves https://github.com/cloudfoundry/bosh/issues/936]
[Resolves https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/issues/33]