### PR TITLE
Fix inconsistencies in disk and vm metadata

### DIFF
--- a/src/bosh-director/lib/bosh/director/metadata_updater.rb
+++ b/src/bosh-director/lib/bosh/director/metadata_updater.rb
@@ -19,6 +19,7 @@ module Bosh::Director
         metadata['deployment'] = instance.deployment.name
         metadata['id'] = instance.uuid
         metadata['job'] = instance.job
+        metadata['instance_group'] = instance.job
         metadata['index'] = instance.index.to_s
         metadata['name'] = "#{instance.job}/#{instance.uuid}"
         metadata['created_at'] = Time.new.getutc.strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -34,9 +35,8 @@ module Bosh::Director
         metadata = metadata.merge(@director_metadata)
         metadata['deployment'] = disk.instance.deployment.name
         metadata['instance_id'] = disk.instance.uuid
-        metadata['job'] = disk.instance.job
         metadata['instance_index'] = disk.instance.index.to_s
-        metadata['instance_name'] = "#{disk.instance.job}/#{disk.instance.uuid}"
+        metadata['instance_group'] = "#{disk.instance.job}"
         metadata['attached_at'] = Time.new.getutc.strftime('%Y-%m-%dT%H:%M:%SZ')
 
         cloud.set_disk_metadata(disk.disk_cid, metadata)

--- a/src/bosh-director/spec/unit/metadata_updater_spec.rb
+++ b/src/bosh-director/spec/unit/metadata_updater_spec.rb
@@ -82,6 +82,7 @@ describe Bosh::Director::MetadataUpdater do
             'job' => 'job-value',
             'index' => '12345',
             'name' => 'job-value/some_instance_id',
+            'instance_group' => 'job-value',
           }
           expect(cloud).to receive(:set_vm_metadata).with('fake-vm-cid', hash_including(expected_vm_metadata))
           metadata_updater.update_vm_metadata(instance, {})
@@ -143,11 +144,15 @@ describe Bosh::Director::MetadataUpdater do
       it 'adds instance specific metadata' do
         expected_disk_metadata = {
           'instance_id' => 'some_instance_id',
-          'job' => 'job-value',
           'instance_index' => '12345',
-          'instance_name' => 'job-value/some_instance_id',
+          'instance_group' => 'job-value',
         }
         expect(cloud).to receive(:set_disk_metadata).with('fake-disk-cid', hash_including(expected_disk_metadata))
+        metadata_updater.update_disk_metadata(cloud, disk, {})
+      end
+
+      it 'does not include job in disk metadata' do
+        expect(cloud).to receive(:set_disk_metadata).with('fake-disk-cid', hash_excluding('job'))
         metadata_updater.update_disk_metadata(cloud, disk, {})
       end
 

--- a/src/bosh-director/spec/unit/vm_creator_spec.rb
+++ b/src/bosh-director/spec/unit/vm_creator_spec.rb
@@ -382,6 +382,7 @@ module Bosh
               'deployment' => 'deployment_name',
               'created_at' => Time.new.getutc.strftime('%Y-%m-%dT%H:%M:%SZ'),
               'job' => 'fake-job',
+              'instance_group' => 'fake-job',
               'index' => '5',
               'director' => 'fake-director-name',
               'id' => instance_model.uuid,

--- a/src/spec/gocli/integration/cpi_spec.rb
+++ b/src/spec/gocli/integration/cpi_spec.rb
@@ -56,6 +56,7 @@ describe 'CPI calls', type: :integration do
           'created_at' => kind_of(String),
           'deployment' => 'simple',
           'job' => /compilation-.*/,
+          'instance_group' => /compilation-.*/,
           'index' => '0',
           'id' => /[0-9a-f]{8}-[0-9a-f-]{27}/,
           'name' => /compilation-.*\/[0-9a-f]{8}-[0-9a-f-]{27}/
