### PR TITLE
Update DNS after updating persistent disks

### DIFF
--- a/src/bosh-director/lib/bosh/director/cloudcheck_helper.rb
+++ b/src/bosh-director/lib/bosh/director/cloudcheck_helper.rb
@@ -197,7 +197,7 @@ module Bosh::Director
     end
 
     def vm_creator(template_cache, dns_encoder)
-      disk_manager = DiskManager.new(@logger)
+      disk_manager = DiskManager.new(@logger, template_cache, dns_encoder)
       agent_broadcaster = AgentBroadcaster.new
       @vm_creator ||= VmCreator.new(@logger, vm_deleter, disk_manager, template_cache, dns_encoder, agent_broadcaster)
     end

--- a/src/bosh-director/lib/bosh/director/deployment_plan/compilation_instance_pool.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/compilation_instance_pool.rb
@@ -4,11 +4,11 @@ module Bosh::Director
 
       def self.create(deployment_plan)
         logger = Config.logger
-        disk_manager = DiskManager.new(logger)
         agent_broadcaster = AgentBroadcaster.new
         powerdns_manager = PowerDnsManagerProvider.create
         vm_deleter = VmDeleter.new(logger, false, Config.enable_virtual_delete_vms)
         dns_encoder = LocalDnsEncoderManager.create_dns_encoder(deployment_plan.use_short_dns_addresses?)
+        disk_manager = DiskManager.new(logger, deployment_plan.template_blob_cache, dns_encoder)
         vm_creator = Bosh::Director::VmCreator.new(logger, vm_deleter, disk_manager, deployment_plan.template_blob_cache, dns_encoder, agent_broadcaster)
         instance_deleter = Bosh::Director::InstanceDeleter.new(deployment_plan.ip_provider, powerdns_manager, disk_manager)
         instance_provider = InstanceProvider.new(deployment_plan, vm_creator, logger)

--- a/src/bosh-director/lib/bosh/director/deployment_plan/steps/pre_cleanup_step.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/steps/pre_cleanup_step.rb
@@ -20,7 +20,8 @@ module Bosh::Director
 
           if !obsolete_plans.empty?
             event_log_stage = Config.event_log.begin_stage('Deleting unneeded instances', obsolete_plans.size)
-            instance_deleter = InstanceDeleter.new(@deployment_plan.ip_provider, PowerDnsManagerProvider.create, DiskManager.new(@logger))
+            dns_encoder = LocalDnsEncoderManager.create_dns_encoder(@deployment_plan.use_short_dns_addresses?)
+            instance_deleter = InstanceDeleter.new(@deployment_plan.ip_provider, PowerDnsManagerProvider.create, DiskManager.new(@logger, @deployment_plan.template_blob_cache, dns_encoder))
 
             instance_deleter.delete_instance_plans(obsolete_plans, event_log_stage)
             @logger.info('Deleted no longer needed instances')

--- a/src/bosh-director/lib/bosh/director/deployment_plan/steps/update_step.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/steps/update_step.rb
@@ -32,8 +32,8 @@ module Bosh::Director
           return @vm_creator if @vm_creator
           template_blob_cache = @deployment_plan.template_blob_cache
           agent_broadcaster = AgentBroadcaster.new
-          disk_manager = DiskManager.new(@logger)
           vm_deleter = Bosh::Director::VmDeleter.new(@logger, false, Config.enable_virtual_delete_vms)
+          disk_manager = DiskManager.new(@logger, template_blob_cache, @dns_encoder)
           @vm_creator = Bosh::Director::VmCreator.new(@logger, vm_deleter, disk_manager, template_blob_cache, @dns_encoder, agent_broadcaster)
         end
 

--- a/src/bosh-director/lib/bosh/director/errand/instance_group_manager.rb
+++ b/src/bosh-director/lib/bosh/director/errand/instance_group_manager.rb
@@ -4,10 +4,10 @@ module Bosh::Director
       @deployment = deployment
       @instance_group = instance_group
       @logger = logger
