### PR TITLE
Add IPv6 manual networking support

### DIFF
--- a/jobs/blobstore/spec
+++ b/jobs/blobstore/spec
@@ -18,6 +18,9 @@ properties:
   blobstore.port:
     description: TCP port blobstore server (ngnix) listens on
     default: 25250
+  blobstore.ipv6_listen:
+    description: Enable binding to IPv6 addresses
+    default: false
   blobstore.backend_port:
     description: TCP port backend blobstore server (simple blobstore) listens on
     default: 25251

--- a/jobs/blobstore/templates/blobstore.conf.erb
+++ b/jobs/blobstore/templates/blobstore.conf.erb
@@ -1,5 +1,7 @@
 server {
-  listen      <%= p("blobstore.port") %>;
+  listen <%= p("blobstore.port") %>;
+  <% if p('blobstore.ipv6_listen') %>listen [::]:<%= p('blobstore.port') %>;<% end %>
+
   server_name "";
 
   access_log  /var/vcap/sys/log/blobstore/blobstore_access.log common_event_format;

--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -49,6 +49,9 @@ properties:
   director.port:
     description: Port that the director nginx listens on
     default: 25555
+  director.ipv6_listen:
+    description: Enable binding to IPv6 addresses
+    default: false
   director.backend_port:
     description: Port that the director listens on
     default: 25556

--- a/jobs/director/templates/nginx.conf.erb
+++ b/jobs/director/templates/nginx.conf.erb
@@ -42,6 +42,7 @@ http {
 
   server {
     listen <%= p('director.port') %>;
+    <% if p('director.ipv6_listen') %>listen [::]:<%= p('director.port') %>;<% end %>
 
     ssl                 on;
     ssl_certificate     /var/vcap/jobs/director/config/ssl/director.pem;

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -12,7 +12,7 @@ packages:
 properties:
   nats.listen_address:
     description: IP address nats mbus listens on
-    default: 0.0.0.0
+    default: 0.0.0.0 # "::" listen all interfaces (IPv6)?
   nats.port:
     description: TCP port nats mbus listens on
     default: 4222

--- a/src/bosh-director/db/migrations/director/20170825141953_change_address_to_be_string_for_ipv6.rb
+++ b/src/bosh-director/db/migrations/director/20170825141953_change_address_to_be_string_for_ipv6.rb
@@ -1,0 +1,18 @@
+Sequel.migration do
+  change do
+    alter_table :ip_addresses do
+      add_column(:address_temp, String, unique: true)
+    end
+
+    self[:ip_addresses].each do |ip_address|
+      self[:ip_addresses].filter(:id => ip_address[:id]).update(address_temp: ip_address[:address].to_s)
+    end
+
+    alter_table :ip_addresses do
+      drop_column :address
+      rename_column :address_temp, :address_str
+      add_index [:address_str], unique: true, address_str: 'unique_address_str'
+      set_column_not_null :address_str
+    end
+  end
+end

--- a/src/bosh-director/db/migrations/migration_digests.json
+++ b/src/bosh-director/db/migrations/migration_digests.json
@@ -119,5 +119,6 @@
   "20170803163303_register_known_az_names": "51ab548d8187c75a1a7dff34861f658dfc11dae9",
   "20170804191205_add_deployment_and_errand_name_to_errand_runs": "4429f1e811e064c236ee4c32b3964992ec7004e5",
   "20170815175515_change_variable_ids_to_bigint": "0488ede3a8d8611f8414e6a9c4f54ec9828a3bff",
-  "20170821141953_remove_unused_credentials_json_columns": "0daf4d1363029304fc84d0df7b7b69fa04713e37"
+  "20170821141953_remove_unused_credentials_json_columns": "0daf4d1363029304fc84d0df7b7b69fa04713e37",
+  "20170825141953_change_address_to_be_string_for_ipv6": "bfc9534474853bb9f729b8725675bd030c8fb4a4"
 }

--- a/src/bosh-director/lib/bosh/director/cidr_range_combiner.rb
+++ b/src/bosh-director/lib/bosh/director/cidr_range_combiner.rb
@@ -33,13 +33,22 @@ module Bosh::Director
         can_combine = true
         while can_combine
           next_range_tuple = range_tuples[i+1]
-          if !next_range_tuple.nil? && (range_tuple[1].succ == next_range_tuple[0])
-            range_tuple[1] = next_range_tuple[1]
-            i += 1
-          elsif !next_range_tuple.nil? && (range_tuple[0] < next_range_tuple[0] && range_tuple[1] > next_range_tuple[1])
-            i += 1
-          else
+          if next_range_tuple.nil?
             can_combine = false
+          else
+            if range_tuple.map(&:version).uniq != next_range_tuple.map(&:version).uniq
+              can_combine = false
+              break
+            end
+            if (range_tuple[1].succ == next_range_tuple[0])
+              range_tuple[1] = next_range_tuple[1]
+              i += 1
+            # does not cover all cases: 10/32, 10/8
+            elsif ((range_tuple[0] < next_range_tuple[0]) && (range_tuple[1] > next_range_tuple[1]))
+              i += 1
+            else
+              can_combine = false
+            end
           end
         end
         combined_ranges << range_tuple

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -180,7 +180,7 @@ module Bosh::Director
 
         @enable_virtual_delete_vms = config.fetch('enable_virtual_delete_vms', false)
 
-        @director_ips = Socket.ip_address_list.reject { |addr| !addr.ip? || !addr.ipv4? || addr.ipv4_loopback? || addr.ipv6_loopback? }.map { |addr| addr.ip_address }
+        @director_ips = Socket.ip_address_list.reject { |addr| !addr.ip? || addr.ipv4_loopback? || addr.ipv6_loopback? || addr.ipv6_linklocal? }.map { |addr| addr.ip_address }
 
         @config_server = config.fetch('config_server', {})
         @config_server_enabled = @config_server['enabled']

--- a/src/bosh-director/lib/bosh/director/deployment_plan/manual_network_subnet.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/manual_network_subnet.rb
@@ -22,7 +22,7 @@ module Bosh::Director
 
         netmask = range.wildcard_mask
         network_id = range.network(:Objectify => true)
-        broadcast = range.broadcast(:Objectify => true)
+        broadcast = range.version == 6 ? range.last(:Objectify => true) : range.broadcast(:Objectify => true)
 
         ignore_missing_gateway = Bosh::Director::Config.ignore_missing_gateway
         gateway_property = safe_property(subnet_spec, "gateway", class: String, optional: ignore_missing_gateway)

--- a/src/bosh-director/lib/bosh/director/models/ip_address.rb
+++ b/src/bosh-director/lib/bosh/director/models/ip_address.rb
@@ -5,8 +5,9 @@ module Bosh::Director::Models
     def validate
       validates_presence :instance_id
       validates_presence :task_id
-      validates_presence :address
-      validates_unique :address
+      validates_presence :address_str
+      validates_unique :address_str
+      raise "Invalid type for address_str column" unless address_str.is_a?(String)
     end
 
     def before_create
@@ -15,6 +16,7 @@ module Bosh::Director::Models
 
     def info
       instance_info = "#{self.instance.deployment.name}.#{self.instance.job}/#{self.instance.index}"
+      formatted_ip = NetAddr::CIDR.create(address_str.to_i).ip
       "#{instance_info} - #{self.network_name} - #{formatted_ip} (#{type})"
     end
 
@@ -24,6 +26,13 @@ module Bosh::Director::Models
 
     def type
       self.static ? 'static' : 'dynamic'
+    end
+
+    def address
+      unless address_str.to_s =~ /\A\d+\z/
+        raise "Unexpected address '#{address_str}' (#{info rescue "missing info"})"
+      end
+      address_str.to_i
     end
 
     def to_s

--- a/src/bosh-director/spec/blueprints.rb
+++ b/src/bosh-director/spec/blueprints.rb
@@ -100,7 +100,7 @@ module Bosh::Director::Models
   end
 
   IpAddress.blueprint do
-    address { NetAddr::CIDR.create(Sham.ip) }
+    address_str { NetAddr::CIDR.create(Sham.ip).to_i.to_s }
     instance  { Instance.make }
     static { false }
     network_name { Sham.name }

--- a/src/bosh-director/spec/unit/cidr_range_combiner_spec.rb
+++ b/src/bosh-director/spec/unit/cidr_range_combiner_spec.rb
@@ -86,5 +86,40 @@ module Bosh::Director
         )
       end
     end
+
+    describe 'when ranges are subsumed by other ranges' do
+      let(:cidr_ranges) do
+        [
+          NetAddr::CIDR.create('192.168.0.11/32'),
+          NetAddr::CIDR.create('192.168.0.8/30'),
+          NetAddr::CIDR.create('192.168.0.8/32'),
+        ]
+      end
+
+      it 'combines the ranges' do
+        pending "does not work but we do not care since currently combinations are only used for logging"
+        expect(range_combiner.combine_ranges(cidr_ranges)).to eq(
+          [["192.168.0.8", "192.168.0.11"]]
+        )
+      end
+    end
+
+    describe 'when ranges are ipv4 and ipv6' do
+      let(:cidr_ranges) do
+        [
+          NetAddr::CIDR.create('192.168.0.8/30'),
+          NetAddr::CIDR.create('fd7a:eeed:e696:968f:0000:0000:0000:0005/128'),
+          NetAddr::CIDR.create('fd7a:eeed:e696:968f:0000:0000:0000:0005/64'),
+          NetAddr::CIDR.create('192.168.0.20/32'),
+        ]
+      end
+
+      it 'combines the ranges' do
+        expect(range_combiner.combine_ranges(cidr_ranges)).to eq(
+          [["192.168.0.8", "192.168.0.11"], ["192.168.0.20", "192.168.0.20"],
+           ["fd7a:eeed:e696:968f:0000:0000:0000:0000", "fd7a:eeed:e696:968f:ffff:ffff:ffff:ffff"]]
+        )
+      end
+    end
   end
 end

--- a/src/bosh-director/spec/unit/config_spec.rb
+++ b/src/bosh-director/spec/unit/config_spec.rb
@@ -39,17 +39,18 @@ describe Bosh::Director::Config do
   describe 'director ips' do
     before do
       allow(Socket).to receive(:ip_address_list).and_return([
-        instance_double(Addrinfo, ip_address: '127.0.0.1', ip?: true, ipv4?: true, ipv6?: false, ipv4_loopback?: true, ipv6_loopback?: false),
-        instance_double(Addrinfo, ip_address: '10.10.0.6', ip?: true, ipv4?: true, ipv6?: false, ipv4_loopback?: false, ipv6_loopback?: false),
-        instance_double(Addrinfo, ip_address: '10.11.0.16', ip?: true, ipv4?: true, ipv6?: false, ipv4_loopback?: false, ipv6_loopback?: false),
-        instance_double(Addrinfo, ip_address: '::1', ip?: true, ipv4?: false, ipv6?: true, ipv4_loopback?: false, ipv6_loopback?: true),
-        instance_double(Addrinfo, ip_address: 'fe80::10bf:eff:fe2c:7405%eth0', ip?: true, ipv4?: false, ipv6?: true, ipv4_loopback?: false, ipv6_loopback?: false),
+        instance_double(Addrinfo, ip_address: '127.0.0.1',   ip?: true, ipv4_loopback?: true,  ipv6_loopback?: false, ipv6_linklocal?: false),
+        instance_double(Addrinfo, ip_address: '10.10.0.6',   ip?: true, ipv4_loopback?: false, ipv6_loopback?: false, ipv6_linklocal?: false),
+        instance_double(Addrinfo, ip_address: '10.11.0.16',  ip?: true, ipv4_loopback?: false, ipv6_loopback?: false, ipv6_linklocal?: false),
+        instance_double(Addrinfo, ip_address: '::1',         ip?: true, ipv4_loopback?: false, ipv6_loopback?: true,  ipv6_linklocal?: false),
+        instance_double(Addrinfo, ip_address: 'fe80::%eth0', ip?: true, ipv4_loopback?: false, ipv6_loopback?: false, ipv6_linklocal?: true),
+        instance_double(Addrinfo, ip_address: 'fd7a::',      ip?: true, ipv4_loopback?: false, ipv6_loopback?: false, ipv6_linklocal?: false),
       ])
     end
 
     it 'should select the non-loopback, ipv4 ips off of the the Socket class' do
       described_class.configure(test_config)
-      expect(described_class.director_ips).to eq(['10.10.0.6','10.11.0.16'])
+      expect(described_class.director_ips).to eq(['10.10.0.6', '10.11.0.16', 'fd7a::'])
     end
   end
 

--- a/src/bosh-director/spec/unit/db/migrations/director/20170825141953_change_address_to_be_string_for_ipv6_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/20170825141953_change_address_to_be_string_for_ipv6_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../../../../db_spec_helper'
+require 'netaddr'
+
+module Bosh::Director
+  describe 'change address column in IP address to be a string to record IPv6 addresses' do
+    let(:db) { DBSpecHelper.db }
+    let(:migration_file) { '20170825141953_change_address_to_be_string_for_ipv6.rb' }
+
+    before { DBSpecHelper.migrate_all_before(migration_file) }
+
+    it 'allows instance_id to be null' do
+      db[:ip_addresses] << {id: 1, instance_id: nil, address: NetAddr::CIDR.create("192.168.50.6").to_i}
+
+      DBSpecHelper.migrate(migration_file)
+
+      expect(db[:ip_addresses].first[:address_str]).to eq(NetAddr::CIDR.create("192.168.50.6").to_i.to_s)
+
+      expect {
+        db[:ip_addresses] << {id: 2, instance_id: nil, address_str: NetAddr::CIDR.create("192.168.50.6").to_i.to_s}
+      }.to raise_error(Sequel::UniqueConstraintViolation, /ip_addresses.address/)
+
+      expect {
+        db[:ip_addresses] << {id: 3, instance_id: nil, address_str: nil}
+      }.to raise_error(Sequel::NotNullConstraintViolation, /ip_addresses.address/)
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/db/migrations/director/add_data_migration_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/add_data_migration_spec.rb
@@ -9,7 +9,7 @@ module Bosh::Director
       # populated with data. This test will fail every time a new migration script is added. Change
       # the file name below to the latest when a test is added.
       # Look at tests in this directory for similar examples: bosh-director/spec/unit/db/migrations/director
-      expect(latest_db_migration_file).to eq('20170821141953_remove_unused_credentials_json_columns.rb')
+      expect(latest_db_migration_file).to eq('20170825141953_change_address_to_be_string_for_ipv6.rb')
     end
   end
 end

--- a/src/bosh-director/spec/unit/deployment_plan/instance_network_reservations_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_network_reservations_spec.rb
@@ -30,9 +30,9 @@ module Bosh::Director
         let(:ip2) { NetAddr::CIDR.create('192.168.0.2').to_i }
 
         before do
-          ip_model1 = Models::IpAddress.make(address: ip1, network_name: 'fake-network')
+          ip_model1 = Models::IpAddress.make(address_str: ip1.to_s, network_name: 'fake-network')
           instance_model.add_ip_address(ip_model1)
-          ip_model2 = Models::IpAddress.make(address: ip2, network_name: 'fake-network')
+          ip_model2 = Models::IpAddress.make(address_str: ip2.to_s, network_name: 'fake-network')
           instance_model.add_ip_address(ip_model2)
         end
 

--- a/src/bosh-director/spec/unit/deployment_plan/instance_planner_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_planner_spec.rb
@@ -344,7 +344,7 @@ describe 'BD::DeploymentPlan::InstancePlanner' do
       let(:existing_instance_model) { BD::Models::Instance.make(job: 'foo-instance_group', index: 0, bootstrap: true, availability_zone: az.name) }
 
       before do
-        BD::Models::IpAddress.make(address: ip_to_i('192.168.1.5'), network_name: 'fake-network', instance: existing_instance_model)
+        BD::Models::IpAddress.make(address_str: ip_to_i('192.168.1.5').to_s, network_name: 'fake-network', instance: existing_instance_model)
 
         allow(deployment).to receive(:network).with('fake-network') { manual_network }
 

--- a/src/bosh-director/spec/unit/deployment_plan/instance_repository_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_repository_spec.rb
@@ -62,7 +62,7 @@ describe Bosh::Director::DeploymentPlan::InstanceRepository do
     describe 'binding existing reservations' do
       context 'when instance has reservations in db' do
         before do
-          existing_instance.add_ip_address(BD::Models::IpAddress.make(address: 123))
+          existing_instance.add_ip_address(BD::Models::IpAddress.make(address_str: "123"))
         end
 
         it 'is using reservation from database' do
@@ -160,7 +160,7 @@ describe Bosh::Director::DeploymentPlan::InstanceRepository do
     describe 'binding existing reservations' do
       context 'when instance has reservations in db' do
         before do
-          existing_instance.add_ip_address(BD::Models::IpAddress.make(address: 123))
+          existing_instance.add_ip_address(BD::Models::IpAddress.make(address_str: "123"))
         end
 
         it 'is using reservation from database' do

--- a/src/bosh-director/spec/unit/deployment_plan/ip_provider/database_ip_repo_ipv6_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/ip_provider/database_ip_repo_ipv6_spec.rb
@@ -9,9 +9,9 @@ module Bosh::Director::DeploymentPlan
         'name' => 'my-manual-network',
         'subnets' => [
           {
-            'range' => '192.168.1.0/29',
-            'gateway' => '192.168.1.1',
-            'dns' => ['192.168.1.1', '192.168.1.2'],
+            'range' => 'fdab:d85c:118d:8a46::/125',
+            'gateway' => 'fdab:d85c:118d:8a46::1',
+            'dns' => ['fdab:d85c:118d:8a46::1', 'fdab:d85c:118d:8a46::2'],
             'static' => [],
             'reserved' => [],
             'cloud_properties' => {},
@@ -82,15 +82,15 @@ module Bosh::Director::DeploymentPlan
       context 'when reservation changes type' do
         context 'from Static to Dynamic' do
           it 'updates type of reservation' do
-            network_spec['subnets'].first['static'] = ['192.168.1.5']
-            static_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, '192.168.1.5')
+            network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::5']
+            static_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::5')
             ip_repo.add(static_reservation)
 
             expect(Bosh::Director::Models::IpAddress.count).to eq(1)
             original_address = Bosh::Director::Models::IpAddress.first
             expect(original_address.static).to eq(true)
 
-            dynamic_reservation = dynamic_reservation_with_ip('192.168.1.5')
+            dynamic_reservation = dynamic_reservation_with_ip('fdab:d85c:118d:8a46::5')
             ip_repo.add(dynamic_reservation)
 
             expect(Bosh::Director::Models::IpAddress.count).to eq(1)
@@ -102,15 +102,15 @@ module Bosh::Director::DeploymentPlan
 
         context 'from Dynamic to Static' do
           it 'update type of reservation' do
-            dynamic_reservation = dynamic_reservation_with_ip('192.168.1.5')
+            dynamic_reservation = dynamic_reservation_with_ip('fdab:d85c:118d:8a46::5')
             ip_repo.add(dynamic_reservation)
 
             expect(Bosh::Director::Models::IpAddress.count).to eq(1)
             original_address = Bosh::Director::Models::IpAddress.first
             expect(original_address.static).to eq(false)
 
-            network_spec['subnets'].first['static'] = ['192.168.1.5']
-            static_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, '192.168.1.5')
+            network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::5']
+            static_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::5')
             ip_repo.add(static_reservation)
 
             expect(Bosh::Director::Models::IpAddress.count).to eq(1)
@@ -122,15 +122,15 @@ module Bosh::Director::DeploymentPlan
 
         context 'from Existing to Static' do
           it 'updates type of reservation' do
-            dynamic_reservation = dynamic_reservation_with_ip('192.168.1.5')
+            dynamic_reservation = dynamic_reservation_with_ip('fdab:d85c:118d:8a46::5')
             ip_repo.add(dynamic_reservation)
 
             expect(Bosh::Director::Models::IpAddress.count).to eq(1)
             original_address = Bosh::Director::Models::IpAddress.first
             expect(original_address.static).to eq(false)
 
-            network_spec['subnets'].first['static'] = ['192.168.1.5']
-            existing_reservation = BD::ExistingNetworkReservation.new(instance_model, network, '192.168.1.5', 'manual')
+            network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::5']
+            existing_reservation = BD::ExistingNetworkReservation.new(instance_model, network, 'fdab:d85c:118d:8a46::5', 'manual')
             ip_repo.add(existing_reservation)
 
             expect(Bosh::Director::Models::IpAddress.count).to eq(1)
@@ -143,8 +143,8 @@ module Bosh::Director::DeploymentPlan
 
       context 'when reservation changes network' do
         it 'updates network name' do
-          network_spec['subnets'].first['static'] = ['192.168.1.5']
-          static_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, '192.168.1.5')
+          network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::5']
+          static_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::5')
           ip_repo.add(static_reservation)
 
           expect(Bosh::Director::Models::IpAddress.count).to eq(1)
