### PR TITLE
Improve HM's handling of "meltdown" state and "rogue" VMs (v2)

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/deployment.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/deployment.rb
@@ -33,11 +33,6 @@ module Bosh::Monitor
         return false
       end
 
-      unless instance.expects_vm
-        @logger.debug("Instance with no VM expected found: #{instance.id}")
-        return false
-      end
-
       instance.deployment = name
       @logger.debug("Discovered new instance #{instance.id}") if @instance_id_to_instance[instance.id].nil?
       @instance_id_to_instance[instance.id] = instance
@@ -64,7 +59,6 @@ module Bosh::Monitor
     # extracts relevant agent data, wraps it into Agent object
     # and adds it to a list of managed agents.
     def upsert_agent(instance)
-
       @logger.info("Adding agent #{instance.agent_id} (#{instance.job}/#{instance.id}) to #{name}...")
 
       agent_id = instance.agent_id

--- a/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
@@ -1,6 +1,7 @@
 module Bosh::Monitor
   module Events
     class Alert < Base
+      CATEGORY_VM_HEALTH = :vm_health
 
       # Considering Bosh::Agent::Alert
       SEVERITY_MAP = {
@@ -11,22 +12,19 @@ module Bosh::Monitor
         -1 => :ignored
       }
 
-      MELTDOWN_STATES = [:alert, :critical, :error]
-
-      attr_reader :created_at, :source, :title
+      attr_reader :created_at, :source, :title, :category
 
       def initialize(attributes = {})
         super
         @kind = :alert
 
-        @id          = @attributes["id"]
-        @severity    = @attributes["severity"]
-        @title       = @attributes["title"]
-        @summary     = @attributes["summary"] || @title
-        @source      = @attributes["source"]
-        @deployment  = @attributes["deployment"] || nil
-        @job         = @attributes["job"] || nil
-        @instance_id = @attributes["instance_id"] || nil
+        @id         = @attributes["id"]
+        @severity   = @attributes["severity"]
+        @category   = @attributes["category"]
+        @title      = @attributes["title"]
+        @summary    = @attributes["summary"] || @title
+        @source     = @attributes["source"]
+        @deployment = @attributes["deployment"]
 
         # This rescue is just to preserve existing test behavior. However, this
         # seems like a pretty wacky way to handle errors - wouldn't we rather
@@ -63,12 +61,11 @@ module Bosh::Monitor
           :kind        => "alert",
           :id          => @id,
           :severity    => @severity,
+          :category    => @category,
           :title       => @title,
           :summary     => @summary,
           :source      => @source,
           :deployment  => @deployment,
-          :job         => @job,
-          :instance_id => @instance_id,
           :created_at  => @created_at.to_i
         }
       end

--- a/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
@@ -58,13 +58,16 @@ module Bosh::Monitor
 
       def to_hash
         {
-          :kind       => "alert",
-          :id         => @id,
-          :severity   => @severity,
-          :title      => @title,
-          :summary    => @summary,
-          :source     => @source,
-          :created_at => @created_at.to_i
+          :kind        => "alert",
+          :id          => @id,
+          :severity    => @severity,
+          :title       => @title,
+          :summary     => @summary,
+          :source      => @source,
+          :deployment  => @deployment,
+          :job         => @job,
+          :instance_id => @instance_id,
+          :created_at  => @created_at.to_i
         }
       end
 

--- a/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
@@ -11,6 +11,8 @@ module Bosh::Monitor
         -1 => :ignored
       }
 
+      MELTDOWN_STATES = [:alert, :critical, :error]
+
       attr_reader :created_at, :source, :title
 
       def initialize(attributes = {})

--- a/src/bosh-monitor/lib/bosh/monitor/instance.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/instance.rb
@@ -42,6 +42,10 @@ module Bosh::Monitor
       "#{@deployment}: #{identifier} [#{attributes.join(', ')}]"
     end
 
+    def expects_vm?
+      !! @expects_vm
+    end
+
     def has_vm?
       @cid != nil
     end

