### PR TITLE
PR improve meltdown handling

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
@@ -58,13 +58,16 @@ module Bosh::Monitor
 
       def to_hash
         {
-          :kind       => "alert",
-          :id         => @id,
-          :severity   => @severity,
-          :title      => @title,
-          :summary    => @summary,
-          :source     => @source,
-          :created_at => @created_at.to_i
+          :kind        => "alert",
+          :id          => @id,
+          :severity    => @severity,
+          :title       => @title,
+          :summary     => @summary,
+          :source      => @source,
+          :deployment  => @deployment,
+          :job         => @job,
+          :instance_id => @instance_id,
+          :created_at  => @created_at.to_i
         }
       end
 

--- a/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
@@ -11,6 +11,8 @@ module Bosh::Monitor
         -1 => :ignored
       }
 
+      MELTDOWN_STATES = [:alert, :critical, :error]
+
       attr_reader :created_at, :source, :title
 
       def initialize(attributes = {})

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
@@ -55,8 +55,9 @@ module Bosh::Monitor
           }
 
           @url.path = "/deployments/#{deployment}/scan_and_fix"
+          state, details = @alert_tracker.state_for(deployment)
 
-          if @alert_tracker.melting_down?(deployment)
+          if state == ResurrectorHelper::AlertTracker::STATE_MELTDOWN
             # freak out
             ts = Time.now.to_i
             @processor.process(:alert,
@@ -99,4 +100,3 @@ module Bosh::Monitor
     end
   end
 end
-

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
@@ -59,14 +59,17 @@ module Bosh::Monitor
 
           if state == ResurrectorHelper::AlertTracker::STATE_MELTDOWN
             # freak out
+            summary = "Skipping resurrection for instance: '#{job}/#{id}'; deployment: #{deployment}; alerts: #{details['alerts'].inspect}"
             ts = Time.now.to_i
             @processor.process(:alert,
                                severity: 1,
-                               source: "HM plugin resurrector",
                                title: "We are in meltdown.",
+                               summary: summary,
+                               source: "HM plugin resurrector",
+                               deployment: deployment,
                                created_at: ts)
 
-            logger.error("(Resurrector) we are in meltdown.")
+            logger.error("(Resurrector) we are in meltdown. #{summary}")
           else
             # queue instead, and only queue if it isn't already in the queue
             # what if we can't keep up with the failure rate?

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
@@ -29,9 +29,12 @@ module Bosh::Monitor::Plugins
     # Service which tracks alerts and decides whether or not the cluster is melting down.
     # When the cluster is melting down, the resurrector backs off on fixing instances.
     class AlertTracker
+      STATE_NORMAL = 'normal'
+      STATE_MANAGED = 'managed'
+      STATE_MELTDOWN = 'meltdown'
 
       # Below this number of down agents we don't consider a meltdown occurring
-      attr_accessor :minimum_down_jobs
+      attr_accessor :count_threshold
 
       # Number of seconds at which an alert is considered "current"; alerts older than
       # this are ignored. Integer number of seconds.
@@ -42,11 +45,34 @@ module Bosh::Monitor::Plugins
       attr_accessor :percent_threshold
 
       def initialize(args={})
-        @instance_manager    = Bhm.instance_manager
-        @alert_times         = {} # maps JobInstanceKey to time of last Alert
-        @minimum_down_jobs   = args.fetch('minimum_down_jobs', 5)
-        @percent_threshold   = args.fetch('percent_threshold', 0.2)
-        @time_threshold      = args.fetch('time_threshold', 600)
+        @instance_manager   = Bhm.instance_manager
+        @alert_times        = {} # maps JobInstanceKey to time of last Alert
+        @count_threshold    = args.fetch('count_threshold', 5)
+        @percent_threshold  = args.fetch('percent_threshold', 0.2)
+        @time_threshold     = args.fetch('time_threshold', 600)
+      end
+
+      def state_for(deployment)
+        agents = fetch_agents(deployment)
+        alerts = fetch_alerts(agents)
+        percent = percent_alerting(agents, alerts)
+        details = {
+          'deployment' => deployment,
+          'alerts' => {
+            'count' => alerts.count,
+            'percent' => "#{percent * 100}%",
+          }
+        }
+
+        if alerts.count > 0
+          if alerts.count >= count_threshold && percent >= percent_threshold
+            return [STATE_MELTDOWN, details]
+          end
+
+          return [STATE_MANAGED, details]
+        end
+
+        [STATE_NORMAL, details]
       end
 
       # "Melting down" means a large part of the cluster is offline and manual intervention
@@ -58,7 +84,7 @@ module Bosh::Monitor::Plugins
           alert_time > (Time.now - time_threshold)
         }.size
 