@@ -152,7 +152,7 @@ module Bosh::Director::DeploymentPlan
           expect(original_address.static).to eq(true)
           expect(original_address.network_name).to eq(network.name)
 
-          static_reservation_on_another_network = BD::DesiredNetworkReservation.new_static(instance_model, other_network, '192.168.1.5')
+          static_reservation_on_another_network = BD::DesiredNetworkReservation.new_static(instance_model, other_network, 'fdab:d85c:118d:8a46::5')
           ip_repo.add(static_reservation_on_another_network)
 
           expect(Bosh::Director::Models::IpAddress.count).to eq(1)
@@ -170,12 +170,12 @@ module Bosh::Director::DeploymentPlan
             raise Sequel::ValidationFailed.new('address and network_name unique')
           end
 
-          network_spec['subnets'].first['static'] = ['192.168.1.5']
-          reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, '192.168.1.5')
+          network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::5']
+          reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::5')
           ip_repo.add(reservation)
 
           saved_address = Bosh::Director::Models::IpAddress.order(:address_str).last
-          expect(saved_address.address_str).to eq(cidr_ip('192.168.1.5').to_s)
+          expect(saved_address.address_str).to eq(cidr_ip('fdab:d85c:118d:8a46::5').to_s)
           expect(saved_address.network_name).to eq('my-manual-network')
           expect(saved_address.task_id).to eq('fake-task-id')
           expect(saved_address.created_at).to_not be_nil
