### PR TITLE
as an operator, i expect to be able to retrieve exact same manifest t…

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -83,15 +83,15 @@ module Bosh::Director
         options['dry_run'] = true if params['dry_run'] == 'true'
 
         if (request.content_length.nil?  || request.content_length.to_i == 0) && (params['state'])
-          manifest = deployment.manifest
+          manifest_text = deployment.manifest
         else
-          manifest_hash = validate_manifest_yml(request.body.read, nil)
-          manifest =  YAML.dump(manifest_hash)
+          manifest_text = request.body.read
+          validate_manifest_yml(manifest_text, nil)
         end
 
         latest_cloud_config = Bosh::Director::Api::CloudConfigManager.new.latest
         latest_runtime_configs = Models::RuntimeConfig.latest_set
-        task = @deployment_manager.create_deployment(current_user, manifest, latest_cloud_config, latest_runtime_configs, deployment, options)
+        task = @deployment_manager.create_deployment(current_user, manifest_text, latest_cloud_config, latest_runtime_configs, deployment, options)
         redirect "/tasks/#{task.id}"
       end
 
@@ -116,15 +116,15 @@ module Bosh::Director
         options['dry_run'] = true if params['dry_run'] == 'true'
 
         if request.content_length.nil? || request.content_length.to_i == 0
-          manifest = deployment.manifest
+          manifest_text = deployment.manifest
         else
-          manifest_hash = validate_manifest_yml(request.body.read, nil)
-          manifest =  YAML.dump(manifest_hash)
+          manifest_text = request.body.read
+          validate_manifest_yml(manifest_text, nil)
         end
 
         latest_cloud_config = Bosh::Director::Api::CloudConfigManager.new.latest
         latest_runtime_configs = Models::RuntimeConfig.latest_set
-        task = @deployment_manager.create_deployment(current_user, manifest, latest_cloud_config, latest_runtime_configs, deployment, options)
+        task = @deployment_manager.create_deployment(current_user, manifest_text, latest_cloud_config, latest_runtime_configs, deployment, options)
         redirect "/tasks/#{task.id}"
       end
 
@@ -345,12 +345,13 @@ module Bosh::Director
       end
 
       post '/', authorization: :create_deployment, :consumes => :yaml do
-        deployment = validate_manifest_yml(request.body.read, nil)
-        unless deployment.kind_of?(Hash)
+        manifest_text = request.body.read
+        manifest_hash = validate_manifest_yml(manifest_text, nil)
+        unless manifest_hash.kind_of?(Hash)
           raise ValidationInvalidType, 'Deployment manifest must be a hash'
         end
 
-        unless deployment['name']
+        unless manifest_hash['name']
           raise ValidationMissingField, "Deployment manifest must have a 'name' key"
         end
 
@@ -375,18 +376,19 @@ module Bosh::Director
         options['runtime_configs'] = runtime_configs
         options['deploy'] = true
 
-        deployment_name = deployment['name']
+        deployment_name = manifest_hash['name']
         options['new'] = Models::Deployment[name: deployment_name].nil? ? true : false
         deployment_model = @deployments_repo.find_or_create_by_name(deployment_name, options)
 
-        task = @deployment_manager.create_deployment(current_user, YAML.dump(deployment), cloud_config, runtime_configs, deployment_model, options, @current_context_id)
+        task = @deployment_manager.create_deployment(current_user, manifest_text, cloud_config, runtime_configs, deployment_model, options, @current_context_id)
 
         redirect "/tasks/#{task.id}"
       end
 
       post '/:deployment/diff', authorization: :diff, :consumes => :yaml do
         begin
-          manifest_hash = validate_manifest_yml(request.body.read, nil)
+          manifest_text = request.body.read
+          manifest_hash = validate_manifest_yml(manifest_text, nil)
 
           ignore_cc = ignore_cloud_config?(manifest_hash)
 
@@ -400,7 +402,7 @@ module Bosh::Director
           after_cloud_config = ignore_cc ? nil : Bosh::Director::Api::CloudConfigManager.new.latest
           after_runtime_configs = Bosh::Director::Models::RuntimeConfig.latest_set
 
-          after_manifest = Manifest.load_from_hash(manifest_hash, after_cloud_config, after_runtime_configs, {:resolve_interpolation => false})
+          after_manifest = Manifest.load_from_text(manifest_text, after_cloud_config, after_runtime_configs, {:resolve_interpolation => false})
           after_manifest.resolve_aliases
 
           redact =  params['redact'] != 'false'

--- a/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
@@ -95,7 +95,7 @@ module Bosh::Director
     def current_states_by_instance(existing_instances, fix = false)
       lock = Mutex.new
       current_states_by_existing_instance = {}