--- a/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
@@ -112,6 +112,7 @@ module Bosh::Monitor
       if agent.timed_out?
         @processor.process(:alert,
                            severity: 2,
+                           category: Events::Alert::CATEGORY_VM_HEALTH,
                            source: agent.name,
                            title: "#{agent.id} has timed out",
                            created_at: ts,
@@ -148,13 +149,13 @@ module Bosh::Monitor
     end
 
     def analyze_instance(instance)
-      unless instance.has_vm?
-        ts = Time.now.to_i
+      if instance.expects_vm? && !instance.has_vm?
         @processor.process(:alert,
                            severity: 2,
+                           category: Events::Alert::CATEGORY_VM_HEALTH,
                            source: instance.name,
                            title: "#{instance.id} has no VM",
-                           created_at: ts,
+                           created_at: Time.now.to_i,
                            deployment: instance.deployment,
                            job: instance.job,
                            instance_id: instance.id)

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/datadog.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/datadog.rb
@@ -90,12 +90,11 @@ module Bosh::Monitor
       def severity_for(alert)
         NORMAL_PRIORITY.include?(alert.severity) ? 'error' : 'warning'
       end
+
       def tags_for(data)
         [].tap do |tags|
           tags << "source:#{data[:source]}"
           tags << "deployment:#{data[:deployment]}"
-          tags << "instance_group:#{data[:job]}"
-          tags << "instance_id:#{data[:instance_id]}"
         end
       end
     end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
@@ -52,6 +52,12 @@ module Bosh::Monitor::Plugins
         @time_threshold     = args.fetch('time_threshold', 600)
       end
 
+      def record(agent_key, alert)
+        if Bosh::Monitor::Events::Alert::MELTDOWN_STATES.include?(alert.severity)
+          @alert_times[agent_key] = alert.created_at
+        end
+      end
+
       def state_for(deployment)
         agents = fetch_agents(deployment)
         alerts = fetch_alerts(agents)
@@ -75,10 +81,6 @@ module Bosh::Monitor::Plugins
         end
 
         [STATE_NORMAL, details]
-      end
-
-      def record(agent_key, alert_time)
-        @alert_times[agent_key] = alert_time
       end
 
       private

--- a/src/bosh-monitor/spec/spec_helper.rb
+++ b/src/bosh-monitor/spec/spec_helper.rb
@@ -40,12 +40,15 @@ end
 
 def make_alert(attrs = {})
   defaults = {
-      :id => 1,
-      :severity => 2,
-      :title => 'Test Alert',
-      :summary => 'Everything is down',
-      :source => 'mysql_node/instance_id_abc',
-      :created_at => Time.now.to_i
+      "id" => 1,
+      "severity" => 2,
+      "title" => 'Test Alert',
+      "summary" => 'Everything is down',
+      "source" => 'mysql_node/instance_id_abc',
+      "deployment" => 'deployment',
+      "job" => 'job',
+      "instance_id" => 'instance_id',
+      "created_at" => Time.now.to_i
   }
   Bhm::Events::Alert.new(defaults.merge(attrs))
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/deployment_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/deployment_spec.rb
@@ -51,10 +51,6 @@ describe Bhm::Deployment do
       expect(deployment.instances.size).to eq(1)
     end
 
-    it "refuse to add instance with 'expects_vm=false'" do
-      expect(deployment.add_instance(Bhm::Instance.create({'id' => 'iuuid', 'job' => 'zb', 'index' => '0', 'expects_vm' => false}))).to be(false)
-    end
-
     it 'overrides existing instance' do
       deployment.add_instance(Bhm::Instance.create({'id' => 'iuuid', 'agent_id' => 'auuid', 'cid' => 'cid', 'expects_vm' => true}))
       updated_instance = Bhm::Instance.create({'id' => 'iuuid', 'agent_id' => 'another-auuid', 'cid' => 'another-cid', 'expects_vm' => true})

--- a/src/bosh-monitor/spec/unit/bosh/monitor/events/alert_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/events/alert_spec.rb
@@ -25,13 +25,16 @@ describe Bhm::Events::Alert do
   it "has hash representation" do
     ts = Time.now
     expect(make_alert(:created_at => ts.to_i).to_hash).to eq({
-      :kind       => "alert",
-      :id         => 1,
-      :severity   => 2,
-      :title      => "Test Alert",
-      :summary    => "Everything is down",
-      :source     => "mysql_node/instance_id_abc",
-      :created_at => ts.to_i
+      :kind        => "alert",
+      :id          => 1,
+      :severity    => 2,
+      :title       => "Test Alert",
+      :summary     => "Everything is down",
+      :source      => "mysql_node/instance_id_abc",
+      :deployment  => "deployment",
+      :job         => "job",
+      :instance_id => "instance_id",
+      :created_at  => ts.to_i
     })
   end
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/events/alert_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/events/alert_spec.rb
@@ -28,12 +28,11 @@ describe Bhm::Events::Alert do
       :kind        => "alert",
       :id          => 1,
       :severity    => 2,
+      :category    => nil,
       :title       => "Test Alert",
       :summary     => "Everything is down",
       :source      => "mysql_node/instance_id_abc",
       :deployment  => "deployment",
-      :job         => "job",
-      :instance_id => "instance_id",
       :created_at  => ts.to_i
     })
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
@@ -268,6 +268,7 @@ module Bhm
               :alert,
               {
                   severity: 2,
+                  category: :vm_health,
                   source: 'mycloud: mutator(some-sort-of-uuid) [id=007, index=0, cid=]',
                   title: '007 has timed out',
                   created_at: anything,
@@ -331,6 +332,16 @@ module Bhm
         expect(event_processor).to_not receive(:process)
         expect(manager.analyze_instance(Bhm::Instance.create(instance))).to be(true)
       end
+
+      context 'when the instances expects a VM, and does not have one' do
+        it 'sends an alert' do
+          instance = {'id' => 'instance-uuid', 'agent_id' => '007', 'index' => '0', 'cid' => nil, 'job' => 'mutator', 'expects_vm' => true}
+          manager.sync_instances('my_deployment', [instance])
+
+          expect(event_processor).to receive(:process)
+          expect(manager.analyze_instance(Bhm::Instance.create(instance))).to be(true)
+        end
+      end
     end
 
     describe '#analyze_instances' do
@@ -360,6 +371,7 @@ module Bhm
             :alert,
             {
                 severity: 2,
+                category: :vm_health,
                 source: 'my_deployment: mutator(instance-uuid) [agent_id=007, index=0, cid=]',
                 title: 'instance-uuid has no VM',
                 created_at: anything,

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
@@ -151,7 +151,7 @@ describe Bhm::Plugins::DataDog do
         expect(msg).to eq('Everything is down')
         expect(options[:msg_title]).to eq('Test Alert')
         expect(options[:date_happened]).to eq(time)
-        expect(options[:tags]).to match_array(['deployment:deployment', 'instance_group:job', 'instance_id:instance_id', 'source:mysql_node/instance_id_abc'])
+        expect(options[:tags]).to match_array(['deployment:deployment', 'source:mysql_node/instance_id_abc'])
         expect(options[:priority]).to eq('normal')
       }.and_return(fake_event)
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
@@ -151,7 +151,7 @@ describe Bhm::Plugins::DataDog do
         expect(msg).to eq('Everything is down')
         expect(options[:msg_title]).to eq('Test Alert')
         expect(options[:date_happened]).to eq(time)
-        expect(options[:tags]).to match_array(['source:mysql_node/instance_id_abc'])
+        expect(options[:tags]).to match_array(['deployment:deployment', 'instance_group:job', 'instance_id:instance_id', 'source:mysql_node/instance_id_abc'])
         expect(options[:priority]).to eq('normal')
       }.and_return(fake_event)
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
@@ -14,7 +14,10 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
         allow(instance_manager).to receive(:get_agents_for_deployment).with('deployment').and_return(agents)
         allow(Bhm).to receive_messages(instance_manager: instance_manager)
 
