### PR TITLE
Update DNS after updating persistent disks

### DIFF
--- a/src/bosh-director/lib/bosh/director/instance_updater.rb
+++ b/src/bosh-director/lib/bosh/director/instance_updater.rb
@@ -104,8 +104,8 @@ module Bosh::Director
 
         release_obsolete_ips(instance_plan)
 
-        update_dns(instance_plan)
         @disk_manager.update_persistent_disk(instance_plan)
+        update_dns(instance_plan)
 
         unless recreated
           instance.update_instance_settings


### PR DESCRIPTION
- there are CPIs that have to re-create a VM for `attach_disk`
- re-creation changes the IP, hence syncing DNS before leads
  to wrong DNS enties in /etc/hosts