### PR TITLE
Also consider STEMCELL_BUILD_NUMBER when determining the build number

### DIFF
--- a/bosh-dev/lib/bosh/dev/build.rb
+++ b/bosh-dev/lib/bosh/dev/build.rb
@@ -42,7 +42,7 @@ module Bosh::Dev
     end
 
     def self.build_number
-      ENV.fetch('CANDIDATE_BUILD_NUMBER', '0000')
+      ENV['CANDIDATE_BUILD_NUMBER'] || ENV['STEMCELL_BUILD_NUMBER'] || '0000'
     end
 
     def initialize(number, bucket_name, download_adapter, logger, skip_promote_artifacts, bearer_token)

--- a/bosh-dev/spec/unit/bosh/dev/build_spec.rb
+++ b/bosh-dev/spec/unit/bosh/dev/build_spec.rb
@@ -21,7 +21,15 @@ module Bosh::Dev
         end
       end
 
-      context 'when CANDIDATE_BUILD_NUMBER is not set' do
+      context 'when STEMCELL_BUILD_NUMBER is set' do
+        let(:environment) { { 'STEMCELL_BUILD_NUMBER' => 'candidate'} }
+
+        it 'returns the specified build number' do
+          expect(subject).to eq('candidate')
+        end
+      end
+
+      context 'when neither CANDIDATE_BUILD_NUMBER nor STEMCELL_BUILD_NUMBER are set' do
         let(:environment) { {} }
 
         it 'returns the default build number' do


### PR DESCRIPTION
40bf0b41 changed the way how the build number is determined (https://github.com/cloudfoundry/bosh/commit/40bf0b413b2608a7a439596d1762ff3f020db838#diff-ebd1e62819e1a31cfb010ad1aa609962R177).

The new method `Bosh::Dev::Build.build_number` does not consider `STEMCELL_BUILD_NUMBER`, though, which makes builds with local os images fail if `STEMCELL_BUILD_NUMBER` is set to something different than `0000` due to a version mismatch in `/etc/stemcell_version`.