### PR TITLE
As an operator, I expect to be able to retrieve exact same manifest t…

### DIFF
--- a/src/bosh-director/db/migrations/director/20171104185823_add_raw_manifest_to_deployments.rb
+++ b/src/bosh-director/db/migrations/director/20171104185823_add_raw_manifest_to_deployments.rb
@@ -1,0 +1,14 @@
+Sequel.migration do
+  change do
+    adapter_scheme =  self.adapter_scheme
+    alter_table(:deployments) do
+      add_column :raw_manifest, [:mysql2, :mysql].include?(adapter_scheme) ? 'longtext' : 'text'
+    end
+
+    self[:deployments].all do |deployment|
+      if deployment[:raw_manifest].nil? || deployment[:raw_manifest].empty?
+        self[:deployments].where(id: deployment[:id]).update(raw_manifest: deployment[:manifest] || '{}')
+      end
+    end
+  end
+end

--- a/src/bosh-director/db/migrations/migration_digests.json
+++ b/src/bosh-director/db/migrations/migration_digests.json
@@ -128,5 +128,6 @@
   "20171010161532_migrate_cloud_configs": "88816313055e4dfeb1816d73831a2e7a1c4b259c",
   "20171011122118_migrate_cpi_configs": "78b31890a8f2ce9bd1bb8b5d9a26bed69fb6dc30",
   "20171018102040_remove_compilation_local_dns_records": "5bb71074f5dfab23c1caef1a9fb1779190cb76d3",
-  "20171030224934_convert_nil_configs_to_empty": "38992699f41df50e7b4b869a9e89a2fd2d8770f2"
+  "20171030224934_convert_nil_configs_to_empty": "38992699f41df50e7b4b869a9e89a2fd2d8770f2",
+  "20171104185823_add_raw_manifest_to_deployments": "358c36dcbed3274a0f3252eeea08a9b5034d9881"
 }

--- a/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
@@ -101,7 +101,7 @@ module Bosh::Director
     def current_states_by_instance(existing_instances, fix = false)
       lock = Mutex.new
       current_states_by_existing_instance = {}
-      is_version_1_manifest = ignore_cloud_config?(@deployment_plan.uninterpolated_manifest_text)
+      is_version_1_manifest = ignore_cloud_config?(@deployment_plan.uninterpolated_manifest_hash)
 
       ThreadPool.new(:max_threads => Config.max_threads).wrap do |pool|
         existing_instances.each do |existing_instance|

--- a/src/bosh-director/lib/bosh/director/deployment_plan/planner.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/planner.rb
@@ -49,7 +49,11 @@ module Bosh::Director
       # @return [Boolean] Indicates whether VMs should be drained
       attr_reader :skip_drain
 
-      attr_reader :uninterpolated_manifest_text
+      # Hash with resolved aliases for stemcells, resource_pools and releases
+      attr_reader :uninterpolated_manifest_hash
+
+      # Text with raw manifest content
+      attr_reader :raw_manifest_text
 
       # @return [DeploymentPlan::Variables] Returns the variables object of deployment
       attr_reader :variables
@@ -68,12 +72,13 @@ module Bosh::Director
       attr_reader :cloud_configs
       attr_reader :runtime_configs
 
-      def initialize(attrs, uninterpolated_manifest_text, cloud_configs, runtime_configs, deployment_model, options = {})
+      def initialize(attrs, uninterpolated_manifest_hash, raw_manifest_text, cloud_configs, runtime_configs, deployment_model, options = {})
         @name = attrs.fetch(:name)
         @properties = attrs.fetch(:properties)
         @releases = {}
 
-        @uninterpolated_manifest_text = Bosh::Common::DeepCopy.copy(uninterpolated_manifest_text)
+        @uninterpolated_manifest_hash = Bosh::Common::DeepCopy.copy(uninterpolated_manifest_hash)
+        @raw_manifest_text = raw_manifest_text
         @cloud_configs = cloud_configs
         @runtime_configs = runtime_configs
         @model = deployment_model

--- a/src/bosh-director/lib/bosh/director/deployment_plan/planner_factory.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/planner_factory.rb
@@ -78,7 +78,7 @@ module Bosh
           @logger.info('Creating deployment plan')
           @logger.info("Deployment plan options: #{plan_options}")
 
-          deployment = Planner.new(attrs, migrated_manifest_object.raw_manifest_hash, cloud_config_consolidator.cloud_configs, runtime_config_consolidator.runtime_configs, deployment_model, plan_options)
+          deployment = Planner.new(attrs, migrated_manifest_object.raw_manifest_hash, migrated_manifest_object.raw_manifest_text, cloud_config_consolidator.cloud_configs, runtime_config_consolidator.runtime_configs, deployment_model, plan_options)
           global_network_resolver = GlobalNetworkResolver.new(deployment, Config.director_ips, @logger)
           ip_provider_factory = IpProviderFactory.new(deployment.using_global_networking?, @logger)
           deployment.cloud_planner = CloudManifestParser.new(@logger).parse(cloud_manifest, global_network_resolver, ip_provider_factory)

--- a/src/bosh-director/lib/bosh/director/deployment_plan/steps/persist_deployment_step.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/steps/persist_deployment_step.rb
@@ -18,7 +18,8 @@ module Bosh::Director
             end
           # end
 
