### PR TITLE
Add configurable timeout for monit director and director_nginx jobs

### DIFF
--- a/jobs/director/monit
+++ b/jobs/director/monit
@@ -1,6 +1,6 @@
 check process director
   with pidfile /var/vcap/sys/run/director/director.pid
-  start program "/var/vcap/jobs/director/bin/director_ctl start"
+  start program "/var/vcap/jobs/director/bin/director_ctl start" with timeout <%= p('director.monit_timeout') %> seconds
   stop program "/var/vcap/jobs/director/bin/director_ctl stop"
   group vcap
   <% if properties.micro %>
@@ -21,6 +21,6 @@ check process director_scheduler
   group vcap
 check process director_nginx
   with pidfile /var/vcap/sys/run/director/nginx.pid
-  start program "/var/vcap/jobs/director/bin/nginx_ctl start"
+  start program "/var/vcap/jobs/director/bin/nginx_ctl start" with timeout <%= p('director.nginx.monit_timeout') %> seconds
   stop program "/var/vcap/jobs/director/bin/nginx_ctl stop"
   group vcap

--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -44,6 +44,9 @@ properties:
   director.backend_port:
     description: Port that the director listens on
     default: 25556
+  director.monit_timeout:
+    description: "Monit timeout for the director process"
+    default: 30    
   director.nginx.workers:
     description: Number of nginx workers for director
     default: 2
@@ -53,6 +56,9 @@ properties:
   director.enable_dedicated_status_worker:
     description: "Separate worker for 'bosh vms' and 'bosh ssh'"
     default: false
+  director.nginx.monit_timeout:
+    description: "Monit timeout for the director_nginx process"
+    default: 30
   director.nginx.ssl_prefer_server_ciphers:
     description: "Prefer server's cipher priority instead of client's (true for On, false for Off)"
     default: true


### PR DESCRIPTION
We saw that the default 30s timeout is enough for our deployment. So with this PR I introduced the possibility to configure the monit timeout for the director and director_nginx jobs.