### PR TITLE
Add new feature: deployment revisions

### DIFF
--- a/src/bosh-director/lib/bosh/director/api.rb
+++ b/src/bosh-director/lib/bosh/director/api.rb
@@ -8,6 +8,7 @@ require 'bosh/director/api/http_constants'
 require 'bosh/director/api/api_helper'
 
 require 'bosh/director/api/deployment_manager'
+require 'bosh/director/api/revision_manager'
 require 'bosh/director/api/instance_manager'
 require 'bosh/director/api/problem_manager'
 require 'bosh/director/api/property_manager'

--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -48,6 +48,7 @@ module Bosh::Director
         @instance_manager = Api::InstanceManager.new
         @deployments_repo = DeploymentPlan::DeploymentRepo.new
         @instance_ignore_manager = Api::InstanceIgnoreManager.new
+        @revision_manager = Api::RevisionManager.new
       end
 
       get '/:deployment/jobs/:job/:index_or_id' do
@@ -143,6 +144,21 @@ module Bosh::Director
 
       get '/:deployment/snapshots' do
         json_encode(@snapshot_manager.snapshots(deployment))
+      end
+
+      get '/:deployment/history' do
+        json_encode(@revision_manager.revisions(deployment.name,
+          include_manifest: params['include_manifest'],
+          include_cloud_config: params['include_cloud_config'],
+          include_runtime_configs: params['include_runtime_configs']))
+      end
+
+      get '/:deployment/history/:revision' do
+        json_encode(@revision_manager.revision(deployment.name, params['revision']))
+      end
+
+      get '/:deployment/diff_revisions' do
+        json_encode(@revision_manager.diff(deployment, params['revision1'], params['revision2'], should_redact: !params.fetch(:no_redact, false)))
       end
 
       get '/:deployment/jobs/:job/:index/snapshots' do

--- a/src/bosh-director/lib/bosh/director/api/revision_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/revision_manager.rb
@@ -1,0 +1,116 @@
+module Bosh::Director
+  module Api
+    class RevisionManager
+      include ApiHelper
+
+      def initialize
+        @event_manager = EventManager.new(true)
+      end
+
+      def create_revision(deployment_name:, user:, task:, started_at:, manifest_text:, cloud_config_id:, runtime_config_ids:, releases:, stemcells:, error: nil)
+        Models::Event.create(
+          timestamp:   Time.now,
+          user:        user,
+          task:        task,
+          action:      "create",
+          object_type: "deployment_revision",
+          object_name: (last_revision_number(deployment_name)+1).to_s,
+          deployment:  deployment_name,
+          context: {
+            manifest_text: manifest_text,
+            started_at: started_at,
+            cloud_config_id: cloud_config_id,
+            runtime_config_ids: runtime_config_ids,
+            releases: releases,
+            stemcells: stemcells,
+          },
+          error: error,
+          )
+      end
+
+      def last_revision_number(deployment_name)
+        Models::Event.where(object_type: 'deployment_revision', deployment: deployment_name).select(:object_name).map{|event| event.object_name.to_i}.sort.last.to_i
+      end
+
+
+      def revisions(deployment_name, include_manifest: false, include_cloud_config: false, include_runtime_configs: false)
+        Models::Event.order_by(Sequel.desc(:id)).
+          where(deployment: deployment_name).
+          and(object_type: 'deployment_revision').all.map do |event|
+            {
+              deployment_name: deployment_name,
+              revision_number: event.object_name.to_i,
+              user: event.user,
+              task: event.task,
+              started_at: event.context['started_at'],
+              completed_at: event.timestamp,
+              error: event.error,
+            }.tap{ |result|
+              result[:manifest_text] = event.context['manifest_text'] if include_manifest
+            }
+          end
+      end
+
+      def revision(deployment_name, revision_number)
+        event = Models::Event.find(object_name: revision_number)
+        cloud_config = Bosh::Director::Models::CloudConfig.find(id: event.context['cloud_config_id'])
+        runtime_configs = Bosh::Director::Models::RuntimeConfig.find_by_ids(event.context['runtime_config_ids'])
+        {
+          deployment_name: deployment_name,
+          revision_number: event.object_name.to_i,
+          user: event.user,
+          task: event.task,
+          started_at: event.context['started_at'],
+          completed_at: event.timestamp,
+          error: event.error,
+          manifest_text: event.context['manifest_text'],
+          releases: event.context['releases'],
+          stemcells: event.context['stemcells'],
+          runtime_configs: runtime_configs.map{ |runtime_config| runtime_config.raw_manifest },
+        }.tap{ |result|
+          result[:cloud_config] = cloud_config.interpolated_manifest(deployment_name) if cloud_config
+        }
+      end
+
+      def diff(deployment, revision1, revision2, should_redact: true)
+        event1 = Models::Event.find(object_name: revision1)
+        event2 = Models::Event.find(object_name: revision2)
+
+        releases1 = releases(event1.context)
+        releases2 = releases(event2.context)
+        {
+          manifest: manifest_from(event1.context).diff(manifest_from(event2.context), should_redact).
+            map { |l| [l.to_s, l.status] },
+          releases: {
+            added: releases2-releases1,
+            removed: releases1-releases2,
+          }
+        }
+      end
+
+      private
+
+      def manifest_from(context)
+        Manifest.load_from_hash(
+              validate_manifest_yml(context['manifest_text'], nil),
+              Bosh::Director::Models::CloudConfig.find(id: context['cloud_config_id']),
+              Bosh::Director::Models::RuntimeConfig.find_by_ids(context['runtime_config_ids']),
+              {resolve_interpolation: false}
+            )
+      end
+
+      def releases(context)
+        manifest_from(context).to_hash['releases'].map do |nv|
+          if nv['version'] == 'latest'
+            "#{nv['name']}/#{context['releases'].keep_if{ |release|
+              release.split('/', 2)[0] == nv['name']
+            }.last.split('/', 2)[1]}"
+          else
+            "#{nv['name']}/#{nv['version']}"
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -1571,6 +1571,39 @@ module Bosh::Director
             end
           end
         end
