### PR TITLE
Json plugin manages processes

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
@@ -1,29 +1,106 @@
+require 'thread'
+
 module Bosh::Monitor::Plugins
+
   class Json < Base
-    attr_reader :processes
+    attr_reader :process_manager
+
+    def initialize(options = {})
+      super(options)
+      @process_manager = options.fetch('process_manager', Bosh::Monitor::Plugins::ProcessManager.new(glob: '/var/vcap/jobs/*/bin/bosh-monitor/*', logger: logger))
+    end
 
     def run
+      process_manager.start
+    end
+
+    def process(event)
+      process_manager.send_event event
+    end
+  end
+
+  class ProcessManager
+    attr_reader :logger
+
+    def initialize(options)
+      @bin_glob = options.fetch(:glob)
+      @logger = options.fetch(:logger)
+
+      @lock = Mutex.new
+      @processes = {}
+    end
+
+    def start
+
       unless EM.reactor_running?
         logger.error("JSON delivery agent can only be started when event loop is running")
         return false
       end
 
-      @processes = Dir[bin_glob].map do |bin|
-        EventMachine::DeferrableChildProcess.open(bin)
-      end
+      start_processes
     end
 
-    def process(event)
-      event_json = event.to_json
-      @processes.each do |process|
-        process.send_data "#{event_json}\n"
+    def send_event(event)
+      @lock.synchronize do
+        @processes.each do |b, process|
+          process.send_data "#{event.to_json}\n"
+        end
       end
     end
 
     private
 
-    def bin_glob
-      options.fetch('bin_glob', '/var/vcap/jobs/*/bin/bosh-monitor/*')
+    def start_processes
+      @lock.synchronize do
+        Dir[@bin_glob].each do |bin|
+          @processes[bin] = start_process(bin)
+        end
+      end
+    end
+
+    def restart_process(bin)
+      @lock.synchronize do
+        @processes[bin] = start_process(bin)
+      end
+    end
+
+    def start_process(bin)
+      process = Bosh::Monitor::Plugins::DeferrableChildProcess.open(bin)
+      process.errback do
+        EM.defer { restart_process bin }
+      end
+
+      process
+    end
+  end
+
+  # EM's DeferrableChildProcess does not give an opportunity
+  # to get the exit status. So we are implementing our own unbind logic to handle the exit status.
+  # This way we can execute our process restart on the err callback (errback).
+  # https://stackoverflow.com/a/12092647
+  class DeferrableChildProcess < EventMachine::Connection
+    include EventMachine::Deferrable
+
+    def initialize
+      super
+      @data = []
+    end
+
+    def self.open cmd
+      EventMachine.popen(cmd, DeferrableChildProcess)
+    end
+
+    def receive_data data
+      @data << data
+    end
+
+    def unbind
+      status = get_status
+      if status.exitstatus != 0
+        fail(status)
+      else
+        succeed(@data.join, status)
+      end
     end
   end
 end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
@@ -3,7 +3,6 @@ require 'thread'
 module Bosh::Monitor::Plugins
 
   class Json < Base
-    attr_reader :process_manager
 
     def initialize(options = {})
       super(options)
@@ -11,40 +10,43 @@ module Bosh::Monitor::Plugins
     end
 
     def run
-      process_manager.start
+      @process_manager.start
     end
 
     def process(event)
-      process_manager.send_event event
+      @process_manager.send_event event
     end
   end
 
   class ProcessManager
-    attr_reader :logger
 
     def initialize(options)
       @bin_glob = options.fetch(:glob)
       @logger = options.fetch(:logger)
+      @check_interval = options.fetch(:check_interval, 60)
 
       @lock = Mutex.new
       @processes = {}
     end
 
     def start
-
       unless EM.reactor_running?
-        logger.error("JSON delivery agent can only be started when event loop is running")
+        @logger.error("JSON Plugin can only be started when event loop is running")
         return false
       end
 
       start_processes
+
+      EventMachine.add_periodic_timer(@check_interval) { start_processes }
     end
 
     def send_event(event)
       @lock.synchronize do
-        @processes.each do |b, process|
+        @processes.each do |_, process|
           process.send_data "#{event.to_json}\n"
         end
+
+        @logger.debug("JSON Plugin: Sent to #{@processes.size} managed processes")
       end
     end
 
@@ -52,8 +54,10 @@ module Bosh::Monitor::Plugins
 
     def start_processes
       @lock.synchronize do
-        Dir[@bin_glob].each do |bin|
+        new_binaries = Dir[@bin_glob] - @processes.keys
+        new_binaries.each do |bin|
           @processes[bin] = start_process(bin)
+          @logger.info("JSON Plugin: Started process #{bin}")
         end
       end
     end
@@ -61,6 +65,7 @@ module Bosh::Monitor::Plugins
     def restart_process(bin)
       @lock.synchronize do
         @processes[bin] = start_process(bin)
+        @logger.info("JSON Plugin: Restarted process #{bin}")
       end
     end
 
@@ -103,4 +108,5 @@ module Bosh::Monitor::Plugins
       end
     end
   end
+
 end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
@@ -24,6 +24,7 @@ module Bosh::Monitor::Plugins
       @bin_glob = options.fetch(:glob)
       @logger = options.fetch(:logger)
       @check_interval = options.fetch(:check_interval, 60)
+      @restart_wait = options.fetch(:restart_wait, 1)
 
       @lock = Mutex.new
       @processes = {}
@@ -72,7 +73,7 @@ module Bosh::Monitor::Plugins
     def start_process(bin)
       process = Bosh::Monitor::Plugins::DeferrableChildProcess.open(bin)
       process.errback do
-        EM.defer { restart_process bin }
+        EventMachine.add_timer(@restart_wait) { restart_process bin }
       end
 
       process


### PR DESCRIPTION
If a json plugin compatible process dies, the json plugin will restart it. Also, jobs appearing in the manifest after the health_monitor will be detected and started.