### PR TITLE
Set ruby default external encoding through LANG

### DIFF
--- a/jobs/director/templates/director_ctl.erb
+++ b/jobs/director/templates/director_ctl.erb
@@ -19,6 +19,7 @@ LD_LIBRARY_PATH=/var/vcap/packages/mysql/lib/mysql:$LD_LIBRARY_PATH
 
 export LD_LIBRARY_PATH
 export PATH
+export LANG=en_US.UTF-8
 
 export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
 export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/2.3.0

--- a/jobs/director/templates/scheduler_ctl.erb
+++ b/jobs/director/templates/scheduler_ctl.erb
@@ -10,6 +10,7 @@ RUNAS=vcap
 PATH=/var/vcap/packages/ruby/bin:$PATH
 PATH=$PATH:/var/vcap/jobs/director/bin
 export PATH
+export LANG=en_US.UTF-8
 
 export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
 export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/2.3.0

--- a/jobs/director/templates/sync_dns_ctl.erb
+++ b/jobs/director/templates/sync_dns_ctl.erb
@@ -8,6 +8,7 @@ PIDFILE=$RUN_DIR/sync_dns.pid
 RUNAS=vcap
 
 export PATH=/var/vcap/packages/ruby/bin:/var/vcap/jobs/director/bin:$PATH
+export LANG=en_US.UTF-8
 
 export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
 export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/2.3.0

--- a/jobs/director/templates/worker_ctl.erb
+++ b/jobs/director/templates/worker_ctl.erb
@@ -19,6 +19,7 @@ LD_LIBRARY_PATH=/var/vcap/packages/mysql/lib/mysql:$LD_LIBRARY_PATH
 PATH=/var/vcap/packages/ruby/bin:$PATH
 PATH=$PATH:/var/vcap/jobs/director/bin
 export PATH LD_LIBRARY_PATH
+export LANG=en_US.UTF-8
 
 export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
 export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/2.3.0


### PR DESCRIPTION
Export `LANG=en_US.UTF-8` in all ruby ctl scripts.
LANG env var is not passed through monit. Ruby
considers LANG to set its default external encoding.
Defaults to `US_ASCII`, if LANG is not set.

Fixes cloudfoundry/cf-release#1234

As there are multiple options to set the external default encoding, please provide feedback or merge, if this approach is acceptable.

[#150369990](https://www.pivotaltracker.com/story/show/150369990)