-        alerts.times { |i| tracker.record(build_key(i), Time.now) }
+        alerts.times do |i|
+          alert = double(Bosh::Monitor::Events::Alert, created_at: Time.now, severity: :error)
+          tracker.record(build_key(i), alert)
+        end
       end
 
       context 'when the number of unresponsive agents is 0' do
@@ -78,9 +81,9 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
 
         it 'excludes those alerts' do
           now = Time.now
-          tracker.record(build_key(0), now - 610)
-          tracker.record(build_key(1), now - 600)
-          tracker.record(build_key(2), now - 60)
+          tracker.record(build_key(0), double(Bosh::Monitor::Events::Alert, created_at: (now - 610), severity: :error))
+          tracker.record(build_key(1), double(Bosh::Monitor::Events::Alert, created_at: (now - 600), severity: :error))
+          tracker.record(build_key(2), double(Bosh::Monitor::Events::Alert, created_at: (now - 60), severity: :error))
 
           state, details = tracker.state_for(deployment)
           expect(state).to be(AlertTracker::STATE_MELTDOWN)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
@@ -1,62 +1,115 @@
 require 'spec_helper'
 
-describe Bhm::Plugins::ResurrectorHelper::AlertTracker do
-  describe '#melting_down?' do
-    let(:agents) {
-      agents = {}
-      100.times.each do |i|
-        agents["00#{i}"]= Bhm::Agent.new("00#{i}", deployment: 'deployment', job: "00#{i}", instance_id: "uuid#{i.to_s}")
-      end
-      agents
-    }
+module Bosh::Monitor::Plugins::ResurrectorHelper
+  describe AlertTracker do
+    subject(:tracker) { AlertTracker.new(config) }
+    let(:config) { {} }
+    let(:agents) { build_agents(10) }
+    let(:alerts) { 0 }
+    let(:deployment) { 'deployment'}
 