-      is_version_1_manifest = ignore_cloud_config?(@deployment_plan.uninterpolated_manifest_text)
+      is_version_1_manifest = ignore_cloud_config?(YAML.load(@deployment_plan.uninterpolated_manifest_text))
 
       ThreadPool.new(:max_threads => Config.max_threads).wrap do |pool|
         existing_instances.each do |existing_instance|

--- a/src/bosh-director/lib/bosh/director/deployment_plan/planner.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/planner.rb
@@ -72,7 +72,7 @@ module Bosh::Director
         @properties = attrs.fetch(:properties)
         @releases = {}
 
-        @uninterpolated_manifest_text = Bosh::Common::DeepCopy.copy(uninterpolated_manifest_text)
+        @uninterpolated_manifest_text = uninterpolated_manifest_text
         @cloud_config = cloud_config
         @runtime_configs = runtime_configs
         @model = deployment_model

--- a/src/bosh-director/lib/bosh/director/deployment_plan/planner_factory.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/planner_factory.rb
@@ -76,7 +76,7 @@ module Bosh
           @logger.info('Creating deployment plan')
           @logger.info("Deployment plan options: #{plan_options}")
 
-          deployment = Planner.new(attrs, migrated_manifest_object.raw_manifest_hash, cloud_config, runtime_config_consolidator.runtime_configs, deployment_model, plan_options)
+          deployment = Planner.new(attrs, migrated_manifest_object.raw_manifest_text, cloud_config, runtime_config_consolidator.runtime_configs, deployment_model, plan_options)
           global_network_resolver = GlobalNetworkResolver.new(deployment, Config.director_ips, @logger)
           ip_provider_factory = IpProviderFactory.new(deployment.using_global_networking?, @logger)
           deployment.cloud_planner = CloudManifestParser.new(@logger).parse(cloud_manifest, global_network_resolver, ip_provider_factory)

--- a/src/bosh-director/lib/bosh/director/deployment_plan/steps/persist_deployment_step.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/steps/persist_deployment_step.rb
@@ -18,7 +18,7 @@ module Bosh::Director
             end
           # end
 
-          @deployment_plan.model.manifest = YAML.dump(@deployment_plan.uninterpolated_manifest_text)
+          @deployment_plan.model.manifest = @deployment_plan.uninterpolated_manifest_text
           @deployment_plan.model.cloud_config = @deployment_plan.cloud_config
           @deployment_plan.model.runtime_configs = @deployment_plan.runtime_configs
           @deployment_plan.model.link_spec = @deployment_plan.link_spec

--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -63,7 +63,7 @@ module Bosh::Director
             Bosh::Director::Models::Deployment.find(name: @deployment_name).add_variable_set(:created_at => Time.now, :writable => true)
           end
 
-          deployment_manifest_object = Manifest.load_from_hash(manifest_hash, cloud_config_model, runtime_config_models)
+          deployment_manifest_object = Manifest.load_from_text(@manifest_text, cloud_config_model, runtime_config_models)
 
           @notifier = DeploymentPlan::Notifier.new(@deployment_name, Config.nats_rpc, logger)
           @notifier.send_start_event unless dry_run?

--- a/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
@@ -28,7 +28,7 @@ module Bosh::Director
         allow(deployment_plan).to receive(:stemcells).and_return({})
         allow(deployment_plan).to receive(:instance_groups_starting_on_deploy).and_return([])
         allow(deployment_plan).to receive(:releases).and_return([])
-        allow(deployment_plan).to receive(:uninterpolated_manifest_text).and_return({})
+        allow(deployment_plan).to receive(:uninterpolated_manifest_text).and_return('{}')
         allow(deployment_plan).to receive(:mark_instance_plans_for_deletion)
         allow(deployment_plan).to receive(:deployment_wide_options).and_return({})
         allow(deployment_plan).to receive(:use_dns_addresses?).and_return(false)

--- a/src/bosh-director/spec/unit/deployment_plan/links/links_resolver_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/links/links_resolver_spec.rb
@@ -5,7 +5,7 @@ describe Bosh::Director::DeploymentPlan::LinksResolver do
 
   let(:deployment_plan) do
     planner_factory = Bosh::Director::DeploymentPlan::PlannerFactory.create(logger)
-    manifest = Bosh::Director::Manifest.load_from_hash(deployment_manifest, nil, [], {:resolve_interpolation => false})
+    manifest = Bosh::Director::Manifest.load_from_text(YAML.dump(deployment_manifest), nil, [], {:resolve_interpolation => false})
     planner = planner_factory.create_from_manifest(manifest, nil, [], {})
     Bosh::Director::DeploymentPlan::Assembler.create(planner).bind_models
     planner
