### PR TITLE
bosh cleanup also delete orphaned disks

### DIFF
--- a/bosh_cli/lib/cli/commands/maintenance.rb
+++ b/bosh_cli/lib/cli/commands/maintenance.rb
@@ -6,8 +6,8 @@ module Bosh::Cli::Command
 
     # bosh cleanup
     usage 'cleanup'
-    desc 'Cleanup releases and stemcells'
-    option '--all', 'Remove all unused releases and stemcells'
+    desc 'Cleanup releases, stemcells and disks'
+    option '--all', 'Remove all unused releases, stemcells and disks'
     def cleanup
       target_required
       auth_required


### PR DESCRIPTION
@cppforlife says that `bosh cleanup`

> it includes orphaned disks as part of cleaning up.

This PR updates the command line help to make that clear