### PR TITLE
Support parallel execution of integration tests

### DIFF
--- a/bosh-dev/lib/bosh/dev/tasks/fly.rake
+++ b/bosh-dev/lib/bosh/dev/tasks/fly.rake
@@ -5,14 +5,24 @@ namespace :fly do
   # bundle exec rake fly:unit
   desc 'Fly unit specs'
   task :unit do
-    execute('test-unit', '-p')
+    execute('test-unit', '-p', {
+        DB: (ENV['DB'] || 'postgresql')
+    })
   end
 
   # bundle exec rake fly:integration
   desc 'Fly integration specs'
   task :integration do
-    env(DB: (ENV['DB'] || 'postgresql'), SPEC_PATH: (ENV['SPEC_PATH'] || nil))
-    execute('test-integration', '-p')
+    execute('test-integration', '-p', {
+        DB: (ENV['DB'] || 'postgresql'), SPEC_PATH: (ENV['SPEC_PATH'] || nil)
+    })
+  end
+
+  # bundle exec rake fly:run["pwd ; ls -al"]
+  task :run, [:command] do |_, args|
+    execute('run', '-p', {
+        COMMAND: %Q|\"#{args[:command]}\"|
+    })
   end
 
   task :integration_parallel do
@@ -21,28 +31,23 @@ namespace :fly do
     num_groups = 24
 
     groups = (1..num_groups).group_by { |i| i%num_workers }.values
-                            .map { |group_values| group_values.join(',') }
+        .map { |group_values| group_values.join(',') }
 
     task_names = groups.each_with_index.map do |group, index|
       name = "integration_#{index + 1}"
       task name do
-        env(DB: (ENV['DB'] || 'postgresql'),
+        execute('test-integration', '-p', {
+            DB: (ENV['DB'] || 'postgresql'),
             SPEC_PATH: (ENV['SPEC_PATH'] || nil),
             GROUP: group,
-            NUM_GROUPS: num_groups)
-        execute('test-integration', '-p')
+            NUM_GROUPS: num_groups
+        })
       end
       name
     end
 
     multitask _parallel_integration: task_names
     Rake::MultiTask[:_parallel_integration].invoke
-  end
-
-  # bundle exec rake fly:run["pwd ; ls -al"]
-  task :run, [:command] do |_, args|
-    env(COMMAND: %Q|\"#{args[:command]}\"|)
-    execute('run', '-p')
   end
 
   private
@@ -56,16 +61,17 @@ namespace :fly do
     "-t #{ENV['CONCOURSE_TARGET']}" if ENV.has_key?('CONCOURSE_TARGET')
   end
 
-  def env(modifications = {})
-    @env ||= {
-      RUBY_VERSION: ENV['RUBY_VERSION'] || Bosh::Dev::RubyVersion.release_version
+  def prepare_env(additional_env = {})
+    env = {
+        RUBY_VERSION: ENV['RUBY_VERSION'] || Bosh::Dev::RubyVersion.release_version
     }
-    @env.merge!(modifications) if modifications
+    env.merge!(additional_env)
 
-    @env.to_a.map { |pair| pair.join('=') }.join(' ')
+    env.to_a.map { |pair| pair.join('=') }.join(' ')
   end
 
-  def execute(task, command_options = nil)
+  def execute(task, command_options = nil, additional_env = {})
+    env = prepare_env(additional_env)
     sh("#{env} fly #{concourse_target} sync")
     sh("#{env} fly #{concourse_target} execute #{concourse_tag} #{command_options} -x -c ci/tasks/#{task}.yml -i bosh-src=$PWD")
   end

--- a/bosh-dev/lib/bosh/dev/tasks/fly.rake
+++ b/bosh-dev/lib/bosh/dev/tasks/fly.rake
@@ -30,6 +30,7 @@ namespace :fly do
             SPEC_PATH: (ENV['SPEC_PATH'] || nil),
             GROUP: group,
             NUM_GROUPS: num_groups)
+        execute('test-integration', '-p')
       end
       name
     end


### PR DESCRIPTION
Hi,

we have added a new task `fly:integration_parallel` that supports parallel execution of fly exec tasks similar to what happens in the concourse pipeline. It runs all one-offs on the `fly-integration` worker. Console output is interlaced, but to have a look what is actually happening one can look on concourse. Using this task execution time is reduced to ca. 30 min.

Signed-off-by: Mauro Morales <mamorales@suse.com>