### PR TITLE
Milliseconds are added to the timestamps in the director task debug logs

### DIFF
--- a/src/bosh-director/spec/unit/job_runner_spec.rb
+++ b/src/bosh-director/spec/unit/job_runner_spec.rb
@@ -107,6 +107,18 @@ module Bosh::Director
       expect(log_contents).not_to include('SELECT NULL')
     end
 
+    it 'should generate timestamp with milliseconds' do
+      Timecop.freeze do
+        make_runner(sample_job_class, 42)
+        Config.logger.debug('test')
+
+        time = Time.new
+        time_format = time.strftime("%Y-%m-%dT%H:%M:%S.") << "%06d " % time.usec
+        log_contents = File.read(task_dir+'/debug')
+        expect(log_contents).to match /D, \[#{time_format}.*\] \[\] DEBUG -- DirectorJobRunner: test/
+      end
+    end
+
     it 'handles task cancellation' do
       job = Class.new(Jobs::BaseJob) do
         define_method(:perform) do |*args|

--- a/src/bosh_common/lib/common/thread_formatter.rb
+++ b/src/bosh_common/lib/common/thread_formatter.rb
@@ -3,7 +3,10 @@ class ThreadFormatter
 
   # get pattern layout for Logging::Logger
   def self.layout
-    Logging.layouts.pattern(:pattern => "%.1l, [%d #%p] [%T] %5l -- %c: %m\n")
+    Logging.layouts.pattern({
+      :pattern => "%.1l, [%d #%p] [%T] %5l -- %c: %m\n",
+      :date_pattern => "%Y-%m-%dT%H:%M:%S.%s"
+    })
   end
 
   attr_accessor :datetime_format


### PR DESCRIPTION
[#147816913](https://www.pivotaltracker.com/story/show/147816913)

Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>