### PR TITLE
Provide better error message in case of disabled cloud-config

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/manifest_validator.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/manifest_validator.rb
@@ -15,7 +15,7 @@ module Bosh
               manifest['jobs'].each do |job|
                 if job.has_key?('migrated_from')
                   raise Bosh::Director::DeploymentInvalidProperty,
-                    "Deployment manifest instance groups contain 'migrated_from', but it can only be used with cloud-config."
+                    "Deployment manifest instance groups contain 'migrated_from', but it can only be used with cloud-config enabled on your bosh director."
                 end
               end
             end
@@ -37,7 +37,7 @@ module Bosh
         def raise_if_has_key(manifest, property)
           if manifest.has_key?(property)
             raise Bosh::Director::DeploymentInvalidProperty,
-              "Deployment manifest contains '#{property}' section, but it can only be used in cloud-config."
+              "Deployment manifest contains '#{property}' section, but it can only be used with cloud-config enabled on your bosh director."
           end
         end
       end

--- a/src/bosh-director/spec/unit/deployment_plan/manifest_validator_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/manifest_validator_spec.rb
@@ -14,7 +14,7 @@ module Bosh
             manifest_validator.validate(manifest_hash, nil)
           }.to raise_error(
               Bosh::Director::DeploymentInvalidProperty,
-              "Deployment manifest contains 'disk_types' section, but it can only be used in cloud-config."
+              "Deployment manifest contains 'disk_types' section, but it can only be used with cloud-config enabled on your bosh director."
             )
         end
 
@@ -24,7 +24,7 @@ module Bosh
             manifest_validator.validate(manifest_hash, nil)
           }.to raise_error(
               Bosh::Director::DeploymentInvalidProperty,
-              "Deployment manifest contains 'vm_types' section, but it can only be used in cloud-config."
+              "Deployment manifest contains 'vm_types' section, but it can only be used with cloud-config enabled on your bosh director."
             )
         end
 
@@ -34,7 +34,7 @@ module Bosh
             manifest_validator.validate(manifest_hash, nil)
           }.to raise_error(
               Bosh::Director::DeploymentInvalidProperty,
-              "Deployment manifest contains 'azs' section, but it can only be used in cloud-config."
+              "Deployment manifest contains 'azs' section, but it can only be used with cloud-config enabled on your bosh director."
             )
         end
 
@@ -51,7 +51,7 @@ module Bosh
               manifest_validator.validate(manifest_hash, nil)
             }.to raise_error(
                 Bosh::Director::DeploymentInvalidProperty,
-                "Deployment manifest instance groups contain 'migrated_from', but it can only be used with cloud-config."
+                "Deployment manifest instance groups contain 'migrated_from', but it can only be used with cloud-config enabled on your bosh director."
               )
           end
         end


### PR DESCRIPTION
Fixes issue #1604 

Trying to provide a better error message that hints to missing cloud-config in director.