### PR TITLE
show explicit -t <target> in 'bosh task <num>' error command

### DIFF
--- a/bosh_cli/lib/cli/base_command.rb
+++ b/bosh_cli/lib/cli/base_command.rb
@@ -186,7 +186,7 @@ module Bosh::Cli
       end
 
       say("\n#{report}") if report
-      say("\nFor a more detailed error report, run: bosh task #{task_id} --debug") if status == :error
+      say("\nFor a more detailed error report, run: bosh -t #{target} task #{task_id} --debug") if status == :error
     end
 
     def auth_required

--- a/bosh_cli/spec/unit/commands/errand_spec.rb
+++ b/bosh_cli/spec/unit/commands/errand_spec.rb
@@ -366,7 +366,7 @@ describe Bosh::Cli::Command::Errand do
               expect(actual).to match_output %(
                 Errand 'fake-errand-name' did not complete
 
-                For a more detailed error report, run: bosh task fake-task-id --debug
+                For a more detailed error report, run: bosh -t fake-target task fake-task-id --debug
               )
             end
 


### PR DESCRIPTION
Previously, error messages from a failed bosh command said to run `bosh task <num> --debug`. Now it includes the explicit target: `bosh -t <target> task <num> --debug`
