### PR TITLE
Stemcell has default hostname of `bosh-stemcell` in place of `localhost`

### DIFF
--- a/bosh-stemcell/spec/stemcells/ubuntu_trusty_spec.rb
+++ b/bosh-stemcell/spec/stemcells/ubuntu_trusty_spec.rb
@@ -50,7 +50,14 @@ describe 'Ubuntu 14.04 stemcell image', stemcell_image: true do
     end
   end
 
-  context 'installed by system-network', {
+  context 'installed by system-network on all IaaSes' do
+    describe file('/etc/hostname') do
+      it { should be_file }
+      its (:content) { should eq('bosh-stemcell') }
+    end
+  end
+
+  context 'installed by system-network on some IaaSes', {
     exclude_on_vsphere: true,
     exclude_on_vcloud: true,
     exclude_on_warden: true,
@@ -61,11 +68,6 @@ describe 'Ubuntu 14.04 stemcell image', stemcell_image: true do
       it { should be_file }
       it { should contain 'auto lo' }
       it { should contain 'iface lo inet loopback' }
-    end
-
-    describe file('/etc/hostname') do
-      it { should be_file }
-      it { should contain 'localhost' }
     end
   end
 

--- a/bosh-stemcell/spec/support/stemcell_centos_rhel_7_shared_examples.rb
+++ b/bosh-stemcell/spec/support/stemcell_centos_rhel_7_shared_examples.rb
@@ -55,6 +55,13 @@ shared_examples_for 'a CentOS 7 or RHEL 7 stemcell' do
     end
   end
 
+  context 'installed by system-network on all IaaSes' do
+    describe file('/etc/hostname') do
+      it { should be_file }
+      its (:content) { should eq('bosh-stemcell') }
+    end
+  end
+
   context 'installed by the system_network stage', {
     exclude_on_warden: true,
     exclude_on_azure: true,
@@ -63,7 +70,7 @@ shared_examples_for 'a CentOS 7 or RHEL 7 stemcell' do
       it { should be_file }
       it { should contain 'NETWORKING=yes' }
       it { should contain 'NETWORKING_IPV6=no' }
-      it { should contain 'HOSTNAME=localhost.localdomain' }
+      it { should contain 'HOSTNAME=bosh-stemcell' }
       it { should contain 'NOZEROCONF=yes' }
     end
 
@@ -86,7 +93,7 @@ shared_examples_for 'a CentOS 7 or RHEL 7 stemcell' do
       it { should be_file }
       it { should contain 'NETWORKING=yes' }
       it { should contain 'NETWORKING_IPV6=no' }
-      it { should contain 'HOSTNAME=localhost.localdomain' }
+      it { should contain 'HOSTNAME=bosh-stemcell' }
       it { should contain 'NOZEROCONF=yes' }
     end
 

--- a/stemcell_builder/stages/system_network/apply.sh
+++ b/stemcell_builder/stages/system_network/apply.sh
@@ -8,9 +8,11 @@ source $base_dir/lib/prelude_apply.bash
 # Remove persistent device names so that eth0 comes up as eth0
 rm -fr $chroot/etc/udev/rules.d/70-persistent-net.rules
 
-if [ -e "$chroot/etc/network/interfaces" ]; then # ubuntu
-  echo -n "localhost" > $chroot/etc/hostname
+# Context on the need to replace the hostname is here:
+# https://github.com/cloudfoundry/bosh/issues/1399
+echo -n "bosh-stemcell" > $chroot/etc/hostname
 
+if [ -e "$chroot/etc/network/interfaces" ]; then # ubuntu
   cat >> $chroot/etc/network/interfaces <<EOS
 auto lo
 iface lo inet loopback
@@ -20,7 +22,7 @@ elif [ -e "$chroot/etc/sysconfig/network" ]; then # centos
   cat >> $chroot/etc/sysconfig/network <<EOS
 NETWORKING=yes
 NETWORKING_IPV6=no
-HOSTNAME=localhost.localdomain
+HOSTNAME=bosh-stemcell
 NOZEROCONF=yes
 EOS
 


### PR DESCRIPTION
Fixes bug https://github.com/cloudfoundry/bosh/issues/1399

- prevents hostname from being set to a too-long string
  - on Google, when Project name is > 13 characters
  - `/sbin/dhclient-script` sets the hostname to a too-long hostname (> 64 characters)
  - `firstboot.sh` is invoked, cleans out VM's ssh keys
  - `firstboot.sh` runs `dpkg-configure` to regenerate ssh-keys
  - `dpkg-reconfigure` fails because hostname is too long
  - keys aren't generated; vcap cannot ssh in

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>

[#129380795](https://www.pivotaltracker.com/story/show/129380795)