### PR TITLE
Optimize performance of /deployments endpoint

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -198,9 +198,9 @@ module Bosh::Director
         deployments = @deployment_manager.all_by_name_asc
           .select { |deployment| @permission_authorizer.is_granted?(deployment, :read, token_scopes) }
           .map do |deployment|
-          cloud_config = if deployment.cloud_config.nil?
+          cloud_config = if deployment.cloud_config_id.nil?
                            'none'
-                         elsif deployment.cloud_config == latest_cloud_config
+                         elsif deployment.cloud_config_id == latest_cloud_config.id
                            'latest'
                          else
                            'outdated'
@@ -208,7 +208,7 @@ module Bosh::Director
 
           {
             'name' => deployment.name,
-            'releases' => deployment.release_versions.map do |rv|
+            'releases' => deployment.release_versions.sort { |a,b| [a.release.name, a.version] <=> [b.release.name, b.version] } .map do |rv|
               {
                 'name' => rv.release.name,
                 'version' => rv.version.to_s

--- a/src/bosh-director/lib/bosh/director/api/deployment_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/deployment_manager.rb
@@ -12,7 +12,10 @@ module Bosh::Director
       end
 
       def all_by_name_asc
-        Bosh::Director::Models::Deployment.order_by(Sequel.asc(:name)).all
+        Bosh::Director::Models::Deployment
+          .eager(:teams, :stemcells, release_versions: :release)
+          .order_by(Sequel.asc(:name))
+          .all
       end
 
       def create_deployment(username, manifest_text, cloud_config, runtime_configs, deployment, options = {}, context_id = '')

--- a/src/bosh-director/lib/bosh/director/models/deployment.rb
+++ b/src/bosh-director/lib/bosh/director/models/deployment.rb
@@ -1,6 +1,6 @@
 module Bosh::Director::Models
   class Deployment < Sequel::Model(Bosh::Director::Config.db)
-    many_to_many :stemcells
+    many_to_many :stemcells, order: [Sequel.asc(:name), Sequel.asc(:version)]
     many_to_many :release_versions
     one_to_many  :job_instances, :class => "Bosh::Director::Models::Instance"
     one_to_many  :instances
@@ -8,7 +8,7 @@ module Bosh::Director::Models
     one_to_many  :problems, :class => "Bosh::Director::Models::DeploymentProblem"
     many_to_one  :cloud_config
     many_to_many :runtime_configs
-    many_to_many :teams
+    many_to_many :teams, order: Sequel.asc(:name)
     one_to_many  :variable_sets, :class => 'Bosh::Director::Models::VariableSet'
 
     def validate


### PR DESCRIPTION
- use Sequel.eager to get deployments association which avoids n+1 queries.
- introduces default sort order on teams and stemcell association
  of deployments model. It's not possible to sort eager queries.
  With eager_graph it is possible but compared to eager it was eight times
  slower.

[#150958551](www.pivotaltracker.com/story/show/150958551)
