### PR TITLE
Support DB connection options requiring paths to files [Fixes #1771]

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -236,7 +236,7 @@ properties:
     description: Name of the director database
     default: bosh
   director.db.connection_options:
-    description: Additional options for the database
+    description: Additional options for the database. Note that 'sslcert', 'sslca', 'sslkey' and 'sslrootcert' can be passed as strings and will be converted to files before being passed to the database client
     default:
       max_connections: 32  #Maximum size of the connection pool
       pool_timeout: 10     #Number of seconds to wait if a connection cannot be acquired before  raising an error
@@ -265,7 +265,7 @@ properties:
     description: Name of the powerdns database
     default: bosh
   dns.db.connection_options:
-    description: Additional options for the powerdns database
+    description: Additional options for the powerdns database. Note that 'sslcert', 'sslca', 'sslkey' and 'sslrootcert' will be converted to files before being passed to the database client
     default:
       max_connections: 32  #Maximum size of the connection pool
       pool_timeout: 10     #Number of seconds to wait if a connection cannot be acquired before  raising an error

--- a/src/bosh-director/bin/bosh-director-migrate
+++ b/src/bosh-director/bin/bosh-director-migrate
@@ -25,7 +25,8 @@ unless config['db'] && config['db']['database']
   abort ('Director database config missing from config file')
 end
 
-db = Bosh::Director::Config.configure_db(config['db'])
+db_filepath_option_dir = File.join(config['dir'], 'db_config')
+db = Bosh::Director::Config.configure_db(config['db'], db_filepath_option_dir)
 
 def migrate(database, schema_table, dir, target = nil)
   options = {}


### PR DESCRIPTION
The BOSH director config allows arbitrary parameters to be passed to Sequel using the `connection_options` object. In order to connect to a MySQL or Postgres database over SSL you need to specify `sslkey`, `sslcert`, `sslca` (mysql) and `sslrootcert` (postgres)<sup>1</sup>. However, these options all refer to _paths to files_ not the contents.

Since there's no easy way to get arbitrary files onto the BOSH director, this means you cannot make secure connections to external databases that use self-signed certs such as Google Cloud SQL<sup>2</sup>.

This commits adds a step in the database configuration code that looks for these fields and saves the contents to `/var/vcap/store/director/db_config` and `/var/vcap/store/director/dns_db_config` before passing the paths to Sequel, fixing #1771.

Some questions:

- Are `/var/vcap/store/director/db_config` and `/var/vcap/store/director/dns_db_config` the right place to store these files?
- As well as the unit tests I've tested manually this by deploying a bosh director that uses the changes to connect to an external MySQL instance and verified that it connects securely. Does it need integration tests as well?
- Should this step happen in `config.rb` or in the bash/erb before being passed to the director process?

cheers,

Pete

---

1) https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc
2) https://cloud.google.com/sql/docs/mysql/configure-ssl-instance