@@ -184,11 +184,11 @@ module Bosh::Director::DeploymentPlan
 
       context 'when reserving an IP with any previous reservation' do
         it 'should fail if it reserved by a different instance' do
-          network_spec['subnets'].first['static'] = ['192.168.1.5']
+          network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::5']
 
           other_instance_model = Bosh::Director::Models::Instance.make(availability_zone: 'az-2')
-          original_static_network_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, '192.168.1.5')
-          new_static_network_reservation = BD::DesiredNetworkReservation.new_static(other_instance_model, network, '192.168.1.5')
+          original_static_network_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::5')
+          new_static_network_reservation = BD::DesiredNetworkReservation.new_static(other_instance_model, network, 'fdab:d85c:118d:8a46::5')
 
           ip_repo.add(original_static_network_reservation)
 
@@ -198,9 +198,9 @@ module Bosh::Director::DeploymentPlan
         end
 
         it 'should succeed if it is reserved by the same instance' do
-          network_spec['subnets'].first['static'] = ['192.168.1.5']
+          network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::5']
 
-          static_network_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, '192.168.1.5')
+          static_network_reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::5')
 
           ip_repo.add(static_network_reservation)
 
@@ -218,7 +218,7 @@ module Bosh::Director::DeploymentPlan
         it 'returns the first in the range' do
           ip_address = ip_repo.allocate_dynamic_ip(reservation, subnet)
 