-          @deployment_plan.model.manifest = YAML.dump(@deployment_plan.uninterpolated_manifest_text)
+          @deployment_plan.model.manifest = YAML.dump(@deployment_plan.uninterpolated_manifest_hash)
+          @deployment_plan.model.raw_manifest = @deployment_plan.raw_manifest_text
           @deployment_plan.model.cloud_configs = @deployment_plan.cloud_configs
           @deployment_plan.model.runtime_configs = @deployment_plan.runtime_configs
           @deployment_plan.model.link_spec = @deployment_plan.link_spec

--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -64,7 +64,8 @@ module Bosh::Director
             Bosh::Director::Models::Deployment.find(name: @deployment_name).add_variable_set(:created_at => Time.now, :writable => true)
           end
 
-          deployment_manifest_object = Manifest.load_from_hash(manifest_hash, cloud_config_models, runtime_config_models)
+          raw_manifest_text = @options.fetch('raw_manifest_text', @manifest_text)
+          deployment_manifest_object = Manifest.load_from_hash(manifest_hash, raw_manifest_text, cloud_config_models, runtime_config_models)
 
           @notifier = DeploymentPlan::Notifier.new(@deployment_name, Config.nats_rpc, logger)
           @notifier.send_start_event unless dry_run?

--- a/src/bosh-director/lib/bosh/director/manifest/manifest.rb
+++ b/src/bosh-director/lib/bosh/director/manifest/manifest.rb
@@ -5,34 +5,37 @@ module Bosh::Director
 
     def self.load_from_model(deployment_model, options = {})
       manifest_text = deployment_model.manifest || '{}'
+      raw_manifest_text = deployment_model.raw_manifest || '{}'
       consolidated_runtime_config = Bosh::Director::RuntimeConfig::RuntimeConfigsConsolidator.new(deployment_model.runtime_configs)
       consolidated_cloud_config = Bosh::Director::CloudConfig::CloudConfigsConsolidator.new(deployment_model.cloud_configs)
-      self.load_manifest(YAML.load(manifest_text), consolidated_cloud_config, consolidated_runtime_config, options)
+      self.load_manifest(YAML.load(manifest_text), raw_manifest_text, consolidated_cloud_config, consolidated_runtime_config, options)
     end
 
-    def self.load_from_hash(manifest_hash, cloud_configs, runtime_configs, options = {})
+    def self.load_from_hash(manifest_hash, raw_manifest_text, cloud_configs, runtime_configs, options = {})
       consolidated_runtime_config = Bosh::Director::RuntimeConfig::RuntimeConfigsConsolidator.new(runtime_configs)
       consolidated_cloud_config = Bosh::Director::CloudConfig::CloudConfigsConsolidator.new(cloud_configs)
-      self.load_manifest(manifest_hash, consolidated_cloud_config, consolidated_runtime_config, options)
+      self.load_manifest(manifest_hash, raw_manifest_text, consolidated_cloud_config, consolidated_runtime_config, options)
     end
 
     def self.generate_empty_manifest
       consolidated_runtime_config = Bosh::Director::RuntimeConfig::RuntimeConfigsConsolidator.new([])
-      self.load_manifest({}, nil, consolidated_runtime_config, {:resolve_interpolation => false})
+      self.load_manifest({}, '{}', nil, consolidated_runtime_config, {:resolve_interpolation => false})
     end
 
     # hybrid_manifest_hash is a resolved raw_manifest except for properties
     attr_reader :hybrid_manifest_hash
     attr_reader :raw_manifest_hash
+    attr_reader :raw_manifest_text
 
     # hybrid_runtime_config_hash a resolved raw_runtime_config_hash except for properties
     attr_reader :hybrid_runtime_config_hash
     # hybrid_cloud_config_hash a resolved raw_cloud_config_hash except for cloud_properties
     attr_reader :hybrid_cloud_config_hash
 
-    def initialize(hybrid_manifest_hash, raw_manifest_hash, hybrid_cloud_config_hash, raw_cloud_config_hash, hybrid_runtime_config_hash, raw_runtime_config_hash)
+    def initialize(hybrid_manifest_hash, raw_manifest_hash, raw_manifest_text, hybrid_cloud_config_hash, raw_cloud_config_hash, hybrid_runtime_config_hash, raw_runtime_config_hash)
       @hybrid_manifest_hash = hybrid_manifest_hash
       @raw_manifest_hash = raw_manifest_hash
+      @raw_manifest_text = raw_manifest_text
 
       @hybrid_cloud_config_hash = hybrid_cloud_config_hash
       @raw_cloud_config_hash = raw_cloud_config_hash
@@ -62,7 +65,7 @@ module Bosh::Director
 
     private
 
-    def self.load_manifest(manifest_hash, consolidated_cloud_config, consolidated_runtime_config, options = {})
+    def self.load_manifest(manifest_hash, raw_manifest_text, consolidated_cloud_config, consolidated_runtime_config, options = {})
       resolve_interpolation = options.fetch(:resolve_interpolation, true)
       ignore_cloud_config = options.fetch(:ignore_cloud_config, false)
 
@@ -87,7 +90,7 @@ module Bosh::Director
         hybrid_runtime_config_hash = Bosh::Common::DeepCopy.copy(raw_runtime_config_hash)
       end
 
-      new(hybrid_manifest_hash, raw_manifest_hash, hybrid_cloud_config_hash, raw_cloud_config_hash, hybrid_runtime_config_hash, raw_runtime_config_hash)
+      new(hybrid_manifest_hash, raw_manifest_hash, raw_manifest_text, hybrid_cloud_config_hash, raw_cloud_config_hash, hybrid_runtime_config_hash, raw_runtime_config_hash)
     end
 
     def resolve_aliases_for_generic_hash(generic_hash)

