### PR TITLE
add NM_CONTROLLED=no to Azure network script

### DIFF
--- a/src/bosh-stemcell/spec/stemcells/azure_spec.rb
+++ b/src/bosh-stemcell/spec/stemcells/azure_spec.rb
@@ -41,4 +41,39 @@ describe 'Azure Stemcell', stemcell_image: true do
       it { should contain('"CreatePartitionIfNoEphemeralDisk": true') }
     end
   end
+
+  context 'installed by the system_azure_network', {
+    exclude_on_aws: true,
+    exclude_on_google: true,
+    exclude_on_vcloud: true,
+    exclude_on_vsphere: true,
+    exclude_on_warden: true,
+    exclude_on_openstack: true,
+  } do
+    case ENV['OS_NAME']
+      when 'ubuntu'
+        describe file('/etc/network/interfaces') do
+          it { should be_file }
+          it { should contain 'auto eth0' }
+          it { should contain 'iface eth0 inet dhcp' }
+        end
+
+      when 'centos'
+        describe file('/etc/sysconfig/network') do
+          it { should be_file }
+          it { should contain 'NETWORKING=yes' }
+          it { should contain 'NETWORKING_IPV6=no' }
+          it { should contain 'HOSTNAME=bosh-stemcell' }
+          it { should contain 'NOZEROCONF=yes' }
+        end
+        describe file('/etc/sysconfig/network-scripts/ifcfg-eth0') do
+          it { should be_file }
+          it { should contain 'DEVICE=eth0' }
+          it { should contain 'BOOTPROTO=dhcp' }
+          it { should contain 'ONBOOT=on' }
+          it { should contain 'TYPE="Ethernet"' }
+          it { should contain 'NM_CONTROLLED=no' }
+        end
+      end
+  end
 end

--- a/src/bosh-stemcell/spec/stemcells/ubuntu_trusty_spec.rb
+++ b/src/bosh-stemcell/spec/stemcells/ubuntu_trusty_spec.rb
@@ -92,22 +92,6 @@ describe 'Ubuntu 14.04 stemcell image', stemcell_image: true do
     end
   end
 
-  context 'installed by system-azure-network', {
-    exclude_on_aws: true,
-    exclude_on_google: true,
-    exclude_on_vcloud: true,
-    exclude_on_vsphere: true,
-    exclude_on_warden: true,
-    exclude_on_openstack: true,
-    exclude_on_softlayer: true,
-  } do
-    describe file('/etc/network/interfaces') do
-      it { should be_file }
-      it { should contain 'auto eth0' }
-      it { should contain 'iface eth0 inet dhcp' }
-    end
-  end
-
   context 'installed by system_open_vm_tools', {
     exclude_on_aws: true,
     exclude_on_google: true,

--- a/src/bosh-stemcell/spec/support/stemcell_centos_rhel_7_shared_examples.rb
+++ b/src/bosh-stemcell/spec/support/stemcell_centos_rhel_7_shared_examples.rb
@@ -81,31 +81,6 @@ shared_examples_for 'a CentOS 7 or RHEL 7 stemcell' do
     end
   end
 
-  context 'installed by the system_azure_network stage', {
-    exclude_on_aws: true,
-    exclude_on_google: true,
-    exclude_on_vcloud: true,
-    exclude_on_vsphere: true,
-    exclude_on_warden: true,
-    exclude_on_openstack: true,
-  } do
-    describe file('/etc/sysconfig/network') do
-      it { should be_file }
-      it { should contain 'NETWORKING=yes' }
-      it { should contain 'NETWORKING_IPV6=no' }
-      it { should contain 'HOSTNAME=bosh-stemcell' }
-      it { should contain 'NOZEROCONF=yes' }
-    end
-
-    describe file('/etc/sysconfig/network-scripts/ifcfg-eth0') do
-      it { should be_file }
-      it { should contain 'DEVICE=eth0' }
-      it { should contain 'BOOTPROTO=dhcp' }
-      it { should contain 'ONBOOT=on' }
-      it { should contain 'TYPE="Ethernet"' }
-    end
-  end
-
   context 'installed by bosh_aws_agent_settings', {
     exclude_on_google: true,
     exclude_on_openstack: true,

--- a/src/stemcell_builder/stages/system_azure_network/apply.sh
+++ b/src/stemcell_builder/stages/system_azure_network/apply.sh
@@ -12,6 +12,8 @@ rm -fr $chroot/etc/udev/rules.d/70-persistent-net.rules
 # https://github.com/cloudfoundry/bosh/issues/1399
 echo -n "bosh-stemcell" > $chroot/etc/hostname
 
+# Context on the need to disable NetworkManager (NM_CONTROLLED=no) is here:
+# https://github.com/Azure/WALinuxAgent/issues/190#issuecomment-226878272
 if [ -e "$chroot/etc/network/interfaces" ]; then # ubuntu
   cat >> $chroot/etc/network/interfaces <<EOS
 auto eth0
@@ -31,6 +33,7 @@ DEVICE=eth0
 BOOTPROTO=dhcp
 ONBOOT=on
 TYPE="Ethernet"
+NM_CONTROLLED=no
 EOS
 
 fi


### PR DESCRIPTION
Fixes the issue that Azure CentOS VM can't be created when it has multiple dynamic NICs.