@@ -73,6 +74,7 @@ describe 'CPI calls', type: :integration do
           'created_at' => kind_of(String),
           'deployment' => 'simple',
           'job' => /compilation-.*/,
+          'instance_group' => /compilation-.*/,
           'index' => '0',
           'id' => /[0-9a-f]{8}-[0-9a-f-]{27}/,
           'name' => /compilation-.*\/[0-9a-f]{8}-[0-9a-f-]{27}/
@@ -110,6 +112,7 @@ describe 'CPI calls', type: :integration do
           'created_at' => kind_of(String),
           'deployment' => 'simple',
           'job' => /compilation-.*/,
+          'instance_group' => /compilation-.*/,
           'index' => '0',
           'id' => /[0-9a-f]{8}-[0-9a-f-]{27}/,
           'name' => /compilation-.*\/[0-9a-f]{8}-[0-9a-f-]{27}/
@@ -127,6 +130,7 @@ describe 'CPI calls', type: :integration do
           'director' => 'TestDirector',
           'deployment' => 'simple',
           'job' => /compilation-.*/,
+          'instance_group' => /compilation-.*/,
           'index' => '0',
           'id' => /[0-9a-f]{8}-[0-9a-f-]{27}/,
           'name' => /compilation-.*\/[0-9a-f]{8}-[0-9a-f-]{27}/
@@ -165,6 +169,7 @@ describe 'CPI calls', type: :integration do
           'created_at' => kind_of(String),
           'deployment' => 'simple',
           'job' => 'foobar',
+          'instance_group' => 'foobar',
           'index' => '0',
           'id' => /[0-9a-f]{8}-[0-9a-f-]{27}/,
           'name' => /foobar\/[0-9a-f]{8}-[0-9a-f-]{27}/
@@ -233,6 +238,7 @@ describe 'CPI calls', type: :integration do
             'created_at' => kind_of(String),
             'deployment' => 'simple',
             'job' => 'first-job',
+            'instance_group' => 'first-job',
             'index' => '0',
             'id' => /[0-9a-f]{8}-[0-9a-f-]{27}/,
             'name' => /first-job\/[0-9a-f]{8}-[0-9a-f-]{27}/
@@ -262,10 +268,9 @@ describe 'CPI calls', type: :integration do
             'director' => 'TestDirector',
             'attached_at' => kind_of(String),
             'deployment' => 'simple',
-            'job' => 'first-job',
+            'instance_group' => 'first-job',
             'instance_index' => '0',
             'instance_id' => /[0-9a-f]{8}-[0-9a-f-]{27}/,
-            'instance_name' => /first-job\/[0-9a-f]{8}-[0-9a-f-]{27}/
           }
         })
 
@@ -340,6 +345,7 @@ describe 'CPI calls', type: :integration do
             'created_at' => kind_of(String),
             'deployment' => 'simple',
             'job' => 'first-job',
+            'instance_group' => 'first-job',
             'index' => '0',
             'id' => /[0-9a-f]{8}-[0-9a-f-]{27}/,
             'name' => /first-job\/[0-9a-f]{8}-[0-9a-f-]{27}/,
@@ -365,10 +371,9 @@ describe 'CPI calls', type: :integration do
             'director' => 'TestDirector',
             'attached_at' => kind_of(String),
             'deployment' => 'simple',
-            'job' => 'first-job',
+            'instance_group' => 'first-job',
             'instance_index' => '0',
             'instance_id' => /[0-9a-f]{8}-[0-9a-f-]{27}/,
-            'instance_name' => /first-job\/[0-9a-f]{8}-[0-9a-f-]{27}/,
             'tag1' => 'value1',
             'tag2' => 'value2'
           }


### PR DESCRIPTION
Use Manifest v2 Schema naming for instance group.
Keep v1 schema tags in VM for backwards compatibility.

[#149144325](https://www.pivotaltracker.com/story/show/149144325)

Signed-off-by: Tom Kiemes <tom.kiemes@sap.com>