+
+        describe 'deployment revisions' do
+          it 'lists the revisions' do
+            Models::Deployment.create(name: 'my-deployment')
+
+            Models::Event.create(
+              deployment:  "my-deployment",
+              user:        "user",
+              task:        "task",
+              timestamp:   Time.utc(2017),
+              action:      "create",
+              object_type: "deployment_revision",
+              context: {
+                manifest_content: "foo",
+                started_at:  Time.utc(2016),
+              },
+              )
+            get '/my-deployment/history', {}, {}
+            expect(last_response.status).to eq(200)
+            body = JSON.parse(last_response.body)
+            expect(body).to eq([
+              {
+                "deployment_name"=>"my-deployment",
+                "revision_number"=>0,
+                "user"=>"user",
+                "task"=>"task",
+                "started_at"=>"2016-01-01 00:00:00 UTC",
+                "completed_at"=>"2017-01-01 00:00:00 UTC",
+                "error"=>nil
+              }
+            ])
+          end
+        end
       end
 
       describe 'authorization' do

--- a/src/bosh-director/spec/unit/api/revision_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/revision_manager_spec.rb
@@ -1,0 +1,156 @@
+require 'spec_helper'
+
+module Bosh::Director
+  describe Api::RevisionManager do
+    let(:task) { '1' }
+    let(:username) { 'FAKE_USER' }
+
+    describe '#create_revision' do
+      it 'creates consecutive revision_numbers per deployment in event.object_name' do
+        expect(create_test_revision("deployment-A").object_name).to eq '1'
+        expect(create_test_revision("deployment-B").object_name).to eq '1'
+        expect(create_test_revision("deployment-A").object_name).to eq '2'
+        expect(create_test_revision("deployment-B").object_name).to eq '2'
+        expect(create_test_revision("deployment-B").object_name).to eq '3'
+        expect(create_test_revision("deployment-A").object_name).to eq '3'
+      end
+    end
+
+    describe '#revisions' do
+      let!(:event) {
+        create_test_revision('my-deployment', manifest_text: 'test-key: test-value')
+      }
+
+      it 'can return a previously created revision' do
+        expect(subject.revisions('my-deployment')).to eq([
+          {
+            deployment_name:"my-deployment",
+            revision_number: 1,
+            user: username,
+            task: task,
+            started_at: event.context['started_at'],
+            completed_at: event.timestamp,
+            error: nil,
+          }
+        ])
+      end
+
+      it 'can return a previously created revision including manifest if specified' do
+        expect(subject.revisions('my-deployment', include_manifest: true)).to eq([
+          {
+            deployment_name:"my-deployment",
+            revision_number: 1,
+            user: username,
+            task: task,
+            started_at: event.context['started_at'],
+            completed_at: event.timestamp,
+            manifest_text: 'test-key: test-value',
+            error: nil,
+          }
+        ])
+      end
+
+      it 'only returns deployment_revision object_types as revision' do
+        Models::Event.create(
+          timestamp:   Time.now,
+          user:        "user",
+          action:      "create",
+          object_type: "some-other-object-type",
+          deployment:  "my-deployment",
+        )
+
+        expect(subject.revisions('my-deployment')).to eq([
+          {
+            deployment_name:"my-deployment",
+            revision_number: 1,
+            user: username,
+            task: task,
+            started_at: event.context['started_at'],
+            completed_at: event.timestamp,
+            error: nil,
+          }
+        ])
+      end
+    end
+
+    describe '#revision' do
+      let!(:event) {
+        create_test_revision('my-deployment', manifest_text: 'test-key: test-value')
+      }
+
+      it 'returns a previously created revison' do
+        expect(subject.revision('my-deployment', event.object_name)).to eq(
+          {
+            deployment_name:"my-deployment",
+            revision_number: 1,
+            user: username,
+            task: task,
+            started_at: event.context['started_at'],
+            completed_at: event.timestamp,
+            manifest_text: 'test-key: test-value',
+            runtime_configs: [],
+            stemcells: [],
+            releases: [],
+            error: nil,
+          }
+        )
+      end
+    end
+
+    describe '#diff' do
+      before do
+        create_test_revision("deployment-A",
+          manifest_text: {
+            'releases' => [
+              {'name' => 'A', 'version' => '2'},
+              {'name' => 'B', 'version' => '1'}
+            ]
+          }.to_yaml,
+          releases: ['A/1', 'A/2', 'B/1'])
+        create_test_revision("deployment-A",
+          manifest_text: {
+            'releases' => [
+              {'name' => 'A', 'version' => 'latest'},
+              {'name' => 'B', 'version' => '2'}
+            ]
+          }.to_yaml,
+          releases: ['A/1', 'A/2', 'A/3', 'B/2'])
+      end
+
+      it 'returns a diff between the manifests' do
+        expect(subject.diff("deployment-A", 1, 2, should_redact: false)[:manifest]).to eq(
+          [
+            ["releases:", nil],
+            ["- name: A", nil],
+            ["  version: '2'", "removed"],
+            ["  version: latest", "added"],
+            ["- name: B", nil],
+            ["  version: '1'", "removed"],
+            ["  version: '2'", "added"]
+          ]
+        )
+      end
+
+      it 'returns releases added and removed, resolving "latest" to concrete version number' do
+        expect(subject.diff("deployment-A", 1, 2, should_redact: false)[:releases]).to eq(
+          {:added=>["A/3", "B/2"], :removed=>["A/2", "B/1"]}
+        )
+      end
+    end
+  end
+end
+
+def create_test_revision(deployment_name, manifest_text: 'key: value', releases: [])
+  subject.create_revision(
+    deployment_name: deployment_name,
+    user: username,
+    task: task,
+    started_at: Time.now,
+    manifest_text: manifest_text,
+    cloud_config_id: nil,
+    runtime_config_ids: [],
+    releases: releases,
+    stemcells: [],
+  )
+end
+

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -316,9 +316,9 @@ module Bosh::Director
             expect {
               job.perform
             }.to change {
-              Models::Event.count }.from(0).to(2)
+              Models::Event.where(object_type: 'deployment').count }.from(0).to(2)
 
