### PR TITLE
remove unneded echo of pid as nginx has same path for pid

### DIFF
--- a/jobs/blobstore/spec
+++ b/jobs/blobstore/spec
@@ -8,6 +8,7 @@ templates:
   mime.types:         config/mime.types
   read_users.erb:     config/read_users
   write_users.erb:    config/write_users
+  utils.sh:           helpers/utils.sh
 
 packages:
 - nginx

--- a/jobs/blobstore/templates/nginx_ctl
+++ b/jobs/blobstore/templates/nginx_ctl
@@ -12,10 +12,16 @@ function pid_exists() {
   ps -p $1 &> /dev/null
 }
 
+source /var/vcap/packages/common/utils.sh
+
 case $1 in
 
   start)
     mkdir -p $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
+
+    pid_guard $PIDFILE "nginx"
+
+    echo $$ > $PIDFILE
 
     chown -R $RUNAS:$RUNAS $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
 

--- a/jobs/blobstore/templates/nginx_ctl
+++ b/jobs/blobstore/templates/nginx_ctl
@@ -12,7 +12,7 @@ function pid_exists() {
   ps -p $1 &> /dev/null
 }
 
-source /var/vcap/packages/common/utils.sh
+source $JOB_DIR/helpers/utils.sh
 
 case $1 in
 

--- a/jobs/blobstore/templates/nginx_ctl
+++ b/jobs/blobstore/templates/nginx_ctl
@@ -17,8 +17,6 @@ case $1 in
   start)
     mkdir -p $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
 
-    echo $$ > $PIDFILE
-
     chown -R $RUNAS:$RUNAS $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
 
     exec chpst -u $RUNAS:$RUNAS /var/vcap/packages/nginx/sbin/nginx -c /var/vcap/jobs/blobstore/config/nginx.conf >>$LOG_DIR/nginx.stdout.log 2>>$LOG_DIR/nginx.stderr.log

