### PR TITLE
Adds unique request ID, start / end times to each CPI call in logs

### DIFF
--- a/src/bosh_cpi/lib/bosh/cpi.rb
+++ b/src/bosh_cpi/lib/bosh/cpi.rb
@@ -3,4 +3,5 @@ module Bosh
 end
 
 require 'bosh/cpi/cli'
+require 'bosh/cpi/logger'
 require 'bosh/cpi/registry_client'

--- a/src/bosh_cpi/lib/bosh/cpi/logger.rb
+++ b/src/bosh_cpi/lib/bosh/cpi/logger.rb
@@ -1,0 +1,15 @@
+require 'logger'
+
+class Bosh::Cpi::Logger < Logger
+
+  def initialize(log_device)
+    super(log_device)
+  end
+
+  def set_request_id(req_id)
+    original_formatter = Logger::Formatter.new
+    self.formatter = proc { |severity, datetime, progname, msg|
+      original_formatter.call(severity, datetime, "[req_id #{req_id}]#{progname}", msg)
+    }
+  end
+end

--- a/src/bosh_cpi/lib/cloud/external_cpi.rb
+++ b/src/bosh_cpi/lib/cloud/external_cpi.rb
@@ -68,7 +68,8 @@ module Bosh::Clouds
 
     def invoke_cpi_method(method_name, *arguments)
       context = {
-          'director_uuid' => @director_uuid
+          'director_uuid' => @director_uuid,
+          'request_id' => "#{Random.rand(100000..999999)}"
       }
       context.merge!(@properties_from_cpi_config) unless @properties_from_cpi_config.nil?
 

--- a/src/bosh_cpi/spec/unit/external_cpi_spec.rb
+++ b/src/bosh_cpi/spec/unit/external_cpi_spec.rb
@@ -21,6 +21,7 @@ describe Bosh::Clouds::ExternalCpi do
     before { FileUtils.mkdir_p('/var/vcap/task/5') }
 
     before { allow(Open3).to receive(:capture3).and_return([cpi_response, 'fake-stderr-data', exit_status]) }
+    before { allow(Random).to receive(:rand).and_return('fake-request-id') }
     let(:exit_status) { instance_double('Process::Status', exitstatus: 0) }
 
     it 'calls cpi binary with correct arguments' do
@@ -28,7 +29,7 @@ describe Bosh::Clouds::ExternalCpi do
 
       expected_env = {'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp'}
       expected_cmd = '/path/to/fake-cpi/bin/cpi'
-      expected_stdin = %({"method":"#{cpi_method}","arguments":#{arguments.to_json},"context":{"director_uuid":"fake-director-uuid"}})
+      expected_stdin = %({"method":"#{cpi_method}","arguments":#{arguments.to_json},"context":{"director_uuid":"fake-director-uuid","request_id":"fake-request-id"}})
 
       expect(Open3).to receive(:capture3).with(expected_env, expected_cmd, stdin_data: expected_stdin, unsetenv_others: true)
       call_cpi_method
@@ -36,6 +37,7 @@ describe Bosh::Clouds::ExternalCpi do
 
     context 'if properties from cpi config are given' do
       let(:director_uuid) {'fake-director-uuid'}
+      let(:request_id) {'fake-request-id'}
       let(:cpi_config_properties) { {'key1' => {'nestedkey1' => 'nestedvalue1'}, 'key2' => 'value2'} }
       let(:external_cpi) { described_class.new('/path/to/fake-cpi/bin/cpi', director_uuid, cpi_config_properties ) }
       let(:logger) { double }
@@ -50,7 +52,7 @@ describe Bosh::Clouds::ExternalCpi do
 
         expected_env = {'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp'}
         expected_cmd = '/path/to/fake-cpi/bin/cpi'
-        context = {'director_uuid' => director_uuid}.merge(cpi_config_properties)
+        context = {'director_uuid' => director_uuid, 'request_id' => request_id}.merge(cpi_config_properties)
         expected_stdin = %({"method":"#{cpi_method}","arguments":#{arguments.to_json},"context":#{context.to_json}})
 
         expect(Open3).to receive(:capture3).with(expected_env, expected_cmd, stdin_data: expected_stdin, unsetenv_others: true)
@@ -62,15 +64,17 @@ describe Bosh::Clouds::ExternalCpi do
 
         expected_env = {'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp'}
         expected_cmd = '/path/to/fake-cpi/bin/cpi'
-        context = {'director_uuid' => director_uuid}.merge(cpi_config_properties)
+        context = {'director_uuid' => director_uuid, 'request_id' => request_id}.merge(cpi_config_properties)
         redacted_context = {
             'director_uuid' => director_uuid,
+            'request_id' => request_id,
             'key1' => '<redacted>',
             'key2' => '<redacted>'
         }
         expected_stdin = %({"method":"#{cpi_method}","arguments":#{arguments.to_json},"context":#{context.to_json}})
         expected_log = %(External CPI sending request: {"method":"#{cpi_method}","arguments":#{arguments.to_json},"context":#{redacted_context.to_json}} with command: #{expected_cmd})
         expect(logger).to receive(:debug).with(expected_log)
+
         expect(Open3).to receive(:capture3).with(expected_env, expected_cmd, stdin_data: expected_stdin, unsetenv_others: true)
         call_cpi_method
       end


### PR DESCRIPTION
- external_cpi gem generates request-uuid and passes to CPI
- Adds Bosh::Cpi::Logger class which can be used by Ruby CPIs
  - Uses standard ruby logger + custom formatter to include request ID
  - Use logger.set_request_id(context['request_id'])

Example:
```
I, [2016-12-12T15:49:13.350615 #77354]  INFO -- [req_id 123456]: Starting current_vm_id...
<CPI LOGS>
I, [2016-12-12T15:49:13.350661 #77354]  INFO -- [req_id 123456]: Finished current_vm_id in 90.45 seconds
```

[#135803903](https://www.pivotaltracker.com/story/show/135803903)

Signed-off-by: Karen Huddleston <khuddleston@pivotal.io>