-        return false if number_of_down_agents < minimum_down_jobs
+        return false if number_of_down_agents < count_threshold
 
         (number_of_down_agents.to_f / total_number_of_agents) >= percent_threshold
       end
@@ -68,6 +94,28 @@ module Bosh::Monitor::Plugins
       end
 
       private
+
+      def fetch_agents(deployment)
+        @instance_manager.get_agents_for_deployment(deployment)
+      end
+
+      def fetch_alerts(agents)
+        {}.tap do |result|
+          agents.values.each do |agent|
+            key = JobInstanceKey.new(agent.deployment, agent.job, agent.instance_id)
+
+            if time = @alert_times.fetch(key, false)
+              t1 = time.to_i
+              t2 = (Time.now - time_threshold).to_i
+              result[key] = time if t1 >= t2
+            end
+          end
+        end
+      end
+
+      def percent_alerting(agents, alerts)
+        alerts.count.to_f / agents.count
+      end
 
       def alerts_for_deployment(deployment)
         agents = @instance_manager.get_agents_for_deployment(deployment)

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
@@ -52,6 +52,12 @@ module Bosh::Monitor::Plugins
         @time_threshold     = args.fetch('time_threshold', 600)
       end
 
+      def record(agent_key, alert)
+        if Bosh::Monitor::Events::Alert::MELTDOWN_STATES.include?(alert.severity)
+          @alert_times[agent_key] = alert.created_at
+        end
+      end
+
       def state_for(deployment)
         agents = fetch_agents(deployment)
         alerts = fetch_alerts(agents)
@@ -75,10 +81,6 @@ module Bosh::Monitor::Plugins
         end
 
         [STATE_NORMAL, details]
-      end
-
-      def record(agent_key, alert_time)
-        @alert_times[agent_key] = alert_time
       end
 
       private

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
@@ -34,7 +34,7 @@ module Bosh::Monitor::Plugins
       STATE_MELTDOWN = 'meltdown'
 
       # Below this number of down agents we don't consider a meltdown occurring
-      attr_accessor :count_threshold
+      attr_accessor :minimum_down_jobs
 
       # Number of seconds at which an alert is considered "current"; alerts older than
       # this are ignored. Integer number of seconds.
@@ -47,7 +47,7 @@ module Bosh::Monitor::Plugins
       def initialize(args={})
         @instance_manager   = Bhm.instance_manager
         @alert_times        = {} # maps JobInstanceKey to time of last Alert
-        @count_threshold    = args.fetch('count_threshold', 5)
+        @minimum_down_jobs  = args.fetch('minimum_down_jobs', 5)
         @percent_threshold  = args.fetch('percent_threshold', 0.2)
         @time_threshold     = args.fetch('time_threshold', 600)
       end
@@ -65,7 +65,7 @@ module Bosh::Monitor::Plugins
         }
 
         if alerts.count > 0
-          if alerts.count >= count_threshold && percent >= percent_threshold
+          if alerts.count >= minimum_down_jobs && percent >= percent_threshold
             # "Melting down" means a large part of the cluster is offline and manual intervention
             # may be required to fix.
             return [STATE_MELTDOWN, details]

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
@@ -60,7 +60,7 @@ module Bosh::Monitor::Plugins
           'deployment' => deployment,
           'alerts' => {
             'count' => alerts.count,
-            'percent' => "#{percent * 100}%",
+            'percent' => "#{(percent * 100).round(1)}%",
           }
         }
 

--- a/src/bosh-monitor/spec/spec_helper.rb
+++ b/src/bosh-monitor/spec/spec_helper.rb
@@ -40,12 +40,15 @@ end
 
 def make_alert(attrs = {})
   defaults = {
-      :id => 1,
-      :severity => 2,
-      :title => 'Test Alert',
-      :summary => 'Everything is down',
-      :source => 'mysql_node/instance_id_abc',
-      :created_at => Time.now.to_i
+      "id" => 1,
+      "severity" => 2,
+      "title" => 'Test Alert',
+      "summary" => 'Everything is down',
+      "source" => 'mysql_node/instance_id_abc',
+      "deployment" => 'deployment',
+      "job" => 'job',
+      "instance_id" => 'instance_id',
+      "created_at" => Time.now.to_i
   }
   Bhm::Events::Alert.new(defaults.merge(attrs))
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/events/alert_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/events/alert_spec.rb
@@ -25,13 +25,16 @@ describe Bhm::Events::Alert do
   it "has hash representation" do
     ts = Time.now
     expect(make_alert(:created_at => ts.to_i).to_hash).to eq({
-      :kind       => "alert",
-      :id         => 1,
-      :severity   => 2,
-      :title      => "Test Alert",
-      :summary    => "Everything is down",
-      :source     => "mysql_node/instance_id_abc",
-      :created_at => ts.to_i
+      :kind        => "alert",
+      :id          => 1,
+      :severity    => 2,
+      :title       => "Test Alert",
+      :summary     => "Everything is down",
+      :source      => "mysql_node/instance_id_abc",
+      :deployment  => "deployment",
+      :job         => "job",
+      :instance_id => "instance_id",
+      :created_at  => ts.to_i
     })
   end
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
@@ -151,7 +151,7 @@ describe Bhm::Plugins::DataDog do
         expect(msg).to eq('Everything is down')
         expect(options[:msg_title]).to eq('Test Alert')
         expect(options[:date_happened]).to eq(time)