-          expected_ip_address = cidr_ip('192.168.1.2')
+          expected_ip_address = cidr_ip('fdab:d85c:118d:8a46::2')
           expect(ip_address).to eq(expected_ip_address)
         end
       end
@@ -234,36 +234,36 @@ module Bosh::Director::DeploymentPlan
         it 'should reserve the next available address' do
           first = ip_repo.allocate_dynamic_ip(reservation, subnet)
           second = ip_repo.allocate_dynamic_ip(reservation, subnet)
-          expect(first).to eq(cidr_ip('192.168.1.2'))
-          expect(second).to eq(cidr_ip('192.168.1.3'))
+          expect(first).to eq(cidr_ip('fdab:d85c:118d:8a46::2'))
+          expect(second).to eq(cidr_ip('fdab:d85c:118d:8a46::3'))
         end
       end
 
       context 'when there are restricted ips' do
         it 'does not reserve them' do
-          network_spec['subnets'].first['reserved'] = ['192.168.1.2', '192.168.1.4']
+          network_spec['subnets'].first['reserved'] = ['fdab:d85c:118d:8a46::2', 'fdab:d85c:118d:8a46::4']
 
-          expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('192.168.1.3'))
-          expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('192.168.1.5'))
+          expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('fdab:d85c:118d:8a46::3'))
+          expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('fdab:d85c:118d:8a46::5'))
         end
       end
 
       context 'when there are static and restricted ips' do
         it 'does not reserve them' do
