### PR TITLE
Add context_id to tasks for deployments and errands

### DIFF
--- a/src/bosh-director/db/migrations/director/20161209104649_add_context_id_to_tasks.rb
+++ b/src/bosh-director/db/migrations/director/20161209104649_add_context_id_to_tasks.rb
@@ -1,7 +1,8 @@
 Sequel.migration do
   change do
     alter_table :tasks do
-      add_column :context_id, String, default: '', null: false
+      add_column :context_id, String, size: 64, default: '', null: false
+      add_index :context_id
     end
   end
 end

--- a/src/bosh-director/db/migrations/director/20161209104649_add_context_id_to_tasks.rb
+++ b/src/bosh-director/db/migrations/director/20161209104649_add_context_id_to_tasks.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table :tasks do
+      add_column :context_id, String, default: '', null: false
+    end
+  end
+end

--- a/src/bosh-director/lib/bosh/director/api/controllers/base_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/base_controller.rb
@@ -70,6 +70,8 @@ module Bosh::Director
               throw(:halt, [401, message])
             end
           end
+
+          @current_context_id = request.env.fetch('X-Bosh-Context-Id', '')
         end
 
         def requires_authentication?

--- a/src/bosh-director/lib/bosh/director/api/controllers/base_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/base_controller.rb
@@ -71,7 +71,11 @@ module Bosh::Director
             end
           end
 
-          @current_context_id = request.env.fetch('X-Bosh-Context-Id', '')
+          @current_context_id = request.env.fetch('HTTP_X_BOSH_CONTEXT_ID', '')
+
+          if @current_context_id.length > 64
+              raise ContextIdViolatedMax, "X-Bosh-Context-Id cannot be more than 64 characters in length"
+          end
         end
 
         def requires_authentication?

--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -257,7 +257,7 @@ module Bosh::Director
         options = {}
         options['force'] = true if params['force'] == 'true'
         options['keep_snapshots'] = true if params['keep_snapshots'] == 'true'
-        task = @deployment_manager.delete_deployment(current_user, deployment, options)
+        task = @deployment_manager.delete_deployment(current_user, deployment, options, @current_context_id)
         redirect "/tasks/#{task.id}"
       end
 
@@ -372,7 +372,7 @@ module Bosh::Director
         options['new'] = Models::Deployment[name: deployment_name].nil? ? true : false
         deployment_model = @deployments_repo.find_or_create_by_name(deployment_name, options)
 
-        task = @deployment_manager.create_deployment(current_user, YAML.dump(deployment), cloud_config, runtime_config, deployment_model, options)
+        task = @deployment_manager.create_deployment(current_user, YAML.dump(deployment), cloud_config, runtime_config, deployment_model, options, @current_context_id)
 
         redirect "/tasks/#{task.id}"
       end
@@ -424,7 +424,8 @@ module Bosh::Director
           Jobs::RunErrand,
           "run errand #{errand_name} from deployment #{deployment.name}",
           [deployment.name, errand_name, keep_alive],
-          deployment
+          deployment,
+          @current_context_id
         )
 
         redirect "/tasks/#{task.id}"

--- a/src/bosh-director/lib/bosh/director/api/controllers/tasks_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/tasks_controller.rb
@@ -50,6 +50,10 @@ module Bosh::Director
           ])
         end
 
+        if context_id = params['context_id']
+          dataset = dataset.filter(:context_id => context_id)
+        end
+
         if limit = params['limit']
           limit = limit.to_i
           limit = 1 if limit < 1

--- a/src/bosh-director/lib/bosh/director/api/deployment_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/deployment_manager.rb
@@ -15,18 +15,18 @@ module Bosh::Director
         Bosh::Director::Models::Deployment.order_by(Sequel.asc(:name)).all
       end
 
-      def create_deployment(username, manifest_text, cloud_config, runtime_config, deployment, options = {})
+      def create_deployment(username, manifest_text, cloud_config, runtime_config, deployment, options = {}, context_id = '')
         cloud_config_id = cloud_config.nil? ? nil : cloud_config.id
         runtime_config_id = runtime_config.nil? ? nil : runtime_config.id
 
         description = 'create deployment'
         description += ' (dry run)' if options['dry_run']
 
-        JobQueue.new.enqueue(username, Jobs::UpdateDeployment, description, [manifest_text, cloud_config_id, runtime_config_id, options], deployment)
+        JobQueue.new.enqueue(username, Jobs::UpdateDeployment, description, [manifest_text, cloud_config_id, runtime_config_id, options], deployment, context_id)
       end
 