--- a/src/bosh-director/spec/unit/addon/addon_spec.rb
+++ b/src/bosh-director/spec/unit/addon/addon_spec.rb
@@ -42,7 +42,7 @@ module Bosh::Director
       end
 
       let(:deployment) do
-        planner = DeploymentPlan::Planner.new({name: deployment_name, properties: {}}, manifest_hash, cloud_configs, {}, deployment_model)
+        planner = DeploymentPlan::Planner.new({name: deployment_name, properties: {}}, manifest_hash, YAML.dump(manifest_hash), cloud_configs, {}, deployment_model)
         planner.update = DeploymentPlan::UpdateConfig.new(manifest_hash['update'])
         planner
       end

--- a/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -705,7 +705,7 @@ module Bosh::Director
           it 'returns manifest' do
             deployment = Models::Deployment.
                 create(:name => 'test_deployment',
-                       :manifest => YAML.dump({'foo' => 'bar'}))
+                       :raw_manifest => YAML.dump({'foo' => 'bar'}))
             get '/test_deployment'
 
             expect(last_response.status).to eq(200)

--- a/src/bosh-director/spec/unit/db/migrations/director/20171104185823_add_raw_manifest_to_deployments_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/20171104185823_add_raw_manifest_to_deployments_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../../../../db_spec_helper'
+
+module Bosh::Director
+  describe 'add_raw_manifest_to_deployments' do
+    let(:db) { DBSpecHelper.db }
+    let(:migration_file) { '20171104185823_add_raw_manifest_to_deployments.rb' }
+
+    before do
+      DBSpecHelper.migrate_all_before(migration_file)
+    end
+
+    it 'adds a raw_manifest column that allows long text' do
+      DBSpecHelper.migrate(migration_file)
+
+      long_text = 'a' * 65536
+
+      db[:deployments] << {id: 1, name: 'fake-deployment-name', manifest: '{}', raw_manifest: long_text}
+
+      deployment = db[:deployments].first
+      expect(deployment[:raw_manifest]).to eq(long_text)
+    end
+
+    context 'when raw_manifest is nil or empty' do
+      it 'puts manifest as raw_manifest' do
+        db[:deployments] << {id: 1, name: 'fake-deployment-name', manifest: YAML.dump({name: 'test'})}
+        DBSpecHelper.migrate(migration_file)
+
+        deployment = db[:deployments].first
+        expect(deployment[:raw_manifest]).to eq("---\n:name: test\n")
+      end
+
+      context 'when manifest is nil' do
+        it 'puts default value' do
+          db[:deployments] << {id: 1, name: 'fake-deployment-name', manifest: nil}
+          DBSpecHelper.migrate(migration_file)
+
+          deployment = db[:deployments].first
+          expect(deployment[:raw_manifest]).to eq("{}")
+        end
+      end
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/db/migrations/director/add_data_migration_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/add_data_migration_spec.rb
@@ -9,7 +9,7 @@ module Bosh::Director
       # populated with data. This test will fail every time a new migration script is added. Change
       # the file name below to the latest when a test is added.
       # Look at tests in this directory for similar examples: bosh-director/spec/unit/db/migrations/director
-      expect(latest_db_migration_file).to eq('20171030224934_convert_nil_configs_to_empty.rb')
+      expect(latest_db_migration_file).to eq('20171104185823_add_raw_manifest_to_deployments.rb')
     end
   end
 end

--- a/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
@@ -28,7 +28,7 @@ module Bosh::Director
         allow(deployment_plan).to receive(:stemcells).and_return({})
         allow(deployment_plan).to receive(:instance_groups_starting_on_deploy).and_return([])
         allow(deployment_plan).to receive(:releases).and_return([])
-        allow(deployment_plan).to receive(:uninterpolated_manifest_text).and_return({})
+        allow(deployment_plan).to receive(:uninterpolated_manifest_hash).and_return({})
         allow(deployment_plan).to receive(:mark_instance_plans_for_deletion)
         allow(deployment_plan).to receive(:deployment_wide_options).and_return({})
         allow(deployment_plan).to receive(:use_dns_addresses?).and_return(false)

--- a/src/bosh-director/spec/unit/deployment_plan/deployment_spec_parser_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/deployment_spec_parser_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Bosh::Director
   describe DeploymentPlan::DeploymentSpecParser do
     subject(:parser) { described_class.new(deployment, event_log, logger) }
-    let(:deployment) { DeploymentPlan::Planner.new(planner_attributes, manifest_hash, cloud_config, runtime_configs, deployment_model, planner_options) }
+    let(:deployment) { DeploymentPlan::Planner.new(planner_attributes, manifest_hash, YAML.dump(manifest_hash), cloud_config, runtime_configs, deployment_model, planner_options) }
     let(:planner_options) { {} }
     let(:event_log) { Config.event_log }
     let(:cloud_config) { Models::Config.make(:cloud) }