-          network_spec['subnets'].first['reserved'] = ['192.168.1.2']
-          network_spec['subnets'].first['static'] = ['192.168.1.4']
+          network_spec['subnets'].first['reserved'] = ['fdab:d85c:118d:8a46::2']
+          network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::4']
 
-          expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('192.168.1.3'))
-          expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('192.168.1.5'))
+          expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('fdab:d85c:118d:8a46::3'))
+          expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('fdab:d85c:118d:8a46::5'))
         end
       end
 
       context 'when there are available IPs between reserved IPs' do
         it 'returns first non-reserved IP' do
-          network_spec['subnets'].first['static'] = ['192.168.1.2', '192.168.1.4']
+          network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::2', 'fdab:d85c:118d:8a46::4']
 
-          reservation_1 = BD::DesiredNetworkReservation.new_static(instance_model, network, '192.168.1.2')
-          reservation_2 = BD::DesiredNetworkReservation.new_static(instance_model, network, '192.168.1.4')
+          reservation_1 = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::2')
+          reservation_2 = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::4')
 
           ip_repo.add(reservation_1)
           ip_repo.add(reservation_2)
@@ -271,13 +271,13 @@ module Bosh::Director::DeploymentPlan
           reservation_3 = BD::DesiredNetworkReservation.new_dynamic(instance_model, network)
           ip_address = ip_repo.allocate_dynamic_ip(reservation_3, subnet)
 
-          expect(ip_address).to eq(cidr_ip('192.168.1.3'))
+          expect(ip_address).to eq(cidr_ip('fdab:d85c:118d:8a46::3'))
         end
       end
 
       context 'when all IPs in the range are taken' do
         it 'returns nil' do
-          network_spec['subnets'].first['range'] = '192.168.1.0/30'
+          network_spec['subnets'].first['range'] = 'fdab:d85c:118d:8a46::0/126'
 
           ip_repo.allocate_dynamic_ip(reservation, subnet)
 
@@ -289,12 +289,12 @@ module Bosh::Director::DeploymentPlan
         it 'returns the next non-reserved IP' do
           ip_address = ip_repo.allocate_dynamic_ip(other_reservation, other_subnet)
 
-          expected_ip_address = cidr_ip('192.168.1.2')
+          expected_ip_address = cidr_ip('fdab:d85c:118d:8a46::2')
           expect(ip_address).to eq(expected_ip_address)
 
           ip_address = ip_repo.allocate_dynamic_ip(reservation, subnet)
 
-          expected_ip_address = cidr_ip('192.168.1.3')
+          expected_ip_address = cidr_ip('fdab:d85c:118d:8a46::3')
           expect(ip_address).to eq(expected_ip_address)
         end
       end
@@ -326,31 +326,31 @@ module Bosh::Director::DeploymentPlan
         shared_examples :retries_on_race_condition do
           context 'when allocating some IPs fails' do
             before do
