### PR TITLE
Bump s3cli to 0.0.53

### DIFF
--- a/release/packages/s3cli/packaging
+++ b/release/packages/s3cli/packaging
@@ -1,5 +1,5 @@
 set -e
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-mv s3cli/s3cli-0.0.51-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
+mv s3cli/s3cli-0.0.53-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/s3cli
 chmod +x ${BOSH_INSTALL_TARGET}/bin/s3cli

--- a/release/packages/s3cli/spec
+++ b/release/packages/s3cli/spec
@@ -1,4 +1,4 @@
 ---
 name: s3cli
 files:
-- s3cli/s3cli-0.0.51-linux-amd64
+- s3cli/s3cli-0.0.53-linux-amd64

--- a/stemcell_builder/stages/aws_cli/config.sh
+++ b/stemcell_builder/stages/aws_cli/config.sh
@@ -9,6 +9,6 @@ source $base_dir/lib/prelude_config.bash
 cd $assets_dir
 rm -rf s3cli
 mkdir s3cli
-current_version=0.0.51
+current_version=0.0.53
 curl -L -o s3cli/s3cli https://s3.amazonaws.com/s3cli-artifacts/s3cli-${current_version}-linux-amd64
-echo "bce6f9c1a1113bec747a3c44222e0904a3bee8cb s3cli/s3cli" | sha1sum -c -
+echo "4d6881fa390c6ecc1e5a0dd73af6951353857106 s3cli/s3cli" | sha1sum -c -


### PR DESCRIPTION
**WARNING:** make sure to add the new s3cli blob via `bosh add-blob` after merging.

Download: https://s3.amazonaws.com/s3cli-artifacts/s3cli-0.0.53-linux-amd64

- Add hostname to region lookup for AWS Mumbai region

[#133601061](https://www.pivotaltracker.com/story/show/133601061)

Signed-off-by: Chris Dutra <cdutra@pivotal.io>