-      def delete_deployment(username, deployment, options = {})
-        JobQueue.new.enqueue(username, Jobs::DeleteDeployment, "delete deployment #{deployment.name}", [deployment.name, options], deployment)
+      def delete_deployment(username, deployment, options = {}, context_id = '')
+        JobQueue.new.enqueue(username, Jobs::DeleteDeployment, "delete deployment #{deployment.name}", [deployment.name, options], deployment, context_id)
       end
 
       def deployment_instances_with_vms(deployment)

--- a/src/bosh-director/lib/bosh/director/api/task_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/task_manager.rb
@@ -27,7 +27,8 @@ module Bosh::Director
           "started_at" => task.started_at ? task.started_at.to_i: nil,
           "result" => task.result,
           "user" => task.username || "admin",
-          "deployment" => task.deployment_name
+          "deployment" => task.deployment_name,
+          "context_id" => task.context_id
         }
       end
 

--- a/src/bosh-director/lib/bosh/director/errors.rb
+++ b/src/bosh-director/lib/bosh/director/errors.rb
@@ -111,6 +111,7 @@ module Bosh::Director
   InstanceTargetStateUndefined = err(70007)
   SnapshotNotFound = err(70008)
   JobNotFound = err(70009, NOT_FOUND)
+  ContextIdViolatedMax = err(70010)
 
   # Extracting job from a release
   JobInvalidArchive = err(80000)

--- a/src/bosh-director/lib/bosh/director/job_queue.rb
+++ b/src/bosh-director/lib/bosh/director/job_queue.rb
@@ -5,8 +5,8 @@ module Bosh::Director
   # Abstracts the delayed jobs system.
 
   class JobQueue
-    def enqueue(username, job_class, description, params, deployment = nil)
-      task = create_task(username, job_class.job_type, description, deployment)
+    def enqueue(username, job_class, description, params, deployment = nil, context_id = '')
+      task = create_task(username, job_class.job_type, description, deployment, context_id)
 
       Delayed::Worker.backend = :sequel
       db_job = Bosh::Director::Jobs::DBJob.new(job_class, task.id, params)
@@ -19,7 +19,7 @@ module Bosh::Director
 
     private
 
-    def create_task(username, type, description, deployment)
+    def create_task(username, type, description, deployment, context_id)
       task = Models::Task.create_with_teams(:username => username,
         :type => type,
         :description => description,
@@ -27,7 +27,8 @@ module Bosh::Director
         :deployment_name => deployment ? deployment.name : nil,
         :timestamp => Time.now,
         :teams => deployment ? deployment.teams : nil,
-        :checkpoint_time => Time.now)
+        :checkpoint_time => Time.now,
+        :context_id => context_id)
       log_dir = File.join(Config.base_dir, 'tasks', task.id.to_s)
       FileUtils.rm_rf(log_dir)
       task_status_file = File.join(log_dir, 'debug')

--- a/src/bosh-director/spec/unit/api/controllers/base_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/base_controller_spec.rb
@@ -95,6 +95,29 @@ module Bosh
               end
             end
           end
+
+          context 'when specifying X-Bosh-Context-Id' do
+            let(:authenticates_successfully) { true }
+            before { basic_authorize 'admin', 'admin' }
+
+            it 'succeeds when the header is below 64 chars' do
+              valid_context_id = "x" * 64
+              header('X-Bosh-Context-Id', 'something')
+
+              get '/test_route'
+              expect(last_response.status).to eq(200)
+            end
+
+            it 'fails when the header is above 64 chars' do
+              invalid_context_id = "x" * 65
+              header('X-Bosh-Context-Id', invalid_context_id)
+
+              get '/test_route'
+              expect(last_response.status).to eq(400)
+              expect(JSON.parse(last_response.body)['code']).to eq(70010)
+              expect(JSON.parse(last_response.body)['description']).to eq('X-Bosh-Context-Id cannot be more than 64 characters in length')
+            end
+          end
         end
       end
     end

--- a/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -51,6 +51,19 @@ module Bosh::Director
               expect_redirect_to_queued_task(last_response)
             end
 
+            it 'accepts a context ID header' do
+              context_id = 'example-context-id'
+              post '/', spec_asset('test_conf.yaml'), {'CONTENT_TYPE' => 'text/yaml', 'X-Bosh-Context-Id' => context_id}
+              task = expect_redirect_to_queued_task(last_response)
+              expect(task.context_id).to eq(context_id)
+            end
+
+            it 'defaults to no context ID' do
+              post '/', spec_asset('test_conf.yaml'), {'CONTENT_TYPE' => 'text/yaml'}
+              task = expect_redirect_to_queued_task(last_response)
+              expect(task.context_id).to eq('')
+            end
+
             it 'only consumes text/yaml' do
               post '/', spec_asset('test_conf.yaml'), {'CONTENT_TYPE' => 'text/plain'}
               expect(last_response.status).to eq(404)