--- a/jobs/blobstore/templates/utils.sh
+++ b/jobs/blobstore/templates/utils.sh
@@ -1,0 +1,89 @@
+
+mkdir -p /var/vcap/sys/log
+
+exec > >(tee -a >(logger -p user.info -t vcap.$(basename $0).stdout) | awk -W interactive '{ gsub(/\\n/, ""); system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).log)
+exec 2> >(tee -a >(logger -p user.error -t vcap.$(basename $0).stderr) | awk -W interactive '{ gsub(/\\n/, ""); system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).err.log)
+
+pid_guard() {
+  echo "------------ STARTING `basename $0` at `date` --------------" | tee /dev/stderr
+  pidfile=$1
+  name=$2
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+
+    if [ -n "$pid" ] && [ -e /proc/$pid ]; then
+      echo "$name is already running, please stop it first"
+      exit 1
+    fi
+
+    echo "Removing stale pidfile..."
+    rm $pidfile
+  fi
+}
+
+wait_pidfile() {
+  pidfile=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+
+    if [ -z "$pid" ]; then
+      echo "Unable to get pid from $pidfile"
+      exit 1
+    fi
+
+    if [ -e /proc/$pid ]; then
+      if [ "$try_kill" = "1" ]; then
+        echo "Killing $pidfile: $pid "
+        kill $pid
+      fi
+      while [ -e /proc/$pid ]; do
+        sleep 0.1
+        [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
+        if [ $timeout -gt 0 ]; then
+          if [ $countdown -eq 0 ]; then
+            if [ "$force" = "1" ]; then
+              echo -ne "\nKill timed out, using kill -9 on $pid... "
+              kill -9 $pid
+              sleep 0.5
+            fi
+            break
+          else
+            countdown=$(( $countdown - 1 ))
+          fi
+        fi
+      done
+      if [ -e /proc/$pid ]; then
+        echo "Timed Out"
+      else
+        echo "Stopped"
+      fi
+    else
+      echo "Process $pid is not running"
+    fi
+
+    rm -f $pidfile
+  else
+    echo "Pidfile $pidfile doesn't exist"
+  fi
+}
+
+kill_and_wait() {
+  pidfile=$1
+  # Monit default timeout for start/stop is 30s
+  # Append 'with timeout {n} seconds' to monit start/stop program configs
+  timeout=${2:-25}
+  force=${3:-1}
+
+  wait_pidfile $pidfile 1 $timeout $force
+}
+
+running_in_container() {
+  # look for a non-root cgroup
+  grep --quiet --invert-match ':/$' /proc/self/cgroup
+}

--- a/jobs/blobstore/templates/utils.sh
+++ b/jobs/blobstore/templates/utils.sh
@@ -1,9 +1,6 @@
 
 mkdir -p /var/vcap/sys/log
 
-exec > >(tee -a >(logger -p user.info -t vcap.$(basename $0).stdout) | awk -W interactive '{ gsub(/\\n/, ""); system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).log)
-exec 2> >(tee -a >(logger -p user.error -t vcap.$(basename $0).stderr) | awk -W interactive '{ gsub(/\\n/, ""); system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).err.log)
-
 pid_guard() {
   echo "------------ STARTING `basename $0` at `date` --------------" | tee /dev/stderr
   pidfile=$1
@@ -20,70 +17,4 @@ pid_guard() {
     echo "Removing stale pidfile..."
     rm $pidfile
   fi
-}
-
-wait_pidfile() {
-  pidfile=$1
-  try_kill=$2
-  timeout=${3:-0}
-  force=${4:-0}
-  countdown=$(( $timeout * 10 ))
-
-  if [ -f "$pidfile" ]; then
-    pid=$(head -1 "$pidfile")
-
-    if [ -z "$pid" ]; then
-      echo "Unable to get pid from $pidfile"
-      exit 1
-    fi
-
-    if [ -e /proc/$pid ]; then
-      if [ "$try_kill" = "1" ]; then
-        echo "Killing $pidfile: $pid "
-        kill $pid
-      fi
-      while [ -e /proc/$pid ]; do
-        sleep 0.1
-        [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
-        if [ $timeout -gt 0 ]; then
-          if [ $countdown -eq 0 ]; then
-            if [ "$force" = "1" ]; then
-              echo -ne "\nKill timed out, using kill -9 on $pid... "
-              kill -9 $pid
-              sleep 0.5
-            fi
-            break
-          else
-            countdown=$(( $countdown - 1 ))
-          fi
-        fi
-      done
-      if [ -e /proc/$pid ]; then
-        echo "Timed Out"
-      else
-        echo "Stopped"
-      fi
-    else
-      echo "Process $pid is not running"
-    fi
-
-    rm -f $pidfile
-  else
-    echo "Pidfile $pidfile doesn't exist"
-  fi
-}
-
-kill_and_wait() {
-  pidfile=$1
-  # Monit default timeout for start/stop is 30s
-  # Append 'with timeout {n} seconds' to monit start/stop program configs
-  timeout=${2:-25}
-  force=${3:-1}
-
-  wait_pidfile $pidfile 1 $timeout $force
-}
-
-running_in_container() {
-  # look for a non-root cgroup
-  grep --quiet --invert-match ':/$' /proc/self/cgroup
 }

--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -22,6 +22,7 @@ templates:
   config_server_ca.cert.erb: config/config_server_ca.cert
   uaa_server_ca.cert.erb: config/uaa_server_ca.cert
   sync_dns_ctl.erb: bin/sync_dns_ctl
+  utils.sh: helpers/utils.sh
 
 packages:
 - director

--- a/jobs/director/templates/nginx_ctl
+++ b/jobs/director/templates/nginx_ctl
@@ -9,10 +9,16 @@ SSL_DIR=/var/vcap/jobs/director/config/ssl
 TMP_DIR=/var/vcap/data/director/tmp
 RUNAS=vcap
 
+source /var/vcap/packages/common/utils.sh
+
 case $1 in
 
   start)
     mkdir -p $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
+
+    pid_guard $PIDFILE "nginx"
+
+    echo $$ > $PIDFILE
 
     chown -R $RUNAS:$RUNAS $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
 

--- a/jobs/director/templates/nginx_ctl
+++ b/jobs/director/templates/nginx_ctl
@@ -9,7 +9,7 @@ SSL_DIR=/var/vcap/jobs/director/config/ssl
 TMP_DIR=/var/vcap/data/director/tmp
 RUNAS=vcap
 
-source /var/vcap/packages/common/utils.sh
+source $JOB_DIR/helpers/utils.sh
 
 case $1 in
 

--- a/jobs/director/templates/nginx_ctl
+++ b/jobs/director/templates/nginx_ctl
@@ -14,8 +14,6 @@ case $1 in
   start)
     mkdir -p $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
 
-    echo $$ > $PIDFILE
-
     chown -R $RUNAS:$RUNAS $RUN_DIR $LOG_DIR $STORE_DIR $TMP_DIR
 
     # workaround. nginx upload module ignores the proxy_temp_path directive

--- a/jobs/director/templates/utils.sh
+++ b/jobs/director/templates/utils.sh
@@ -1,0 +1,89 @@
+
+mkdir -p /var/vcap/sys/log
+
+exec > >(tee -a >(logger -p user.info -t vcap.$(basename $0).stdout) | awk -W interactive '{ gsub(/\\n/, ""); system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).log)
+exec 2> >(tee -a >(logger -p user.error -t vcap.$(basename $0).stderr) | awk -W interactive '{ gsub(/\\n/, ""); system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).err.log)
+
+pid_guard() {
+  echo "------------ STARTING `basename $0` at `date` --------------" | tee /dev/stderr
+  pidfile=$1
+  name=$2
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+
+    if [ -n "$pid" ] && [ -e /proc/$pid ]; then
+      echo "$name is already running, please stop it first"
+      exit 1
+    fi
+
+    echo "Removing stale pidfile..."
+    rm $pidfile
+  fi
+}
+
+wait_pidfile() {
+  pidfile=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+
+    if [ -z "$pid" ]; then
+      echo "Unable to get pid from $pidfile"
+      exit 1
+    fi
+
+    if [ -e /proc/$pid ]; then
+      if [ "$try_kill" = "1" ]; then
+        echo "Killing $pidfile: $pid "
+        kill $pid
+      fi
+      while [ -e /proc/$pid ]; do
+        sleep 0.1
+        [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
+        if [ $timeout -gt 0 ]; then
+          if [ $countdown -eq 0 ]; then
+            if [ "$force" = "1" ]; then
+              echo -ne "\nKill timed out, using kill -9 on $pid... "
+              kill -9 $pid
+              sleep 0.5
+            fi
+            break
+          else
+            countdown=$(( $countdown - 1 ))
+          fi
+        fi
+      done
+      if [ -e /proc/$pid ]; then
+        echo "Timed Out"
+      else
+        echo "Stopped"
+      fi
+    else
+      echo "Process $pid is not running"
+    fi
+
+    rm -f $pidfile
+  else
+    echo "Pidfile $pidfile doesn't exist"
+  fi
+}
+
+kill_and_wait() {
+  pidfile=$1
+  # Monit default timeout for start/stop is 30s
+  # Append 'with timeout {n} seconds' to monit start/stop program configs
+  timeout=${2:-25}
+  force=${3:-1}
+
+  wait_pidfile $pidfile 1 $timeout $force
+}
+
+running_in_container() {
+  # look for a non-root cgroup
+  grep --quiet --invert-match ':/$' /proc/self/cgroup
+}

--- a/jobs/director/templates/utils.sh
+++ b/jobs/director/templates/utils.sh
@@ -1,9 +1,6 @@
 
 mkdir -p /var/vcap/sys/log
 
-exec > >(tee -a >(logger -p user.info -t vcap.$(basename $0).stdout) | awk -W interactive '{ gsub(/\\n/, ""); system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).log)
-exec 2> >(tee -a >(logger -p user.error -t vcap.$(basename $0).stderr) | awk -W interactive '{ gsub(/\\n/, ""); system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }' >>/var/vcap/sys/log/$(basename $0).err.log)
-
 pid_guard() {
   echo "------------ STARTING `basename $0` at `date` --------------" | tee /dev/stderr
   pidfile=$1
@@ -20,70 +17,4 @@ pid_guard() {
     echo "Removing stale pidfile..."
     rm $pidfile
   fi
-}
-
-wait_pidfile() {
-  pidfile=$1
-  try_kill=$2
-  timeout=${3:-0}
-  force=${4:-0}
-  countdown=$(( $timeout * 10 ))
-
-  if [ -f "$pidfile" ]; then
-    pid=$(head -1 "$pidfile")
-
-    if [ -z "$pid" ]; then
-      echo "Unable to get pid from $pidfile"
-      exit 1
-    fi
-
-    if [ -e /proc/$pid ]; then
-      if [ "$try_kill" = "1" ]; then
-        echo "Killing $pidfile: $pid "
-        kill $pid
-      fi
-      while [ -e /proc/$pid ]; do
-        sleep 0.1
-        [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
-        if [ $timeout -gt 0 ]; then
-          if [ $countdown -eq 0 ]; then
-            if [ "$force" = "1" ]; then
-              echo -ne "\nKill timed out, using kill -9 on $pid... "
-              kill -9 $pid
-              sleep 0.5
-            fi
-            break
-          else
-            countdown=$(( $countdown - 1 ))
-          fi
-        fi
-      done
-      if [ -e /proc/$pid ]; then
-        echo "Timed Out"
-      else
-        echo "Stopped"
-      fi
-    else
-      echo "Process $pid is not running"
-    fi
-
-    rm -f $pidfile
-  else
-    echo "Pidfile $pidfile doesn't exist"
-  fi
-}
-
-kill_and_wait() {
-  pidfile=$1
-  # Monit default timeout for start/stop is 30s
-  # Append 'with timeout {n} seconds' to monit start/stop program configs
-  timeout=${2:-25}
-  force=${3:-1}
-
-  wait_pidfile $pidfile 1 $timeout $force
-}
-
-running_in_container() {
-  # look for a non-root cgroup
-  grep --quiet --invert-match ':/$' /proc/self/cgroup
 }


### PR DESCRIPTION
This commit removes the unnecessary creation of the nginx pid file in the nginx_ctl script as nginx will create the pid itself.
The removed line causes an issue if the start script is called when nginx is already running. The pid will be overwritten and causes monit to fail. Further monit is no longer able to stop the process.