@@ -623,7 +623,7 @@ Unable to process links for deployment. Errors are:
     context 'when there is a cloud config' do
       let(:deployment_plan) do
         planner_factory = Bosh::Director::DeploymentPlan::PlannerFactory.create(logger)
-        manifest = Bosh::Director::Manifest.load_from_hash(deployment_manifest, cloud_config, [], {:resolve_interpolation => false})
+        manifest = Bosh::Director::Manifest.load_from_text(YAML.dump(deployment_manifest), cloud_config, [], {:resolve_interpolation => false})
 
         planner = planner_factory.create_from_manifest(manifest, cloud_config, [], {})
         Bosh::Director::DeploymentPlan::Assembler.create(planner).bind_models

--- a/src/bosh-director/spec/unit/deployment_plan/manifest_migrator_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/manifest_migrator_spec.rb
@@ -5,7 +5,7 @@ module Bosh
     describe DeploymentPlan::ManifestMigrator do
       subject { DeploymentPlan::ManifestMigrator.new }
       let(:manifest_hash) { Bosh::Spec::Deployments.simple_manifest }
-      let(:manifest) { Manifest.new(manifest_hash, manifest_hash, nil, nil, nil, nil)}
+      let(:manifest) { Manifest.new(manifest_hash, YAML.dump(manifest_hash), nil, nil, nil, nil)}
       let(:cloud_config) { nil }
       let(:migrated_manifest) { subject.migrate(manifest, cloud_config)[0] }
       let(:migrated_manifest_hash) { migrated_manifest.hybrid_manifest_hash }

--- a/src/bosh-director/spec/unit/deployment_plan/manual_network_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/manual_network_spec.rb
@@ -8,7 +8,7 @@ describe Bosh::Director::DeploymentPlan::ManualNetwork do
    manifest_hash['networks'].first['subnets'].first['static'] = static_ips
    manifest_hash
   end
-  let(:manifest) { Bosh::Director::Manifest.new(manifest_hash, manifest_hash, nil, nil, nil, nil) }
+  let(:manifest) { Bosh::Director::Manifest.new(manifest_hash, YAML.dump(manifest_hash), nil, nil, nil, nil) }
   let(:network_range) { '192.168.1.0/24' }
   let(:static_ips) { [] }
   let(:network_spec) { manifest_hash['networks'].first }
@@ -59,7 +59,7 @@ describe Bosh::Director::DeploymentPlan::ManualNetwork do
         manifest['networks'].first['subnets'] << Bosh::Spec::Deployments.subnet({
             'range' => '192.168.1.0/28',
           })
-        Bosh::Director::Manifest.new(manifest, manifest, nil, nil, nil, nil)
+        Bosh::Director::Manifest.new(manifest, YAML.dump(manifest), nil, nil, nil, nil)
       end
 
       it 'should raise an error' do

--- a/src/bosh-director/spec/unit/deployment_plan/placement_planner/static_ips_availability_zone_picker_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/placement_planner/static_ips_availability_zone_picker_spec.rb
@@ -23,7 +23,7 @@ module Bosh::Director::DeploymentPlan
     let(:planner) { planner_factory.create_from_manifest(manifest, cloud_config_model, [], {}) }
     let(:planner_factory) { PlannerFactory.new(deployment_manifest_migrator, manifest_validator, deployment_repo, logger) }
     let(:manifest_validator) { Bosh::Director::DeploymentPlan::ManifestValidator.new }
-    let(:manifest) { Bosh::Director::Manifest.new(manifest_hash, manifest_hash, cloud_config_hash, cloud_config_hash, nil, nil) }
+    let(:manifest) { Bosh::Director::Manifest.new(manifest_hash, YAML.dump(manifest_hash), cloud_config_hash, cloud_config_hash, nil, nil) }
     let(:job) { planner.instance_groups.first }
     let(:job_availability_zones) { ['zone1', 'zone2'] }
     let(:job_networks) { [{'name' => 'a', 'static_ips' => static_ips}] }

--- a/src/bosh-director/spec/unit/deployment_plan/planner_factory_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/planner_factory_spec.rb
@@ -17,7 +17,7 @@ module Bosh
         let(:cloud_config_hash) { Bosh::Spec::Deployments.simple_cloud_config }
         let(:runtime_config_hash) { Bosh::Spec::Deployments.simple_runtime_config }
         let(:manifest_with_config_keys) { Bosh::Spec::Deployments.simple_manifest.merge({"name" => "with_keys"}) }