-      @disk_manager = DiskManager.new(logger)
       @template_blob_cache = @deployment.template_blob_cache
       agent_broadcaster = AgentBroadcaster.new
       @dns_encoder = LocalDnsEncoderManager.create_dns_encoder(@deployment.use_short_dns_addresses?)
+      @disk_manager = DiskManager.new(logger, @template_blob_cache, @dns_encoder)
       @powerdns_manager = PowerDnsManagerProvider.create
       @vm_deleter = Bosh::Director::VmDeleter.new(logger, false, Config.enable_virtual_delete_vms)
       @vm_creator = Bosh::Director::VmCreator.new(logger, @vm_deleter, @disk_manager, @template_blob_cache, @dns_encoder, agent_broadcaster)

--- a/src/bosh-director/lib/bosh/director/instance_updater.rb
+++ b/src/bosh-director/lib/bosh/director/instance_updater.rb
@@ -6,7 +6,7 @@ module Bosh::Director
 
     def self.new_instance_updater(ip_provider, template_blob_cache, dns_encoder)
       logger = Config.logger
-      disk_manager = DiskManager.new(logger)
+      disk_manager = DiskManager.new(logger, template_blob_cache, dns_encoder)
       agent_broadcaster = AgentBroadcaster.new
       dns_state_updater = DirectorDnsStateUpdater.new(dns_encoder)
       vm_deleter = VmDeleter.new(logger, false, Config.enable_virtual_delete_vms)
@@ -104,8 +104,8 @@ module Bosh::Director
 
         instance_plan.release_obsolete_network_plans(@ip_provider)
 
-        update_dns(instance_plan)
         @disk_manager.update_persistent_disk(instance_plan)
+        update_dns(instance_plan)
 
         unless recreated
           instance.update_instance_settings

--- a/src/bosh-director/lib/bosh/director/job_updater_factory.rb
+++ b/src/bosh-director/lib/bosh/director/job_updater_factory.rb
@@ -7,7 +7,7 @@ module Bosh::Director
     end
 
     def new_job_updater(ip_provider, job)
-      JobUpdater.new(ip_provider, job, DiskManager.new(@logger), @template_blob_cache, @dns_encoder)
+      JobUpdater.new(ip_provider, job, DiskManager.new(@logger, @template_blob_cache, @dns_encoder), @template_blob_cache, @dns_encoder)
     end
   end
 end

--- a/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
@@ -18,7 +18,10 @@ module Bosh::Director
         @instance_id = instance_id
         @disk_cid = disk_cid
         @transactor = Transactor.new
-        @disk_manager = DiskManager.new(logger)
+        # TODO this will have to take deployment plan into account
+        dns_encoder = LocalDnsEncoderManager.create_dns_encoder(false)
+        template_blob_cache = Bosh::Director::Core::Templates::TemplateBlobCache.new
+        @disk_manager = DiskManager.new(logger, template_blob_cache, dns_encoder)
         @orphan_disk_manager = OrphanDiskManager.new(logger)
       end
 
@@ -76,6 +79,7 @@ module Bosh::Director
 
         if instance.state == 'stopped'
           @disk_manager.attach_disk(disk, instance.deployment.tags)
+          # TODO DNS: We will have to update instance.spec, render templates and trigger DNS broadcast
         end
       end
     end

--- a/src/bosh-director/lib/bosh/director/jobs/delete_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/delete_deployment.rb
@@ -27,7 +27,9 @@ module Bosh::Director
           ip_provider = DeploymentPlan::IpProviderFactory.new(true, logger)
 
           powerdns_manager = PowerDnsManagerProvider.create
-          disk_manager = DiskManager.new(logger)
+          template_blob_cache = Bosh::Director::Core::Templates::TemplateBlobCache.new
+          dns_encoder = LocalDnsEncoderManager.create_dns_encoder(false)
+          disk_manager = DiskManager.new(logger, template_blob_cache, dns_encoder)
           instance_deleter = InstanceDeleter.new(ip_provider, powerdns_manager, disk_manager, force: @force)
           deployment_deleter = DeploymentDeleter.new(Config.event_log, logger, powerdns_manager, Config.max_threads)
 