@@ -106,7 +119,7 @@ module Bosh::Director
 
                 allow_any_instance_of(DeploymentManager)
                   .to receive(:create_deployment)
-                  .with(anything, anything, cloud_config, runtime_config, anything, anything)
+                  .with(anything, anything, cloud_config, runtime_config, anything, anything, anything)
                   .and_return(Models::Task.make)
 
                 post "/?#{URI.encode_www_form(deployment_context)}", spec_asset('test_conf.yaml'), {'CONTENT_TYPE' => 'text/yaml'}
@@ -160,7 +173,7 @@ module Bosh::Director
             it 'does not skip draining' do
               allow_any_instance_of(DeploymentManager)
                 .to receive(:create_deployment)
-                .with(anything(), anything(), anything(), anything(), anything(), hash_excluding('skip_drain'))
+                .with(anything(), anything(), anything(), anything(), anything(), hash_excluding('skip_drain'), anything())
                 .and_return(OpenStruct.new(:id => 1))
               post '/', spec_asset('test_conf.yaml'), { 'CONTENT_TYPE' => 'text/yaml' }
               expect(last_response).to be_redirect
@@ -171,7 +184,7 @@ module Bosh::Director
             it 'skips draining' do
               allow_any_instance_of(DeploymentManager)
                 .to receive(:create_deployment)
-                .with(anything(), anything(), anything(), anything(), anything(), hash_including('skip_drain' => '*'))
+                .with(anything(), anything(), anything(), anything(), anything(), hash_including('skip_drain' => '*'),  anything())
                 .and_return(OpenStruct.new(:id => 1))
               post '/?skip_drain=*', spec_asset('test_conf.yaml'), { 'CONTENT_TYPE' => 'text/yaml' }
               expect(last_response).to be_redirect
@@ -182,7 +195,7 @@ module Bosh::Director
             it 'skips draining' do
               expect_any_instance_of(DeploymentManager)
                 .to receive(:create_deployment)
-                .with(anything(), anything(), anything(), anything(), anything(), hash_including('skip_drain' => 'job_one,job_two'))
+                .with(anything(), anything(), anything(), anything(), anything(), hash_including('skip_drain' => 'job_one,job_two'), anything())
                 .and_return(OpenStruct.new(:id => 1))
               post '/?skip_drain=job_one,job_two', spec_asset('test_conf.yaml'), { 'CONTENT_TYPE' => 'text/yaml' }
               expect(last_response).to be_redirect
@@ -193,7 +206,7 @@ module Bosh::Director
             it 'passes the parameter' do
               allow_any_instance_of(DeploymentManager)
                 .to receive(:create_deployment)
-                .with(anything(), anything(), anything(), anything(), anything(), hash_including('fix' => true))
+                .with(anything(), anything(), anything(), anything(), anything(), hash_including('fix' => true), anything())
                 .and_return(OpenStruct.new(:id => 1))
               post '/?fix=true', spec_asset('test_conf.yaml'), {'CONTENT_TYPE' => 'text/yaml'}
               expect(last_response).to be_redirect
@@ -204,7 +217,7 @@ module Bosh::Director
             it 'calls create deployment with deployment name' do
               expect_any_instance_of(DeploymentManager)
                   .to receive(:create_deployment)
-                          .with(anything(), anything(), anything(), anything(), deployment, hash_excluding('skip_drain'))
+                          .with(anything(), anything(), anything(), anything(), deployment, hash_excluding('skip_drain'), anything())
                           .and_return(OpenStruct.new(:id => 1))
               post '/', spec_asset('test_manifest.yml'), { 'CONTENT_TYPE' => 'text/yaml' }
               expect(last_response).to be_redirect
@@ -215,7 +228,7 @@ module Bosh::Director
             it 'to false' do
               expect_any_instance_of(DeploymentManager)
                   .to receive(:create_deployment)
-                          .with(anything(), anything(), anything(), anything(), deployment, hash_including('new' => false))
+                          .with(anything(), anything(), anything(), anything(), deployment, hash_including('new' => false), anything())
                           .and_return(OpenStruct.new(:id => 1))
               post '/', spec_asset('test_manifest.yml'), { 'CONTENT_TYPE' => 'text/yaml' }
             end
