### PR TITLE
Get /deployment/:name/{instances|vms} returns ips even if format is not full

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -507,8 +507,17 @@ module Bosh::Director
             'index' => instance.index,
             'id' => instance.uuid,
             'az' => instance.availability_zone,
+            'ips' => ips(instance),
         }
       end
+
+      def ips(instance)
+        result = instance.ip_addresses.map {|ip| NetAddr::CIDR.create(ip.address).ip }
+        if result.empty? && instance.spec && instance.spec['networks']
+          result = instance.spec['networks'].map {|_, network| network['ip']}
+        end
+        result
+       end
     end
   end
 end


### PR DESCRIPTION
I need to periodically (each 1-5 mins) gather the IP addresses of deployment instances and/or vms. Right now, the only way to get them is to use the [GET /deployments/{name}/instances](http://bosh.io/docs/director-api-v1.html#instances) API with the `format=full` parameter. Using that parameter means that BOSH is going to create a [new task](https://github.com/cloudfoundry/bosh/blob/develop/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb#L238). The end result is that my BOSH director will be filled with lots of tasks each day.

Looking at the [vm_state](https://github.com/cloudfoundry/bosh/blob/develop/src/bosh-director/lib/bosh/director/jobs/vm_state.rb#L50) task I realized that the task is not really picking up the vm IP address from the agent. It's just using the IP address stored at the BOSH DB, and if it is not stored there, then it's picking up the one from the network spec.

This PR changes the output of the [GET /deployments/{name}/instances](http://bosh.io/docs/director-api-v1.html#instances) and [GET /deployments/{name}/vms](http://bosh.io/docs/director-api-v1.html#vms) API calls adding the instance/vm IP addresses even when the `format` parameter is not `full`. In this way, I can gather the IP addresses without incurring into a BOSH task.