### PR TITLE
Registry should die after 10 sec

### DIFF
--- a/jobs/registry/templates/registry_ctl.erb
+++ b/jobs/registry/templates/registry_ctl.erb
@@ -55,7 +55,15 @@ case $1 in
     if [ ! -z $PID ] && pid_exists $PID; then
       kill $PID
     fi
-    while [ -e /proc/$PID ]; do sleep 0.1; done
+    TRIES=0
+    while [ -e /proc/$PID ]
+    do
+      TRIES=$(( $TRIES + 1 ))
+      if [ $TRIES -gt 100 ]; then
+        kill -9 $PID
+      fi
+      sleep 0.1
+    done
     rm -f $PIDFILE
     ;;
 


### PR DESCRIPTION
- currently we wait forever until the
  registry process dies
- we have seen registry process ignoring
  kill and hanging forever in production
- wait for max. 10 seconds, then force kill it

(same as for director, scheduler and workers
, see commit 156ef3ec9 )

Signed-off-by: Jan Sievers <jan.sievers@sap.com>