--- a/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
@@ -52,7 +52,9 @@ module Bosh::Director
 
       def reattach_disk(reboot = false)
         cloud = CloudFactory.create_with_latest_configs.get_for_az(@instance.availability_zone)
+        # TODO should this call DiskManager.attach_disk?
         cloud.attach_disk(@vm_cid, @disk_cid)
+        # TODO DNS: We will have to update instance.spec, render templates and trigger DNS broadcast
         MetadataUpdater.build.update_disk_metadata(cloud, @disk, @disk.instance.deployment.tags)
         if reboot
           reboot_vm(@instance)

--- a/src/bosh-director/spec/unit/deployment_plan/compilation_instance_pool_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/compilation_instance_pool_spec.rb
@@ -34,7 +34,7 @@ module Bosh::Director
     let(:dns_encoder) { DnsEncoder.new }
     let(:vm_creator) { VmCreator.new(Config.logger, vm_deleter, disk_manager, template_blob_cache, dns_encoder, agent_broadcaster) }
     let(:template_blob_cache) { instance_double(Bosh::Director::Core::Templates::TemplateBlobCache) }
-    let(:disk_manager) { DiskManager.new(logger) }
+    let(:disk_manager) { DiskManager.new(logger, template_blob_cache, dns_encoder) }
     let(:compilation_config) do
       compilation_spec = {
         'workers' => n_workers,
@@ -402,7 +402,7 @@ module Bosh::Director
 
     describe '.create' do
       let(:instance_reuser) { InstanceReuser.new }
-      let(:disk_manager) { DiskManager.new(logger) }
+      let(:disk_manager) { DiskManager.new(logger, template_blob_cache, dns_encoder) }
       let(:agent_broadcaster) { AgentBroadcaster.new }
       let(:powerdns_manager) { PowerDnsManagerProvider.create }
       let(:vm_deleter) { instance_double('Bosh::Director::VmDeleter') }
@@ -412,7 +412,7 @@ module Bosh::Director
 
       before do
         allow(InstanceReuser).to receive(:new).and_return(instance_reuser)
-        allow(DiskManager).to receive(:new).with(logger).and_return(disk_manager)
+        allow(DiskManager).to receive(:new).with(logger, anything, anything).and_return(disk_manager)
         allow(AgentBroadcaster).to receive(:new).and_return(agent_broadcaster)
         allow(PowerDnsManagerProvider).to receive(:create).and_return(powerdns_manager)
         allow(VmDeleter).to receive(:new).with(logger, false, false).and_return(vm_deleter)

--- a/src/bosh-director/spec/unit/deployment_plan/steps/package_compile_step_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/package_compile_step_spec.rb
@@ -11,7 +11,7 @@ module Bosh::Director
     let(:dns_encoder) { instance_double(DnsEncoder) }
     let(:vm_creator) { VmCreator.new(Config.logger, vm_deleter, disk_manager, template_blob_cache, dns_encoder, agent_broadcaster) }
     let(:template_blob_cache) { instance_double(Bosh::Director::Core::Templates::TemplateBlobCache) }
-    let(:disk_manager) { DiskManager.new(logger) }
+    let(:disk_manager) { DiskManager.new(logger, template_blob_cache, dns_encoder) }
     let(:release_version_model) { Models::ReleaseVersion.make(version: 'new') }
     let(:reuse_compilation_vms) { false }
     let(:number_of_workers) { 3 }
@@ -560,7 +560,7 @@ module Bosh::Director
       before { allow(SecureRandom).to receive(:uuid).and_return('deadbeef') }
 
       let(:vm_creator) { Bosh::Director::VmCreator.new(logger, vm_deleter, disk_manager, template_blob_cache, dns_encoder, agent_broadcaster) }
-      let(:disk_manager) { DiskManager.new(logger) }
+      let(:disk_manager) { DiskManager.new(logger, template_blob_cache, dns_encoder) }
 
       it 'reuses compilation VMs' do
         prepare_samples

--- a/src/bosh-director/spec/unit/deployment_plan/steps/pre_cleanup_step_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/pre_cleanup_step_spec.rb
@@ -18,7 +18,9 @@ module Bosh::Director
           instance_groups_starting_on_deploy: [],
           ip_provider: ip_provider,
           tags: {},
-          instance_plans_for_obsolete_instance_groups: [existing_instance_plan]
+          template_blob_cache: Bosh::Director::Core::Templates::TemplateBlobCache.new,
+          instance_plans_for_obsolete_instance_groups: [existing_instance_plan],
+          use_short_dns_addresses?: false
         )
       end
 

