### PR TITLE
Add config server to info endpoint

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/info_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/info_controller.rb
@@ -26,9 +26,16 @@ module Bosh::Director
             },
             'snapshots' => {
               'status' => Config.enable_snapshots
+            },
+            'config_server' => {
+              'status' => Config.config_server_enabled,
+              'extras' => {
+                'urls' => @config.config_server_urls
+              }
             }
           }
         }
+
         content_type(:json)
         json_encode(status)
       end

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -375,6 +375,11 @@ module Bosh::Director
       end
     end
 
+    def config_server_urls
+      cfg_server_url = Config.config_server['url']
+      cfg_server_url ? [cfg_server_url] : []
+    end
+
     def worker_logger
       logger = Logging::Logger.new('DirectorWorker')
       logging_config = hash.fetch('logging', {})

--- a/src/bosh-director/spec/unit/api/controllers/info_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/info_controller_spec.rb
@@ -74,6 +74,12 @@ module Bosh::Director
             },
             'snapshots' => {
               'status' => false
+            },
+            'config_server' => {
+              'status' => false,
+              'extras' => {
+                'urls' => []
+              }
             }
           }
         }
@@ -137,6 +143,28 @@ module Bosh::Director
               }
             )
           end
+        end
+      end
+
+      context 'when configured with a config server' do
+        let(:test_config) do
+          base_config.merge({
+            'config_server' => {
+              'enabled' => true,
+              'url' => 'https://config.example.com'
+            }
+          })
+        end
+
+        it 'reports that config server feature is enabled with the uri' do
+          get '/'
+          response_hash = JSON.parse(last_response.body)
+          expect(response_hash['features']['config_server']).to eq(
+            'status' => true,
+            'extras' => {
+              'urls' => ['https://config.example.com']
+            }
+          )
         end
       end
     end

--- a/src/bosh-director/spec/unit/config_spec.rb
+++ b/src/bosh-director/spec/unit/config_spec.rb
@@ -189,6 +189,14 @@ describe Bosh::Director::Config do
           expect(described_class.config_server['uaa']['ca_cert_path']).to eq('fake-uaa-ca-cert-path')
         end
 
+        context 'config server urls' do
+          it 'should return an array of urls' do
+            described_class.configure(test_config)
+            config = Bosh::Director::Config.new(test_config)
+            expect(config.config_server_urls).to eq(['https://127.0.0.1:8080'])
+          end
+        end
+
         context 'when url is not https' do
           before {
             test_config["config_server"]["url"] = "http://127.0.0.1:8080"


### PR DESCRIPTION
## Why

As a bosh API consumer
I want to know whether a config server is enabled
So that I can discover the config server

## What

Add config server details to `GET /info` endpoint

Sam & @jamesjoshuahill