### PR TITLE
Cleanup task output directory before start

### DIFF
--- a/bosh-director/lib/bosh/director/job_queue.rb
+++ b/bosh-director/lib/bosh/director/job_queue.rb
@@ -29,6 +29,7 @@ module Bosh::Director
         :teams => deployment ? deployment.teams : nil,
         :checkpoint_time => Time.now)
       log_dir = File.join(Config.base_dir, 'tasks', task.id.to_s)
+      FileUtils.rmdir(log_dir) if File.directory?(log_dir)
       task_status_file = File.join(log_dir, 'debug')
       FileUtils.mkdir_p(log_dir)
 

--- a/bosh-director/lib/bosh/director/job_queue.rb
+++ b/bosh-director/lib/bosh/director/job_queue.rb
@@ -29,7 +29,7 @@ module Bosh::Director
         :teams => deployment ? deployment.teams : nil,
         :checkpoint_time => Time.now)
       log_dir = File.join(Config.base_dir, 'tasks', task.id.to_s)
-      FileUtils.rmdir(log_dir) if File.directory?(log_dir)
+      FileUtils.rm_rf(log_dir)
       task_status_file = File.join(log_dir, 'debug')
       FileUtils.mkdir_p(log_dir)
 

--- a/bosh-director/spec/unit/job_queue_spec.rb
+++ b/bosh-director/spec/unit/job_queue_spec.rb
@@ -51,6 +51,13 @@ module Bosh::Director
         subject.enqueue('whoami', job_class, description, [], deployment)
       end
 
+      it 'should clean up old log dir' do
+        subject.enqueue('whoami', job_class, description, [], deployment)
+        Models::Task.last.delete
+        expect(FileUtils).to receive(:rmdir).with("#{tmpdir}/tasks/1")
+        subject.enqueue('whoami', job_class, description, [], deployment)
+      end
+
       it 'should create the task debug output file' do
         task = subject.enqueue('fake-user', job_class, description, [], deployment)
 

--- a/bosh-director/spec/unit/job_queue_spec.rb
+++ b/bosh-director/spec/unit/job_queue_spec.rb
@@ -53,9 +53,10 @@ module Bosh::Director
 
       it 'should clean up old log dir' do
         subject.enqueue('whoami', job_class, description, [], deployment)
+        first_line = File.open("#{tmpdir}/tasks/1/debug", &:readline)
         Models::Task.last.delete
-        expect(FileUtils).to receive(:rmdir).with("#{tmpdir}/tasks/1")
         subject.enqueue('whoami', job_class, description, [], deployment)
+        expect(File.open("#{tmpdir}/tasks/1/debug", &:readline)).not_to eq(first_line)
       end
 
       it 'should create the task debug output file' do


### PR DESCRIPTION
[#114582319](https://www.pivotaltracker.com/story/show/114582319)

Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>