-        expect(options[:tags]).to match_array(['source:mysql_node/instance_id_abc'])
+        expect(options[:tags]).to match_array(['deployment:deployment', 'instance_group:job', 'instance_id:instance_id', 'source:mysql_node/instance_id_abc'])
         expect(options[:priority]).to eq('normal')
       }.and_return(fake_event)
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
@@ -14,7 +14,10 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
         allow(instance_manager).to receive(:get_agents_for_deployment).with('deployment').and_return(agents)
         allow(Bhm).to receive_messages(instance_manager: instance_manager)
 
-        alerts.times { |i| tracker.record(build_key(i), Time.now) }
+        alerts.times do |i|
+          alert = double(Bosh::Monitor::Events::Alert, created_at: Time.now, severity: :error)
+          tracker.record(build_key(i), alert)
+        end
       end
 
       context 'when the number of unresponsive agents is 0' do
@@ -78,9 +81,9 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
 
         it 'excludes those alerts' do
           now = Time.now
-          tracker.record(build_key(0), now - 610)
-          tracker.record(build_key(1), now - 600)
-          tracker.record(build_key(2), now - 60)
+          tracker.record(build_key(0), double(Bosh::Monitor::Events::Alert, created_at: (now - 610), severity: :error))
+          tracker.record(build_key(1), double(Bosh::Monitor::Events::Alert, created_at: (now - 600), severity: :error))
+          tracker.record(build_key(2), double(Bosh::Monitor::Events::Alert, created_at: (now - 60), severity: :error))
 
           state, details = tracker.state_for(deployment)
           expect(state).to be(AlertTracker::STATE_MELTDOWN)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
@@ -1,62 +1,164 @@
 require 'spec_helper'
 
-describe Bhm::Plugins::ResurrectorHelper::AlertTracker do
-  describe '#melting_down?' do
-    let(:agents) {
-      agents = {}
-      100.times.each do |i|
-        agents["00#{i}"]= Bhm::Agent.new("00#{i}", deployment: 'deployment', job: "00#{i}", instance_id: "uuid#{i.to_s}")
-      end
-      agents
-    }
+module Bhm::Plugins::ResurrectorHelper
+  describe AlertTracker do
+    subject(:tracker) { AlertTracker.new(config) }
+    let(:config) { {} }
+    let(:agents) { build_agents(10) }
+    let(:alerts) { 0 }
+    let(:deployment) { 'deployment'}
 
