### PR TITLE
Use tasks config to limit number of workers for each job group

### DIFF
--- a/src/bosh-director/db/migrations/director/20171210183015_add_job_groups.rb
+++ b/src/bosh-director/db/migrations/director/20171210183015_add_job_groups.rb
@@ -1,0 +1,17 @@
+Sequel.migration do
+  up do
+    create_table :delayed_job_groups do
+      primary_key :group_id
+      String :config_content, null: false
+      Integer :limit
+    end
+
+    create_table :delayed_job_groups_jobs do
+      foreign_key :job_id, :delayed_jobs, on_delete: :cascade, null: false
+      foreign_key :delayed_job_group_id, :delayed_job_groups, on_delete: :cascade, null: false
+      unique %i[job_id delayed_job_group_id]
+    end
+
+    set_column_type :delayed_job_groups, :config_content, 'longtext' if %i[mysql mysql2].include? adapter_scheme
+  end
+end

--- a/src/bosh-director/db/migrations/migration_digests.json
+++ b/src/bosh-director/db/migrations/migration_digests.json
@@ -134,6 +134,7 @@
   "20171113000000_add_links_api": "3e852a8b0d8b8ce46a4e8a3c59dc7f6125606c5f",
   "20171117230219_add_network_spec_to_vms": "86943d47455e06382190cef6ee6faea71dd1151f",
   "20171201153629_remove_unused_template_columns": "a1853f2f9c44a82717dba7809ae5149789b95d01",
+  "20171210183015_add_job_groups": "fa6c0410cd8e2abcc0478a6e2c0d568b4e657c33",
   "20180119183014_add_stemcell_matches": "c01cc3aefbfd865086c839ca794f1235f16932a0",
   "20180119233828_add_vm_id_to_ip_addresses": "128151233382b1482dab8029ee61bf0774c27ed7",
   "20180130182844_rename_stemcell_matches_to_stemcell_uploads": "e6b72ee8aab1f46893ca25245745371defa5cbf7",

--- a/src/bosh-director/lib/bosh/director.rb
+++ b/src/bosh-director/lib/bosh/director.rb
@@ -248,6 +248,7 @@ require 'bosh/director/api/controllers/link_consumers_controller'
 require 'bosh/director/api/controllers/links_controller'
 require 'bosh/director/api/controllers/link_address_controller'
 require 'bosh/director/api/route_configuration'
+require 'bosh/director/api/tasks_config_manager'
 
 require 'bosh/director/step_executor'
 

--- a/src/bosh-director/lib/bosh/director/api/config_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/config_manager.rb
@@ -2,6 +2,10 @@ module Bosh
   module Director
     module Api
       class ConfigManager
+        def initialize
+          @tasks_config_manager = TasksConfigManager.new
+        end
+
         def create(type, name, config_yaml, team_id = nil)
           config = Bosh::Director::Models::Config.new(
             type: type,
@@ -10,6 +14,8 @@ module Bosh
             team_id: team_id,
           )
           config.save
+          @tasks_config_manager.rebuild_groups if type == 'tasks'
+          config
         end
 
         def find(type: nil, name: nil, limit: 1)
@@ -53,9 +59,11 @@ module Bosh
         end
 
         def delete(type, name)
-          Bosh::Director::Models::Config
+          config = Bosh::Director::Models::Config
             .where(type: type, name: name, deleted: false)
             .update(deleted: true)
+          @tasks_config_manager.rebuild_groups if type == 'tasks'
+          config
         end
 
         def delete_by_id(id)

