### PR TITLE
Make bosh follow 301 redirects when downloading releases

### DIFF
--- a/bosh-director/lib/bosh/director/download_helper.rb
+++ b/bosh-director/lib/bosh/director/download_helper.rb
@@ -24,7 +24,7 @@ module Bosh::Director
                 end
               end
 
-            when Net::HTTPFound
+            when Net::HTTPFound, Net::HTTPMovedPermanently
               raise ResourceError, "Too many redirects at '#{remote_file}'." if num_redirects >= 9
               location = response.header['location']
               raise ResourceError, "No location header for redirect found at '#{remote_file}'." if location.nil?


### PR DESCRIPTION
It currently follows 302 redirects, but throws the following error for a
301 redirect:

```
ERROR -- DirectorJobRunner: Downloading remote release from http://example.com/path/to/release.tgz failed: Moved Permanently
```

This updates it to handle 301s in the same way as 302s.