-            event_1 = Models::Event.first
+            event_1 = Models::Event.where(object_type: 'deployment').first
             expect(event_1.user).to eq(task.username)
             expect(event_1.object_type).to eq('deployment')
             expect(event_1.deployment).to eq('deployment-name')
@@ -326,7 +326,7 @@ module Bosh::Director
             expect(event_1.task).to eq("#{task.id}")
             expect(event_1.timestamp).to eq(Time.now)
 
-            event_2 = Models::Event.order(:id).last
+            event_2 = Models::Event.where(object_type: 'deployment').order(:id).last
             expect(event_2.parent_id).to eq(1)
             expect(event_2.user).to eq(task.username)
             expect(event_2.object_type).to eq('deployment')
@@ -351,8 +351,8 @@ module Bosh::Director
               expect {
                 job.perform
               }.to change {
-                Models::Event.count }.from(0).to(2)
-              expect(Models::Event.order(:id).last.context).to eq({'before' => {}, 'after' => {'releases' => ['release/version-1'], 'stemcells' => ['stemcell/version-1']}})
+                Models::Event.where(object_type: 'deployment').count }.from(0).to(2)
+              expect(Models::Event.where(object_type: 'deployment').order(:id).last.context).to eq({'before' => {}, 'after' => {'releases' => ['release/version-1'], 'stemcells' => ['stemcell/version-1']}})
             end
           end
 
