### PR TITLE
Allow exactly one vm config in instance group

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/compilation_config.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/compilation_config.rb
@@ -68,7 +68,7 @@ module Bosh::Director
 
         if [vm_type_name, vm_resources, @cloud_properties].reject { |v| v.nil? || v.empty? }.count > 1
           raise Bosh::Director::CompilationConfigBadVmConfiguration,
-            "Compilation config specifies more than one of 'vm_type', 'vm_resources', and 'cloud_properties' keys, only one is allowed."
+            "Compilation config specifies more than one of 'vm_type', 'vm_resources', or 'cloud_properties', only one is allowed."
         end
 
         if vm_type_name

--- a/src/bosh-director/spec/unit/deployment_plan/compilation_config_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/compilation_config_spec.rb
@@ -106,7 +106,7 @@ describe Bosh::Director::DeploymentPlan::CompilationConfig do
             [vm_type]
           )
         }.to raise_error BD::CompilationConfigBadVmConfiguration,
-          "Compilation config specifies more than one of 'vm_type', 'vm_resources', and 'cloud_properties' keys, only one is allowed."
+          "Compilation config specifies more than one of 'vm_type', 'vm_resources', or 'cloud_properties', only one is allowed."
       end
 
       context 'when vm_resources is configured' do
@@ -126,7 +126,7 @@ describe Bosh::Director::DeploymentPlan::CompilationConfig do
               {},
               [vm_type]
             )
-          }.to raise_error(BD::CompilationConfigBadVmConfiguration, "Compilation config specifies more than one of 'vm_type', 'vm_resources', and 'cloud_properties' keys, only one is allowed.")
+          }.to raise_error(BD::CompilationConfigBadVmConfiguration, "Compilation config specifies more than one of 'vm_type', 'vm_resources', or 'cloud_properties', only one is allowed.")
         end
       end
 
@@ -251,7 +251,7 @@ describe Bosh::Director::DeploymentPlan::CompilationConfig do
                   'some' => 'value'
                 }
               }, {})
-            }.to raise_error(BD::CompilationConfigBadVmConfiguration, "Compilation config specifies more than one of 'vm_type', 'vm_resources', and 'cloud_properties' keys, only one is allowed.")
+            }.to raise_error(BD::CompilationConfigBadVmConfiguration, "Compilation config specifies more than one of 'vm_type', 'vm_resources', or 'cloud_properties', only one is allowed.")
           end
         end
       end

--- a/src/bosh-director/spec/unit/deployment_plan/instance_group_spec_parser_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_group_spec_parser_spec.rb
@@ -1244,26 +1244,38 @@ module Bosh::Director
             end
           end
 
-          context 'when vm requirements and vm types are given' do
-            before do
-              instance_group_spec.merge!(
-                'vm_type' => 'fake-vm-type',
-              ).merge!(
-                vm_resources
-              )
+          context 'when more than one vm resource config is given' do
+            let(:resource_pool_config) { { 'resource_pool' => 'fake-resource-pool' } }
+            let(:vm_type) { { 'vm_type' => 'fake-vm-type' } }
 
+            before do
               allow(deployment_plan).to receive(:vm_type).with('fake-vm-type').and_return(
-                VmType.new({
-                  'name' => 'fake-vm-type',
-                  'cloud_properties' => {}
-                })
+                VmType.new('name' => 'fake-vm-type', 'cloud_properties' => {})
               )
             end
 
-            it 'raises an error' do
+            it 'raises an error for vm_type, vm_resources' do
+              instance_group_spec.merge!(vm_type).merge!(vm_resources)
+
               expect {
                 parsed_instance_group
-              }.to raise_error(InstanceGroupBadVmConfiguration, "Instance group 'instance-group-name' specifies both 'vm_type' and 'vm_resources' keys, only one is allowed.")
+              }.to raise_error(InstanceGroupBadVmConfiguration, "Instance group 'instance-group-name' can only specify one of 'resource_pool', 'vm_type' or 'vm_resources' keys.")
+            end
+
+            it 'raises an error for vm_type, vm_resources, resource_pool' do
+              instance_group_spec.merge!(resource_pool_config).merge!(vm_type).merge!(vm_resources)
+
+              expect {
+                parsed_instance_group
+              }.to raise_error(InstanceGroupBadVmConfiguration, "Instance group 'instance-group-name' can only specify one of 'resource_pool', 'vm_type' or 'vm_resources' keys.")
+            end
+
+            it 'raises an error for vm_type, resource_pool' do
+              instance_group_spec.merge!(resource_pool_config).merge!(vm_resources)
+
+              expect {
+                parsed_instance_group
+              }.to raise_error(InstanceGroupBadVmConfiguration, "Instance group 'instance-group-name' can only specify one of 'resource_pool', 'vm_type' or 'vm_resources' keys.")
             end
           end
 

