### PR TITLE
Ignore dns_record_name when validating the change between old_network…

### DIFF
--- a/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
@@ -273,7 +273,7 @@ module Bosh
         end
 
         def remove_dns_record_name_from_network_settings(network_settings)
-          network_settings.each_value do |network_setting|
+          network_settings.each do |name, network_setting|
             if network_setting.has_key?("dns_record_name")
               network_setting.delete("dns_record_name")
             end

--- a/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
@@ -269,7 +269,16 @@ module Bosh
 
         def network_settings_changed?(old_network_settings, new_network_settings)
           return false if old_network_settings == {}
-          old_network_settings != new_network_settings
+          remove_dns_record_name_from_network_settings(old_network_settings) != new_network_settings
+        end
+
+        def remove_dns_record_name_from_network_settings(network_settings)
+          network_settings.each_value do |network_setting|
+            if network_setting.has_key?("dns_record_name")
+              network_setting.delete("dns_record_name")
+            end
+          end
+          network_settings
         end
 
         def env_changed?

--- a/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
@@ -120,16 +120,15 @@ module Bosh::Director::DeploymentPlan
         end
 
         it 'should ignore dns_record_name change of network settings' do
-          let(:network_settings) do
-            {
+          old_network_settings = {
                 'existing-network' =>{
                     'type' => 'dynamic',
                     'cloud_properties' =>{},
                     'dns_record_name' => '0.job-1.my-network.deployment.bosh',
                     'dns' => '10.0.0.1',
                 },
-            }
-          end
+          }
+
 
           new_network_settings = {
               'existing-network' =>{

--- a/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
@@ -119,6 +119,29 @@ module Bosh::Director::DeploymentPlan
           instance_plan.networks_changed?
         end
 
+        it 'should ignore dns_record_name change of network settings' do
+          let(:network_settings) do
+            {
+                'existing-network' =>{
+                    'type' => 'dynamic',
+                    'cloud_properties' =>{},
+                    'dns_record_name' => '0.job-1.my-network.deployment.bosh',
+                    'dns' => '10.0.0.1',
+                },
+            }
+          end
+
+          new_network_settings = {
+              'existing-network' =>{
+                  'type' => 'dynamic',
+                  'cloud_properties' =>{},
+                  'dns' => '10.0.0.1',
+              },
+          }
+
+          expect(instance_plan.networks_changed?).to be_falsey
+        end
+
         context 'when there are obsolete plans' do
           let(:network_plans) do
             [


### PR DESCRIPTION
This PR aims to fix the issue [1360](https://github.com/cloudfoundry/bosh/issues/1360). 