-    let(:job_instance_keys) {
-      100.times.map do |i|
+    describe '#state_for' do
+      before do
+        instance_manager = double(Bhm::InstanceManager)
+        allow(instance_manager).to receive(:get_agents_for_deployment).with('deployment').and_return(agents)
+        allow(Bhm).to receive_messages(instance_manager: instance_manager)
+
+        alerts.times { |i| tracker.record(build_key(i), Time.now) }
+      end
+
+      context 'when the number of unresponsive agents is 0' do
+        it 'reports as "normal"' do
+          state, details = tracker.state_for(deployment)
+          expect(state).to be(AlertTracker::STATE_NORMAL)
+          expect(details).to eq({
+            'deployment' => 'deployment',
+            'alerts' => { 'count' => 0, 'percent' => '0.0%' }
+          })
+        end
+      end
+
+      context 'when the number of unresponsive agents is below the meltdown count threshold' do
+        let(:config) { { 'minimum_down_jobs' => 2, 'percent_threshold' => 0.0 } }
+        let(:alerts) { 1 }
+
+        it 'reports as "managed"' do
+          state, details = tracker.state_for(deployment)
+          expect(state).to be(AlertTracker::STATE_MANAGED)
+          expect(details).to eq({
+            'deployment' => deployment,
+            'alerts' => { 'count' => 1, 'percent' => '10.0%' }
+          })
+        end
+      end
+
+      context 'when the number of unresponsive agents is at/above the meltdown count threshold' do
+        context 'and below the percent threshold' do
+          let(:config) { { 'minimum_down_jobs' => 2, 'percent_threshold' => 0.21 } }
+          let(:alerts) { 2 }
+
+          it 'reports as "managed"' do
+            state, details = tracker.state_for(deployment)
+            expect(state).to be(AlertTracker::STATE_MANAGED)
+            expect(details).to eq({
+              'deployment' => deployment,
+              'alerts' => { 'count' => 2, 'percent' => '20.0%' }
+            })
+          end
+        end
+
+        context 'and at/above the percent threshold' do
+          let(:config) { { 'minimum_down_jobs' => 2, 'percent_threshold' => 0.20 } }
+          let(:alerts) { 2 }
+
+          it 'reports as "meltdown"' do
+            state, details = tracker.state_for(deployment)
+            expect(state).to be(AlertTracker::STATE_MELTDOWN)
+            expect(details).to eq({
+              'deployment' => deployment,
+              'alerts' => { 'count' => 2, 'percent' => '20.0%' }
+            })
+          end
+        end
+      end
+
+      context 'when recorded alerts are outside of the time threshold' do
+        let(:config) { { 'minimum_down_jobs' => 2, 'time_threshold' => 600 } }
+        let(:alerts) { 0 }
+
+        it 'excludes those alerts' do
+          now = Time.now
+          tracker.record(build_key(0), now - 610)
+          tracker.record(build_key(1), now - 600)
+          tracker.record(build_key(2), now - 60)
+
+          state, details = tracker.state_for(deployment)
+          expect(state).to be(AlertTracker::STATE_MELTDOWN)
+          expect(details).to eq({
+            'deployment' => deployment,
+            'alerts' => { 'count' => 2, 'percent' => '20.0%' }
+          })
+        end
+      end
+
+      def build_agents(count)
+        {}.tap do |result|
+          count.times { |i| result["00#{i}"]= Bhm::Agent.new("00#{i}", deployment: 'deployment', job: "00#{i}", instance_id: "uuid#{i.to_s}") }
+        end
+      end
+
+      def build_key(i)
         Bhm::Plugins::ResurrectorHelper::JobInstanceKey.new('deployment', "00#{i}", "uuid#{i.to_s}")
       end
-    }
-
-    before do
-      mock_instance_manager = double(Bhm::InstanceManager)
-      allow(mock_instance_manager).to receive(:get_agents_for_deployment).with('deployment').and_return(agents)
-      allow(Bhm).to receive_messages(instance_manager: mock_instance_manager)
-    end
-
-    it 'is melting down if more than 30% of agents are down' do
-      alert_tracker = described_class.new('percent_threshold' => 0.3)
-      31.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
-
-      expect(alert_tracker.melting_down?('deployment')).to be(true)
-    end
-
-    it 'is not melting down if less than 30% of agents are down' do
-      alert_tracker = described_class.new('percent_threshold' => 0.3)
-      29.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
-
-      expect(alert_tracker.melting_down?('deployment')).to be(false)
-    end
-
-    it 'is not melting down if less than 7 agents are down' do
-      alert_tracker = described_class.new('minimum_down_jobs' => 7, 'percent_threshold' => 0.01)
-      6.times { |i| alert_tracker.record(job_instance_keys[i], Time.now) }
-
-      expect(alert_tracker.melting_down?('deployment')).to be(false)
-    end
-
-    it 'is not melting down if all agents are responding' do
-      alert_tracker = described_class.new('percent_threshold' => 0.0)
-
-      expect(alert_tracker.melting_down?('deployment')).to be(false)
     end
   end