-              network_spec['subnets'].first['range'] = '192.168.1.0/29'
+              network_spec['subnets'].first['range'] = 'fdab:d85c:118d:8a46::0/125'
 
               fail_saving_ips([
-                  cidr_ip('192.168.1.2'),
-                  cidr_ip('192.168.1.3'),
-                  cidr_ip('192.168.1.4'),
+                  cidr_ip('fdab:d85c:118d:8a46::2'),
+                  cidr_ip('fdab:d85c:118d:8a46::3'),
+                  cidr_ip('fdab:d85c:118d:8a46::4'),
                 ],
                 fail_error
               )
             end
 
             it 'retries until it succeeds' do
-              expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('192.168.1.5'))
+              expect(ip_repo.allocate_dynamic_ip(reservation, subnet)).to eq(cidr_ip('fdab:d85c:118d:8a46::5'))
             end
           end
 
           context 'when allocating any IP fails' do
             before do
-              network_spec['subnets'].first['range'] = '192.168.1.0/29'
-              network_spec['subnets'].first['reserved'] = ['192.168.1.5', '192.168.1.6']
+              network_spec['subnets'].first['range'] = 'fdab:d85c:118d:8a46::0/125'
+              network_spec['subnets'].first['reserved'] = ['fdab:d85c:118d:8a46::5', 'fdab:d85c:118d:8a46::6']
 
               fail_saving_ips([
-                  cidr_ip('192.168.1.2'),
-                  cidr_ip('192.168.1.3'),
-                  cidr_ip('192.168.1.4')
+                  cidr_ip('fdab:d85c:118d:8a46::2'),
+                  cidr_ip('fdab:d85c:118d:8a46::3'),
+                  cidr_ip('fdab:d85c:118d:8a46::4')
                 ],
                 fail_error
               )
@@ -384,15 +384,15 @@ module Bosh::Director::DeploymentPlan
 
     describe :delete do
       before do
-        network_spec['subnets'].first['static'] = ['192.168.1.5']
+        network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::5']
 
-        reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, '192.168.1.5')
+        reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::5')
         ip_repo.add(reservation)
       end
 
       it 'deletes IP address' do
         expect {
-          ip_repo.delete('192.168.1.5', 'does not matter')
+          ip_repo.delete('fdab:d85c:118d:8a46::5', 'does not matter')
         }.to change {
             Bosh::Director::Models::IpAddress.all.size
           }.by(-1)

--- a/src/bosh-director/spec/unit/deployment_plan/manual_network_subnet_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/manual_network_subnet_spec.rb
@@ -38,6 +38,38 @@ describe 'Bosh::Director::DeploymentPlan::ManualNetworkSubnet' do
       expect(subnet.dns).to eq(nil)
     end
 