@@ -363,10 +363,10 @@ module Bosh::Director
               expect {
                 job.perform
               }.to change {
-                Models::Event.count }.from(0).to(2)
+                Models::Event.where(object_type: 'deployment').count }.from(0).to(2)
 
-              expect(Models::Event.first.action).to eq('create')
-              expect(Models::Event.order(:id).last.action).to eq('create')
+              expect(Models::Event.where(object_type: 'deployment').first.action).to eq('create')
+              expect(Models::Event.where(object_type: 'deployment').order(:id).last.action).to eq('create')
             end
           end
 
@@ -375,9 +375,9 @@ module Bosh::Director
               expect {
                 job.perform
               }.to change {
-                Models::Event.count }.from(0).to(2)
-              expect(Models::Event.first.action).to eq('update')
-              expect(Models::Event.order(:id).last.action).to eq('update')
+                Models::Event.where(object_type: 'deployment').count }.from(0).to(2)
+              expect(Models::Event.where(object_type: 'deployment').first.action).to eq('update')
+              expect(Models::Event.where(object_type: 'deployment').order(:id).last.action).to eq('update')
             end
           end
 

--- a/src/spec/integration/deployment_revisions_spec.rb
+++ b/src/spec/integration/deployment_revisions_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe 'deployment revisions', type: :integration do
+  with_reset_sandbox_before_all
+
+  before(:all) do
+    manifest_hash = Bosh::Spec::Deployments.simple_manifest
+    manifest_hash['jobs'][0]['persistent_disk_pool'] = 'disk_a'
+    manifest_hash['jobs'][0]['instances'] = 1
+    cloud_config = Bosh::Spec::Deployments.simple_cloud_config
+    disk_pool = Bosh::Spec::Deployments.disk_pool
+    cloud_config['disk_pools'] = [disk_pool]
+    cloud_config['compilation']['reuse_compilation_vms'] = true
+
+    deploy_from_scratch(manifest_hash: manifest_hash, cloud_config_hash: cloud_config)
+
+    cloud_config['compilation']['reuse_compilation_vms'] = false
+    upload_cloud_config(cloud_config_hash: cloud_config)
+
+    manifest_hash['jobs'][0]['instances'] = 2
+    deploy_simple_manifest(manifest_hash: manifest_hash)
+
+    manifest_hash['jobs'][0]['instances'] = 3
+    deploy_simple_manifest(manifest_hash: manifest_hash)
+
+    update_release
+    manifest_hash['releases'][0]['version'] = 'latest'
+    deploy_simple_manifest(manifest_hash: manifest_hash)
+  end
+
+  describe '/deployments/:deployment/diff_revisions' do
+    it "returns a diff between 2 revisions" do
+      Net::HTTP.start('localhost', 61004, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+        request = Net::HTTP::Get.new(URI("https://localhost:61004/deployments/simple/diff_revisions?revision1=1&revision2=2"))
+        request.basic_auth('test', 'test')
+        response = http.request request
+        expect(response.code).to eq('200')
+
+        expect(response.body).to eq('{'\
+          '"manifest":['\
+            '['\
+              '"compilation:",'\
+              'null'\
+            '],'\
+            '['\
+              '"  reuse_compilation_vms: true",'\
+              '"removed"'\
+            '],'\
+            '['\
+              '"  reuse_compilation_vms: false",'\
+              '"added"'\
+            '],'\
+            '['\
+              '"",'\
+              'null'\
+            '],'\
+            '['\
+              '"jobs:",'\
+              'null'\
+            '],'\
+            '['\
+              '"- name: foobar",'\
+              'null'\
+            '],'\
+            '['\
+              '"  instances: 1",'\
+              '"removed"'\
+            '],'\
+            '['\
+              '"  instances: 2",'\
+              '"added"'\
+            ']'\
+          '],'\
+          '"releases":{'\
+            '"added":[],'\
+            '"removed":[]'\
+          '}'\
+        '}')
+      end
+    end
+  end
+
+  describe '/deployments/:deployment/history' do
+    it "returns a history" do
+      Net::HTTP.start('localhost', 61004, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
+        request = Net::HTTP::Get.new(URI("https://localhost:61004/deployments/simple/history"))
+        request.basic_auth('test', 'test')
+        response = http.request request
+        expect(response.code).to eq('200')
+
+        expect(scrub_time(response.body)).to eq('['\
+          '{'\
+            '"deployment_name":"simple",'\
+            '"revision_number":4,'\
+            '"user":"test",'\
+            '"task":"7",'\
+            '"started_at":"0000-00-00 00:00:00 -0000",'\
+            '"completed_at":"0000-00-00 00:00:00 UTC",'\
+            '"error":null'\
+          '},'\
+          '{'\
+            '"deployment_name":"simple",'\
+            '"revision_number":3,'\
+            '"user":"test",'\
+            '"task":"5",'\
+            '"started_at":"0000-00-00 00:00:00 -0000",'\
+            '"completed_at":"0000-00-00 00:00:00 UTC",'\
+            '"error":null'\
+          '},'\
+          '{'\
+            '"deployment_name":"simple",'\
+            '"revision_number":2,'\
+            '"user":"test",'\
+            '"task":"4",'\
+            '"started_at":"0000-00-00 00:00:00 -0000",'\
+            '"completed_at":"0000-00-00 00:00:00 UTC",'\
+            '"error":null'\
+          '},'\
+          '{'\
+            '"deployment_name":"simple",'\
+            '"revision_number":1,'\
+            '"user":"test",'\
+            '"task":"3",'\
+            '"started_at":"0000-00-00 00:00:00 -0000",'\
+            '"completed_at":"0000-00-00 00:00:00 UTC",'\
+            '"error":null'\
+          '}'\
+        ']')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses https://github.com/cloudfoundry/bosh/issues/1525 (which contains much more context and discussions with @cppforlife). Here's what this feature allows (taken partially from the issue):

## Some examples of its usage

**Get the history of a deployment including deployment manifests at any point in time:**
```bash
curl -k 'https://test:test@localhost:61004/deployments/simple/history' | jq
```
```yaml
[
  {
    "deployment_name": "simple",
    "revision_number": 4,
    "user": "test",
    "task": "7",
    "started_at": "2017-07-17 23:18:59 +0200",
    "completed_at": "2017-07-17 21:19:22 UTC",
    "error": null,
    "manifest_text": "---\nname: simple\ndirector_uuid: deadbeef\nreleases:\n- name: bosh-release\n  version: latest\nupdate:\n  canaries: 2\n  canary_watch_time: 4000\n  max_in_flight: 1\n  update_watch_time: 20\njobs:\n- name: foobar\n  templates:\n  - name: foobar\n  resource_pool: a\n  instances: 3\n  networks:\n  - name: a\n  properties: {}\n  persistent_disk_pool: disk_a\n"
  },
  {
    "deployment_name": "simple",
    "revision_number": 3,
    "user": "test",
    "task": "5",
    "started_at": "2017-07-17 23:18:44 +0200",
    "completed_at": "2017-07-17 21:18:53 UTC",
    "error": null,
    "manifest_text": "---\nname: simple\ndirector_uuid: deadbeef\nreleases:\n- name: bosh-release\n  version: 0.1-dev\nupdate:\n  canaries: 2\n  canary_watch_time: 4000\n  max_in_flight: 1\n  update_watch_time: 20\njobs:\n- name: foobar\n  templates:\n  - name: foobar\n  resource_pool: a\n  instances: 3\n  networks:\n  - name: a\n  properties: {}\n  persistent_disk_pool: disk_a\n"
  },
  {
    "deployment_name": "simple",
    "revision_number": 2,
    "user": "test",
    "task": "4",
    "started_at": "2017-07-17 23:18:32 +0200",
    "completed_at": "2017-07-17 21:18:41 UTC",
    "error": null,
    "manifest_text": "---\nname: simple\ndirector_uuid: deadbeef\nreleases:\n- name: bosh-release\n  version: 0.1-dev\nupdate:\n  canaries: 2\n  canary_watch_time: 4000\n  max_in_flight: 1\n  update_watch_time: 20\njobs:\n- name: foobar\n  templates:\n  - name: foobar\n  resource_pool: a\n  instances: 2\n  networks:\n  - name: a\n  properties: {}\n  persistent_disk_pool: disk_a\n"
  },
  {
    "deployment_name": "simple",
    "revision_number": 1,
    "user": "test",
    "task": "3",
    "started_at": "2017-07-17 23:18:18 +0200",
    "completed_at": "2017-07-17 21:18:28 UTC",
    "error": null,
    "manifest_text": "---\nname: simple\ndirector_uuid: deadbeef\nreleases:\n- name: bosh-release\n  version: 0.1-dev\nupdate:\n  canaries: 2\n  canary_watch_time: 4000\n  max_in_flight: 1\n  update_watch_time: 20\njobs:\n- name: foobar\n  templates:\n  - name: foobar\n  resource_pool: a\n  instances: 1\n  networks:\n  - name: a\n  properties: {}\n  persistent_disk_pool: disk_a\n"
  }
]
```


**Get the differences of manifests and releases for one deployment between two points in time:**

```bash
curl -k 'https://test:test@localhost:61004/deployments/simple/diff_revisions?revision1=3&revision2=4' | jq
```

```yaml
{
  "manifest": [
    [
      "releases:",
      null
    ],
    [
      "- name: bosh-release",
      null
    ],
    [
      "  version: 0.1-dev",
      "removed"
    ],
    [
      "  version: latest",
      "added"
    ]
  ],
  "releases": {
    "added": [
      "bosh-release/0+dev.2"
    ],
    "removed": [
      "bosh-release/0.1-dev"
    ]
  }
}

```
## A few notes on the implementation
* I debated long with myself if I should call the new entity `deployment_revision` or `audit_log_entry` (and similarly `history` versus `audit_log`). The latter would emphasize usefulness in contexts where precise audit_logs of production systems are required. OTOH, it's really different revisions of the same deployment. Suggestions welcome.
* I also debated with myself, if I should invent a completely new event type, or if I should simply formalize the existing deployment event. In the end, I decided for a new event type, as I feel like this is a first class concept, which I do not necessarily want to mix with the existing event structure.
* Using `object_name` as revision number is a bit hacky and I'm not super happy with it.
* The code comes only with a partially complete suite of tests just yet, but I can of course add them, should we decide to go forward with this.
* I have also not added CLI commands. Also waiting for feedback first.