-end
 
-describe Bhm::Plugins::ResurrectorHelper::JobInstanceKey do
-  it 'hashes properly' do
-    key1 = described_class.new('deployment', 'job', 'uuid0')
-    key2 = described_class.new('deployment', 'job', 'uuid0')
-    hash = { key1 => 'foo' }
+  describe JobInstanceKey do
+    it 'hashes properly' do
+      key1 = described_class.new('deployment', 'job', 'uuid0')
+      key2 = described_class.new('deployment', 'job', 'uuid0')
+      hash = { key1 => 'foo' }
 
-    expect(hash[key2]).to eq('foo')
+      expect(hash[key2]).to eq('foo')
+    end
   end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
@@ -1,179 +1,183 @@
 require 'spec_helper'
 
-describe 'Bhm::Plugins::Resurrector' do
-  include Support::UaaHelpers
+module Bosh::Monitor::Plugins
+  describe Resurrector do
+    include Support::UaaHelpers
 
-  let(:options) {
-    {
-      'director' => {
-        'endpoint' => 'http://foo.bar.com:25555',
-        'user' => 'user',
-        'password' => 'password',
-        'client_id' => 'client-id',
-        'client_secret' => 'client-secret',
-        'ca_cert' => 'ca-cert'
+    let(:options) {
+      {
+        'director' => {
+          'endpoint' => 'http://foo.bar.com:25555',
+          'user' => 'user',
+          'password' => 'password',
+          'client_id' => 'client-id',
+          'client_secret' => 'client-secret',
+          'ca_cert' => 'ca-cert'
+        }
       }
     }
-  }
-  let(:plugin) { Bhm::Plugins::Resurrector.new(options) }
-  let(:uri) { 'http://foo.bar.com:25555' }
-  let(:status_uri) { "#{uri}/info" }
+    let(:plugin) { Bhm::Plugins::Resurrector.new(options) }
+    let(:uri) { 'http://foo.bar.com:25555' }
+    let(:status_uri) { "#{uri}/info" }
 
-  before do
-    stub_request(:get, status_uri).
-      to_return(status: 200, body: JSON.dump({'user_authentication' => user_authentication}))
-  end
-
-  let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload(deployment: 'd', job: 'j', instance_id: 'i')) }
-
-  let(:user_authentication) { {} }
-
-  it 'should construct a usable url' do
-    expect(plugin.url.to_s).to eq(uri)
-  end
-
-  context 'when the event machine reactor is not running' do
-    it 'should not start' do
-      expect(plugin.run).to be(false)
+    before do
+      stub_request(:get, status_uri).
+        to_return(status: 200, body: JSON.dump({'user_authentication' => user_authentication}))
     end
