### PR TITLE
Update director monit

### DIFF
--- a/jobs/director/monit
+++ b/jobs/director/monit
@@ -1,6 +1,6 @@
 check process director
   with pidfile /var/vcap/sys/run/director/director.pid
-  start program "/var/vcap/jobs/director/bin/director_ctl start"
+  start program "/var/vcap/jobs/director/bin/director_ctl start" with timeout 75 seconds
   stop program "/var/vcap/jobs/director/bin/director_ctl stop"
   group vcap
   <% if properties.micro %>
@@ -21,6 +21,6 @@ check process director_scheduler
   group vcap
 check process director_nginx
   with pidfile /var/vcap/sys/run/director/nginx.pid
-  start program "/var/vcap/jobs/director/bin/nginx_ctl start"
+  start program "/var/vcap/jobs/director/bin/nginx_ctl start" with timeout 75 seconds
   stop program "/var/vcap/jobs/director/bin/nginx_ctl stop"
   group vcap


### PR DESCRIPTION
Increase timeout of `director` and `director_nginx` as we were facing problems with the default 30s timeout.
We tried many values and 75s is the best we found (we were facing problems on Openstack but not on AWS).