-        let(:manifest) { Manifest.new(hybrid_manifest_hash, raw_manifest_hash, cloud_config_hash, cloud_config_hash, runtime_config_hash, runtime_config_hash)}
+        let(:manifest) { Manifest.new(hybrid_manifest_hash, YAML.dump(raw_manifest_hash), cloud_config_hash, cloud_config_hash, runtime_config_hash, runtime_config_hash)}
         let(:plan_options) { {} }
         let(:event_log_io) { StringIO.new("") }
         let(:logger_io) { StringIO.new("") }
@@ -129,7 +129,7 @@ LOGMESSAGE
             end
 
             it 'calls planner new with appropriate arguments' do
-              expect(Planner).to receive(:new).with(expected_attrs, raw_manifest_hash,cloud_config_model, runtime_config_models, deployment_model, expected_plan_options).and_call_original
+              expect(Planner).to receive(:new).with(expected_attrs, YAML.dump(raw_manifest_hash), cloud_config_model, runtime_config_models, deployment_model, expected_plan_options).and_call_original
               planner
             end
           end

--- a/src/bosh-director/spec/unit/deployment_plan/planner_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/planner_spec.rb
@@ -96,9 +96,9 @@ module Bosh::Director
         end
 
         it 'manifest should be immutable' do
-          subject = Planner.new(planner_attributes, minimal_manifest, cloud_config, runtime_config_consolidator, deployment_model, options)
+          subject = Planner.new(planner_attributes, YAML.dump(minimal_manifest), cloud_config, runtime_config_consolidator, deployment_model, options)
           minimal_manifest['name'] = 'new_name'
-          expect(subject.uninterpolated_manifest_text['name']).to eq('minimal')
+          expect(YAML.load(subject.uninterpolated_manifest_text)['name']).to eq('minimal')
         end
 
         it 'should parse recreate' do

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -119,7 +119,7 @@ module Bosh::Director
               allow(Time).to receive(:now).and_return(fixed_time)
               allow(deployment_model).to receive(:add_variable_set)
 
-              allow(Bosh::Director::Manifest).to receive(:load_from_hash).and_return(manifest)
+              allow(Bosh::Director::Manifest).to receive(:load_from_text).and_return(manifest)
 
               allow(deployment_instance_group).to receive(:unignored_instance_plans).and_return(instance_plans)
               allow(deployment_instance_group).to receive(:referenced_variable_sets).and_return([])
@@ -175,7 +175,7 @@ module Bosh::Director
             let(:manifest) { instance_double( Bosh::Director::Manifest)}
 
             before do
-              allow(Bosh::Director::Manifest).to receive(:load_from_hash).and_return(manifest)
+              allow(Bosh::Director::Manifest).to receive(:load_from_text).and_return(manifest)
               expect(Models::Deployment).to_not receive(:find).with({name: 'deployment-name'})
             end
 
@@ -196,7 +196,7 @@ module Bosh::Director
             let(:manifest_error) { Exception.new('oh noes!') }
 
             it 'should not raise when manifest cannot be loaded' do
-              expect(Bosh::Director::Manifest).to receive(:load_from_hash).and_raise manifest_error
+              expect(Bosh::Director::Manifest).to receive(:load_from_text).and_raise manifest_error
 
               expect { job.perform }.to raise_error(manifest_error)
             end
@@ -217,7 +217,7 @@ module Bosh::Director
             allow(planner).to receive(:instance_groups).and_return([deployment_instance_group])
             allow(Models::Deployment).to receive(:[]).with(name: 'deployment-name').and_return(deployment_model)
             allow(deployment_model).to receive(:current_variable_set).and_return(variable_set_1)
-            allow(Bosh::Director::Manifest).to receive(:load_from_hash).and_return(manifest)
+            allow(Bosh::Director::Manifest).to receive(:load_from_text).and_return(manifest)
           end
 
           it 'binds models, renders templates, compiles packages, runs post-deploy scripts, marks variable_sets' do
@@ -480,7 +480,7 @@ Unable to render instance groups for deployment. Errors are:
             allow(notifier).to receive(:send_start_event)
             allow(JobRenderer).to receive(:render_job_instances_with_cache).and_raise(error_msgs)
             allow(planner).to receive(:instance_models).and_return([])
-            allow(Bosh::Director::Manifest).to receive(:load_from_hash).and_return(manifest)
+            allow(Bosh::Director::Manifest).to receive(:load_from_text).and_return(manifest)
           end
 
           it 'formats the error messages' do