--- a/src/bosh-director/spec/unit/deployment_plan/global_network_resolver_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/global_network_resolver_spec.rb
@@ -15,6 +15,7 @@ module Bosh::Director
       DeploymentPlan::Planner.new(
         {name: 'current-deployment', properties: {}},
         '',
+        '',
         cloud_configs,
         runtime_configs,
         deployment_model

--- a/src/bosh-director/spec/unit/deployment_plan/instance_network_reservations_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_network_reservations_spec.rb
@@ -9,6 +9,7 @@ module Bosh::Director
       DeploymentPlan::Planner.new(
         {name: 'foo-deployment', properties: {}},
         '',
+        '',
         cloud_config,
         runtime_config,
         deployment_model

--- a/src/bosh-director/spec/unit/deployment_plan/links/links_resolver_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/links/links_resolver_spec.rb
@@ -5,7 +5,7 @@ describe Bosh::Director::DeploymentPlan::LinksResolver do
 
   let(:deployment_plan) do
     planner_factory = Bosh::Director::DeploymentPlan::PlannerFactory.create(logger)
-    manifest = Bosh::Director::Manifest.load_from_hash(deployment_manifest, [], [], {:resolve_interpolation => false})
+    manifest = Bosh::Director::Manifest.load_from_hash(deployment_manifest, YAML.dump(deployment_manifest), [], [], {:resolve_interpolation => false})
     planner = planner_factory.create_from_manifest(manifest, [], [], {})
     Bosh::Director::DeploymentPlan::Assembler.create(planner).bind_models
     planner
@@ -623,7 +623,7 @@ Unable to process links for deployment. Errors are:
     context 'when there is a cloud config' do
       let(:deployment_plan) do
         planner_factory = Bosh::Director::DeploymentPlan::PlannerFactory.create(logger)
-        manifest = Bosh::Director::Manifest.load_from_hash(deployment_manifest, cloud_configs, [], {:resolve_interpolation => false})
+        manifest = Bosh::Director::Manifest.load_from_hash(deployment_manifest, YAML.dump(deployment_manifest), cloud_configs, [], {:resolve_interpolation => false})
 
         planner = planner_factory.create_from_manifest(manifest, cloud_configs, [], {})
         Bosh::Director::DeploymentPlan::Assembler.create(planner).bind_models

--- a/src/bosh-director/spec/unit/deployment_plan/manifest_migrator_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/manifest_migrator_spec.rb
@@ -5,7 +5,7 @@ module Bosh
     describe DeploymentPlan::ManifestMigrator do
       subject { DeploymentPlan::ManifestMigrator.new }
       let(:manifest_hash) { Bosh::Spec::Deployments.simple_manifest }
-      let(:manifest) { Manifest.new(manifest_hash, manifest_hash, nil, nil, nil, nil)}
+      let(:manifest) { Manifest.new(manifest_hash, manifest_hash, YAML.dump(manifest_hash), nil, nil, nil, nil)}
       let(:cloud_config) { {} }
       let(:migrated_manifest) { subject.migrate(manifest, cloud_config)[0] }
       let(:migrated_manifest_hash) { migrated_manifest.hybrid_manifest_hash }

--- a/src/bosh-director/spec/unit/deployment_plan/manual_network_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/manual_network_spec.rb
@@ -8,7 +8,7 @@ describe Bosh::Director::DeploymentPlan::ManualNetwork do
    manifest_hash['networks'].first['subnets'].first['static'] = static_ips
    manifest_hash
   end
-  let(:manifest) { Bosh::Director::Manifest.new(manifest_hash, manifest_hash, {}, {}, nil, nil) }
+  let(:manifest) { Bosh::Director::Manifest.new(manifest_hash, manifest_hash, YAML.dump(manifest_hash), {}, {}, nil, nil) }
   let(:network_range) { '192.168.1.0/24' }
   let(:static_ips) { [] }
   let(:network_spec) { manifest_hash['networks'].first }
@@ -59,7 +59,7 @@ describe Bosh::Director::DeploymentPlan::ManualNetwork do
         manifest['networks'].first['subnets'] << Bosh::Spec::Deployments.subnet({
             'range' => '192.168.1.0/28',
           })
-        Bosh::Director::Manifest.new(manifest, manifest, {}, {}, nil, nil)
+        Bosh::Director::Manifest.new(manifest, manifest, YAML.dump(manifest), {}, {}, nil, nil)
       end
 
       it 'should raise an error' do

--- a/src/bosh-director/spec/unit/deployment_plan/placement_planner/static_ips_availability_zone_picker_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/placement_planner/static_ips_availability_zone_picker_spec.rb
@@ -23,7 +23,7 @@ module Bosh::Director::DeploymentPlan
     let(:planner) { planner_factory.create_from_manifest(manifest, cloud_configs, [], {}) }
     let(:planner_factory) { PlannerFactory.new(deployment_manifest_migrator, manifest_validator, deployment_repo, logger) }
     let(:manifest_validator) { Bosh::Director::DeploymentPlan::ManifestValidator.new }
-    let(:manifest) { Bosh::Director::Manifest.new(manifest_hash, manifest_hash, cloud_config_hash, cloud_config_hash, nil, nil) }
+    let(:manifest) { Bosh::Director::Manifest.new(manifest_hash, manifest_hash, YAML.dump(manifest_hash), cloud_config_hash, cloud_config_hash, nil, nil) }
     let(:job) { planner.instance_groups.first }
     let(:job_availability_zones) { ['zone1', 'zone2'] }
     let(:job_networks) { [{'name' => 'a', 'static_ips' => static_ips}] }

--- a/src/bosh-director/spec/unit/deployment_plan/planner_factory_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/planner_factory_spec.rb
@@ -17,7 +17,7 @@ module Bosh
         let(:cloud_config_hash) { Bosh::Spec::Deployments.simple_cloud_config }
         let(:runtime_config_hash) { Bosh::Spec::Deployments.simple_runtime_config }
         let(:manifest_with_config_keys) { Bosh::Spec::Deployments.simple_manifest.merge({"name" => "with_keys"}) }
-        let(:manifest) { Manifest.new(hybrid_manifest_hash, raw_manifest_hash, cloud_config_hash, cloud_config_hash, runtime_config_hash, runtime_config_hash)}
+        let(:manifest) { Manifest.new(hybrid_manifest_hash, raw_manifest_hash, YAML.dump(raw_manifest_hash), cloud_config_hash, cloud_config_hash, runtime_config_hash, runtime_config_hash)}
         let(:plan_options) { {} }
         let(:event_log_io) { StringIO.new("") }
         let(:logger_io) { StringIO.new("") }
@@ -128,7 +128,7 @@ LOGMESSAGE
             end
 
             it 'calls planner new with appropriate arguments' do
-              expect(Planner).to receive(:new).with(expected_attrs, raw_manifest_hash, cloud_configs, runtime_config_models, deployment_model, expected_plan_options).and_call_original
+              expect(Planner).to receive(:new).with(expected_attrs, raw_manifest_hash, YAML.dump(raw_manifest_hash), cloud_configs, runtime_config_models, deployment_model, expected_plan_options).and_call_original
               planner
             end
           end

--- a/src/bosh-director/spec/unit/deployment_plan/planner_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/planner_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 module Bosh::Director
   module DeploymentPlan
     describe Planner do
-      subject(:planner) { described_class.new(planner_attributes, minimal_manifest, cloud_configs, runtime_config_consolidator, deployment_model, options) }
+      subject(:planner) { described_class.new(planner_attributes, minimal_manifest, YAML.dump(minimal_manifest), cloud_configs, runtime_config_consolidator, deployment_model, options) }
 
       let(:options) { {} }
       let(:event_log) { instance_double('Bosh::Director::EventLog::Log') }
@@ -97,15 +97,15 @@ module Bosh::Director
         end
 
         it 'manifest should be immutable' do
-          subject = Planner.new(planner_attributes, minimal_manifest, cloud_configs, runtime_config_consolidator, deployment_model, options)
+          subject = Planner.new(planner_attributes, minimal_manifest, YAML.dump(minimal_manifest), cloud_configs, runtime_config_consolidator, deployment_model, options)
           minimal_manifest['name'] = 'new_name'
-          expect(subject.uninterpolated_manifest_text['name']).to eq('minimal')
+          expect(subject.uninterpolated_manifest_hash['name']).to eq('minimal')
         end
 
         it 'should parse recreate' do
           expect(planner.recreate).to be_falsey
 
-          plan = described_class.new(planner_attributes, manifest_text, cloud_configs, runtime_config_consolidator, deployment_model, 'recreate' => true)
+          plan = described_class.new(planner_attributes, manifest_text, YAML.dump(manifest_text), cloud_configs, runtime_config_consolidator, deployment_model, 'recreate' => true)
           expect(plan.recreate).to be_truthy
         end
 

--- a/src/bosh-director/spec/unit/deployment_plan/steps/persist_deployment_step_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/persist_deployment_step_spec.rb
@@ -37,6 +37,14 @@ module Bosh::Director
           }
         }
       end