@@ -223,7 +236,7 @@ module Bosh::Director
             it 'to true' do
               expect_any_instance_of(DeploymentManager)
                   .to receive(:create_deployment)
-                          .with(anything(), anything(), anything(), anything(), anything(), hash_including('new' => true))
+                          .with(anything(), anything(), anything(), anything(), anything(), hash_including('new' => true), anything())
                           .and_return(OpenStruct.new(:id => 1))
                Models::Deployment.first.delete
               post '/', spec_asset('test_manifest.yml'), { 'CONTENT_TYPE' => 'text/yaml' }
@@ -238,6 +251,16 @@ module Bosh::Director
 
             delete '/test_deployment'
             expect_redirect_to_queued_task(last_response)
+          end
+
+          it 'accepts a context id' do
+            context_id = 'example-context-id'
+            deployment = Models::Deployment.create(:name => 'test_deployment', :manifest => YAML.dump({'foo' => 'bar'}))
+
+            delete '/test_deployment', "", {'X-Bosh-Context-Id' => context_id}
+
+            task = expect_redirect_to_queued_task(last_response)
+            expect(task.context_id).to eq(context_id)
           end
         end
 
@@ -1080,6 +1103,27 @@ module Bosh::Director
                   ).and_return(task)
 
                   perform({})
+                end
+
+                it 'sets context id on the RunErrand task' do
+                  context_id = 'example-context-id'
+                  expect(job_queue).to receive(:enqueue).with(
+                    'admin',
+                    Jobs::RunErrand,
+                    'run errand fake-errand-name from deployment fake-dep-name',
+                    ['fake-dep-name', 'fake-errand-name', false],
+                    deployment,
+                    context_id
+                  ).and_return(task)
+
+                  post(
+                    '/fake-dep-name/errands/fake-errand-name/runs',
+                    JSON.dump({}),
+                    {
+                      'CONTENT_TYPE' => 'application/json',
+                      'X-Bosh-Context-Id' => context_id
+                    }
+                  )
                 end
 
                 it 'enqueues a keep-alive task' do

--- a/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -53,7 +53,8 @@ module Bosh::Director
 
             it 'accepts a context ID header' do
               context_id = 'example-context-id'
-              post '/', spec_asset('test_conf.yaml'), {'CONTENT_TYPE' => 'text/yaml', 'X-Bosh-Context-Id' => context_id}
+              header('X-Bosh-Context-Id', context_id)
+              post '/', spec_asset('test_conf.yaml'), {'CONTENT_TYPE' => 'text/yaml'}
               task = expect_redirect_to_queued_task(last_response)
               expect(task.context_id).to eq(context_id)
             end
@@ -257,7 +258,8 @@ module Bosh::Director
             context_id = 'example-context-id'
             deployment = Models::Deployment.create(:name => 'test_deployment', :manifest => YAML.dump({'foo' => 'bar'}))
 
-            delete '/test_deployment', "", {'X-Bosh-Context-Id' => context_id}
+            header('X-Bosh-Context-Id', context_id)
+            delete '/test_deployment'
 
             task = expect_redirect_to_queued_task(last_response)
             expect(task.context_id).to eq(context_id)
@@ -1099,7 +1101,8 @@ module Bosh::Director
                     Jobs::RunErrand,
                     'run errand fake-errand-name from deployment fake-dep-name',
                     ['fake-dep-name', 'fake-errand-name', false],
-                    deployment
+                    deployment,
+                    ""
                   ).and_return(task)
 
                   perform({})
@@ -1116,12 +1119,12 @@ module Bosh::Director
                     context_id
                   ).and_return(task)
 
+                  header('X-Bosh-Context-Id', context_id)
                   post(
                     '/fake-dep-name/errands/fake-errand-name/runs',
                     JSON.dump({}),
                     {
-                      'CONTENT_TYPE' => 'application/json',
-                      'X-Bosh-Context-Id' => context_id
+                      'CONTENT_TYPE' => 'application/json'
                     }
                   )
                 end
@@ -1132,7 +1135,8 @@ module Bosh::Director
                     Jobs::RunErrand,
                     'run errand fake-errand-name from deployment fake-dep-name',
                     ['fake-dep-name', 'fake-errand-name', true],
-                    deployment
+                    deployment,
+                    ""
                   ).and_return(task)
 
                   perform({'keep-alive' => true})

