### PR TITLE
Better Documentation for NATS related certificates

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -213,9 +213,11 @@ properties:
   nats.tls.client_ca.private_key:
     description: Private Key for NATs mutual TLS (Director uses to generate Agent cert)
   nats.tls.director.certificate:
-    description: Certificate for NATs mutual TLS (Director client)
+    description: |
+      Certificate for NATs mutual TLS client (Director client). The Common-Name for this certificate
+      should be "default.director.bosh-internal"
   nats.tls.director.private_key:
-    description: Private Key for NATs mutual TLS (Director client)
+    description: Private Key for NATs mutual TLS client (Director client)
 
   # Director Database
   director.db.adapter:

--- a/jobs/health_monitor/spec
+++ b/jobs/health_monitor/spec
@@ -57,7 +57,9 @@ properties:
   hm.nats.certs.private_key:
     description: Private Key for establishing mutual TLS with NATs
   hm.nats.certs.certificate:
-    description: Certificate for establishing mutual TLS with NATs
+    description: |
+      Certificate for establishing mutual TLS with NATs. The Common-Name for the certificate
+      should be "default.hm.bosh-internal"
 
   #
   # NATS options (to get alerts from agents)

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -34,7 +34,9 @@ properties:
   nats.tls.ca:
     description: CA cert used by NATS server to verify clients certificates (For Mutual TLS Connections)
   nats.tls.server.certificate:
-    description: Certificate used by the NATS server to serve TLS connections
+    description: |
+      Certificate used by the NATS server to serve TLS connections. The Common-Name for the certificate
+      should be "default.nats.bosh-internal"
   nats.tls.server.private_key:
     description: Private Key used by the NATS server to serve TLS connections
   nats.tls.timeout:


### PR DESCRIPTION
- If an oparator is not using bosh-deployment, they will have
  hard time figuring out the correct common-names for the
  NATS certificates to be generated. This pull request documents
  what each certificate common-name should be.

Signed-off-by: Jamil Shamy <jshamy@pivotal.io>