### PR TITLE
Don't swallow JSON errors when writing instance.spec

### DIFF
--- a/bosh-director/lib/bosh/director/models/instance.rb
+++ b/bosh-director/lib/bosh/director/models/instance.rb
@@ -112,11 +112,7 @@ module Bosh::Director::Models
       if spec.nil?
         self.spec_json = nil
       else
-        begin
-          self.spec_json = JSON.generate(spec)
-        rescue JSON::GeneratorError
-          self.spec_json = 'error'
-        end
+        self.spec_json = JSON.generate(spec)
       end
     end
 

--- a/bosh-director/spec/unit/cloudcheck_helper_spec.rb
+++ b/bosh-director/spec/unit/cloudcheck_helper_spec.rb
@@ -119,7 +119,7 @@ module Bosh::Director
         end
 
         it 'whines on invalid spec format' do
-          instance.update(spec: 'error')
+          instance.update(spec_json: 'error')
 
           expect {
             test_problem_handler.apply_resolution(:recreate_vm)

--- a/bosh-director/spec/unit/dns/dns_manager_spec.rb
+++ b/bosh-director/spec/unit/dns/dns_manager_spec.rb
@@ -551,7 +551,7 @@ module Bosh::Director
         context 'when instance.spec is not nil' do
           context 'when spec[networks] is nil' do
             it 'skips the instance' do
-              test_validate_spec('{"networks": nil}')
+              test_validate_spec('{"networks": null}')
             end
           end
 


### PR DESCRIPTION
We ran into an issue where a second deployment of a manifest would always fail at the preparing deployment stage with the error: `undefined method 'fetch' for "error":String`. The initial deployment had completed without error, so this second deployment should have been a no-op.

Upon digging, this was being raised in [`instance_network_reservations.rb`#L30](https://github.com/cloudfoundry/bosh/blob/0c3b651/bosh-director/lib/bosh/director/deployment_plan/instance_network_reservations.rb#L30) because instance.spec was returning the string 'error' as opposed to a hash.

With the code change in this PR applied to our bosh, the first deployment failed with an error which led to the problem in our manifest (we had an infinity value in there due to some YAML incompatability issues in our pipeline).

This conditional was originally added in a commit to switch away from Yajl (5b08045), which didn't mention anything about adding it.

Fixing this has also revealed a bug in the dns manager spec (writing `nil` instead of `null` in the JSON string).