### PR TITLE
Force director to use proxy settings for remote download

### DIFF
--- a/bosh-director/lib/bosh/director/download_helper.rb
+++ b/bosh-director/lib/bosh/director/download_helper.rb
@@ -13,7 +13,7 @@ module Bosh::Director
     def download_remote_file(resource, remote_file, local_file, num_redirects = 0)
       @logger.info("Downloading remote #{resource} from #{remote_file}") if @logger
       uri = URI.parse(remote_file)
-      Net::HTTP.start(uri.host, uri.port,
+      Net::HTTP.start(uri.host, uri.port, :ENV,
                       :use_ssl => uri.scheme == 'https',
                       :verify_mode => OpenSSL::SSL::VERIFY_NONE) do |http|
         http.request_get(uri.request_uri) do |response|

--- a/bosh-director/spec/unit/download_helper_spec.rb
+++ b/bosh-director/spec/unit/download_helper_spec.rb
@@ -15,7 +15,7 @@ describe Bosh::Director::DownloadHelper do
 
   describe 'download_remote_file' do
     it 'should download a remote file' do
-      expect(Net::HTTP).to receive(:start).with('example.com', 80, use_ssl: false, verify_mode: verify_mode).and_yield(http).once
+      expect(Net::HTTP).to receive(:start).with('example.com', 80, :ENV, use_ssl: false, verify_mode: verify_mode).and_yield(http).once
       expect(http).to receive(:request_get).and_yield(http_200)
       expect(http_200).to receive(:read_body) do |&block|
         block.call("contents 1\n")
@@ -32,8 +32,8 @@ describe Bosh::Director::DownloadHelper do
       let(:redirect_location) { remote_file }
 
       it 'should follow the redirect' do
-        expect(Net::HTTP).to receive(:start).with('redirector.example.com', 80, use_ssl: false, verify_mode: verify_mode).and_yield(http).once
-        expect(Net::HTTP).to receive(:start).with('example.com', 80, use_ssl: false, verify_mode: verify_mode).and_yield(http).once
+        expect(Net::HTTP).to receive(:start).with('redirector.example.com', 80, :ENV, use_ssl: false, verify_mode: verify_mode).and_yield(http).once
+        expect(Net::HTTP).to receive(:start).with('example.com', 80, :ENV, use_ssl: false, verify_mode: verify_mode).and_yield(http).once
         expect(http).to receive(:request_get).with(URI.parse(redirect_url).request_uri).and_yield(http_302)
         expect(http).to receive(:request_get).with(URI.parse(remote_file).request_uri).and_yield(http_200)
         expect(http_200).to receive(:read_body)
@@ -45,7 +45,7 @@ describe Bosh::Director::DownloadHelper do
         let(:redirect_location) { '/file.tgz' }
 
         it 'should evaluate the location relative to the server and follow the redirect' do
-          expect(Net::HTTP).to receive(:start).with('redirector.example.com', 80, use_ssl: false, verify_mode: verify_mode).and_yield(http).twice
+          expect(Net::HTTP).to receive(:start).with('redirector.example.com', 80, :ENV, use_ssl: false, verify_mode: verify_mode).and_yield(http).twice
           expect(http).to receive(:request_get).with(URI.parse(redirect_url).request_uri).and_yield(http_302)
           expect(http).to receive(:request_get).with('/file.tgz').and_yield(http_200)
           expect(http_200).to receive(:read_body)
@@ -57,7 +57,7 @@ describe Bosh::Director::DownloadHelper do
           let(:redirect_location) { 'file.tgz' }
 
           it 'should evaulate the location relative to the server and path and follow the redirect' do
-            expect(Net::HTTP).to receive(:start).with('redirector.example.com', 80, use_ssl: false, verify_mode: verify_mode).and_yield(http).twice
+            expect(Net::HTTP).to receive(:start).with('redirector.example.com', 80, :ENV, use_ssl: false, verify_mode: verify_mode).and_yield(http).twice
             expect(http).to receive(:request_get).with(URI.parse(redirect_url).request_uri).and_yield(http_302)
             expect(http).to receive(:request_get).with('/redirect/to/file.tgz').and_yield(http_200)
             expect(http_200).to receive(:read_body)
@@ -71,7 +71,7 @@ describe Bosh::Director::DownloadHelper do
         let(:http_302) { Net::HTTPFound.new('1.1', '302', 'Found') }
 
         it 'should raise an error if no location is specified in a 302' do
-          allow(Net::HTTP).to receive(:start).with('redirector.example.com', 80, use_ssl: false, verify_mode: verify_mode).and_yield(http)
+          allow(Net::HTTP).to receive(:start).with('redirector.example.com', 80, :ENV, use_ssl: false, verify_mode: verify_mode).and_yield(http)
           expect(http).to receive(:request_get).with(URI.parse(redirect_url).request_uri).and_yield(http_302)
 
           expect {
@@ -91,7 +91,7 @@ describe Bosh::Director::DownloadHelper do
     end
 
     it 'should return a ResourceNotFound exception if remote server returns a NotFound error' do
-      expect(Net::HTTP).to receive(:start).with('example.com', 80, use_ssl: false, verify_mode: verify_mode).and_yield(http)
+      expect(Net::HTTP).to receive(:start).with('example.com', 80, :ENV, use_ssl: false, verify_mode: verify_mode).and_yield(http)
       expect(http).to receive(:request_get).and_yield(http_404)
 
       expect {
@@ -115,5 +115,6 @@ describe Bosh::Director::DownloadHelper do
         download_remote_file('resource', remote_file, local_file)
       }.to raise_error(Bosh::Director::ResourceError, 'Downloading remote resource failed. Check task debug log for details.')
     end
+
   end
 end


### PR DESCRIPTION
Previously, the Net::HTTP.start() call in the download helper
for the bosh director was ignoring the http_proxy/https_proxy
environment variables. This remedies that.