### PR TITLE
fix monit restart director_nginx did not work

### DIFF
--- a/release/jobs/director/templates/nginx_ctl
+++ b/release/jobs/director/templates/nginx_ctl
@@ -9,6 +9,10 @@ SSL_DIR=/var/vcap/jobs/director/config/ssl
 TMP_DIR=/var/vcap/data/director/tmp
 RUNAS=vcap
 
+function pid_exists() {
+  ps -p $1 &> /dev/null
+}
+
 case $1 in
 
   start)
@@ -41,7 +45,9 @@ case $1 in
 
   stop)
     PID=$(head -1 $PIDFILE)
-    kill $PID
+    if [ ! -z $PID ] && pid_exists $PID; then
+      kill $PID
+    fi
     while [ -e /proc/$PID ]; do sleep 0.1; done
     rm -f $PIDFILE
     ;;

--- a/release/jobs/director/templates/nginx_ctl
+++ b/release/jobs/director/templates/nginx_ctl
@@ -9,16 +9,10 @@ SSL_DIR=/var/vcap/jobs/director/config/ssl
 TMP_DIR=/var/vcap/data/director/tmp
 RUNAS=vcap
 
-function pid_exists() {
-  ps -p $1 &> /dev/null
-}
-
 case $1 in
 
   start)
     mkdir -p $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
-
-    echo $$ > $PIDFILE
 
     chown -R $RUNAS:$RUNAS $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
 
@@ -39,15 +33,14 @@ case $1 in
         -signkey $STORE_DIR/director.key -out $STORE_DIR/director.pem
     fi
 
-    exec chpst -u $RUNAS:$RUNAS /var/vcap/packages/nginx/sbin/nginx -c $JOB_DIR/config/nginx.conf \
+    chpst -u $RUNAS:$RUNAS /var/vcap/packages/nginx/sbin/nginx -c $JOB_DIR/config/nginx.conf \
       >>$LOG_DIR/nginx.stdout.log 2>>$LOG_DIR/nginx.stderr.log
+    ps aux | awk '/[m]aster/ && /nginx.conf/ && /director/{print $2}' > ${PIDFILE}
     ;;
 
   stop)
     PID=$(head -1 $PIDFILE)
-    if [ ! -z $PID ] && pid_exists $PID; then
-      kill $PID
-    fi
+    kill $PID
     while [ -e /proc/$PID ]; do sleep 0.1; done
     rm -f $PIDFILE
     ;;


### PR DESCRIPTION
When I ran  `monit restart director_nginx`, it failed and `monit summary` showed that `Process director_nginx does not exist`. 

The reason is that the PID file does not match the PID of the running director_nginx process.

The fix in this PR directly borrows how the stop function is written for the `blobstore_nginx` job.