### PR TITLE
Add query options to get events

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/events_controller.rb
@@ -50,6 +50,22 @@ module Bosh::Director
           events = events.where(instance: params['instance'])
         end
 
+        if params['user']
+          events = events.where(user: params['user'])
+        end
+
+        if params['action']
+          events = events.where(action: params['action'])
+        end
+
+        if params['object_type']
+          events = events.where(object_type: params['object_type'])
+        end
+
+        if params['object_id']
+          events = events.where(object_name: params['object_id'])
+        end
+
         events = events.limit(EVENT_LIMIT).map do |event|
           @event_manager.event_to_hash(event)
         end

--- a/src/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
@@ -138,6 +138,67 @@ module Bosh::Director
           end
         end
 
+        context 'when user is specified' do
+          before do
+            basic_authorize 'admin', 'admin'
+            Models::Event.make('user' => 'admin')
+            Models::Event.make('user' => 'user')
+          end
+
+          it 'returns a filtered list of events' do
+            get '?user=admin'
+            events = JSON.parse(last_response.body)
+            expect(events.size).to eq(1)
+            expect(events[0]['user']).to eq('admin')
+          end
+        end
+
+        context 'when action is specified' do
+          before do
+            basic_authorize 'admin', 'admin'
+            Models::Event.make('action' => 'delete')
+            Models::Event.make('action' => 'update')
+          end
+
+          it 'returns a filtered list of events' do
+            get '?action=delete'
+            events = JSON.parse(last_response.body)
+            expect(events.size).to eq(1)
+            expect(events[0]['action']).to eq('delete')
+          end
+        end
+
+        context 'when object_type is specified' do
+          before do
+            basic_authorize 'admin', 'admin'
+            Models::Event.make('object_type' => 'deployment')
+            Models::Event.make('object_type' => 'instance')
+          end
+
+          it 'returns a filtered list of events' do
+            get '?object_type=deployment'
+            events = JSON.parse(last_response.body)
+            expect(events.size).to eq(1)
+            expect(events[0]['object_type']).to eq('deployment')
+          end
+        end
+
+        context 'when object_id is specified' do
+          before do
+            basic_authorize 'admin', 'admin'
+            Models::Event.make('object_name' => 'fake_name')
+            Models::Event.make('object_name' => 'another_name')
+          end
+
+          it 'returns a filtered list of events' do
+            get '?object_id=fake_name'
+            events = JSON.parse(last_response.body)
+            expect(events.size).to eq(1)
+            expect(events[0]['object_name']).to eq('fake_name')
+          end
+        end
+
+
         context 'when several filters are specified' do
           before do
             basic_authorize 'admin', 'admin'
@@ -160,6 +221,27 @@ module Bosh::Director
               expect(events[0]['deployment']).to eq('name')
             end
           end
+
+          context 'when user, action, object_id and object_type are specified' do
+            before do
+              Models::Event.make('user' => 'admin')
+              Models::Event.make('user' => 'admin', 'action' => 'update', 'object_name' => 'test', 'object_type' => 'deployment')
+              Models::Event.make('user' => 'admin', 'action' => 'update', 'object_name' => 'test', 'object_type' => 'deployment1')
+              Models::Event.make('object_name' => 'something')
+              Models::Event.make('object_type' => 'deployment')
+            end
+
+            it 'returns the ended results' do
+              get '?user=admin&action=update&object_id=test&object_type=deployment'
+              events = JSON.parse(last_response.body)
+              expect(events.size).to eq(1)
+              expect(events[0]['user']).to eq('admin')
+              expect(events[0]['action']).to eq('update')
+              expect(events[0]['object_name']).to eq('test')
+              expect(events[0]['object_type']).to eq('deployment')
+            end
+          end
+
 
           context 'when before and after are specified' do
             before do

--- a/src/spec/gocli/integration/cli_events_spec.rb
+++ b/src/spec/gocli/integration/cli_events_spec.rb
@@ -64,7 +64,7 @@ describe 'cli: events', type: :integration do
     )
 
     instance_name = parse_first_instance_name(output)
-    output = bosh_runner.run("events --task 6 --instance #{instance_name}", deployment_name: 'simple', json: true)
+    output = bosh_runner.run("events --task 6 --instance #{instance_name} --action delete", deployment_name: 'simple', json: true)
     data = table(output)
     columns = ['Action', 'Object Type', 'Deployment', 'Instance', 'Task ID']
     expect(get_details(data, columns)).to contain_exactly(


### PR DESCRIPTION
User, action, object_name, object_type parameters are possible

[#135753041](https://www.pivotaltracker.com/story/show/135753041)

Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>