### PR TITLE
Skip sending incomplete events

### DIFF
--- a/bosh-monitor/lib/bosh/monitor/plugins/graphite.rb
+++ b/bosh-monitor/lib/bosh/monitor/plugins/graphite.rb
@@ -18,7 +18,7 @@ module Bosh::Monitor
 
       def process(event)
         if !valid?(event)
-          logger.warn("Skipping invalid heartbeat: #{event..to_s}")
+          logger.warn("Skipping invalid heartbeat: #{event.to_s}")
           return
         end
 

--- a/bosh-monitor/lib/bosh/monitor/plugins/graphite.rb
+++ b/bosh-monitor/lib/bosh/monitor/plugins/graphite.rb
@@ -17,28 +17,30 @@ module Bosh::Monitor
       end
 
       def process(event)
-        if valid?(event)
+        if !valid?(event)
+          logger.warn("Skipping invalid heartbeat: #{event..to_s}")
+          return
+        end
 
-          metrics = event.metrics
+        metrics = event.metrics
 
-          unless metrics.kind_of?(Enumerable)
-            raise PluginError, "Invalid event metrics: Enumerable expected, #{metrics.class} given"
-          end
+        unless metrics.kind_of?(Enumerable)
+          raise PluginError, "Invalid event metrics: Enumerable expected, #{metrics.class} given"
+        end
 
-          metrics.each do |metric|
-            metric_name = get_metric_name(event, metric)
-            metric_timestamp = get_metric_timestamp(metric.timestamp)
-            metric_value = metric.value
-            @connection.send_metric(metric_name, metric_value, metric_timestamp)
-          end
+        metrics.each do |metric|
+          metric_name = get_metric_name(event, metric)
+          metric_timestamp = get_metric_timestamp(metric.timestamp)
+          metric_value = metric.value
+          @connection.send_metric(metric_name, metric_value, metric_timestamp)
         end
       end
 
       private
 
       def valid?(event)
-        (event.is_a? Bosh::Monitor::Events::Heartbeat) && 
-          event.node_id && 
+        (event.is_a? Bosh::Monitor::Events::Heartbeat) &&
+          event.node_id &&
           event.deployment &&
           event.job
       end

--- a/bosh-monitor/lib/bosh/monitor/plugins/graphite.rb
+++ b/bosh-monitor/lib/bosh/monitor/plugins/graphite.rb
@@ -17,7 +17,7 @@ module Bosh::Monitor
       end
 
       def process(event)
-        if (event.is_a? Bosh::Monitor::Events::Heartbeat) && event.node_id
+        if valid?(event)
 
           metrics = event.metrics
 
@@ -35,6 +35,13 @@ module Bosh::Monitor
       end
 
       private
+
+      def valid?(event)
+        (event.is_a? Bosh::Monitor::Events::Heartbeat) && 
+          event.node_id && 
+          event.deployment &&
+          event.job
+      end
 
       def get_metric_name heartbeat, metric
         [get_metric_prefix(heartbeat), metric.name.to_s.gsub('.', '_')].join '.'

--- a/bosh-monitor/spec/unit/bosh/monitor/plugins/graphite_spec.rb
+++ b/bosh-monitor/spec/unit/bosh/monitor/plugins/graphite_spec.rb
@@ -84,6 +84,32 @@ describe Bhm::Plugins::Graphite do
           EM.stop
         end
       end
+
+      it "skips sending metrics if deployment is missing" do
+        event = make_heartbeat(timestamp: Time.now.to_i, deployment: nil)
+        EM.run do
+          plugin.run
+
+          expect(connection).not_to receive(:send_metric)
+
+          plugin.process(event)
+
+          EM.stop
+        end
+      end
+
+      it "skips sending metrics if job is missing" do
+        event = make_heartbeat(timestamp: Time.now.to_i, job: nil)
+        EM.run do
+          plugin.run
+
+          expect(connection).not_to receive(:send_metric)
+
+          plugin.process(event)
+
+          EM.stop
+        end
+      end
     end
   end
 end

--- a/bosh-monitor/spec/unit/bosh/monitor/plugins/graphite_spec.rb
+++ b/bosh-monitor/spec/unit/bosh/monitor/plugins/graphite_spec.rb
@@ -78,6 +78,7 @@ describe Bhm::Plugins::Graphite do
           plugin.run
 
           expect(connection).not_to receive(:send_metric)
+          expect(plugin.logger).to receive(:warn).with(/Skipping.*from mysql_node. .agent_id=deadbeef index=0/)
 
           plugin.process(event)
 
@@ -91,6 +92,7 @@ describe Bhm::Plugins::Graphite do
           plugin.run
 
           expect(connection).not_to receive(:send_metric)
+          expect(plugin.logger).to receive(:warn).with(/Skipping.*from mysql_node.node_id_abc .agent_id=deadbeef index=0/)
 
           plugin.process(event)
 
@@ -104,6 +106,7 @@ describe Bhm::Plugins::Graphite do
           plugin.run
 
           expect(connection).not_to receive(:send_metric)
+          expect(plugin.logger).to receive(:warn).with(/Skipping.*from .node_id_abc .agent_id=deadbeef index=0/)
 
           plugin.process(event)
 


### PR DESCRIPTION
If a heartbeat does not contain all of a node_id, deployment
and job, skip it. This is for issue #1468.