-    let(:job_instance_keys) {
-      100.times.map do |i|
+    describe '#state_for' do
+      before do
+        instance_manager = double(Bhm::InstanceManager)
+        allow(instance_manager).to receive(:get_agents_for_deployment).with('deployment').and_return(agents)
+        allow(Bhm).to receive_messages(instance_manager: instance_manager)
+
+        alerts.times { |i| tracker.record(build_key(i), Time.now) }
+      end
+
+      context 'when the number of unresponsive agents is 0' do
+        it 'reports as "normal"' do
+          state, details = tracker.state_for(deployment)
+          expect(state).to be(AlertTracker::STATE_NORMAL)
+          expect(details).to eq({
+            'deployment' => 'deployment',
+            'alerts' => { 'count' => 0, 'percent' => '0.0%' }
+          })
+        end
+      end
+
+      context 'when the number of unresponsive agents is below the meltdown count threshold' do
+        let(:config) { { 'count_threshold' => 2, 'percent_threshold' => 0.0 } }
+        let(:alerts) { 1 }
+
+        it 'reports as "managed"' do
+          state, details = tracker.state_for(deployment)
+          expect(state).to be(AlertTracker::STATE_MANAGED)
+          expect(details).to eq({
+            'deployment' => deployment,
+            'alerts' => { 'count' => 1, 'percent' => '10.0%' }
+          })
+        end
+      end
+
+      context 'when the number of unresponsive agents is at/above the meltdown count threshold' do
+        context 'and below the percent threshold' do
+          let(:config) { { 'count_threshold' => 2, 'percent_threshold' => 0.21 } }
+          let(:alerts) { 2 }
+
+          it 'reports as "managed"' do
+            state, details = tracker.state_for(deployment)
+            expect(state).to be(AlertTracker::STATE_MANAGED)
+            expect(details).to eq({
+              'deployment' => deployment,
+              'alerts' => { 'count' => 2, 'percent' => '20.0%' }
+            })
+          end
+        end
+
+        context 'and at/above the percent threshold' do
+          let(:config) { { 'count_threshold' => 2, 'percent_threshold' => 0.20 } }
+          let(:alerts) { 2 }
+
+          it 'reports as "meltdown"' do
+            state, details = tracker.state_for(deployment)
+            expect(state).to be(AlertTracker::STATE_MELTDOWN)
+            expect(details).to eq({
+              'deployment' => deployment,
+              'alerts' => { 'count' => 2, 'percent' => '20.0%' }
+            })
+          end
+        end
+      end
+
+      context 'when recorded alerts are outside of the time threshold' do
+        let(:config) { { 'count_threshold' => 2, 'time_threshold' => 600 } }
+        let(:alerts) { 0 }
+
+        it 'excludes those alerts' do
+          now = Time.now
+          tracker.record(build_key(0), now - 610)
+          tracker.record(build_key(1), now - 600)
+          tracker.record(build_key(2), now - 60)
+
+          state, details = tracker.state_for(deployment)
+          expect(state).to be(AlertTracker::STATE_MELTDOWN)
+          expect(details).to eq({
+            'deployment' => deployment,
+            'alerts' => { 'count' => 2, 'percent' => '20.0%' }
+          })
+        end
+      end
+
+      def build_agents(count)
+        {}.tap do |result|
+          count.times { |i| result["00#{i}"]= Bhm::Agent.new("00#{i}", deployment: 'deployment', job: "00#{i}", instance_id: "uuid#{i.to_s}") }
+        end
+      end
+
+      def build_key(i)
         Bhm::Plugins::ResurrectorHelper::JobInstanceKey.new('deployment', "00#{i}", "uuid#{i.to_s}")
       end
-    }
-
-    before do
-      mock_instance_manager = double(Bhm::InstanceManager)
-      allow(mock_instance_manager).to receive(:get_agents_for_deployment).with('deployment').and_return(agents)
-      allow(Bhm).to receive_messages(instance_manager: mock_instance_manager)
     end
 
-    it 'is melting down if more than 30% of agents are down' do
-      alert_tracker = described_class.new('percent_threshold' => 0.3)
-      31.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
+    describe '#melting_down?' do
+      let(:agents) {
+        agents = {}
+        100.times.each do |i|
+          agents["00#{i}"]= Bhm::Agent.new("00#{i}", deployment: 'deployment', job: "00#{i}", instance_id: "uuid#{i.to_s}")
+        end
+        agents
+      }
 
-      expect(alert_tracker.melting_down?('deployment')).to be(true)
-    end
+      let(:job_instance_keys) {
+        100.times.map do |i|
+          Bhm::Plugins::ResurrectorHelper::JobInstanceKey.new('deployment', "00#{i}", "uuid#{i.to_s}")
+        end
+      }
 
-    it 'is not melting down if less than 30% of agents are down' do
-      alert_tracker = described_class.new('percent_threshold' => 0.3)
-      29.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
+      before do
+        mock_instance_manager = double(Bhm::InstanceManager)
+        allow(mock_instance_manager).to receive(:get_agents_for_deployment).with('deployment').and_return(agents)
+        allow(Bhm).to receive_messages(instance_manager: mock_instance_manager)
+      end
 
-      expect(alert_tracker.melting_down?('deployment')).to be(false)
-    end
+      it 'is melting down if more than 30% of agents are down' do
+        alert_tracker = described_class.new('percent_threshold' => 0.3)
+        31.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
 
-    it 'is not melting down if less than 7 agents are down' do
-      alert_tracker = described_class.new('minimum_down_jobs' => 7, 'percent_threshold' => 0.01)
-      6.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
+        expect(alert_tracker.melting_down?('deployment')).to be(true)
+      end
 
-      expect(alert_tracker.melting_down?('deployment')).to be(false)
-    end
+      it 'is not melting down if less than 30% of agents are down' do
+        alert_tracker = described_class.new('percent_threshold' => 0.3)
+        29.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
 
