### PR TITLE
Fix date header in bosh-monitor email plugin to conform with rfc5322

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/plugins/email.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/email.rb
@@ -89,13 +89,7 @@ module Bosh::Monitor
         started = Time.now
         logger.info("Sending email...")
 
-        headers = {
-          "From"         => smtp_options["from"],
-          "To"           => recipients.join(", "),
-          "Subject"      => subject,
-          "Date"         => date,
-          "Content-Type" => "text/plain; charset=\"iso-8859-1\""
-        }
+        headers = create_headers(subject, date)
 
         smtp_client_options = {
           :domain   => smtp_options["domain"],
@@ -132,6 +126,16 @@ module Bosh::Monitor
 
       rescue => e
         logger.error("Error sending email: #{e}")
+      end
+
+      def create_headers(subject, date)
+        {
+          "From"         => smtp_options["from"],
+          "To"           => recipients.join(", "),
+          "Subject"      => subject,
+          "Date"         => date.strftime("%a, %-d %b %Y %T %z"),
+          "Content-Type" => "text/plain; charset=\"iso-8859-1\""
+        }
       end
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/email_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/email_spec.rb
@@ -118,4 +118,13 @@ describe Bhm::Plugins::Email do
     expect(@plugin.queue_size(:heartbeat)).to eq(0)
   end
 
+
+  it 'writes datetime headers compliant with rfc5322' do
+    headers = @plugin.create_headers("Some subject", Time.now)
+    date_key = 'Date'
+    expect(headers).to be_truthy
+    date_value = headers['Date']
+    expect(date_value).to be_truthy
+    expect(/[[:alpha:]]{3}, \d{1,2} [[:alpha:]]{3} \d{4} \d{2}:\d{2}:\d{2} [\+,\-].+/).to match(date_value)
+  end
 end


### PR DESCRIPTION
The date header in the email plugin of bosh-monitor did not conform to rfc5322, causing problems in some mail clients.