--- a/src/bosh-director/lib/bosh/director/api/tasks_config_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/tasks_config_manager.rb
@@ -1,0 +1,162 @@
+module Bosh::Director
+  module Api
+    class TasksConfigManager
+      include ValidationHelper
+      WORKER_DEFAULT_LIMIT = 100
+
+      def add_to_groups(delayed_job)
+        Transactor.new.retryable_transaction(Bosh::Director::Config.db) do
+          configs = tasks_configs
+          unless configs.empty?
+            payload_object = delayed_job.send(:payload_object)
+            task_id = payload_object.task_id
+            tasks_configs.each do |tasks_config|
+              begin
+                delayed_group = tasks_config[:delayed_group]
+                delayed_group.add_delayed_job(delayed_job) if tasks_config[:tasks_config].applies?(task_id)
+              rescue Sequel::ValidationFailed, Sequel::DatabaseError => e
+                error_message = e.message.downcase
+                raise e unless error_message.include?('unique') || error_message.include?('duplicate')
+                next
+              end
+            end
+          end
+        end
+      end
+
+      def rebuild_groups
+        cleanup
+
+        raw_tasks_configs.each do |raw_tasks_config|
+          Bosh::Director::Models::DelayedJobGroup.create(
+            config_content: raw_tasks_config.tasks_config_text,
+            limit: raw_tasks_config.rate_limit? ? raw_tasks_config.rate_limit : WORKER_DEFAULT_LIMIT,
+          )
+        end
+
+        delayed_jobs = Delayed::Backend::Sequel::Job.where(::Sequel.expr(failed_at: nil)).all
+        delayed_jobs.each do |delayed_job|
+          add_to_groups(delayed_job)
+        end
+      end
+
+      private
+
+      def cleanup
+        Models::DelayedJobGroup.dataset.delete
+      end
+
+      def raw_tasks_configs
+        tasks_configs = ConfigManager.new.find(type: 'tasks', name: nil)
+        parsed_configs = []
+        if !tasks_configs.nil? && !tasks_configs.empty?
+          content_hash = YAML.safe_load(tasks_configs[0].content)
+          tasks_config_hashes = safe_property(content_hash, 'rules', class: Array, default: [])
+          tasks_config_hashes.each do |tasks_config_hash|
+            parsed_configs << TasksConfig.parse(tasks_config_hash)
+          end
+        end
+
+        parsed_configs
+      end
+
+      def tasks_configs
+        delayed_groups = Bosh::Director::Models::DelayedJobGroup.all
+        parsed_configs = []
+
+        unless delayed_groups.empty?
+          delayed_groups.each do |delayed_group|
+            parsed_configs << {
+              delayed_group: delayed_group,
+              tasks_config: TasksConfig.parse(YAML.safe_load(delayed_group.config_content)),
+            }
+          end
+        end
+
+        parsed_configs
+      end
+
+      class TasksConfig
+        extend ValidationHelper
+
+        attr_reader :tasks_config_hash
+
+        def initialize(options, include_filter, exclude_filter, tasks_config_hash)
+          @options = options
+          @include_filter = include_filter
+          @exclude_filter = exclude_filter
+          @task_manager = TaskManager.new
+          @tasks_config_hash = tasks_config_hash
+        end
+
+        def self.parse(tasks_config_hash)
+          options = safe_property(tasks_config_hash, 'options', class: Hash, default: {})
+          include_filter = Filter.parse(safe_property(tasks_config_hash, 'include', class: Hash, optional: true), :include)
+          exclude_filter = Filter.parse(safe_property(tasks_config_hash, 'exclude', class: Hash, optional: true), :exclude)
+
+          new(options, include_filter, exclude_filter, tasks_config_hash)
+        end
+
+        def rate_limit?
+          @options.key?('rate_limit')
+        end
+
+        def tasks_config_text
+          YAML.dump(@tasks_config_hash)
+        end
+
+        def rate_limit
+          @options['rate_limit']
+        end
+
+        def applies?(task_id)
+          task = @task_manager.find_task(task_id)
+          @include_filter.applies?(task.deployment_name, task.teams.map(&:name)) &&
+            !@exclude_filter.applies?(task.deployment_name, task.teams.map(&:name))
+        end
+      end
+
+      class Filter
+        extend ValidationHelper
+
+        attr_reader :applicable_deployment_names, :applicable_teams
+
+        def initialize(applicable_deployment_names, applicable_teams, filter_type)
+          @applicable_deployment_names = applicable_deployment_names
+          @applicable_teams = applicable_teams
+          @filter_type = filter_type
+        end
+
+        def self.parse(filter_hash, filter_type)
+          applicable_deployment_names = safe_property(filter_hash, 'deployments', class: Array, default: [])
+          applicable_teams = safe_property(filter_hash, 'teams', class: Array, default: [])
+          new(applicable_deployment_names, applicable_teams, filter_type)
+        end
+
+        def applies?(deployment_name, deployment_teams)
+          return false if teams? && !applicable_team?(deployment_teams)
+
+          return @applicable_deployment_names.include?(deployment_name) if deployments?
+
+          return true if @filter_type == :include
+
+          # @filter_type == :exclude case
+          teams?
+        end
+
+        def teams?
+          !@applicable_teams.nil? && !@applicable_teams.empty?
+        end
+
+        def applicable_team?(deployment_teams)
+          return false if deployment_teams.nil? || deployment_teams.empty? || @applicable_teams.nil?
+          !(@applicable_teams & deployment_teams).empty?
+        end
+
+        def deployments?
+          !@applicable_deployment_names.nil? && !@applicable_deployment_names.empty?
+        end
+      end
+    end
+  end
+end

