### PR TITLE
Require YAML module in Bosh::Template::Test::Job

### DIFF
--- a/src/bosh-template/lib/bosh/template/test/job.rb
+++ b/src/bosh-template/lib/bosh/template/test/job.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module Bosh::Template::Test
   class Job
     def initialize(release_path, name)


### PR DESCRIPTION
This avoids the need to require the YAML module in addition to the Bosh::Template::Test module in test files.

Currently consumers must require the YAML module in addition to the Bosh::Template::Test module in their tests:

```
require 'bosh/template/test'
require 'yaml'

# some tests...
```

Otherwise they will see:

```
Failure/Error: job = release.job('my-job-name')

     NameError:
       uninitialized constant Bosh::Template::Test::Job::YAML
```