### PR TITLE
Log error messages reported in body of responses from CredHub

### DIFF
--- a/src/bosh-director/spec/unit/config_server/client_spec.rb
+++ b/src/bosh-director/spec/unit/config_server/client_spec.rb
@@ -1940,7 +1940,11 @@ module Bosh::Director::ConfigServer
 
   class SampleForbiddenResponse < Net::HTTPForbidden
     def initialize
-      super(nil, '403', 'There was a problem.')
+      super(nil, '403', '')
+    end
+
+    def body
+      '{"error": "There was a problem."}'
     end
   end
 end


### PR DESCRIPTION
The code was reporting the value of the "message" attribute of the HTTP response from CredHub, but the detailed error message is contained in the body, under the key "error."

[#150933164] Submit PR to fix the lack of descriptive error in BOSH generation failure message

Signed-off-by: Edie Beer <ebeer@pivotal.io>