--- a/src/bosh-director/spec/unit/api/deployment_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/deployment_manager_spec.rb
@@ -21,6 +21,7 @@ module Bosh::Director
 
           expect(create_task.description).to eq('create deployment')
           expect(create_task.deployment_name).to eq('DEPLOYMENT_NAME')
+          expect(create_task.context_id).to eq('')
         end
 
         it 'passes a nil cloud config id and runtime config id if there is no cloud config or runtime config' do
@@ -31,6 +32,15 @@ module Bosh::Director
 
           subject.create_deployment(username, 'manifest', nil, nil, deployment, options)
         end
+
+        it 'passes context id' do
+          cloud_config = Models::CloudConfig.make
+          runtime_config = Models::RuntimeConfig.make
+          context_id = 'example-context-id'
+          create_task = subject.create_deployment(username, 'manifest', cloud_config, runtime_config, deployment, options, context_id)
+
+          expect(create_task.context_id).to eq context_id
+        end
     end
 
     describe '#delete_deployment' do
@@ -39,6 +49,12 @@ module Bosh::Director
 
         expect(delete_task.description).to eq('delete deployment DEPLOYMENT_NAME')
         expect(delete_task.deployment_name).to eq('DEPLOYMENT_NAME')
+      end
+
+      it 'passes context id' do
+        context_id = 'example-context-id'
+        delete_task = subject.delete_deployment(username, deployment, options, context_id)
+        expect(delete_task.context_id).to eq context_id
       end
     end
 

--- a/src/bosh-director/spec/unit/db/migrations/director/20161209104649_add_context_id_to_tasks_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/20161209104649_add_context_id_to_tasks_spec.rb
@@ -1,0 +1,18 @@
+require 'db_spec_helper'
+
+module Bosh::Director
+  describe 'adding context id to tasks' do
+    let(:db) { DBSpecHelper.db }
+    let(:migration_file) { '20161209104649_add_context_id_to_tasks.rb' }
+
+    before { DBSpecHelper.migrate_all_before(migration_file) }
+
+    it 'sets the default value of the context_id to empty string' do
+      db[:tasks] << {id: 1, state: 'alabama', timestamp: '2016-12-09 11:53:42', description: 'descr', type: 'type'}
+
+      DBSpecHelper.migrate(migration_file)
+
+      expect(db[:tasks].first[:context_id]).to eq('')
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/db/migrations/director/add_data_migration_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/add_data_migration_spec.rb
@@ -9,7 +9,7 @@ module Bosh::Director
       # populated with data. This test will fail every time a new migration script is added. Change
       # the file name below to the latest when a test is added.
       # Look at tests in this directory for similar examples: bosh-director/spec/unit/db/migrations/director
-      expect(latest_db_migration_file).to eq('20161109201807_create_placeholder_name_id_mapping.rb')
+      expect(latest_db_migration_file).to eq('20161209104649_add_context_id_to_tasks.rb')
     end
   end
 end

--- a/src/bosh-director/spec/unit/job_queue_spec.rb
+++ b/src/bosh-director/spec/unit/job_queue_spec.rb
@@ -45,6 +45,14 @@ module Bosh::Director
         expect(Delayed::Job.first[:queue]).to eq('sample')
       end
 
+      it 'enqueues a job with a context id' do
+        expect(Jobs::DBJob).to receive(:new).with(job_class, 1, ['foo', 'bar']).and_return(Jobs::DBJob.new(job_class, 1,  ['foo', 'bar']))
+        expect(Delayed::Job.count).to eq(0)
+        context_id = 'example-context-id'
+        retval = subject.enqueue('whoami', job_class, description, ['foo', 'bar'], deployment, context_id)
+        expect(retval.context_id).to eq(context_id)
+      end
+
       it 'should clean up old tasks of the given type' do
         expect(task_remover).to receive(:remove).with(job_class.job_type)
 


### PR DESCRIPTION
CF BOSH Tracker story [#134702861](https://www.pivotaltracker.com/n/projects/956238/stories/134702861)

## Why

As a bosh user
I can assign a context to bosh deployments and errands
So that I can query a group of bosh tasks

This could be extended to other bosh tasks in future.

## What

This PR extends the BOSH Director API.
No changes to the bosh CLI.

Accept `X-Bosh-Context-Id` header in the following requests:
- `POST /deployments` - create & update deployment
- `DELETE /deployments/:deployment` - delete deployment
- `POST /deployments/:deployment/errands/:errand_name/runs` - run errand

Accept `context_id` query parameter for:
- `GET /tasks` - list tasks

Add `context_id` column to tasks table
Add `context_id` to JSON response for tasks

Sam and @jamesjoshuahill 

cc: @avade