### PR TITLE
Improve HM Heartbeat Reporting

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/events/heartbeat.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/events/heartbeat.rb
@@ -1,7 +1,7 @@
 module Bosh::Monitor
   module Events
     class Heartbeat < Base
-      HEALTHY_STATES = ['stopped', 'starting', 'running']
+      HEALTHY_STATES = ['running']
 
       attr_reader :agent_id, :deployment, :job, :index, :metrics, :instance_id, :teams
 
@@ -109,14 +109,7 @@ module Bosh::Monitor
         add_metric('system.disk.persistent.percent', @persistent_disk['percent'])
         add_metric('system.disk.persistent.inode_percent', @persistent_disk['inode_percent'])
 
-        if HEALTHY_STATES.include?(@job_state)
-          add_metric('system.healthy', 1)
-          add_metric('system.unhealthy', 0)
-        else
-          add_metric('system.healthy', 0)
-          add_metric('system.unhealthy', 1)
-        end
-
+        add_metric('system.healthy', HEALTHY_STATES.include?(@job_state) ? 1 : 0)
         add_metric("system.health.#{@job_state}", 1)
       end
     end

--- a/src/bosh-monitor/lib/bosh/monitor/events/heartbeat.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/events/heartbeat.rb
@@ -1,6 +1,7 @@
 module Bosh::Monitor
   module Events
     class Heartbeat < Base
+      HEALTHY_STATES = ['stopped', 'starting', 'running']
 
       attr_reader :agent_id, :deployment, :job, :index, :metrics, :instance_id, :teams
 
@@ -107,9 +108,17 @@ module Bosh::Monitor
         add_metric('system.disk.ephemeral.inode_percent', @ephemeral_disk['inode_percent'])
         add_metric('system.disk.persistent.percent', @persistent_disk['percent'])
         add_metric('system.disk.persistent.inode_percent', @persistent_disk['inode_percent'])
-        add_metric('system.healthy', @job_state == 'running' ? 1 : 0)
-      end
 
+        if HEALTHY_STATES.include?(@job_state)
+          add_metric('system.healthy', 1)
+          add_metric('system.unhealthy', 0)
+        else
+          add_metric('system.healthy', 0)
+          add_metric('system.unhealthy', 1)
+        end
+
+        add_metric("system.health.#{@job_state}", 1)
+      end
     end
   end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/events/heartbeat_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/events/heartbeat_spec.rb
@@ -5,27 +5,6 @@ describe Bhm::Events::Heartbeat do
 
   let(:heartbeat) { make_heartbeat(timestamp: timestamp) }
 
-  context 'validations' do
-    it 'requires id' do
-      expect(make_heartbeat(:id => nil)).not_to be_valid
-    end
-
-    it 'requires timestamp' do
-      expect(make_heartbeat(:timestamp => nil)).not_to be_valid
-    end
-
-    it 'supports attributes validation' do
-      bad_heartbeat = make_heartbeat(:id => nil, :timestamp => nil)
-      expect(bad_heartbeat).not_to be_valid
-      expect(bad_heartbeat.error_message).to eq('id is missing, timestamp is missing')
-    end
-
-    it 'should be valid' do
-      expect(heartbeat).to be_valid
-      expect(heartbeat.kind).to eq(:heartbeat)
-    end
-  end
-
   it 'has short description' do
     expect(heartbeat.short_description).to eq('Heartbeat from mysql_node/instance_id_abc (agent_id=deadbeef index=0) @ 2011-11-02 01:08:19 UTC')
 
@@ -115,4 +94,24 @@ describe Bhm::Events::Heartbeat do
     expect(metrics['system.healthy']).to eq(1)
   end
 