-    it 'is not melting down if all agents are responding' do
-      alert_tracker = described_class.new('percent_threshold' => 0.0)
+        expect(alert_tracker.melting_down?('deployment')).to be(false)
+      end
 
-      expect(alert_tracker.melting_down?('deployment')).to be(false)
+      it 'is not melting down if less than 7 agents are down' do
+        alert_tracker = described_class.new('count_threshold' => 7, 'percent_threshold' => 0.01)
+        6.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
+
+        expect(alert_tracker.melting_down?('deployment')).to be(false)
+      end
+
+      it 'is not melting down if all agents are responding' do
+        alert_tracker = described_class.new('percent_threshold' => 0.0)
+
+        expect(alert_tracker.melting_down?('deployment')).to be(false)
+      end
     end
   end
-end
 
-describe Bhm::Plugins::ResurrectorHelper::JobInstanceKey do
-  it 'hashes properly' do
-    key1 = described_class.new('deployment', 'job', 'uuid0')
-    key2 = described_class.new('deployment', 'job', 'uuid0')
-    hash = { key1 => 'foo' }
+  describe JobInstanceKey do
+    it 'hashes properly' do
+      key1 = described_class.new('deployment', 'job', 'uuid0')
+      key2 = described_class.new('deployment', 'job', 'uuid0')
+      hash = { key1 => 'foo' }
 
-    expect(hash[key2]).to eq('foo')
+      expect(hash[key2]).to eq('foo')
+    end
   end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-module Bosh::Monitor::Plugins
+module Bosh::Monitor::Plugins::ResurrectorHelper
   describe AlertTracker do
     subject(:tracker) { AlertTracker.new(config) }
     let(:config) { {} }

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-module Bhm::Plugins::ResurrectorHelper
+module Bosh::Monitor::Plugins
   describe AlertTracker do
     subject(:tracker) { AlertTracker.new(config) }
     let(:config) { {} }
@@ -99,55 +99,6 @@ module Bhm::Plugins::ResurrectorHelper
 
       def build_key(i)
         Bhm::Plugins::ResurrectorHelper::JobInstanceKey.new('deployment', "00#{i}", "uuid#{i.to_s}")
-      end
-    end
-
-    describe '#melting_down?' do
-      let(:agents) {
-        agents = {}
-        100.times.each do |i|
-          agents["00#{i}"]= Bhm::Agent.new("00#{i}", deployment: 'deployment', job: "00#{i}", instance_id: "uuid#{i.to_s}")
-        end
-        agents
-      }
-
-      let(:job_instance_keys) {
-        100.times.map do |i|
-          Bhm::Plugins::ResurrectorHelper::JobInstanceKey.new('deployment', "00#{i}", "uuid#{i.to_s}")
-        end
-      }
-
-      before do
-        mock_instance_manager = double(Bhm::InstanceManager)
-        allow(mock_instance_manager).to receive(:get_agents_for_deployment).with('deployment').and_return(agents)
-        allow(Bhm).to receive_messages(instance_manager: mock_instance_manager)
-      end
-
-      it 'is melting down if more than 30% of agents are down' do
-        alert_tracker = described_class.new('percent_threshold' => 0.3)
-        31.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
-
-        expect(alert_tracker.melting_down?('deployment')).to be(true)
-      end
-
-      it 'is not melting down if less than 30% of agents are down' do
-        alert_tracker = described_class.new('percent_threshold' => 0.3)
-        29.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
-
-        expect(alert_tracker.melting_down?('deployment')).to be(false)
-      end
-
-      it 'is not melting down if less than 7 agents are down' do
-        alert_tracker = described_class.new('count_threshold' => 7, 'percent_threshold' => 0.01)
-        6.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
-
-        expect(alert_tracker.melting_down?('deployment')).to be(false)
-      end
-
-      it 'is not melting down if all agents are responding' do
-        alert_tracker = described_class.new('percent_threshold' => 0.0)
-
-        expect(alert_tracker.melting_down?('deployment')).to be(false)
       end
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
@@ -29,7 +29,7 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
       end
 
       context 'when the number of unresponsive agents is below the meltdown count threshold' do
-        let(:config) { { 'count_threshold' => 2, 'percent_threshold' => 0.0 } }
+        let(:config) { { 'minimum_down_jobs' => 2, 'percent_threshold' => 0.0 } }
         let(:alerts) { 1 }
 
         it 'reports as "managed"' do
@@ -44,7 +44,7 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
 
       context 'when the number of unresponsive agents is at/above the meltdown count threshold' do
         context 'and below the percent threshold' do