--- a/src/bosh-director/spec/unit/deployment_plan/instance_group_spec_parser_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_group_spec_parser_spec.rb
@@ -1195,7 +1195,7 @@ module Bosh::Director
 
         end
 
-        describe 'vm requirements' do
+        describe 'vm resources' do
           let(:vm_resources) do
             {
               'vm_resources' => {
@@ -1233,7 +1233,7 @@ module Bosh::Director
               instance_group_spec.merge!(vm_resources)
             end
 
-            it 'parses the vm requirements' do
+            it 'parses the vm resources' do
               instance_group = nil
               expect {
                 instance_group = parsed_instance_group
@@ -1244,7 +1244,7 @@ module Bosh::Director
             end
           end
 
-          context 'when more than one vm resource config is given' do
+          context 'when more than one vm config is given' do
             let(:resource_pool_config) { { 'resource_pool' => 'fake-resource-pool' } }
             let(:vm_type) { { 'vm_type' => 'fake-vm-type' } }
 
@@ -1252,14 +1252,6 @@ module Bosh::Director
               allow(deployment_plan).to receive(:vm_type).with('fake-vm-type').and_return(
                 VmType.new('name' => 'fake-vm-type', 'cloud_properties' => {})
               )
-            end
-
-            it 'raises an error for vm_type, vm_resources' do
-              instance_group_spec.merge!(vm_type).merge!(vm_resources)
-
-              expect {
-                parsed_instance_group
-              }.to raise_error(InstanceGroupBadVmConfiguration, "Instance group 'instance-group-name' can only specify one of 'resource_pool', 'vm_type' or 'vm_resources' keys.")
             end
 
             it 'raises an error for vm_type, vm_resources, resource_pool' do
@@ -1270,8 +1262,24 @@ module Bosh::Director
               }.to raise_error(InstanceGroupBadVmConfiguration, "Instance group 'instance-group-name' can only specify one of 'resource_pool', 'vm_type' or 'vm_resources' keys.")
             end
 
-            it 'raises an error for vm_type, resource_pool' do
+            it 'raises an error for vm_type, vm_resources' do
+              instance_group_spec.merge!(vm_type).merge!(vm_resources)
+
+              expect {
+                parsed_instance_group
+              }.to raise_error(InstanceGroupBadVmConfiguration, "Instance group 'instance-group-name' can only specify one of 'resource_pool', 'vm_type' or 'vm_resources' keys.")
+            end
+
+            it 'raises an error for resource_pool, vm_resources' do
               instance_group_spec.merge!(resource_pool_config).merge!(vm_resources)
+
+              expect {
+                parsed_instance_group
+              }.to raise_error(InstanceGroupBadVmConfiguration, "Instance group 'instance-group-name' can only specify one of 'resource_pool', 'vm_type' or 'vm_resources' keys.")
+            end
+
+            it 'raises an error for resource_pool, vm_type' do
+              instance_group_spec.merge!(resource_pool_config).merge!(vm_type)
 
               expect {
                 parsed_instance_group
@@ -1279,7 +1287,7 @@ module Bosh::Director
             end
           end
 
-          context 'when neither vm type, vm requirements nor resource pool are given' do
+          context 'when neither vm type, vm resources nor resource pool are given' do
             it 'raises an error' do
               expect {
                 parsed_instance_group


### PR DESCRIPTION
Allow exactly one of `resource_pool`, `vm_type`, or `vm_resources` per instance group.

This is a follow up to the [previously reverted commits](https://github.com/cloudfoundry/bosh/commit/c24c0982fcd87c9666c8db7155f9e6e0c1becffb).
The change for the compilation block is not necessary anymore because maximum one of `vm_resources`, `vm_type` or `cloud_properties` was already enforced in the compilation block.

[#151750562](https://www.pivotaltracker.com/story/show/151750562)

We ran integration tests. `fly:integration_gocli_parallel` produced the same errors as the [current pipeline](https://main.bosh-ci.cf-app.com/teams/main/pipelines/bosh/jobs/integration-postgres-gocli-sha2/builds/1003). Other than that we did not see new failures.