### PR TITLE
Use /scratch mount for docker data-dir in main-bosh-docker

### DIFF
--- a/ci/docker/main-bosh-docker/start-bosh.sh
+++ b/ci/docker/main-bosh-docker/start-bosh.sh
@@ -99,7 +99,7 @@ function start_docker() {
 
   local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
 
-  local server_args="--mtu ${mtu} --host ${DOCKER_HOST} --tlsverify --tlscacert=${certs_dir}/ca.pem --tlscert=${certs_dir}/server-cert.pem --tlskey=${certs_dir}/server-key.pem"
+  local server_args="--mtu ${mtu} --host ${DOCKER_HOST} --tlsverify --tlscacert=${certs_dir}/ca.pem --tlscert=${certs_dir}/server-cert.pem --tlskey=${certs_dir}/server-key.pem --data-root /scratch/docker"
   local registry=""
 
   for registry in $1; do


### PR DESCRIPTION
Avoids the following error in recent versions of concourse...

    Deploying:
      Creating instance bosh/0:
        Creating VM:
          Creating vm with stemcell cid bosh.io/stemcells:bc05e9fa-ede3-4250-6adf-8f91d30a170a:
            CPI create_vm method responded with error: CmdError{"type":"Bosh::Clouds::CloudError","message":"Creating VM with agent ID {{d52dc281-7207-4c4f-58b0-df2fd5c89ba8}}: Creating container: Error response from daemon: error creating aufs mount to /var/lib/docker/aufs/mnt/eaa48325c874cccbb68e0138d742fb1283a32511434d84576725fb566bda6233-init: invalid argument","ok_to_retry":false}

Related...

 * https://github.com/concourse/concourse/issues/1045
 * https://github.com/concourse/docker-image-resource/blob/7ffaffb69b052c02cffa9a1bfed30b355af2c453/assets/common.sh#L64

Built [dpb587/bosh-main-bosh-docker:scratch](https://hub.docker.com/r/dpb587/bosh-main-bosh-docker/) and tested this change with concourse 3.1.1. Docker daemon seems to create the data directory, so I'm fairly certain it's backward-compatible with older Concourses. Might want to test it on a <3 version to be sure.