+
+      let(:raw_manifest_text) do
+      %Q(---
+        name: minimal
+        releases:
+          - name: appcloud
+            version: "0.1")
+      end
       let(:cloud_config) { Models::Config.make(:cloud)}
       let(:runtime_configs) { [Models::Config.make(:runtime), Models::Config.make(:runtime), Models::Config.make(:runtime), Models::Config.make(:runtime)] }
       let(:link_spec) {
@@ -57,7 +65,8 @@ module Bosh::Director
       }
 
       before do
-        allow(deployment_planner).to receive(:uninterpolated_manifest_text).and_return(minimal_manifest)
+        allow(deployment_planner).to receive(:uninterpolated_manifest_hash).and_return(minimal_manifest)
+        allow(deployment_planner).to receive(:raw_manifest_text).and_return(raw_manifest_text)
         Bosh::Director::App.new(Bosh::Director::Config.load_hash(SpecHelper.spec_get_director_config))
         allow(deployment_planner).to receive(:model).and_return(deployment_model)
       end
@@ -112,6 +121,12 @@ module Bosh::Director
             subject.perform
             reloaded_model = deployment_model.reload
             expect(reloaded_model.manifest).to eq(YAML.dump(minimal_manifest))
+          end
+
+          it 'saves original raw manifest' do
+            subject.perform
+            reloaded_model = deployment_model.reload
+            expect(reloaded_model.raw_manifest).to eq(raw_manifest_text)
           end
 
           it 'saves cloud config' do

--- a/src/bosh-director/spec/unit/deployment_plan/steps/update_step_functional_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/update_step_functional_spec.rb
@@ -36,7 +36,7 @@ module Bosh::Director::DeploymentPlan::Steps
 
     let(:deployment_plan) do
       planner_factory = Bosh::Director::DeploymentPlan::PlannerFactory.create(logger)
-      manifest = Bosh::Director::Manifest.new(deployment_manifest, deployment_manifest, nil, nil, nil, nil)
+      manifest = Bosh::Director::Manifest.new(deployment_manifest, deployment_manifest, YAML.dump(deployment_manifest), nil, nil, nil, nil)
       deployment_plan = planner_factory.create_from_manifest(manifest, cloud_config, runtime_configs, {})
       Bosh::Director::DeploymentPlan::Assembler.create(deployment_plan).bind_models
       deployment_plan

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -357,6 +357,23 @@ module Bosh::Director
             end
           end
 
