### PR TITLE
Director should wait for the agent to be ready when mounting a persis…

### DIFF
--- a/src/bosh-director/lib/bosh/director/disk_manager.rb
+++ b/src/bosh-director/lib/bosh/director/disk_manager.rb
@@ -177,6 +177,7 @@ module Bosh::Director
     # @todo[multi-disks] the rescue is duplicated with migrate_disk
     def mount_disk(disk)
       agent_client = agent_client(disk.instance)
+      agent_client.wait_until_ready
       agent_client.mount_disk(disk.disk_cid)
     rescue => e
       @logger.debug("Failed to mount disk, deleting new disk. #{e.inspect}")

--- a/src/bosh-director/spec/unit/disk_manager_spec.rb
+++ b/src/bosh-director/spec/unit/disk_manager_spec.rb
@@ -47,6 +47,7 @@ module Bosh::Director
       allow(cloud_collection).to receive(:detach_disk)
       allow(agent_client).to receive(:stop)
       allow(agent_client).to receive(:mount_disk)
+      allow(agent_client).to receive(:wait_until_ready)
       allow(agent_client).to receive(:migrate_disk)
       allow(agent_client).to receive(:unmount_disk)
       allow(agent_client).to receive(:update_settings)
@@ -59,6 +60,7 @@ module Bosh::Director
         it 'attaches + mounts disk' do
           expect(cloud_factory).to receive(:for_availability_zone).with(instance_model.availability_zone).once.and_return(cloud_collection)
           expect(cloud_collection).to receive(:attach_disk).with('vm234', 'disk123')
+          expect(agent_client).to receive(:wait_until_ready)
           expect(agent_client).to receive(:mount_disk).with('disk123')
           disk_manager.attach_disk(persistent_disk)
         end

--- a/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
@@ -237,6 +237,7 @@ module Bosh::Director
         let(:agent_client) do
           instance_double(AgentClient,
             mount_disk: nil,
+            wait_until_ready: nil,
             list_disk: ['original-disk-cid'],
             stop: nil,
             unmount_disk: nil
@@ -275,7 +276,7 @@ module Bosh::Director
 
         let(:original_disk) { nil }
 
-        let(:agent_client) { instance_double(AgentClient, mount_disk: nil) }
+        let(:agent_client) { instance_double(AgentClient, mount_disk: nil, wait_until_ready: nil) }
         before do
           allow(Config.cloud).to receive(:attach_disk)
           allow(AgentClient).to receive(:with_vm_credentials_and_agent_id).and_return(agent_client)


### PR DESCRIPTION
…tent disk

There are CPIs that need to recreate a VM in order to attach a volume.
Specifically the Kubernetes CPI @ https://github.com/sap/bosh-kubernetes-cpi-release does that.

Attaching persistent disk otherwise fails with a timeout.

@cppforlife Here is the pull request. Would be nice to get it into fix branch as well for faster release.