+  context 'validations' do
+    it 'requires id' do
+      expect(make_heartbeat(:id => nil)).not_to be_valid
+    end
+
+    it 'requires timestamp' do
+      expect(make_heartbeat(:timestamp => nil)).not_to be_valid
+    end
+
+    it 'supports attributes validation' do
+      bad_heartbeat = make_heartbeat(:id => nil, :timestamp => nil)
+      expect(bad_heartbeat).not_to be_valid
+      expect(bad_heartbeat.error_message).to eq('id is missing, timestamp is missing')
+    end
+
+    it 'should be valid' do
+      expect(heartbeat).to be_valid
+      expect(heartbeat.kind).to eq(:heartbeat)
+    end
+  end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/events/heartbeat_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/events/heartbeat_spec.rb
@@ -72,13 +72,6 @@ describe Bhm::Events::Heartbeat do
   end
 
   it 'has metrics' do
-    hb = heartbeat
-    metrics = hb.metrics.inject({}) do |h, m|
-      expect(m).to be_kind_of(Bhm::Metric)
-      expect(m.tags).to eq({'job' => 'mysql_node', 'index' => '0', 'id' => 'instance_id_abc'})
-      h[m.name] = m.value; h
-    end
-
     expect(metrics['system.load.1m']).to eq(0.2)
     expect(metrics['system.cpu.user']).to eq(22.3)
     expect(metrics['system.cpu.sys']).to eq(23.4)
@@ -188,6 +181,8 @@ describe Bhm::Events::Heartbeat do
 
   def metrics
     metrics = heartbeat.metrics.inject({}) do |hash, metric|
+      expect(metric).to be_kind_of(Bhm::Metric)
+      expect(metric.tags).to eq({'job' => 'mysql_node', 'index' => '0', 'id' => 'instance_id_abc'})
       hash[metric.name] = metric.value;
       hash
     end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/events/heartbeat_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/events/heartbeat_spec.rb
@@ -50,7 +50,6 @@ describe Bhm::Events::Heartbeat do
           {:name => "system.disk.persistent.percent", :value => "97", :timestamp => 1320196099, :tags => {"job" => "mysql_node", "index" => "0", "id" => "instance_id_abc"}},
           {:name => "system.disk.persistent.inode_percent", :value => "10", :timestamp => 1320196099, :tags => {"job" => "mysql_node", "index" => "0", "id" => "instance_id_abc"}},
           {:name => "system.healthy", :value => "1", :timestamp => 1320196099, :tags => {"job" => "mysql_node", "index" => "0", "id" => "instance_id_abc"}},
-          {:name => "system.unhealthy", :value => "0", :timestamp => 1320196099, :tags => {"job" => "mysql_node", "index" => "0", "id" => "instance_id_abc"}},
           {:name => "system.health.running", :value => "1", :timestamp => 1320196099, :tags => {"job" => "mysql_node", "index" => "0", "id" => "instance_id_abc"}}
       ],
     })
@@ -87,6 +86,7 @@ describe Bhm::Events::Heartbeat do
     expect(metrics['system.disk.persistent.percent']).to eq(97)
     expect(metrics['system.disk.persistent.inode_percent']).to eq(10)
     expect(metrics['system.healthy']).to eq(1)
+    expect(metrics['system.health.running']).to eq(1)
   end
 
   context 'validations' do
@@ -114,9 +114,8 @@ describe Bhm::Events::Heartbeat do
     context 'when state is "stopped"' do
       let(:heartbeat) { make_heartbeat({ :job_state => 'stopped' }) }
 
-      it 'reports as "healthy"' do
-        expect(metrics['system.healthy']).to eq(1)
-        expect(metrics['system.unhealthy']).to eq(0)
+      it 'does not report as "healthy"' do
+        expect(metrics['system.healthy']).to eq(0)
       end
 
       it 'reports health as "stopped"' do
@@ -127,9 +126,8 @@ describe Bhm::Events::Heartbeat do
     context 'when state is "starting"' do
       let(:heartbeat) { make_heartbeat({ :job_state => 'starting' }) }
 
-      it 'reports as "healthy"' do
-        expect(metrics['system.healthy']).to eq(1)
-        expect(metrics['system.unhealthy']).to eq(0)
+      it 'does not report as "healthy"' do
+        expect(metrics['system.healthy']).to eq(0)
       end
 
       it 'reports health as "starting"' do