+    it 'should create an IPv6 subnet spec' do
+      subnet = make_subnet(
+        {
+          'range' => 'fdab:d85c:118d:8a46::/64',
+          'gateway' => 'fdab:d85c:118d:8a46::1',
+          'reserved' => [
+            'fdab:d85c:118d:8a46::10-fdab:d85c:118d:8a46::ff',
+            'fdab:d85c:118d:8a46::101',
+          ],
+          'static' => [
+            'fdab:d85c:118d:8a46::210-fdab:d85c:118d:8a46::2ff',
+            'fdab:d85c:118d:8a46::301',
+          ],
+          'dns' => [
+            '2001:4860:4860::8888',
+            '2001:4860:4860::8844',
+          ],
+          'cloud_properties' => {'foo' => 'bar'}
+        },
+        [],
+      )
+
+      expect(subnet.range.ip).to eq('fdab:d85c:118d:8a46:0000:0000:0000:0000')
+      subnet.range.ip.size == 2**64
+      expect(subnet.netmask).to eq('ffff:ffff:ffff:ffff:0000:0000:0000:0000')
+      expect(subnet.gateway).to eq('fdab:d85c:118d:8a46:0000:0000:0000:0001')
+      expect(subnet.dns).to eq([
+        "2001:4860:4860:0000:0000:0000:0000:8888",
+        "2001:4860:4860:0000:0000:0000:0000:8844",
+      ])
+    end
+
     it 'should require a range' do
       expect {
         make_subnet(

--- a/src/bosh-director/spec/unit/deployment_plan/network_planner/vip_static_ips_planner_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/network_planner/vip_static_ips_planner_spec.rb
@@ -59,8 +59,8 @@ module Bosh::Director
       context 'when instance already has vip networks' do
         context 'when existing instance IPs can be reused' do
           before do
-            Models::IpAddress.make(address: ip_to_i('69.69.69.69'), network_name: 'fake-network-1', instance: instance_plan.existing_instance)
-            Models::IpAddress.make(address: ip_to_i('79.79.79.79'), network_name: 'fake-network-2', instance: instance_plan.existing_instance)
+            Models::IpAddress.make(address_str: ip_to_i('69.69.69.69').to_s, network_name: 'fake-network-1', instance: instance_plan.existing_instance)
+            Models::IpAddress.make(address_str: ip_to_i('79.79.79.79').to_s, network_name: 'fake-network-2', instance: instance_plan.existing_instance)
           end
 
           it 'assigns vip static IP that instance is currently using' do
@@ -75,8 +75,8 @@ module Bosh::Director
 
         context 'when existing instance static IP is no longer in the list of IPs' do
           before do
-            Models::IpAddress.make(address: ip_to_i('65.65.65.65'), network_name: 'fake-network-1', instance: instance_plan.existing_instance)
-            Models::IpAddress.make(address: ip_to_i('79.79.79.79'), network_name: 'fake-network-2', instance: instance_plan.existing_instance)
+            Models::IpAddress.make(address_str: ip_to_i('65.65.65.65').to_s, network_name: 'fake-network-1', instance: instance_plan.existing_instance)
+            Models::IpAddress.make(address_str: ip_to_i('79.79.79.79').to_s, network_name: 'fake-network-2', instance: instance_plan.existing_instance)
           end
 
           it 'picks new IP for instance' do
@@ -96,8 +96,8 @@ module Bosh::Director
           end
 
           before do
-            Models::IpAddress.make(address: ip_to_i('68.68.68.68'), network_name: 'fake-network-1', instance: instance_plans[1].existing_instance)
-            Models::IpAddress.make(address: ip_to_i('77.77.77.77'), network_name: 'fake-network-2', instance: instance_plans[1].existing_instance)
+            Models::IpAddress.make(address_str: ip_to_i('68.68.68.68').to_s, network_name: 'fake-network-1', instance: instance_plans[1].existing_instance)
+            Models::IpAddress.make(address_str: ip_to_i('77.77.77.77').to_s, network_name: 'fake-network-2', instance: instance_plans[1].existing_instance)
           end
 
           it 'properly assigns vip IPs based on current instance IPs' do

--- a/src/bosh-director/spec/unit/deployment_plan/placement_planner/availability_zone_picker_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/placement_planner/availability_zone_picker_spec.rb
@@ -406,7 +406,7 @@ module Bosh::Director::DeploymentPlan
 
           it 'should raise' do
             existing_0 = existing_instance_with_az(0, az1.name, [])
-            Bosh::Director::Models::IpAddress.make(instance_id: existing_0.id, task_id: "my-ip-address-task-id", address: 1234567890, network_name: "network_A")
+            Bosh::Director::Models::IpAddress.make(instance_id: existing_0.id, task_id: "my-ip-address-task-id", address_str: "1234567890", network_name: "network_A")
             existing_0.update(ignore: true)
             expect {
               zone_picker.place_and_match_in([desired_instance], [existing_0])
@@ -417,7 +417,7 @@ module Bosh::Director::DeploymentPlan
         describe 'when adding/removing networks for instance groups with ignored vms' do
           it 'should raise' do
             existing_0 = existing_instance_with_az(0, az1.name, [])
-            Bosh::Director::Models::IpAddress.make(instance_id: existing_0.id, task_id: "my-ip-address-task-id", address: 1234567890, network_name: "old-network")
+            Bosh::Director::Models::IpAddress.make(instance_id: existing_0.id, task_id: "my-ip-address-task-id", address_str: "1234567890", network_name: "old-network")
             existing_0.update(ignore: true)
             expect {
               zone_picker.place_and_match_in([desired_instance], [existing_0])
@@ -431,7 +431,7 @@ module Bosh::Director::DeploymentPlan
           it 'should place and match existing instances' do
             existing_0 = existing_instance_with_az(0, nil, [])
             existing_0.update(ignore: true)
-            Bosh::Director::Models::IpAddress.make(instance_id: existing_0.id, task_id: "my-ip-address-task-id", address: 1234567890, network_name: "network_A")
+            Bosh::Director::Models::IpAddress.make(instance_id: existing_0.id, task_id: "my-ip-address-task-id", address_str: "1234567890", network_name: "network_A")
             results = zone_picker.place_and_match_in([desired_instance], [existing_0])
 
             existing = results.select(&:existing?)
@@ -448,7 +448,7 @@ module Bosh::Director::DeploymentPlan
           it 'should raise' do
             existing_0 = existing_instance_with_az(0, nil, [])
             existing_0.update(ignore: true)
-            Bosh::Director::Models::IpAddress.make(instance_id: existing_0.id, task_id: "my-ip-address-task-id", address: 1234567890, network_name: "network_A")
+            Bosh::Director::Models::IpAddress.make(instance_id: existing_0.id, task_id: "my-ip-address-task-id", address_str: "1234567890", network_name: "network_A")
 
             desired_instances = []
             expect {
@@ -467,8 +467,8 @@ module Bosh::Director::DeploymentPlan
             existing_zone2_2 = existing_instance_with_az(2, '2')
             existing_zone2_3 = existing_instance_with_az(3, '2')
 
-            Bosh::Director::Models::IpAddress.make(instance_id: existing_zone1_0.id, task_id: "my-ip-address-task-id", address: 1234567890, network_name: "network_A")
-            Bosh::Director::Models::IpAddress.make(instance_id: existing_zone1_1.id, task_id: "my-ip-address-task-id", address: 1234567891, network_name: "network_A")
+            Bosh::Director::Models::IpAddress.make(instance_id: existing_zone1_0.id, task_id: "my-ip-address-task-id", address_str: "1234567890", network_name: "network_A")
+            Bosh::Director::Models::IpAddress.make(instance_id: existing_zone1_1.id, task_id: "my-ip-address-task-id", address_str: "1234567891", network_name: "network_A")
 
             existing_zone1_0.update(ignore: true)
             existing_zone1_1.update(ignore: true)
@@ -495,8 +495,8 @@ module Bosh::Director::DeploymentPlan
             existing_zone1_3 = existing_instance_with_az(3, nil)
             ignored_existing_zone1_4 = existing_instance_with_az(4, nil)
 
-            Bosh::Director::Models::IpAddress.make(instance_id: ignored_existing_zone1_0.id, task_id: "my-ip-address-task-id", address: 1234567890, network_name: "network_A")
-            Bosh::Director::Models::IpAddress.make(instance_id: ignored_existing_zone1_4.id, task_id: "my-ip-address-task-id", address: 1234567891, network_name: "network_A")
+            Bosh::Director::Models::IpAddress.make(instance_id: ignored_existing_zone1_0.id, task_id: "my-ip-address-task-id", address_str: "1234567890", network_name: "network_A")
+            Bosh::Director::Models::IpAddress.make(instance_id: ignored_existing_zone1_4.id, task_id: "my-ip-address-task-id", address_str: "1234567891", network_name: "network_A")
 
             ignored_existing_zone1_0.update(ignore: true)
             ignored_existing_zone1_4.update(ignore: true)

--- a/src/bosh-director/spec/unit/deployment_plan/placement_planner/static_ips_availability_zone_picker_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/placement_planner/static_ips_availability_zone_picker_spec.rb
@@ -922,7 +922,7 @@ module Bosh::Director::DeploymentPlan
     def existing_instance_with_az_and_ips(az, ips, network_name = 'a')
       instance = Bosh::Director::Models::Instance.make(availability_zone: az, deployment: deployment_model, job: job.name)
       ips.each do |ip|
-        instance.add_ip_address(Bosh::Director::Models::IpAddress.make(address: NetAddr::CIDR.create(ip).to_i, network_name: network_name))
+        instance.add_ip_address(Bosh::Director::Models::IpAddress.make(address_str: NetAddr::CIDR.create(ip).to_i.to_s, network_name: network_name))
       end
       instance
     end

--- a/src/bosh-director/spec/unit/jobs/vm_state_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/vm_state_spec.rb
@@ -50,7 +50,7 @@ module Bosh::Director
       let(:agent) { instance_double('Bosh::Director::AgentClient') }
 
       it 'parses agent info into vm_state WITHOUT vitals' do
-        Models::IpAddress.make(instance_id: instance.id, address: NetAddr::CIDR.create('1.1.1.1').to_i, task_id: '12345')
+        Models::IpAddress.make(instance_id: instance.id, address_str: NetAddr::CIDR.create('1.1.1.1').to_i.to_s, task_id: '12345')
         expect(agent).to receive(:get_state).with('full').and_return(
           'vm_cid' => 'fake-vm-cid',
           'networks' => {'test' => {'ip' => '1.1.1.1'}},
@@ -75,8 +75,8 @@ module Bosh::Director
 
       context 'when there are two networks' do
         before {
-          Models::IpAddress.make(instance_id: instance.id, address: NetAddr::CIDR.create('1.1.1.1').to_i, task_id: '12345')
-          Models::IpAddress.make(instance_id: instance.id, address: NetAddr::CIDR.create('2.2.2.2').to_i, task_id: '12345')
+          Models::IpAddress.make(instance_id: instance.id, address_str: NetAddr::CIDR.create('1.1.1.1').to_i.to_s, task_id: '12345')
+          Models::IpAddress.make(instance_id: instance.id, address_str: NetAddr::CIDR.create('2.2.2.2').to_i.to_s, task_id: '12345')
         }
 
         it "returns the ip addresses from 'Models::Instance.ip_addresses'" do
@@ -107,7 +107,7 @@ module Bosh::Director
       end
 
       it 'parses agent info into vm_state WITH vitals' do
-        Models::IpAddress.make(instance_id: instance.id, address: NetAddr::CIDR.create('1.1.1.1').to_i, task_id: '12345')
+        Models::IpAddress.make(instance_id: instance.id, address_str: NetAddr::CIDR.create('1.1.1.1').to_i.to_s, task_id: '12345')
         stub_agent_get_state_to_return_state_with_vitals
 
         job = Jobs::VmState.new(@deployment.id, 'full')
@@ -335,7 +335,7 @@ module Bosh::Director
       end
 
       it 'should return processes info' do
-        Models::IpAddress.make(instance_id: instance.id, address: NetAddr::CIDR.create('1.1.1.1').to_i, task_id: '12345')
+        Models::IpAddress.make(instance_id: instance.id, address_str: NetAddr::CIDR.create('1.1.1.1').to_i.to_s, task_id: '12345')
         instance.update(spec: {'vm_type' => {'name' => 'fake-vm-type', 'cloud_properties' => {}}})
 
         expect(agent).to receive(:get_state).with('full').and_return(

--- a/src/bosh-director/spec/unit/models/ip_address_spec.rb
+++ b/src/bosh-director/spec/unit/models/ip_address_spec.rb
@@ -7,7 +7,7 @@ module Bosh::Director::Models
       described_class.make(
         instance: instance,
         network_name: 'foonetwork',
-        address: NetAddr::CIDR.create('10.10.0.1').to_i,
+        address_str: NetAddr::CIDR.create('10.10.0.1').to_i.to_s,
         static: true
       )
     end
@@ -25,15 +25,40 @@ module Bosh::Director::Models
     context 'validations' do
       it 'should require ip address' do
         invalid_ip = IpAddress.make
-        invalid_ip.address = nil
+
+        invalid_ip.address_str = ""
         expect {
           invalid_ip.save
-        }.to raise_error /address presence/
+        }.to raise_error /address_str presence/
 
-        invalid_ip.address = NetAddr::CIDR.create('10.10.0.1').to_i
+        invalid_ip.address_str = NetAddr::CIDR.create('10.10.0.1').to_i.to_s
         expect {
           invalid_ip.save
         }.not_to raise_error
+      end
+    end
+
+    describe '#address' do
+      it 'returns address in int form from address str' do
+        expect(subject.address).to eq(168427521)
+      end
+
+      it 'raises an error when the address is an empty string' do
+        invalid_ip = IpAddress.make
+        invalid_ip.address_str = ""
+        expect { invalid_ip.address }.to raise_error(/Unexpected address/)
+      end
+
+      it 'raises an error when the address is a string that does not contain an integer' do
+        invalid_ip = IpAddress.make
+        invalid_ip.address_str = "168427521a"
+        expect { invalid_ip.address }.to raise_error(/Unexpected address '168427521a'/)
+      end
+
+      it 'raises an error when the address is padded' do
+        invalid_ip = IpAddress.make
+        invalid_ip.address_str = "  168427521  "
+        expect { invalid_ip.address }.to raise_error(/Unexpected address '  168427521  '/)
       end
     end
   end


### PR DESCRIPTION
- switches IpAddress model to store ip addresses as strings
- renamed column to address_str to avoid confusion that address returns int string

Tests running: https://main.bosh-ci.cf-app.com/teams/main/pipelines/ipv6