### PR TITLE
Add rake task to dump postgresql schema

### DIFF
--- a/src/bosh-dev/lib/bosh/dev/sandbox/postgresql.rb
+++ b/src/bosh-dev/lib/bosh/dev/sandbox/postgresql.rb
@@ -32,6 +32,11 @@ module Bosh::Dev::Sandbox
       @runner.run(%Q{echo 'revoke connect on database "#{db_name}" from public; drop database "#{db_name}";' | PGPASSWORD=#{@password} psql -h #{@host} -p #{@port} -U #{@username} > /dev/null 2>&1})
     end
 
+    def dump_db
+      @logger.info("Dumping postgres database schema for #{db_name}")
+      @runner.run(%Q{PGPASSWORD=#{@password} pg_dump -h #{@host} -p #{@port} -U #{@username} -s "#{db_name}"})
+    end
+
     def load_db_initial_state(initial_state_assets_dir)
       sql_dump_path = File.join(initial_state_assets_dir, 'postgres_db_snapshot.sql')
       load_db(sql_dump_path)

--- a/src/bosh-dev/lib/bosh/dev/tasks/db.rake
+++ b/src/bosh-dev/lib/bosh/dev/tasks/db.rake
@@ -1,0 +1,32 @@
+namespace :db do
+  namespace :schema do
+    desc 'Dump database schema'
+    task :dump do
+      director_config = {
+        'db' => {
+          'database' => "director_latest_tmp",
+          'adapter' => 'postgresql',
+          'user' => 'postgres'
+        },
+        'cloud' => {}
+      }
+      director_config_path = Tempfile.new('director_config')
+      File.open(director_config_path.path, 'w') { |f| f.write(YAML.dump(director_config)) }
+
+      require 'bosh/dev/sandbox/postgresql'
+      @logger = Logging.logger(STDOUT)
+      @database = Bosh::Dev::Sandbox::Postgresql.new(director_config['db']['database'], @logger, 5432)
+      @database.drop_db
+      @database.create_db
+
+      require 'bosh/dev/sandbox/database_migrator'
+      director_dir = File.expand_path('../../../../../../bosh-director', __FILE__)
+      Bosh::Dev::Sandbox::DatabaseMigrator.new(director_dir, director_config_path.path, @logger).migrate
+      File.unlink(director_config_path)
+
+      File.open('postgresql.schema.sql', 'w') do |f|
+        f.puts @database.dump_db
+      end
+    end
+  end
+end


### PR DESCRIPTION
This rake task should help with analyzing the database.
No more running integration tests and putting in a sleep statement or breakpoint, finding the right director database (the names are all hashes) and finally figuring out credentials just to look at the current schema SQL.

Instead this task creates a database `director_latest_tmp`, runs migrations and dumps the schema to STDOUT and the file `https://github.com/manno/bosh/tree/performance-integration-test`.

The resulting database is missing test data of course, so for running `EXPLAIN ANALYZE` we  might still want to mess with integration test databases.