### PR TITLE
Fix progress indication for the Terminal.app on macOS

### DIFF
--- a/bosh_cli/lib/cli/interactive_progress_renderer.rb
+++ b/bosh_cli/lib/cli/interactive_progress_renderer.rb
@@ -48,11 +48,11 @@ module Bosh::Cli
     end
 
     def save_cursor_position
-      say("\033[s", "")
+      say("\033\067", "")
     end
 
     def restore_cursor_position
-      say("\033[u", "")
+      say("\033\070", "")
     end
 
     def up(count = 1)


### PR DESCRIPTION
Some commands, e.g. "bosh sync blobs" indicate the progress of background
jobs by continuously rewriting a status line in the terminal.
Example: downloading 14.4M (9%) - the percentage is updated to show
progress.

Unfortunately, the Terminal.app does not support the [s and [u escape
sequences to save and restore the cursor position, which leads to
chaotically overwriting the screen with the progress updates in the
Terminal.app, instead of just updating the status line.

Fortunately, both the Terminal.app and iTerm.app support the functionally
equivalent 7 and 8 escape sequences to save and restore the cursor
positions, as described in the ANSI/VT100 Terminal Control Escape
Sequences [1] document.

The octal representation of the ANSI character 7 is \067 and \070 for 8.

Simple example for trying out in the terminal:

  $ echo -e "\033[sHello world\033[uHELLO"
  HELLO world # in iTerm.app - this is the expected result
  Hello worldHELLO # in Terminal.app -- broken

  $ echo -e "\033\067Hello world\033\070HELLO"
  HELLO world # in iTerm.app and in Terminal.app

So the fix is to replace the hard coded escape sequences [s, [u with the
(octal representation of) 7, 8 escape sequences. The octal representation
is necessary to separate it from the octal representation of the ESC
character.

[1] http://www.termsys.demon.co.uk/vtansi.htm
      Save current cursor position                         <ESC>[s
      Restores cursor position after a Save Cursor         <ESC>[u
      Save current cursor position & Attrs                 <ESC>7
      Restores cursor position after a Save Cursor & Attrs <ESC>8