--- a/src/bosh-director/lib/bosh/director/jobs/db_job.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/db_job.rb
@@ -19,6 +19,11 @@ module Bosh::Director
         @worker_name = job.locked_by
       end
 
+      def enqueue(job)
+        @tasks_config_manager ||= Api::TasksConfigManager.new
+        @tasks_config_manager.add_to_groups(job)
+      end
+
       def perform
         Config.db.transaction(:retry_on => [Sequel::DatabaseConnectionError]) do
           if Models::Task.where(id: @task_id, state: 'queued').update(state: 'processing', checkpoint_time: Time.now) != 1

--- a/src/bosh-director/lib/bosh/director/models.rb
+++ b/src/bosh-director/lib/bosh/director/models.rb
@@ -43,6 +43,7 @@ require 'bosh/director/models/variable'
 require 'bosh/director/models/variable_set'
 require 'bosh/director/models/vm'
 require 'delayed_job_sequel'
+require 'bosh/director/models/delayed_job_group'
 
 module Bosh::Director
   module Models

--- a/src/bosh-director/lib/bosh/director/models/delayed_job_group.rb
+++ b/src/bosh-director/lib/bosh/director/models/delayed_job_group.rb
@@ -1,0 +1,40 @@
+require 'delayed/backend/sequel'
+
+module Bosh
+  module Director
+    module Models
+      Delayed::Backend::Sequel::Job.class_eval do
+        many_to_many :delayed_job_groups, class: 'Bosh::Director::Models::DelayedJobGroup'
+
+        def self.all_blocked_jobs
+          delayed_job_groups = db[:delayed_job_groups]
+          delayed_job_groups_jobs = db[:delayed_job_groups_jobs]
+          non_reservable_groups = delayed_job_groups.where do |group|
+            job_ids_in_group = delayed_job_groups_jobs.where(delayed_job_group_id: group.group_id).select(:job_id)
+            group.limit <= filter(failed_at: nil).exclude(locked_by: nil).where(id: job_ids_in_group).select { count.function.* }
+          end
+
+          delayed_job_groups_jobs.where(delayed_job_group_id: non_reservable_groups.select(:group_id)).select(:job_id)
+        end
+
+        module ReadyToRunExtension
+          def ready_to_run(worker_name, max_run_time)
+            super(worker_name, max_run_time).exclude(id: all_blocked_jobs)
+          end
+        end
+
+        class << self
+          prepend ReadyToRunExtension
+        end
+      end
+
+      class DelayedJobGroup < Sequel::Model(Bosh::Director::Config.db)
+        many_to_many :delayed_jobs, class: 'Delayed::Backend::Sequel::Job', right_key: :job_id
+
+        def validate
+          validates_presence [:config_content]
+        end
+      end
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/api/config_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/config_manager_spec.rb
@@ -3,9 +3,11 @@ require 'spec_helper'
 describe Bosh::Director::Api::ConfigManager do
   subject(:manager) { Bosh::Director::Api::ConfigManager.new }
 
+  let(:name) { 'some-name' }
+
   describe '#create' do
     let(:type) { 'my-type' }
-    let(:name) { 'some-name' }
+
     let(:valid_yaml) { YAML.dump("---\n{key: value") }
 
     it 'saves the config' do
@@ -16,6 +18,13 @@ describe Bosh::Director::Api::ConfigManager do
       config = Bosh::Director::Models::Config.first
       expect(config.created_at).to_not be_nil
       expect(config.content).to eq(valid_yaml)
+    end
+
+    context 'when type == tasks' do
+      it 'calls TasksConfigManager to rebuild groups' do
+        expect_any_instance_of(Bosh::Director::Api::TasksConfigManager).to receive(:rebuild_groups)
+        manager.create('tasks', name, '{}')
+      end
     end
   end
 