-  end
 
-  context 'when the event machine reactor is running' do
-    around do |example|
-      EM.run do
-        example.call
-        EM.stop
+    let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload(deployment: 'd', job: 'j', instance_id: 'i')) }
+
+    let(:user_authentication) { {} }
+
+    it 'should construct a usable url' do
+      expect(plugin.url.to_s).to eq(uri)
+    end
+
+    context 'when the event machine reactor is not running' do
+      it 'should not start' do
+        expect(plugin.run).to be(false)
       end
     end
 
-    context 'alerts with deployment, job and id' do
-      let (:event_processor) { Bhm::EventProcessor.new }
-
-      before do
-        Bhm.event_processor = event_processor
-        @don = double(Bhm::Plugins::ResurrectorHelper::AlertTracker, record: nil)
-        expect(Bhm::Plugins::ResurrectorHelper::AlertTracker).to receive(:new).and_return(@don)
-      end
-
-      it 'should be delivered' do
-        expect(@don).to receive(:melting_down?).and_return(false)
-        plugin.run
-
-        request_url = "#{uri}/deployments/d/scan_and_fix"
-        request_data = {
-            head: {
-                'Content-Type' => 'application/json',
-                'authorization' => %w[user password]
-            },
-            body: '{"jobs":{"j":["i"]}}'
-        }
-        expect(plugin).to receive(:send_http_put_request).with(request_url, request_data)
-
-        plugin.process(alert)
-      end
-
-      context 'when auth provider is using UAA token issuer' do
-        let(:user_authentication) do
-          {
-            'type' => 'uaa',
-            'options' => {
-              'url' => 'uaa-url',
-            }
-          }
+    context 'when the event machine reactor is running' do
+      around do |example|
+        EM.run do
+          example.call
+          EM.stop
         end
+      end
+
+      context 'alerts with deployment, job and id' do
+        let (:event_processor) { Bhm::EventProcessor.new }
 
         before do
-          token_issuer = instance_double(CF::UAA::TokenIssuer)
-
-          allow(File).to receive(:exist?).with('ca-cert').and_return(true)
-          allow(File).to receive(:read).with('ca-cert').and_return("test")
-
-          allow(CF::UAA::TokenIssuer).to receive(:new).with(
-            'uaa-url', 'client-id', 'client-secret', {ssl_ca_file: 'ca-cert'}
-          ).and_return(token_issuer)
-          allow(token_issuer).to receive(:client_credentials_grant).
-            and_return(token)
+          Bhm.event_processor = event_processor
+          @don = double(Bhm::Plugins::ResurrectorHelper::AlertTracker, record: nil)
+          expect(Bhm::Plugins::ResurrectorHelper::AlertTracker).to receive(:new).and_return(@don)
         end
