### PR TITLE
Allow trimming empty lines in templates

### DIFF
--- a/bosh-director-core/lib/bosh/director/core/templates/source_erb.rb
+++ b/bosh-director-core/lib/bosh/director/core/templates/source_erb.rb
@@ -8,7 +8,7 @@ module Bosh::Director::Core::Templates
     def initialize(src_name, dest_name, erb_contents, template_name)
       @src_name = src_name
       @dest_name = dest_name
-      erb = ERB.new(erb_contents)
+      erb = ERB.new(erb_contents, safe_level = nil, trim_mode = "-")
       erb.filename = File.join(template_name, src_name)
       @erb = erb
     end

--- a/bosh-director-core/spec/bosh/director/core/templates/source_erb_spec.rb
+++ b/bosh-director-core/spec/bosh/director/core/templates/source_erb_spec.rb
@@ -47,6 +47,36 @@ module Bosh::Director::Core::Templates
           }.to raise_error(expected_message)
         end
       end
+
+      context 'when no space trimming is used' do
+        let(:erb_contents) do
+          <<-EOF
+first line
+<% a= 1 %>
+second line
+          EOF
+        end
+        let(:logger) { instance_double('Logger') }
+
+        it 'contains an empty newline in the rendered result' do
+          expect(subject.render(context, logger)).to eq("first line\n\nsecond line\n")
+        end
+      end
+
+      context 'when space trimming is used' do
+        let(:erb_contents) do
+          <<-EOF
+first line
+<% a= 1 -%>
+second line
+          EOF
+        end
+        let(:logger) { instance_double('Logger') }
+
+        it 'does not contain an empty newline in the rendered result' do
+          expect(subject.render(context, logger)).to eq("first line\nsecond line\n")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
You can use `<% -%>` to [trim empty lines](http://ruby-doc.org/stdlib-2.1.3/libdoc/erb/rdoc/ERB.html#method-c-new) in a job template.
[fixes #1086]

[Original PR](https://github.com/cloudfoundry/bosh/pull/1159) that promised this feature didn't actually help, because that class doesn't seem to be used anywhere except in the [gem's binary](https://github.com/cloudfoundry/bosh/blob/master/bosh-template/bin/bosh-template#L23).