-          let(:config) { { 'count_threshold' => 2, 'percent_threshold' => 0.21 } }
+          let(:config) { { 'minimum_down_jobs' => 2, 'percent_threshold' => 0.21 } }
           let(:alerts) { 2 }
 
           it 'reports as "managed"' do
@@ -58,7 +58,7 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
         end
 
         context 'and at/above the percent threshold' do
-          let(:config) { { 'count_threshold' => 2, 'percent_threshold' => 0.20 } }
+          let(:config) { { 'minimum_down_jobs' => 2, 'percent_threshold' => 0.20 } }
           let(:alerts) { 2 }
 
           it 'reports as "meltdown"' do
@@ -73,7 +73,7 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
       end
 
       context 'when recorded alerts are outside of the time threshold' do
-        let(:config) { { 'count_threshold' => 2, 'time_threshold' => 600 } }
+        let(:config) { { 'minimum_down_jobs' => 2, 'time_threshold' => 600 } }
         let(:alerts) { 0 }
 
         it 'excludes those alerts' do

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
@@ -1,179 +1,181 @@
 require 'spec_helper'
 
-describe 'Bhm::Plugins::Resurrector' do
-  include Support::UaaHelpers
+module Bosh::Monitor::Plugins
+  describe Resurrector do
+    include Support::UaaHelpers
 
-  let(:options) {
-    {
-      'director' => {
-        'endpoint' => 'http://foo.bar.com:25555',
-        'user' => 'user',
-        'password' => 'password',
-        'client_id' => 'client-id',
-        'client_secret' => 'client-secret',
-        'ca_cert' => 'ca-cert'
+    let(:options) {
+      {
+        'director' => {
+          'endpoint' => 'http://foo.bar.com:25555',
+          'user' => 'user',
+          'password' => 'password',
+          'client_id' => 'client-id',
+          'client_secret' => 'client-secret',
+          'ca_cert' => 'ca-cert'
+        }
       }
     }
-  }
-  let(:plugin) { Bhm::Plugins::Resurrector.new(options) }
-  let(:uri) { 'http://foo.bar.com:25555' }
-  let(:status_uri) { "#{uri}/info" }
+    let(:plugin) { Bhm::Plugins::Resurrector.new(options) }
+    let(:uri) { 'http://foo.bar.com:25555' }
+    let(:status_uri) { "#{uri}/info" }
 
-  before do
-    stub_request(:get, status_uri).
-      to_return(status: 200, body: JSON.dump({'user_authentication' => user_authentication}))
-  end
-
-  let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload(deployment: 'd', job: 'j', instance_id: 'i')) }
-
-  let(:user_authentication) { {} }
-
-  it 'should construct a usable url' do
-    expect(plugin.url.to_s).to eq(uri)
-  end
-
-  context 'when the event machine reactor is not running' do
-    it 'should not start' do
-      expect(plugin.run).to be(false)
+    before do
+      stub_request(:get, status_uri).
+        to_return(status: 200, body: JSON.dump({'user_authentication' => user_authentication}))
     end
-  end
 
-  context 'when the event machine reactor is running' do
-    around do |example|
-      EM.run do
-        example.call
-        EM.stop
+    let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload(deployment: 'd', job: 'j', instance_id: 'i')) }
+
+    let(:user_authentication) { {} }
+
+    it 'should construct a usable url' do
+      expect(plugin.url.to_s).to eq(uri)
+    end
+
+    context 'when the event machine reactor is not running' do
+      it 'should not start' do
+        expect(plugin.run).to be(false)
       end
     end
 
-    context 'alerts with deployment, job and id' do
-      let (:event_processor) { Bhm::EventProcessor.new }
-
-      before do
-        Bhm.event_processor = event_processor
-        @don = double(Bhm::Plugins::ResurrectorHelper::AlertTracker, record: nil)
-        expect(Bhm::Plugins::ResurrectorHelper::AlertTracker).to receive(:new).and_return(@don)
-      end
-
-      it 'should be delivered' do
-        expect(@don).to receive(:melting_down?).and_return(false)
-        plugin.run
-
-        request_url = "#{uri}/deployments/d/scan_and_fix"
-        request_data = {
-            head: {
-                'Content-Type' => 'application/json',
-                'authorization' => %w[user password]
-            },
-            body: '{"jobs":{"j":["i"]}}'
-        }
-        expect(plugin).to receive(:send_http_put_request).with(request_url, request_data)
-
-        plugin.process(alert)
-      end
-
-      context 'when auth provider is using UAA token issuer' do
-        let(:user_authentication) do
-          {
-            'type' => 'uaa',
-            'options' => {
-              'url' => 'uaa-url',
-            }
-          }
+    context 'when the event machine reactor is running' do
+      around do |example|
+        EM.run do
+          example.call
+          EM.stop
         end
