### PR TITLE
Configure director log level.

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -134,6 +134,9 @@ properties:
   director.remove_dev_tools:
     description: When true, remove dev tool packages from non-compilation VMs
     default: false
+  director.log_level:
+    description: Log level
+    default: debug
   director.log_access_events_to_syslog:
     description: Access to api is logged to the syslog
     default: false

--- a/jobs/director/templates/director.yml.erb.erb
+++ b/jobs/director/templates/director.yml.erb.erb
@@ -9,7 +9,7 @@ params = {
   'max_tasks' => p('director.max_tasks'),
   'max_threads' => p('director.max_threads'),
   'logging' => {
-    'level' => 'DEBUG',
+    'level' => p('director.log_level'),
     'file' =>  "/var/vcap/sys/log/director/<" + "%= ENV['COMPONENT'] %" + ">.debug.log"
   },
   'mbus' => "nats://#{p('nats.address')}:#{p('nats.port')}",


### PR DESCRIPTION
We're seeing huge numbers of debug logs for sql queries by the director. It would be useful to bump the log level to info or higher to silence those messages.

cc @sharms