@@ -142,7 +140,6 @@ describe Bhm::Events::Heartbeat do
 
       it 'reports as "healthy"' do
         expect(metrics['system.healthy']).to eq(1)
-        expect(metrics['system.unhealthy']).to eq(0)
       end
 
       it 'reports health as "running"' do
@@ -153,9 +150,8 @@ describe Bhm::Events::Heartbeat do
     context 'when state is "failing"' do
       let(:heartbeat) { make_heartbeat({ :job_state => 'failing' }) }
 
-      it 'reports as "unhealthy"' do
+      it 'does not report as "healthy"' do
         expect(metrics['system.healthy']).to eq(0)
-        expect(metrics['system.unhealthy']).to eq(1)
       end
 
       it 'reports health as "failing"' do
@@ -166,9 +162,8 @@ describe Bhm::Events::Heartbeat do
     context 'when state is "unknown"' do
       let(:heartbeat) { make_heartbeat({ :job_state => 'unknown' }) }
 
-      it 'reports as "unhealthy"' do
+      it 'does not report as "healthy"' do
         expect(metrics['system.healthy']).to eq(0)
-        expect(metrics['system.unhealthy']).to eq(1)
       end
 
       it 'reports health as "unknown"' do

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/cloud_watch_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/cloud_watch_spec.rb
@@ -52,7 +52,9 @@ describe Bhm::Plugins::CloudWatch do
             "system.disk.ephemeral.inode_percent",
             "system.disk.persistent.percent",
             "system.disk.persistent.inode_percent",
-            "system.healthy"
+            "system.healthy",
+            "system.unhealthy",
+            "system.health.running"
         ])
       end
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/cloud_watch_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/cloud_watch_spec.rb
@@ -53,7 +53,6 @@ describe Bhm::Plugins::CloudWatch do
             "system.disk.persistent.percent",
             "system.disk.persistent.inode_percent",
             "system.healthy",
-            "system.unhealthy",
             "system.health.running"
         ])
       end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
@@ -109,6 +109,8 @@ describe Bhm::Plugins::DataDog do
         disk.persistent.percent
         disk.persistent.inode_percent
         healthy
+        unhealthy
+        health.running
       ].each do |metric|
         expect(dog_client).to receive(:emit_points).with("bosh.healthmonitor.system.#{metric}", anything, anything)
       end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
@@ -109,7 +109,6 @@ describe Bhm::Plugins::DataDog do
         disk.persistent.percent
         disk.persistent.inode_percent
         healthy
-        unhealthy
         health.running
       ].each do |metric|
         expect(dog_client).to receive(:emit_points).with("bosh.healthmonitor.system.#{metric}", anything, anything)


### PR DESCRIPTION
The BOSH Agent [sends heartbeats](https://github.com/cloudfoundry/bosh-agent/blob/master/jobsupervisor/monit_job_supervisor.go#L249-L275) with one of the following states:

- "stopped"
- "starting"
- "running"
- "failing"
- "unknown"

However, the BOSH Health Monitor reports "running" state as `system.healthy = 1` and all other states as `system.healthy = 0`.

This change addresses that as follows:

- In addition to "running", "starting" and "stopped" are now considered as healthy. **NOTE:** it could be argued that "stopped" should be considered as unhealthy. However, it's generally going to be the case that a process on the instance is stopped because a `bosh deploy` is underway, or some other similar and intentional action. For processes that are actually in a bad state, and not down intentionally, those are very likely to be reported as "failing" or "unknown". Thus...
- A `system.unhealthy` metric is added in order to make it easier to monitor for unhealthy states. So, "failing" and "unknown" states will emit `system.unhealthy = 1`, and all others will emit `system.unhealthy = 0`.
- A distinct metric is added for each particular state, making it easier to add detailed monitoring:
  - `system.health.stopped = 1`
  - `system.health.starting = 1`
  - `system.health.running = 1`
  - `system.health.failing = 1`
  - `system.health.unknown = 1`