-        let(:token) { uaa_token_info('fake-token-id') }
 
-        it 'uses UAA token' do
-          expect(@don).to receive(:melting_down?).and_return(false)
+        it 'should be delivered' do
+          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_NORMAL, {}])
           plugin.run
 
           request_url = "#{uri}/deployments/d/scan_and_fix"
           request_data = {
-            head: {
-              'Content-Type' => 'application/json',
-              'authorization' => token.auth_header
-            },
-            body: '{"jobs":{"j":["i"]}}'
+              head: {
+                  'Content-Type' => 'application/json',
+                  'authorization' => %w[user password]
+              },
+              body: '{"jobs":{"j":["i"]}}'
           }
           expect(plugin).to receive(:send_http_put_request).with(request_url, request_data)
 
           plugin.process(alert)
         end
-      end
 
-      it 'does not deliver while melting down' do
-        expect(@don).to receive(:melting_down?).and_return(true)
-        plugin.run
-        expect(plugin).not_to receive(:send_http_put_request)
-        plugin.process(alert)
-      end
+        context 'when auth provider is using UAA token issuer' do
+          let(:user_authentication) do
+            {
+              'type' => 'uaa',
+              'options' => {
+                'url' => 'uaa-url',
+              }
+            }
+          end
 
-      it 'should alert through EventProcessor while melting down' do
-        expect(@don).to receive(:melting_down?).and_return(true)
-        expected_time = Time.new
-        allow(Time).to receive(:now).and_return(expected_time)
-        alert_option = {
-            :severity => 1,
-            :source => "HM plugin resurrector",
-            :title => "We are in meltdown.",
-            :created_at => expected_time.to_i
-        }
-        expect(event_processor).to receive(:process).with(:alert, alert_option)
-        plugin.run
-        plugin.process(alert)
-      end
-    end
+          before do
+            token_issuer = instance_double(CF::UAA::TokenIssuer)
 
-    context 'alerts without deployment, job and id' do
-      let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload) }
+            allow(File).to receive(:exist?).with('ca-cert').and_return(true)
+            allow(File).to receive(:read).with('ca-cert').and_return("test")
 
-      it 'should not be delivered' do
-        plugin.run
+            allow(CF::UAA::TokenIssuer).to receive(:new).with(
+              'uaa-url', 'client-id', 'client-secret', {ssl_ca_file: 'ca-cert'}
+            ).and_return(token_issuer)
+            allow(token_issuer).to receive(:client_credentials_grant).
+              and_return(token)
+          end
+          let(:token) { uaa_token_info('fake-token-id') }
 
-        expect(plugin).not_to receive(:send_http_put_request)
+          it 'uses UAA token' do
+            expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_NORMAL, {}])
+            plugin.run
 
-        plugin.process(alert)
-      end
-    end
+            request_url = "#{uri}/deployments/d/scan_and_fix"
+            request_data = {
+              head: {
+                'Content-Type' => 'application/json',
+                'authorization' => token.auth_header
+              },
+              body: '{"jobs":{"j":["i"]}}'
+            }
+            expect(plugin).to receive(:send_http_put_request).with(request_url, request_data)
 
-    context 'when director status is not 200' do
-      before do
-        stub_request(:get, status_uri).to_return(status: 500, headers: {}, body: 'Failed')
-      end
-
-      it 'returns false' do
-        plugin.run
-
-        expect(plugin).not_to receive(:send_http_put_request)
-
-        plugin.process(alert)
-      end
-
-      context 'when director starts responding' do
-        before do
-          stub_request(:get, status_uri).to_return({status: 500}, {status: 200, body: '{}'})
+            plugin.process(alert)
+          end
         end
 