@@ -248,6 +257,13 @@ describe Bosh::Director::Api::ConfigManager do
         expect(count).to eq(0)
       end
     end
+
+    context 'when type == tasks' do
+      it 'calls TasksConfigManager to rebuild groups' do
+        expect_any_instance_of(Bosh::Director::Api::TasksConfigManager).to receive(:rebuild_groups)
+        manager.delete('tasks', name)
+      end
+    end
   end
 
   describe '#delete_by_id' do
@@ -280,7 +296,12 @@ describe Bosh::Director::Api::ConfigManager do
         expect(count).to eq(0)
       end
     end
+
+    context 'when type == tasks' do
+      it 'calls TasksConfigManager to rebuild groups' do
+        expect_any_instance_of(Bosh::Director::Api::TasksConfigManager).to receive(:rebuild_groups)
+        manager.delete('tasks', name)
+      end
+    end
   end
-
-
 end

--- a/src/bosh-director/spec/unit/api/tasks_config_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/tasks_config_manager_spec.rb
@@ -1,0 +1,200 @@
+require 'spec_helper'
+require 'delayed_job'
+
+module Bosh::Director
+  describe Api::TasksConfigManager do
+    def handler(task_id)
+      "--- !ruby/object:Bosh::Director::Jobs::DBJob\n" \
+        "job_class: !ruby/class 'Bosh::Director::Jobs::UpdateDeployment'\ntask_id: #{task_id}"
+    end
+
+    def load_configs(content)
+      Models::Config.create(
+        type: 'tasks',
+        name: 'tasks',
+        content: content,
+      )
+      manager.rebuild_groups
+    end
+
+    let(:manager) { described_class.new }
+    subject(:config_manager) { Api::ConfigManager.new }
+
+    let(:tasks_configs_content) do
+      {
+        'rules' => [
+          tasks_config_1,
+        ],
+      }
+    end
+
+    let(:tasks_config_1) do
+      {
+        'options' => { 'rate_limit' => 0 },
+        'include' => include_spec,
+        'exclude' => exclude_spec,
+      }
+    end
+
+    let(:tasks_config_2) do
+      {
+        'options' => { 'rate_limit' => 1 },
+      }
+    end
+
+    let(:include_spec) do
+      {
+        'deployments' => ['deployment_include'],
+        'teams' => ['team-1'],
+      }
+    end
+    let(:exclude_spec) { { 'deployments' => ['deployment_exclude'] } }
+    let(:task) { make_task_with_team(id: 43, state: :queued, deployment_name: 'deployment_include', teams: teams) }
+    let(:teams) do
+      [Models::Team.make(name: 'team-1'), Bosh::Director::Models::Team.make(name: 'team-2')]
+    end
+
+    describe '#rebuild_groups' do
+      it 'creates new groups' do
+        load_configs(YAML.dump(tasks_configs_content))
+        expect(Models::DelayedJobGroup.count).to eq(1)
+        groups = Models::DelayedJobGroup.all
+        expect(groups[0].config_content).to eq(YAML.dump(tasks_configs_content['rules'][0]))
+        expect(groups[0].limit).to eq(0)
+      end
+
+      it 'adds a job to the group' do
+        job = Delayed::Job.create(
+          priority: 1,
+          attempts: 2,
+          handler: handler(task.id),
+          queue: 'test',
+        )
+
+        load_configs(YAML.dump(tasks_configs_content))
+        expect(job.delayed_job_groups.count).to eq(1)
+      end
+
+      context 'when groups already exist' do
+        it 'does a cleanup' do
+          load_configs(YAML.dump(tasks_configs_content))
+          groups = Models::DelayedJobGroup.all
+
+          load_configs(YAML.dump(tasks_configs_content))
+          new_groups = Models::DelayedJobGroup.all
+          expect(groups.size).to eq(1)
+          expect(new_groups.size).to eq(1)
+          expect((new_groups - groups).empty?).to be_falsey
+        end
+      end
+    end
+
+    describe '#add_to_groups' do
+      let(:job) do
+        Delayed::Job.create(
+          priority: 1,
+          attempts: 2,
+          handler: handler(task.id),
+          queue: 'test',
+        )
+      end
+
+      it 'does not raise when unique constraint failed' do
+        load_configs(YAML.dump(tasks_configs_content))
+        manager.add_to_groups(job)
+        manager.add_to_groups(job)
+        expect(job.delayed_job_groups.count).to eq(1)
+      end
+
+      context 'when the tasks_config is applicable by deployment name' do
+        let(:include_spec) { { 'deployments' => ['deployment_include'] } }
+
+        it 'applies' do
+          load_configs(YAML.dump(tasks_configs_content))
+          manager.add_to_groups(job)
+          expect(job.delayed_job_groups.count).to eq(1)
+        end
+      end
+
+      context 'when the tasks_config is not applicable by deployment name' do
+        let(:include_spec) { { 'deployments' => ['no_findy'] } }
+
+        it 'does not apply' do
+          load_configs(YAML.dump(tasks_configs_content))
+          manager.add_to_groups(job)
+          expect(job.delayed_job_groups.count).to eq(0)
+        end
+      end
+
+      context 'when the tasks_config is applicable by teams' do
+        let(:include_spec) { { 'teams' => ['team-1'] } }
+
+        it 'applies' do
+          load_configs(YAML.dump(tasks_configs_content))
+          manager.add_to_groups(job)
+          expect(job.delayed_job_groups.count).to eq(1)
+        end
+      end
+
+      context 'when the tasks_config is not applicable by teams' do
+        let(:include_spec) { { 'teams' => ['team_3'] } }
+
+        it 'does not apply' do
+          load_configs(YAML.dump(tasks_configs_content))
+          manager.add_to_groups(job)
+          expect(job.delayed_job_groups.count).to eq(0)
+        end
+      end
+
+      context 'when the tasks_config has empty include and exclude' do
+        let(:include_spec) { {} }
+        let(:exclude_spec) { {} }
+
+        it 'applies' do
+          load_configs(YAML.dump(tasks_configs_content))
+          manager.add_to_groups(job)
+          expect(job.delayed_job_groups.count).to eq(1)
+        end
+      end
+
+      context 'when the tasks_config has include and exclude' do
+        let(:include_spec) { { 'deployments' => ['deployment_include'] } }
+
+        context 'when they are the same' do
+          let(:exclude_spec) { { 'deployments' => ['deployment_include'] } }
+
+          it 'does not apply' do
+            load_configs(YAML.dump(tasks_configs_content))
+            manager.add_to_groups(job)
+            expect(job.delayed_job_groups.count).to eq(0)
+          end
+        end
+
+        context 'when include is for deployment and exlude is for team' do
+          let(:exclude_spec) { { 'teams' => ['team-1', 'team-2'] } }
+
+          it 'does not apply' do
+            load_configs(YAML.dump(tasks_configs_content))
+            manager.add_to_groups(job)
+            expect(job.delayed_job_groups.count).to eq(0)
+          end
+        end
+      end
+
+      context 'when there are several groups' do
+        it 'applies for all applicable groups' do
+          tasks_configs_content_extended =
+            {
+              'rules' => [
+                tasks_config_1,
+                tasks_config_2,
+              ],
+            }
+          load_configs(YAML.dump(tasks_configs_content_extended))
+          manager.add_to_groups(job)
+          expect(job.delayed_job_groups.count).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/db/migrations/director/20171210183015_add_job_groups_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/20171210183015_add_job_groups_spec.rb
@@ -1,0 +1,27 @@
+require_relative '../../../../db_spec_helper'
+
+module Bosh::Director
+  describe 'During migrations' do
+    let(:db) { DBSpecHelper.db }
+    let(:migration_file) { '20171210183015_add_job_groups.rb' }
+
+    before do
+      DBSpecHelper.migrate_all_before(migration_file)
+    end
+
+    it 'creates the appropriate tables' do
+      DBSpecHelper.migrate(migration_file)
+      expect(db.table_exists?(:delayed_job_groups)).to be_truthy
+      expect(db.table_exists?(:delayed_job_groups_jobs)).to be_truthy
+    end
+
+    it 'ensures that fields allow texts longer than 65535 character' do
+      DBSpecHelper.migrate(migration_file)
+
+      really_long_text = 'a' * 65536
+      db[:delayed_job_groups] << { limit: 5, config_content: really_long_text }
+
+      expect(db[:delayed_job_groups].map { |cp| cp[:config_content].length }).to eq([really_long_text.length])
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/models/delayed_job_group_spec.rb
+++ b/src/bosh-director/spec/unit/models/delayed_job_group_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+module Bosh::Director::Models
+  describe DelayedJobGroup do
+    it 'extend sequel delayed_job model' do
+      expect(Delayed::Backend::Sequel::Job.methods.include?(:all_blocked_jobs)).to be_truthy
+    end
+  end
+end

