### PR TITLE
S3 Blobstore in read only mode ignores advanced configs

### DIFF
--- a/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
+++ b/blobstore_client/lib/blobstore_client/s3_blobstore_client.rb
@@ -49,7 +49,7 @@ module Bosh
           end
 
           @options[:bucket] ||= @options[:bucket_name]
-          @options[:endpoint] ||= S3BlobstoreClient::ENDPOINT
+          @options[:endpoint] ||= @aws_options[:endpoint] || S3BlobstoreClient::ENDPOINT
           @simple = SimpleBlobstoreClient.new(@options)
         end
 


### PR DESCRIPTION
Defect:
When no credentials are provided and no endpoint is set, the
S3BlobstoreClient will create a SimpleBlobstore based off of the bucket
name and the default endpoint (S3BlobstoreClient::ENDPOINT).
This ignores any options that would be used when credentials are set.

Fix:
If no endpoint is set, use the resolved endpoint from the @aws_options.
If no endpoint is resolved there, default back to S3BlobstoreClient::ENDPOINT

Fixes issue #1462