### PR TITLE
save logs and stderr when error occurs

### DIFF
--- a/bosh_cpi/lib/cloud/external_cpi.rb
+++ b/bosh_cpi/lib/cloud/external_cpi.rb
@@ -85,12 +85,12 @@ module Bosh::Clouds
       parsed_response = parsed_response(cpi_response)
       validate_response(parsed_response)
 
+      save_cpi_log(parsed_response['log'])
+      save_cpi_log(stderr)
+
       if parsed_response['error']
         handle_error(parsed_response['error'], method_name)
       end
-
-      save_cpi_log(parsed_response['log'])
-      save_cpi_log(stderr)
 
       parsed_response['result']
     end

--- a/bosh_cpi/spec/unit/external_cpi_spec.rb
+++ b/bosh_cpi/spec/unit/external_cpi_spec.rb
@@ -156,6 +156,16 @@ describe Bosh::Clouds::ExternalCpi do
         it 'raises an error constructed from error response' do
           expect { call_cpi_method }.to raise_error(error_class, "CPI error '#{error_class}' with message 'fake-error-message' in '#{method}' CPI method")
         end
+
+        it 'saves log and stderr' do
+          begin
+            call_cpi_method
+          rescue
+            expect(File.read(cpi_log_path)).to eq('fake-logfake-stderr-data')
+          else
+            fail 'It should throw exception'
+          end
+        end
       end
 
       def self.it_raises_an_error_with_ok_to_retry(error_class)


### PR DESCRIPTION
- as of now when the External CPI returns a response with error the
BOSH director only raises the exception and does NOT save the logs or stderr

[#134605661](https://www.pivotaltracker.com/story/show/134605661)

Signed-off-by: Chris Dutra <cdutra@pivotal.io>