### PR TITLE
Update system guest package for Google stemcell

### DIFF
--- a/bosh-stemcell/spec/stemcells/google_spec.rb
+++ b/bosh-stemcell/spec/stemcells/google_spec.rb
@@ -21,16 +21,33 @@ describe 'Google Stemcell', stemcell_image: true do
     let(:mode) { '644' }
     let(:owner) { 'root' }
     let(:group) { 'root' }
+
+    describe 'Google agent has configuration file' do
+      subject { file('/etc/default/instance_configs.cfg.template') }
+
+      it { should be_file }
+      it { should be_owned_by(owner) }
+      it { should be_grouped_into(group) }
+    end
+
     case ENV['OS_NAME']
       when 'ubuntu'
         [
-          '/etc/init/google-accounts-manager-service.conf',
-          '/etc/init/google-accounts-manager-task.conf',
-          '/etc/init/google-clock-sync-manager.conf'
+          '/etc/init/google-accounts-daemon.conf',
+          '/etc/init/google-clock-skew-daemon.conf',
+          '/etc/init/google-instance-setup.conf',
+          '/etc/init/google-ip-forwarding-daemon.conf',
+          '/etc/init/google-network-setup.conf',
+          '/etc/init/google-shutdown-scripts.conf',
+          '/etc/init/google-startup-scripts.conf',
+          '/usr/bin/google_instance_setup',
+          '/usr/bin/google_ip_forwarding_daemon',
+          '/usr/bin/google_accounts_daemon',
+          '/usr/bin/google_clock_skew_daemon',
+          '/usr/bin/google_metadata_script_runner',
         ].each do |conf_file|
           describe file(conf_file) do
             it { should be_file }
-            it { should be_mode(mode) }
             it { should be_owned_by(owner) }
             it { should be_grouped_into(group) }
           end

--- a/stemcell_builder/stages/system_google_packages/apply.sh
+++ b/stemcell_builder/stages/system_google_packages/apply.sh
@@ -7,21 +7,20 @@ set -e
 base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_apply.bash
 
-# Copy google daemon packages into chroot
-cp -R $assets_dir/usr $chroot/
-
-# Configure the Google guest environment
-# https://github.com/GoogleCloudPlatform/compute-image-packages#configuration
-cp $assets_dir/instance_configs.cfg.template $chroot/etc/default/
-
 os_type="$(get_os_type)"
 if [ "${os_type}" == "ubuntu" ]
 then
-  # Run google-accounts-manager and google-clock-sync-manager with upstart
-  cp $assets_dir/etc/init/google-accounts-manager-{task,service}.conf $chroot/etc/init/
-  cp $assets_dir/google-address-manager.conf $chroot/etc/init/
-  cp $assets_dir/google-clock-sync-manager.conf $chroot/etc/init/
-  chmod 0644 $chroot/etc/init/google*
+  # Copy google daemon packages into chroot
+  mkdir -p $chroot/tmp/google
+  cp -R $assets_dir/google/*.deb $chroot/tmp/google/
+
+  # Configure the Google guest environment
+  # https://github.com/GoogleCloudPlatform/compute-image-packages#configuration
+  cp $assets_dir/instance_configs.cfg.template $chroot/etc/default/
+
+  run_in_chroot $chroot "apt-get update"
+  run_in_chroot $chroot "apt-get install -y python-setuptools python-boto"
+  run_in_chroot $chroot "dpkg --force-all -i /tmp/google/*.deb"
 elif [ "${os_type}" == "rhel" -o "${os_type}" == "centos" ]
 then
   run_in_chroot $chroot "/bin/systemctl enable /usr/lib/systemd/system/google-accounts-manager.service"
@@ -33,4 +32,4 @@ else
 fi
 
 # Hack: replace google metadata hostname with ip address (bosh agent might set a dns that it's unable to resolve the hostname)
-run_in_chroot $chroot "find /usr/share/google -type f -exec sed -i 's/metadata.google.internal/169.254.169.254/g' {} +"
+run_in_chroot $chroot "sed -i 's/metadata.google.internal/169.254.169.254/g' /usr/lib/python2.7/dist-packages/google_compute_engine/metadata_watcher.py"

--- a/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
+++ b/stemcell_builder/stages/system_google_packages/assets/instance_configs.cfg.template
@@ -1,3 +1,10 @@
-'InstanceSetup': {
-    'set_host_keys': 'false',
-},
+[Daemons]
+accounts_daemon = true
+clock_skew_daemon = true
+ip_forwarding_daemon = true
+[InstanceSetup]
+network_enabled = true
+optimize_local_ssd = true
+set_host_keys = false
+shutdown = false
+startup = false

--- a/stemcell_builder/stages/system_google_packages/config.sh
+++ b/stemcell_builder/stages/system_google_packages/config.sh
@@ -6,12 +6,15 @@ base_dir=$(readlink -nf $(dirname $0)/../..)
 source $base_dir/lib/prelude_config.bash
 
 # Download package source from github into assets directory
-cd $assets_dir
+mkdir -p $assets_dir/google
+cd $assets_dir/google
 
-wget -O compute-src.tar.gz https://github.com/GoogleCloudPlatform/compute-image-packages/archive/1.3.3.tar.gz
-echo "dd115b7d56c08a3c62180a9b72552a54f7babd4f compute-src.tar.gz" | sha1sum -c -
+# Download google-image-packages
+wget https://storage.googleapis.com/bosh-cpi-artifacts/google-compute-engine-init-trusty_2.1.0-0.1474913068_amd64.deb
+echo "229a1cd551b865cab199516e7572412fa4fde903  google-compute-engine-init-trusty_2.1.0-0.1474913068_amd64.deb" | sha1sum -c -
 
-mkdir compute-src
-tar xvf compute-src.tar.gz -C compute-src
-cp -R compute-src/compute-image-packages-1.3.3/google-daemon/{etc,usr} .
-rm -rf compute-src compute-src.tar.gz
+wget https://storage.googleapis.com/bosh-stemcell-artifacts/google-compute-engine-trusty_2.2.3-0.1474912841_all.deb
+echo "0da71ccd637145f34ef4e97bcdc741d5b8177081  google-compute-engine-trusty_2.2.3-0.1474912841_all.deb" | sha1sum -c -
+
+wget https://storage.googleapis.com/bosh-stemcell-artifacts/google-config-trusty_2.0.0-0.1474912881_amd64.deb
+echo "d8cc6556a73e5766a032230b900f6a24e30e66df  google-config-trusty_2.0.0-0.1474912881_amd64.deb" | sha1sum -c -


### PR DESCRIPTION
This change uses the latest `compute-image-packages` for Google guest VMs.
The new package allows more granular configuration of daemons and improves
compatibility with other services on boot.

https://github.com/GoogleCloudPlatform/compute-image-packages/releases/tag/20160803

[#130996079](https://www.pivotaltracker.com/story/show/130996079)