### PR TITLE
Ignore dns_record_name when validating changes of network_settings

### DIFF
--- a/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
@@ -1,3 +1,5 @@
+require 'common/deep_copy'
+
 module Bosh
   module Director
     module DeploymentPlan
@@ -274,10 +276,13 @@ module Bosh
 
         def remove_dns_record_name_from_network_settings(network_settings)
           return network_settings if network_settings.nil?
-          network_settings.each do |name, network_setting|
+
+          modified_network_settings = Bosh::Common::DeepCopy.copy(network_settings)
+
+          modified_network_settings.each do |name, network_setting|
             network_setting.delete_if{|key, value| key == "dns_record_name"}
           end
-          network_settings
+          modified_network_settings
         end
 
         def env_changed?

--- a/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
@@ -269,7 +269,14 @@ module Bosh
 
         def network_settings_changed?(old_network_settings, new_network_settings)
           return false if old_network_settings == {}
-          old_network_settings != new_network_settings
+          remove_dns_record_name_from_network_settings(old_network_settings) != new_network_settings
+        end
+
+        def remove_dns_record_name_from_network_settings(network_settings)
+          network_settings.each do |name, network_setting|
+            network_setting.delete_if{|key, value| key == "dns_record_name"}
+          end
+          network_settings
         end
 
         def env_changed?

--- a/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
@@ -273,6 +273,7 @@ module Bosh
         end
 
         def remove_dns_record_name_from_network_settings(network_settings)
+          return network_settings if network_settings == {}
           network_settings.each do |name, network_setting|
             network_setting.delete_if{|key, value| key == "dns_record_name"}
           end

--- a/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
+++ b/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
@@ -273,7 +273,7 @@ module Bosh
         end
 
         def remove_dns_record_name_from_network_settings(network_settings)
-          return network_settings if network_settings == {}
+          return network_settings if network_settings.nil?
           network_settings.each do |name, network_setting|
             network_setting.delete_if{|key, value| key == "dns_record_name"}
           end

--- a/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
@@ -119,25 +119,31 @@ module Bosh::Director::DeploymentPlan
           instance_plan.networks_changed?
         end
 
-        it 'should ignore dns_record_name change of network settings' do
-          old_network_settings = {
-              'existing-network' =>{
-                  'type' => 'dynamic',
-                  'cloud_properties' =>{},
-                  'dns_record_name' => '0.job-1.my-network.deployment.bosh',
-                  'dns' => '10.0.0.1',
-              },
-          }
+        context 'when dns_record_name exists in network_settings' do
+          let(:network_settings) do
+            {
+                'existing-network' =>{
+                    'type' => 'dynamic',
+                    'cloud_properties' =>{},
+                    'dns_record_name' => '0.job-1.my-network.deployment.bosh',
+                    'dns' => '10.0.0.1',
+                }
+            }
+          end
 
-          new_network_settings = {
-              'existing-network' =>{
-                  'type' => 'dynamic',
-                  'cloud_properties' =>{},
-                  'dns' => '10.0.0.1',
-              },
-          }
+          let(:new_network_settings) do
+            {
+                'existing-network' =>{
+                    'type' => 'dynamic',
+                    'cloud_properties' =>{},
+                    'dns' => '10.0.0.1',
+                }
+            }
+          end
 
-          expect(instance_plan.networks_changed?).to be_falsey
+          it 'should ignore dns_record_name when comparing old and new network_settings' do
+            expect(instance_plan.networks_changed?).to be_falsey
+          end
         end
 
         context 'when there are obsolete plans' do

--- a/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
@@ -119,6 +119,27 @@ module Bosh::Director::DeploymentPlan
           instance_plan.networks_changed?
         end
 
+        it 'should ignore dns_record_name change of network settings' do
+          old_network_settings = {
+              'existing-network' =>{
+                  'type' => 'dynamic',
+                  'cloud_properties' =>{},
+                  'dns_record_name' => '0.job-1.my-network.deployment.bosh',
+                  'dns' => '10.0.0.1',
+              },
+          }
+
+          new_network_settings = {
+              'existing-network' =>{
+                  'type' => 'dynamic',
+                  'cloud_properties' =>{},
+                  'dns' => '10.0.0.1',
+              },
+          }
+
+          expect(instance_plan.networks_changed?).to be_falsey
+        end
+
         context 'when there are obsolete plans' do
           let(:network_plans) do
             [

--- a/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
+++ b/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
@@ -130,19 +130,22 @@ module Bosh::Director::DeploymentPlan
                 }
             }
           end
-
-          let(:new_network_settings) do
-            {
+          
+          it 'should ignore dns_record_name when comparing old and new network_settings' do
+            new_network_settings = {
                 'existing-network' =>{
                     'type' => 'dynamic',
                     'cloud_properties' =>{},
                     'dns' => '10.0.0.1',
                 }
             }
-          end
 
-          it 'should ignore dns_record_name when comparing old and new network_settings' do
-            expect(instance_plan.networks_changed?).to be_falsey
+            allow(logger).to receive(:debug)
+            expect(logger).to_not receive(:debug).with(
+                "networks_changed? network settings changed FROM: #{network_settings} TO: #{new_network_settings} on instance #{instance_plan.existing_instance}"
+            )
+
+            instance_plan.networks_changed?
           end
         end
 


### PR DESCRIPTION
This PR aims to fix the issue [1360] (https://github.com/cloudfoundry/bosh/issues/1360)