### PR TITLE
Remove nats-tls ops file from main-bosh-docker

### DIFF
--- a/ci/docker/main-bosh-docker/start-bosh.sh
+++ b/ci/docker/main-bosh-docker/start-bosh.sh
@@ -163,7 +163,6 @@ function main() {
       command bosh int bosh.yml \
         -o docker/cpi.yml \
         -o jumpbox-user.yml \
-        -o experimental/nats-tls.yml \
         -v director_name=docker \
         -v internal_cidr=10.245.0.0/16 \
         -v internal_gw=10.245.0.1 \


### PR DESCRIPTION
The nats-tls feature is no longer optional or experiemental,
remove the nats-tls opsfile from the start-bosh script in the
main-bosh-docker Docker image

Signed-off-by: Konstantin Semenov <ksemenov@pivotal.io>