+          context 'when raw_manifest is specified in options' do
+            let(:raw_manifest_text) { '{ name: raw }' }
+            let(:options) { {'raw_manifest_text' => raw_manifest_text} }
+
+            it 'uses options raw_manifest_text value as raw_manifest' do
+              expect(Bosh::Director::Manifest).to receive(:load_from_hash).with(Hash, raw_manifest_text, nil, Array)
+              job.perform
+            end
+          end
+
+          context 'when raw_manifest is not specified in options' do
+            it 'uses manifest value as raw_manifest' do
+              expect(Bosh::Director::Manifest).to receive(:load_from_hash).with(Hash, manifest_content, nil, Array)
+              job.perform
+            end
+          end
+
           it 'should store new events' do
             expect {
               job.perform

--- a/src/bosh-director/spec/unit/manifest/manifest_spec.rb
+++ b/src/bosh-director/spec/unit/manifest/manifest_spec.rb
@@ -3,11 +3,12 @@ require 'spec_helper'
 module Bosh::Director
   describe Manifest do
     subject(:manifest_object) do
-      described_class.new(hybrid_manifest_hash, raw_manifest_hash, hybrid_cloud_config_hash, raw_cloud_config_hash, hybrid_runtime_config_hash, raw_runtime_config_hash)
+      described_class.new(hybrid_manifest_hash, raw_manifest_hash, raw_manifest_text, hybrid_cloud_config_hash, raw_cloud_config_hash, hybrid_runtime_config_hash, raw_runtime_config_hash)
     end
 
     let(:hybrid_manifest_hash) { {} }
     let(:raw_manifest_hash) { {} }
+    let(:raw_manifest_text) { '{}' }
 
     let(:hybrid_cloud_config_hash) { {} }
     let(:raw_cloud_config_hash) { {} }
@@ -43,9 +44,15 @@ module Bosh::Director
       let(:deployment_model) {instance_double(Bosh::Director::Models::Deployment)}
       let(:runtime_configs) { [ Models::Config.make(type: 'runtime'), Models::Config.make(type: 'runtime') ] }
       let(:manifest_hash) { {"name"=>"a_deployment", "name-1"=>"my-name-1"} }
+      let(:manifest_text) do
+        %Q(---
+         name: a_deployment
+         name-1: my-name-1)
+      end
 
       before do
         allow(deployment_model).to receive(:manifest).and_return(manifest_hash.to_json)
+        allow(deployment_model).to receive(:raw_manifest).and_return(manifest_text)
         allow(deployment_model).to receive(:cloud_configs).and_return([cloud_config])
         allow(deployment_model).to receive(:runtime_configs).and_return(runtime_configs)
         allow(variables_interpolator).to receive(:interpolate_deployment_manifest).and_return(manifest_hash)
@@ -58,6 +65,7 @@ module Bosh::Director
         result =  Manifest.load_from_model(deployment_model)
         expect(result.hybrid_manifest_hash).to eq({"name"=>"a_deployment", "name-1"=>"my-name-1"})
         expect(result.raw_manifest_hash).to eq({"name"=>"a_deployment", "name-1"=>"my-name-1"})
+        expect(result.raw_manifest_text).to eq(manifest_text)
         expect(result.hybrid_cloud_config_hash).to eq(cloud_config.raw_manifest)
         expect(result.hybrid_runtime_config_hash).to eq({'my_runtime' => 'foo_value'})
       end
@@ -66,6 +74,7 @@ module Bosh::Director
         result = Manifest.load_from_model(deployment_model, {:ignore_cloud_config => true})
         expect(result.hybrid_manifest_hash).to eq({"name"=>"a_deployment", "name-1"=>"my-name-1"})
         expect(result.raw_manifest_hash).to eq({"name"=>"a_deployment", "name-1"=>"my-name-1"})
+        expect(result.raw_manifest_text).to eq(manifest_text)
         expect(result.hybrid_cloud_config_hash).to eq(nil)
         expect(result.hybrid_runtime_config_hash).to eq({'my_runtime' => 'foo_value'})
       end
@@ -73,6 +82,7 @@ module Bosh::Director
       context 'when empty manifests exist' do
         before do
           allow(deployment_model).to receive(:manifest).and_return(nil)
+          allow(deployment_model).to receive(:raw_manifest).and_return(nil)
           allow(deployment_model).to receive(:cloud_configs).and_return([cloud_config])
           allow(deployment_model).to receive(:runtime_configs).and_return([])
           allow(Bosh::Director::RuntimeConfig::RuntimeConfigsConsolidator).to receive(:new).with([]).and_return(consolidated_runtime_config)
@@ -85,6 +95,7 @@ module Bosh::Director
           result =  Manifest.load_from_model(deployment_model, {:ignore_cloud_config => false})
           expect(result.hybrid_manifest_hash).to eq({})
           expect(result.raw_manifest_hash).to eq({})
+          expect(result.raw_manifest_text).to eq('{}')
           expect(result.hybrid_cloud_config_hash).to eq(cloud_config.raw_manifest)
           expect(result.hybrid_runtime_config_hash).to eq({})
         end
@@ -133,6 +144,15 @@ module Bosh::Director
       let(:raw_runtime_config_hash) { {'raw_runtime' => '((foo))'} }
       let(:hybrid_runtime_config_hash) { {'my_runtime' => 'foo_value'} }
 
+      let(:raw_manifest_text) do
+        %Q(---
+        name: minimal
+        releases:
+        - name: simple
+          version: latest
+       )
+      end
+
       let(:hybrid_cloud_config_hash) { cloud_config.raw_manifest }
       let(:raw_cloud_config_hash) { cloud_config.raw_manifest }
 
@@ -145,12 +165,12 @@ module Bosh::Director
 
       it 'creates a manifest object from a cloud config, a manifest text, and a runtime config' do
         expect(
-          Manifest.load_from_hash(hybrid_manifest_hash, [cloud_config], runtime_configs).to_yaml
+          Manifest.load_from_hash(hybrid_manifest_hash, raw_manifest_text, [cloud_config], runtime_configs).to_yaml
         ).to eq(manifest_object.to_yaml)
       end
 
       it 'ignores cloud config when ignore_cloud_config is true' do
-        result = Manifest.load_from_hash(hybrid_manifest_hash, [cloud_config], runtime_configs, {:ignore_cloud_config => true})
+        result = Manifest.load_from_hash(hybrid_manifest_hash, YAML.dump(hybrid_manifest_hash), [cloud_config], runtime_configs, {:ignore_cloud_config => true})
         expect(result.hybrid_manifest_hash).to eq({})
         expect(result.raw_manifest_hash).to eq({})
         expect(result.hybrid_cloud_config_hash).to eq(nil)
@@ -166,7 +186,7 @@ module Bosh::Director
 
         it 'calls the manifest resolver with correct values' do
           expect(variables_interpolator).to receive(:interpolate_deployment_manifest).with({'smurf' => '((smurf_placeholder))'}).and_return({'smurf' => 'blue'})
-          manifest_object_result = Manifest.load_from_hash(passed_in_manifest_hash, [cloud_config], runtime_configs)
+          manifest_object_result = Manifest.load_from_hash(passed_in_manifest_hash, YAML.dump(passed_in_manifest_hash), [cloud_config], runtime_configs)
           expect(manifest_object_result.hybrid_manifest_hash).to eq({'smurf' => 'blue'})
           expect(manifest_object_result.raw_manifest_hash).to eq({'smurf' => '((smurf_placeholder))'})
           expect(manifest_object_result.hybrid_cloud_config_hash).to eq(cloud_config.raw_manifest)
@@ -176,7 +196,7 @@ module Bosh::Director
         it 'respects resolve_interpolation flag when calling the manifest resolver' do
           expect(variables_interpolator).to_not receive(:interpolate_deployment_manifest)
 
-          manifest_object_result = Manifest.load_from_hash(passed_in_manifest_hash, [cloud_config], runtime_configs, {:resolve_interpolation => false})
+          manifest_object_result = Manifest.load_from_hash(passed_in_manifest_hash, YAML.dump(passed_in_manifest_hash), [cloud_config], runtime_configs, {:resolve_interpolation => false})
           expect(manifest_object_result.hybrid_manifest_hash).to eq({'smurf' => '((smurf_placeholder))'})
           expect(manifest_object_result.raw_manifest_hash).to eq({'smurf' => '((smurf_placeholder))'})
           expect(manifest_object_result.hybrid_cloud_config_hash).to eq(cloud_config.raw_manifest)
@@ -195,6 +215,7 @@ module Bosh::Director
         result_manifest  = Manifest.generate_empty_manifest
         expect(result_manifest.hybrid_manifest_hash).to eq({})
         expect(result_manifest.raw_manifest_hash).to eq({})
+        expect(result_manifest.raw_manifest_text).to eq('{}')
         expect(result_manifest.hybrid_cloud_config_hash).to eq(nil)
         expect(result_manifest.hybrid_runtime_config_hash).to eq({})
       end
@@ -386,6 +407,7 @@ module Bosh::Director
         described_class.new(
           new_hybrid_manifest_hash,
           new_raw_manifest_hash,
+          YAML.dump(new_raw_manifest_hash),
           new_hybrid_cloud_config_hash,
           new_raw_cloud_config_hash,
           new_hybrid_runtime_config_hash,

--- a/src/bosh-director/spec/unit/runtime_config/runtime_filter_spec.rb
+++ b/src/bosh-director/spec/unit/runtime_config/runtime_filter_spec.rb
@@ -10,7 +10,7 @@ module Bosh::Director
       planner_attributes = {name: deployment_name, properties: {}}
       cloud_config = Bosh::Spec::Deployments.simple_cloud_config
       manifest = Bosh::Spec::Deployments.simple_manifest
-      planner = DeploymentPlan::Planner.new(planner_attributes, manifest, [Models::Config.make(:cloud, content: YAML.dump(cloud_config))], Bosh::Spec::Deployments.simple_runtime_config, deployment_model)
+      planner = DeploymentPlan::Planner.new(planner_attributes, manifest, YAML.dump(manifest), [Models::Config.make(:cloud, content: YAML.dump(cloud_config))], Bosh::Spec::Deployments.simple_runtime_config, deployment_model)
 
       release1 = Models::Release.make(name: '1')
       release2 = Models::Release.make(name: '2')

--- a/src/spec/assets/manifests/manifest_with_yaml_boolean_values.yml
+++ b/src/spec/assets/manifests/manifest_with_yaml_boolean_values.yml
@@ -1,0 +1,27 @@
+director_uuid: deadbeef
+jobs:
+- instances: 1
+  name: foobar
+  networks:
+  - name: a
+  properties:
+    quote:
+      "n": "yes"
+      "y": "no"
+  stemcell: default
+  templates:
+  - name: foobar
+  vm_type: a
+name: simple
+releases:
+- name: bosh-release
+  version: 0.1-dev
+stemcells:
+- alias: default
+  name: ubuntu-stemcell
+  version: 1
+update:
+  canaries: 2
+  canary_watch_time: 4000
+  max_in_flight: 1
+  update_watch_time: 20

--- a/src/spec/gocli/integration/cli_manifest_spec.rb
+++ b/src/spec/gocli/integration/cli_manifest_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../spec_helper'
+
+describe 'cli: manifest', type: :integration do
+  with_reset_sandbox_before_each
+
+  it 'should return the same manifest that was submitted' do
+    cloud_config = Bosh::Spec::NewDeployments.simple_cloud_config
+
+    deploy_from_scratch(manifest_file: 'manifests/manifest_with_yaml_boolean_values.yml', cloud_config_hash: cloud_config)
+    manifest_output = bosh_runner.run('manifest', deployment_name: 'simple')
+
+    expect(manifest_output).to match(File.open(spec_asset("manifests/manifest_with_yaml_boolean_values.yml")).read)
+
+    #check that yaml 'boolean' values keep as "n" and "y"
+    expect(manifest_output).to match(<<-OUT)
+  properties:
+    quote:
+      "n": "yes"
+      "y": "no"
+    OUT
+  end
+end

--- a/src/spec/gocli/integration/cli_recreate_spec.rb
+++ b/src/spec/gocli/integration/cli_recreate_spec.rb
@@ -72,6 +72,35 @@ describe 'recreate instance', type: :integration do
     expect(director.instances).not_to match_array(initial_instances.map(&:vm_cid))
   end
 
+  context 'when a new release is uploaded and the release version in the manifest is latest ' do
+    it 'recreates an instance with initially resolved release version' do
+      release_filename = spec_asset('unsorted-release-0+dev.1.tgz')
+      stemcell_filename = spec_asset('valid_stemcell.tgz')
+      manifest_hash = Bosh::Spec::NewDeployments.simple_manifest_with_stemcell
+      manifest_hash['releases'] = [{
+        'name' => 'unsorted-release',
+        'version' => 'latest'
+      }]
+
+      deployment_manifest = yaml_file('simple', manifest_hash)
+      cloud_config_manifest = yaml_file('cloud_manifest', Bosh::Spec::NewDeployments.simple_cloud_config)
+
+      bosh_runner.run("update-cloud-config #{cloud_config_manifest.path}")
+      bosh_runner.run("upload-stemcell #{stemcell_filename}")
+      bosh_runner.run("upload-release #{release_filename}")
+
+      bosh_runner.run("deploy #{deployment_manifest.path}", deployment_name: 'simple')
+      bosh_runner.run("upload-release #{spec_asset('unsorted-release-0+dev.2.tgz')}")
+      bosh_runner.run('recreate', deployment_name: 'simple')
+
+      table_output = table(bosh_runner.run('releases', json: true))
+      expect(table_output).to include(
+        {"commit_hash" => String, "name" => "unsorted-release", "version" => "0+dev.2"},
+        {"commit_hash" => String, "name" => "unsorted-release", "version" => "0+dev.1*"}
+      )
+    end
+  end
+
   context 'with dry run flag' do
     context 'when a vm has been deleted' do
       it 'does not try to recreate that vm' do

--- a/src/spec/gocli/integration/vm_types_and_stemcells_spec.rb
+++ b/src/spec/gocli/integration/vm_types_and_stemcells_spec.rb
@@ -54,14 +54,16 @@ describe 'vm_types and stemcells', type: :integration do
     ])
   end
 