--- a/src/spec/gocli/integration/tasks_config_spec.rb
+++ b/src/spec/gocli/integration/tasks_config_spec.rb
@@ -1,0 +1,60 @@
+require_relative '../../spec_helper'
+
+describe 'tasks config', type: :integration do
+  with_reset_sandbox_before_each
+
+  let(:config_limit_1) { yaml_file('config', Bosh::Spec::NewDeployments.tasks_config) }
+  let(:config_limit_2) { yaml_file('config', Bosh::Spec::NewDeployments.tasks_config(limit: 2)) }
+
+  it 'applies rate_limit number for delayed job groups' do
+    create_and_upload_test_release
+    upload_stemcell
+
+    cloud_config = Bosh::Spec::NewDeployments.simple_cloud_config
+    upload_cloud_config(cloud_config_hash: cloud_config)
+    first_deployment_manifest = Bosh::Spec::NetworkingManifest.deployment_manifest(
+      name: 'first', instances: 1,
+      job: 'foobar_without_packages'
+    )
+    second_deployment_manifest = Bosh::Spec::NetworkingManifest.deployment_manifest(
+      name: 'second', instances: 1,
+      job: 'foobar_without_packages'
+    )
+
+    bosh_runner.run("update-config --type tasks --name default #{config_limit_1.path}")
+    first_task_id = Bosh::Spec::DeployHelper.start_deploy(first_deployment_manifest)
+    second_task_id = Bosh::Spec::DeployHelper.start_deploy(second_deployment_manifest)
+
+    Bosh::Spec::DeployHelper.wait_for_task_to_succeed(first_task_id)
+    Bosh::Spec::DeployHelper.wait_for_task_to_succeed(second_task_id)
+
+    output = bosh_runner.run('events --object-type=deployment', json: true)
+    data = table(output)
+
+    # with rate_limit = 1 firstly first deployment, then the second one
+    expect(data[0]['deployment']).to eq(data[1]['deployment'])
+
+    bosh_runner.run("update-config --type tasks --name default #{config_limit_2.path}")
+
+    first_deployment_manifest['instance_groups'] = [Bosh::Spec::NewDeployments.simple_instance_group(
+      instances: 2,
+      job: 'foobar_without_packages',
+    )]
+    second_deployment_manifest['instance_groups'] = [Bosh::Spec::NewDeployments.simple_instance_group(
+      instances: 2,
+      job: 'foobar_without_packages',
+    )]
+
+    first_task_id = Bosh::Spec::DeployHelper.start_deploy(first_deployment_manifest)
+    second_task_id = Bosh::Spec::DeployHelper.start_deploy(second_deployment_manifest)
+
+    Bosh::Spec::DeployHelper.wait_for_task_to_succeed(first_task_id)
+    Bosh::Spec::DeployHelper.wait_for_task_to_succeed(second_task_id)
+
+    output = bosh_runner.run('events --object-type=deployment --action=update', json: true)
+    data = table(output)
+
+    # with rate_limit = 2 two deployments are in parallel
+    expect(data[0]['deployment']).not_to eq(data[1]['deployment'])
+  end
+end

--- a/src/spec/support/new_deployments.rb
+++ b/src/spec/support/new_deployments.rb
@@ -608,5 +608,15 @@ module Bosh::Spec
         ],
       }
     end
+
+    def self.tasks_config(options = {})
+      {
+        'rules' => [{
+          'options' => {
+            'rate_limit' => options.fetch(:limit, 1),
+          },
+        }],
+      }
+    end
   end
 end


### PR DESCRIPTION
Job groups allow to group job and specify how many workers can execute jobs of the perticular group at the same time.
Standard delayed jobs mechanism to sort jobs for workers was extended to take into account also number of processing jobs for each group.

DelayedJobGroup was added to let grouping delayed jobs by configs.
Delayed::Backend::Sequel::Job was extended to have extra filter for available jobs.
TasksConfigManager was added to parse tasks configs and apply jobs to groups

[#145853311](https://www.pivotaltracker.com/story/show/145853311)
Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>