+      end
+
+      context 'alerts with deployment, job and id' do
+        let (:event_processor) { Bhm::EventProcessor.new }
 
         before do
-          token_issuer = instance_double(CF::UAA::TokenIssuer)
-
-          allow(File).to receive(:exist?).with('ca-cert').and_return(true)
-          allow(File).to receive(:read).with('ca-cert').and_return("test")
-
-          allow(CF::UAA::TokenIssuer).to receive(:new).with(
-            'uaa-url', 'client-id', 'client-secret', {ssl_ca_file: 'ca-cert'}
-          ).and_return(token_issuer)
-          allow(token_issuer).to receive(:client_credentials_grant).
-            and_return(token)
+          Bhm.event_processor = event_processor
+          @don = double(Bhm::Plugins::ResurrectorHelper::AlertTracker, record: nil)
+          expect(Bhm::Plugins::ResurrectorHelper::AlertTracker).to receive(:new).and_return(@don)
         end
-        let(:token) { uaa_token_info('fake-token-id') }
 
-        it 'uses UAA token' do
-          expect(@don).to receive(:melting_down?).and_return(false)
+        it 'should be delivered' do
+          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_NORMAL, {}])
           plugin.run
 
           request_url = "#{uri}/deployments/d/scan_and_fix"
           request_data = {
-            head: {
-              'Content-Type' => 'application/json',
-              'authorization' => token.auth_header
-            },
-            body: '{"jobs":{"j":["i"]}}'
+              head: {
+                  'Content-Type' => 'application/json',
+                  'authorization' => %w[user password]
+              },
+              body: '{"jobs":{"j":["i"]}}'
           }
           expect(plugin).to receive(:send_http_put_request).with(request_url, request_data)
 
           plugin.process(alert)
         end
-      end
 
-      it 'does not deliver while melting down' do
-        expect(@don).to receive(:melting_down?).and_return(true)
-        plugin.run
-        expect(plugin).not_to receive(:send_http_put_request)
-        plugin.process(alert)
-      end
+        context 'when auth provider is using UAA token issuer' do
+          let(:user_authentication) do
+            {
+              'type' => 'uaa',
+              'options' => {
+                'url' => 'uaa-url',
+              }
+            }
+          end
 
-      it 'should alert through EventProcessor while melting down' do
-        expect(@don).to receive(:melting_down?).and_return(true)
-        expected_time = Time.new
-        allow(Time).to receive(:now).and_return(expected_time)
-        alert_option = {
-            :severity => 1,
-            :source => "HM plugin resurrector",
-            :title => "We are in meltdown.",
-            :created_at => expected_time.to_i
-        }
-        expect(event_processor).to receive(:process).with(:alert, alert_option)
-        plugin.run
-        plugin.process(alert)
-      end
-    end
+          before do
+            token_issuer = instance_double(CF::UAA::TokenIssuer)
 
-    context 'alerts without deployment, job and id' do
-      let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload) }
+            allow(File).to receive(:exist?).with('ca-cert').and_return(true)
+            allow(File).to receive(:read).with('ca-cert').and_return("test")
 
-      it 'should not be delivered' do
-        plugin.run
+            allow(CF::UAA::TokenIssuer).to receive(:new).with(
+              'uaa-url', 'client-id', 'client-secret', {ssl_ca_file: 'ca-cert'}
+            ).and_return(token_issuer)
+            allow(token_issuer).to receive(:client_credentials_grant).
+              and_return(token)
+          end
+          let(:token) { uaa_token_info('fake-token-id') }
 
-        expect(plugin).not_to receive(:send_http_put_request)
+          it 'uses UAA token' do
+            expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_NORMAL, {}])
+            plugin.run
 
-        plugin.process(alert)
-      end
-    end
+            request_url = "#{uri}/deployments/d/scan_and_fix"
+            request_data = {
+              head: {
+                'Content-Type' => 'application/json',
+                'authorization' => token.auth_header
+              },
+              body: '{"jobs":{"j":["i"]}}'
+            }
+            expect(plugin).to receive(:send_http_put_request).with(request_url, request_data)
 
-    context 'when director status is not 200' do
-      before do
-        stub_request(:get, status_uri).to_return(status: 500, headers: {}, body: 'Failed')
-      end
-
-      it 'returns false' do
-        plugin.run
-
-        expect(plugin).not_to receive(:send_http_put_request)
-
-        plugin.process(alert)
-      end
-
-      context 'when director starts responding' do
-        before do
-          stub_request(:get, status_uri).to_return({status: 500}, {status: 200, body: '{}'})
+            plugin.process(alert)
+          end
         end
 