-  it 'saves manifest with resolved latest stemcell versions' do
+  it 'resolves latest stemcell versions' do
     manifest_hash['stemcells'].first['version'] = 'latest'
     deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
-    expect(bosh_runner.run('manifest', deployment_name: 'simple')).to match_output %(
-stemcells:
-- alias: default
-  name: ubuntu-stemcell
-  version: '1'
+    manifest_hash['stemcells'].first['version'] = '3'
+    deploy_output = deploy(manifest_hash: manifest_hash, failure_expected: true, redact_diff: true)
+    expect(deploy_output).to match_output %(
+  stemcells:
+  - name: ubuntu-stemcell
+-   version: '1'
++   version: '3'
     )
   end
 

--- a/src/spec/support/integration_example_group.rb
+++ b/src/spec/support/integration_example_group.rb
@@ -116,7 +116,11 @@ module IntegrationExampleGroup
       end
     end
 
-    cmd += " #{deployment_file(deployment_hash).path}"
+    if options[:manifest_file]
+      cmd += " #{spec_asset(options[:manifest_file])}"
+    else
+      cmd += " #{deployment_file(deployment_hash).path}"
+    end
 
     bosh_runner.run(cmd, options)
   end


### PR DESCRIPTION
…hat was submitted.

Manifest text, which is sent to director, is stored at database as raw_manifest and retrieved from it without modifications.

Several variables were renamed to show whether they are text or hash.
New :manifest_file option was added to deploy method of IntegrationExampleGroup to support ability to pass manifest files from fs directly.
Usage of manifest hash which is based on manifest text in the actual deployment process is out of the scope

(#150869116)[https://www.pivotaltracker.com/story/show/150869116]

Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>