### PR TITLE
Update system guest package for Google stemcell

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -142,6 +142,7 @@ module Bosh::Stemcell
 
     def google_stages
       [
+        :rsyslog_config,
         :system_network,
         :system_google_modules,
         :system_google_packages,

--- a/bosh-stemcell/spec/stemcells/google_spec.rb
+++ b/bosh-stemcell/spec/stemcells/google_spec.rb
@@ -21,16 +21,33 @@ describe 'Google Stemcell', stemcell_image: true do
     let(:mode) { '644' }
     let(:owner) { 'root' }
     let(:group) { 'root' }
+
+    describe 'Google agent has configuration file' do
+      subject { file('/etc/default/instance_configs.cfg.template') }
+
+      it { should be_file }
+      it { should be_owned_by(owner) }
+      it { should be_grouped_into(group) }
+    end
+
     case ENV['OS_NAME']
       when 'ubuntu'
         [
-          '/etc/init/google-accounts-manager-service.conf',
-          '/etc/init/google-accounts-manager-task.conf',
-          '/etc/init/google-clock-sync-manager.conf'
+          '/etc/init/google-accounts-daemon.conf',
+          '/etc/init/google-clock-skew-daemon.conf',
+          '/etc/init/google-instance-setup.conf',
+          '/etc/init/google-ip-forwarding-daemon.conf',
+          '/etc/init/google-network-setup.conf',
+          '/etc/init/google-shutdown-scripts.conf',
+          '/etc/init/google-startup-scripts.conf',
+          '/usr/bin/google_instance_setup',
+          '/usr/bin/google_ip_forwarding_daemon',
+          '/usr/bin/google_accounts_daemon',
+          '/usr/bin/google_clock_skew_daemon',
+          '/usr/bin/google_metadata_script_runner',
         ].each do |conf_file|
           describe file(conf_file) do
             it { should be_file }
-            it { should be_mode(mode) }
             it { should be_owned_by(owner) }
             it { should be_grouped_into(group) }
           end

--- a/stemcell_builder/stages/rsyslog_config/assets/rsyslog_upstart.conf
+++ b/stemcell_builder/stages/rsyslog_config/assets/rsyslog_upstart.conf
@@ -11,12 +11,6 @@ stop on runlevel [06]
 expect fork
 respawn
 
-pre-start script
-	until mountpoint -q /var/log; do
-	  sleep .1
-	done
-end script
-
 script
     . /etc/default/rsyslog
     exec /usr/sbin/rsyslogd $RSYSLOGD_OPTIONS

--- a/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
+++ b/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
@@ -1,3 +1,10 @@
-'InstanceSetup': {
-    'set_host_keys': 'false',
-},
+[Daemons]
+accounts_daemon = true
+clock_skew_daemon = true
+ip_forwarding_daemon = true
+[InstanceSetup]
+network_enabled = true
+optimize_local_ssd = true
+set_host_keys = false
+shutdown = false
+startup = false

--- a/stemcell_builder/stages/system_google_packages/config.sh
+++ b/stemcell_builder/stages/system_google_packages/config.sh
@@ -8,10 +8,9 @@ source $base_dir/lib/prelude_config.bash
 # Download package source from github into assets directory
 cd $assets_dir
 
-wget -O compute-src.tar.gz https://github.com/GoogleCloudPlatform/compute-image-packages/archive/1.3.3.tar.gz
-echo "dd115b7d56c08a3c62180a9b72552a54f7babd4f compute-src.tar.gz" | sha1sum -c -
+# Download google-image-packages
+wget https://storage.googleapis.com/bosh-stemcell-artifacts/google-compute-engine-init-ubuntu-trusty_2.1.0-0.1474671297_amd64.deb
+echo "8081f1a3a92c7a64b762f8382dc42c952633cb08  google-compute-engine-init-ubuntu-trusty_2.1.0-0.1474671297_amd64.deb" | sha1sum -c -
 
-mkdir compute-src
-tar xvf compute-src.tar.gz -C compute-src
-cp -R compute-src/compute-image-packages-1.3.3/google-daemon/{etc,usr} .
-rm -rf compute-src compute-src.tar.gz
+wget https://storage.googleapis.com/bosh-stemcell-artifacts/google-compute-engine-wheezy_2.1.3-0.1474395669_all.deb
+echo "820d7d06afd7a60d884fea1570a6e5ba108b967b  google-compute-engine-wheezy_2.1.3-0.1474395669_all.deb" | sha1sum -c -


### PR DESCRIPTION
This change uses the latest [`compute-image-packages`] for Google guest VMs.
The new package allows more granular configuration of daemons and improves
compatibility with other services on boot.

[`compute-image-packages`]: https://github.com/GoogleCloudPlatform/compute-image-packages/releases/tag/20160803