### PR TITLE
Set ownership of blobstore to vcap even when it is empty

### DIFF
--- a/jobs/blobstore/templates/bbr_restore
+++ b/jobs/blobstore/templates/bbr_restore
@@ -6,8 +6,9 @@ rm -rf /var/vcap/store/blobstore/*
 
 cp -rl $ARTIFACT_DIRECTORY/store /var/vcap/store/blobstore/
 
+chown -R vcap:vcap /var/vcap/store/blobstore/
+
 if [ -n "$(ls -A /var/vcap/store/blobstore/store)" ]; then
   find /var/vcap/store/blobstore/store -type d | xargs -n 127 chmod 0700
   find /var/vcap/store/blobstore/store -type f | xargs -n 127 chmod 0600
-  chown -R vcap:vcap /var/vcap/store/blobstore/
 fi


### PR DESCRIPTION
We were seeing our `/var/vcap/store/blobstore/store` dir being created with ownership set to `root`.

We traced it down to it being created after a BBR restore happened. 
This scenario will happen if the blobstore is empty at the time of backup/restore.