@@ -569,7 +569,7 @@ Unable to render instance groups for deployment. Errors are:
             allow(JobRenderer).to receive(:render_job_instances_with_cache).with(anything, template_blob_cache, anything)
             allow(planner).to receive(:instance_models).and_return([])
             allow(planner).to receive(:instance_groups).and_return([deployment_instance_group])
-            allow(Bosh::Director::Manifest).to receive(:load_from_hash).and_return(manifest)
+            allow(Bosh::Director::Manifest).to receive(:load_from_text).and_return(manifest)
           end
 
           it 'should exit before trying to create vms' do
@@ -598,7 +598,7 @@ Unable to render instance groups for deployment. Errors are:
           before do
             expect(notifier).to receive(:send_start_event).ordered
             expect(notifier).to receive(:send_error_event).ordered
-            allow(Bosh::Director::Manifest).to receive(:load_from_hash).and_return(manifest)
+            allow(Bosh::Director::Manifest).to receive(:load_from_text).and_return(manifest)
           end
 
           it 'does not compile or update' do

--- a/src/spec/assets/manifests/manifest_with_yaml_boolean_values.yml
+++ b/src/spec/assets/manifests/manifest_with_yaml_boolean_values.yml
@@ -1,0 +1,22 @@
+director_uuid: deadbeef
+jobs:
+- instances: 1
+  name: foobar
+  networks:
+  - name: a
+  properties:
+    quote:
+      "n": "yes"
+      "y": "no"
+  resource_pool: a
+  templates:
+  - name: foobar
+name: simple
+releases:
+- name: bosh-release
+  version: 0.1-dev
+update:
+  canaries: 2
+  canary_watch_time: 4000
+  max_in_flight: 1
+  update_watch_time: 20

--- a/src/spec/gocli/integration/cli_manifest_spec.rb
+++ b/src/spec/gocli/integration/cli_manifest_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../spec_helper'
+
+describe 'cli: manifest', type: :integration do
+  with_reset_sandbox_before_each
+
+  it 'should return the same manifest that was submitted' do
+    cloud_config = Bosh::Spec::Deployments.simple_cloud_config
+
+    deploy_from_scratch(manifest_file: 'manifests/manifest_with_yaml_boolean_values.yml', cloud_config_hash: cloud_config)
+    manifest_output = bosh_runner.run('manifest', deployment_name: 'simple')
+
+    expect(manifest_output).to match(File.open(spec_asset("manifests/manifest_with_yaml_boolean_values.yml")).read)
+
+    #check that yaml 'boolean' values keep as "n" and "y"
+    expect(manifest_output).to match(<<-OUT)
+  properties:
+    quote:
+      "n": "yes"
+      "y": "no"
+    OUT
+  end
+end

--- a/src/spec/gocli/integration/vm_types_and_stemcells_spec.rb
+++ b/src/spec/gocli/integration/vm_types_and_stemcells_spec.rb
@@ -62,15 +62,18 @@ describe 'vm_types and stemcells', type: :integration do
     ])
   end
 
-  it 'saves manifest with resolved latest stemcell versions' do
+  it 'uses manifest with resolved latest stemcell versions' do
     manifest_hash['stemcells'].first['version'] = 'latest'
     deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
-    expect(bosh_runner.run('manifest', deployment_name: 'simple')).to match_output %(
-stemcells:
-- alias: default
-  os: toronto-os
-  version: '1'
-    )
+    expect(table(bosh_runner.run('deployments', json: true))).to eq([
+      {
+        'name' => 'simple',
+        'release_s' => 'bosh-release/0+dev.1',
+        'stemcell_s' => 'ubuntu-stemcell/1',
+        'team_s' => '',
+        'cloud_config' => 'latest'
+      }
+    ])
   end
 
   context 'when env on a job changes' do

--- a/src/spec/support/integration_example_group.rb
+++ b/src/spec/support/integration_example_group.rb
@@ -116,7 +116,11 @@ module IntegrationExampleGroup
       end
     end
 
-    cmd += " #{deployment_file(deployment_hash).path}"
+    if options[:manifest_file]
+      cmd += " #{spec_asset(options[:manifest_file])}"
+    else
+      cmd += " #{deployment_file(deployment_hash).path}"
+    end
 
     bosh_runner.run(cmd, options)
   end


### PR DESCRIPTION
…hat was submitted

Manifest text, which is sent to director, is stored at database and retrieved from it without modifications.

Manifest.load_from_hash was renamed to Manifest.load_from_text according to input parameter type.
New :manifest_file option was added to deploy method of IntegrationExampleGroup to support ability to pass manifest files from fs directly.
Usage of hash which is based on manifest text in the actual deployment process is out of the scope

(#150869116)[https://www.pivotaltracker.com/story/show/150869116]

Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>