-        it 'starts sending alerts' do
+        it 'does not deliver while melting down' do
+          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MELTDOWN, {}])
+          plugin.run
+          expect(plugin).not_to receive(:send_http_put_request)
+          plugin.process(alert)
+        end
+
+        it 'should alert through EventProcessor while melting down' do
+          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MELTDOWN, {}])
+          expected_time = Time.new
+          allow(Time).to receive(:now).and_return(expected_time)
+          alert_option = {
+              :severity => 1,
+              :source => "HM plugin resurrector",
+              :title => "We are in meltdown.",
+              :created_at => expected_time.to_i
+          }
+          expect(event_processor).to receive(:process).with(:alert, alert_option)
+          plugin.run
+          plugin.process(alert)
+        end
+      end
+
+      context 'alerts without deployment, job and id' do
+        let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload) }
+
+        it 'should not be delivered' do
           plugin.run
 
-          expect(plugin).to receive(:send_http_put_request).once
+          expect(plugin).not_to receive(:send_http_put_request)
 
-          plugin.process(alert) # fails to send request
           plugin.process(alert)
+        end
+      end
+
+      context 'when director status is not 200' do
+        before do
+          stub_request(:get, status_uri).to_return(status: 500, headers: {}, body: 'Failed')
+        end
+
+        it 'returns false' do
+          plugin.run
+
+          expect(plugin).not_to receive(:send_http_put_request)
+
+          plugin.process(alert)
+        end
+
+        context 'when director starts responding' do
+          before do
+            stub_request(:get, status_uri).to_return({status: 500}, {status: 200, body: '{}'})
+          end
+
+          it 'starts sending alerts' do
+            plugin.run
+
+            expect(plugin).to receive(:send_http_put_request).once
+
+            plugin.process(alert) # fails to send request
+            plugin.process(alert)
+          end
         end
       end
     end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
@@ -128,8 +128,10 @@ module Bosh::Monitor::Plugins
           allow(Time).to receive(:now).and_return(expected_time)
           alert_option = {
               :severity => 1,
-              :source => "HM plugin resurrector",
               :title => "We are in meltdown.",
+              :summary => "Skipping resurrection for instance: 'j/i'; deployment: d; alerts: nil",
+              :source => "HM plugin resurrector",
+              :deployment => "d",
               :created_at => expected_time.to_i
           }
           expect(event_processor).to receive(:process).with(:alert, alert_option)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
@@ -25,7 +25,7 @@ module Bosh::Monitor::Plugins
         to_return(status: 200, body: JSON.dump({'user_authentication' => user_authentication}))
     end
 
-    let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload(deployment: 'd', job: 'j', instance_id: 'i')) }
+    let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload(deployment: 'd', job: 'j', instance_id: 'i', severity: 1)) }
 
     let(:user_authentication) { {} }
 
@@ -57,7 +57,7 @@ module Bosh::Monitor::Plugins
         end
 
         it 'should be delivered' do
-          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_NORMAL, {}])
+          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MANAGED, {}])
           plugin.run
 
           request_url = "#{uri}/deployments/d/scan_and_fix"
@@ -98,7 +98,7 @@ module Bosh::Monitor::Plugins
           let(:token) { uaa_token_info('fake-token-id') }
 
           it 'uses UAA token' do
-            expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_NORMAL, {}])
+            expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MANAGED, {}])
             plugin.run
 
             request_url = "#{uri}/deployments/d/scan_and_fix"
@@ -167,6 +167,9 @@ module Bosh::Monitor::Plugins
 
         context 'when director starts responding' do
           before do
+            @don = double(Bhm::Plugins::ResurrectorHelper::AlertTracker, record: nil)
+            expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MANAGED, {}])
+            expect(Bhm::Plugins::ResurrectorHelper::AlertTracker).to receive(:new).and_return(@don)
             stub_request(:get, status_uri).to_return({status: 500}, {status: 200, body: '{}'})
           end
 


### PR DESCRIPTION
This PR improves the bosh-monitor handling of meltdown state. The key changes are:

- Adds additional deployment/instance details to logs and alerts, for debugging purposes.
- Increases the fidelity of severity in alerts, which (notably) means that many alerts that previously reported as "normal" now show actual status.
- Adds consideration of alert severity when determining meltdown state. Specifically, "warning" alerts no longer trigger "meltdown" state.