--- a/src/bosh-director/spec/unit/deployment_plan/steps/update_errands_step_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/update_errands_step_spec.rb
@@ -25,7 +25,8 @@ module Bosh::Director
       let(:deployment_plan) do
         instance_double('Bosh::Director::DeploymentPlan::Planner',
           errand_instance_groups: [errand_instance_group, ignored_errand_instance_group],
-                ip_provider: ip_provider
+          ip_provider: ip_provider,
+          template_blob_cache: Bosh::Director::Core::Templates::TemplateBlobCache.new
         )
       end
 

--- a/src/bosh-director/spec/unit/instance_deleter_spec.rb
+++ b/src/bosh-director/spec/unit/instance_deleter_spec.rb
@@ -24,7 +24,9 @@ module Bosh::Director
 
     let(:options) { {} }
     let(:deleter) { InstanceDeleter.new(ip_provider, powerdns_manager, disk_manager, options) }
-    let(:disk_manager) { DiskManager.new(logger) }
+    let(:template_blob_cache) { instance_double(Bosh::Director::Core::Templates::TemplateBlobCache) }
+    let(:dns_encoder) { instance_double(DnsEncoder) }
+    let(:disk_manager) { DiskManager.new(logger, template_blob_cache, dns_encoder) }
 
     describe '#delete_instance_plans' do
       let(:network_plan) { DeploymentPlan::NetworkPlanner::Plan.new(reservation: reservation) }

--- a/src/bosh-director/spec/unit/job_updater_spec.rb
+++ b/src/bosh-director/spec/unit/job_updater_spec.rb
@@ -4,7 +4,7 @@ module Bosh::Director
   describe JobUpdater do
     subject(:job_updater) { described_class.new(ip_provider, job, disk_manager, template_blob_cache, dns_encoder) }
     let(:template_blob_cache) { instance_double(Bosh::Director::Core::Templates::TemplateBlobCache) }
-    let(:disk_manager) { DiskManager.new(logger) }
+    let(:disk_manager) { DiskManager.new(logger, template_blob_cache, dns_encoder) }
 
     let(:ip_provider) { instance_double('Bosh::Director::DeploymentPlan::IpProvider') }
     let(:dns_encoder) { instance_double(DnsEncoder) }

--- a/src/bosh-director/spec/unit/vm_creator_spec.rb
+++ b/src/bosh-director/spec/unit/vm_creator_spec.rb
@@ -8,7 +8,7 @@ module Bosh
         logger, vm_deleter, disk_manager, template_blob_cache, dns_encoder, agent_broadcaster
       ) }
 
-      let(:disk_manager) { DiskManager.new(logger) }
+      let(:disk_manager) { DiskManager.new(logger, template_blob_cache, dns_encoder) }
       let(:cloud) { instance_double('Bosh::Cloud') }
       let(:cloud_factory) { instance_double(CloudFactory) }
       let(:vm_deleter) { VmDeleter.new(logger, false, false) }


### PR DESCRIPTION
- there are CPIs that have to re-create a VM for `attach_disk`
- re-creation changes the IP, hence syncing DNS before leads
  to wrong DNS enties in /etc/hosts