-        it 'starts sending alerts' do
+        it 'does not deliver while melting down' do
+          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MELTDOWN, {}])
+          plugin.run
+          expect(plugin).not_to receive(:send_http_put_request)
+          plugin.process(alert)
+        end
+
+        it 'should alert through EventProcessor while melting down' do
+          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MELTDOWN, {}])
+          expected_time = Time.new
+          allow(Time).to receive(:now).and_return(expected_time)
+          alert_option = {
+              :severity => 1,
+              :title => "We are in meltdown.",
+              :summary => "Skipping resurrection for instance: 'j/i'; deployment: d; alerts: nil",
+              :source => "HM plugin resurrector",
+              :deployment => "d",
+              :created_at => expected_time.to_i
+          }
+          expect(event_processor).to receive(:process).with(:alert, alert_option)
+          plugin.run
+          plugin.process(alert)
+        end
+      end
+
+      context 'alerts without deployment, job and id' do
+        let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload) }
+
+        it 'should not be delivered' do
           plugin.run
 
-          expect(plugin).to receive(:send_http_put_request).once
+          expect(plugin).not_to receive(:send_http_put_request)
 
-          plugin.process(alert) # fails to send request
           plugin.process(alert)
+        end
+      end
+
+      context 'when director status is not 200' do
+        before do
+          stub_request(:get, status_uri).to_return(status: 500, headers: {}, body: 'Failed')
+        end
+
+        it 'returns false' do
+          plugin.run
+
+          expect(plugin).not_to receive(:send_http_put_request)
+
+          plugin.process(alert)
+        end
+
+        context 'when director starts responding' do
+          before do
+            stub_request(:get, status_uri).to_return({status: 500}, {status: 200, body: '{}'})
+          end
+
+          it 'starts sending alerts' do
+            plugin.run
+
+            expect(plugin).to receive(:send_http_put_request).once
+
+            plugin.process(alert) # fails to send request
+            plugin.process(alert)
+          end
         end
       end
     end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
@@ -25,7 +25,7 @@ module Bosh::Monitor::Plugins
         to_return(status: 200, body: JSON.dump({'user_authentication' => user_authentication}))
     end
 
-    let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload(deployment: 'd', job: 'j', instance_id: 'i')) }
+    let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload(deployment: 'd', job: 'j', instance_id: 'i', severity: 1)) }
 
     let(:user_authentication) { {} }
 
@@ -57,7 +57,7 @@ module Bosh::Monitor::Plugins
         end
 
         it 'should be delivered' do
-          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_NORMAL, {}])
+          expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MANAGED, {}])
           plugin.run
 
           request_url = "#{uri}/deployments/d/scan_and_fix"
@@ -98,7 +98,7 @@ module Bosh::Monitor::Plugins
           let(:token) { uaa_token_info('fake-token-id') }
 
           it 'uses UAA token' do
-            expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_NORMAL, {}])
+            expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MANAGED, {}])
             plugin.run
 
             request_url = "#{uri}/deployments/d/scan_and_fix"
@@ -167,6 +167,9 @@ module Bosh::Monitor::Plugins
 
         context 'when director starts responding' do
           before do
+            @don = double(Bhm::Plugins::ResurrectorHelper::AlertTracker, record: nil)
+            expect(@don).to receive(:state_for).and_return([ResurrectorHelper::AlertTracker::STATE_MANAGED, {}])
+            expect(Bhm::Plugins::ResurrectorHelper::AlertTracker).to receive(:new).and_return(@don)
             stub_request(:get, status_uri).to_return({status: 500}, {status: 200, body: '{}'})
           end
 


### PR DESCRIPTION
This PR improves the bosh-monitor handling of meltdown state and of "rogue" VMs. The key changes are:

- Adds additional deployment/instance details to logs and alerts.
- Increases the fidelity of severity in alerts, which (notably) means that many alerts that previously reported as "normal" now show actual status (warning/error).
- Adds consideration of alert *category* when determining meltdown state. Specifically, "VM health" alerts might trigger "meltdown" state, but others (such as SSH login/logout) will not do so.
- Adds a check to see that an does not have VM, in addition to it expecting one. This allows all instances to be recorded, there by resolving an issue in which errand jobs were considered "rogue".
