### PR TITLE
Avoid installing EFI grub

### DIFF
--- a/bosh-stemcell/spec/support/stemcell_shared_examples.rb
+++ b/bosh-stemcell/spec/support/stemcell_shared_examples.rb
@@ -20,6 +20,12 @@ shared_examples_for 'All Stemcells' do
     end
   end
 
+  context 'grub does not install an EFI bootloader' do
+    describe file('/boot/efi') do
+      it { should_not be_directory }
+    end
+  end
+
   context 'disable remote host login (stig: V-38491)' do
     describe command('find /home -name .rhosts') do
       its (:stdout) { should eq('') }

--- a/stemcell_builder/stages/image_install_grub/apply.sh
+++ b/stemcell_builder/stages/image_install_grub/apply.sh
@@ -77,7 +77,7 @@ if ! is_ppc64le; then
     echo "(hd0) ${device}" > ${image_mount_point}/device.map
 
     # install bootsector into disk image file
-    run_in_chroot ${image_mount_point} "grub2-install -v --no-floppy --grub-mkdevicemap=/device.map ${device}"
+    run_in_chroot ${image_mount_point} "grub2-install -v --no-floppy --grub-mkdevicemap=/device.map --target=i386-pc ${device}"
 
     cat >${image_mount_point}/etc/default/grub <<EOF
 GRUB_CMDLINE_LINUX="vconsole.keymap=us net.ifnames=0 crashkernel=auto selinux=0 plymouth.enable=0 console=ttyS0,115200n8 earlyprintk=ttyS0 rootdelay=300 audit=1"


### PR DESCRIPTION
If the machine which is running the docker container is booting from EFI, then the
grub2-install inside the chroot, inside docker, will see
/sys/firmware/efi and decide to install an EFI bootloader. This will fail. The stemcell
should not be using EFI at all.