### PR TITLE
as a director user, i expect to create configs such that only my team…

### DIFF
--- a/src/bosh-director/db/migrations/director/20180114173605_add_team_id_to_configs.rb
+++ b/src/bosh-director/db/migrations/director/20180114173605_add_team_id_to_configs.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  up do
+    alter_table(:configs) do
+      add_column :team_id, Integer
+    end
+  end
+end

--- a/src/bosh-director/db/migrations/migration_digests.json
+++ b/src/bosh-director/db/migrations/migration_digests.json
@@ -132,5 +132,6 @@
   "20171104185823_add_manifest_text_to_deployments": "fbb7a4d05c9e12ad6d1fdf3ec04fc5dccf09cad1",
   "20171113000000_add_links_api": "f54258df34eae567eb5b4363eb65311aedab4f20",
   "20171117230219_add_network_spec_to_vms": "86943d47455e06382190cef6ee6faea71dd1151f",
-  "20171201153629_remove_unused_template_columns": "a1853f2f9c44a82717dba7809ae5149789b95d01"
+  "20171201153629_remove_unused_template_columns": "a1853f2f9c44a82717dba7809ae5149789b95d01",
+  "20180114173605_add_team_id_to_configs": "aea2f011f14db397c57df44712106f1161cb1edd"
 }

--- a/src/bosh-director/lib/bosh/director/api/config_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/config_manager.rb
@@ -2,11 +2,12 @@ module Bosh
   module Director
     module Api
       class ConfigManager
-        def create(type, name, config_yaml)
+        def create(type, name, config_yaml, team_id = nil)
           config = Bosh::Director::Models::Config.new(
               type: type,
               name: name,
-              content: config_yaml
+              content: config_yaml,
+              team_id: team_id
           )
           config.save
         end

--- a/src/bosh-director/lib/bosh/director/models/config.rb
+++ b/src/bosh-director/lib/bosh/director/models/config.rb
@@ -27,6 +27,11 @@ module Bosh
         def raw_manifest
           YAML.load content
         end
+
+        def teams
+          return [] if self.team_id.nil?
+          Team.where(id: [self.team_id]).all
+        end
       end
     end
   end

--- a/src/bosh-director/lib/bosh/director/permission_authorizer.rb
+++ b/src/bosh-director/lib/bosh/director/permission_authorizer.rb
@@ -44,6 +44,19 @@ module Bosh::Director
             else
               raise ArgumentError, "Unexpected permission for deployment: #{permission}"
           end
+        when lambda { |s| s.instance_of?(Models::Config) }
+          expected_scope << subject_team_scopes(subject, 'admin')
+
+          case permission
+            when :admin
+              # already allowed with initial expected_scope
+            when :read
+              expected_scope << subject_team_scopes(subject, 'read')
+              expected_scope << director_permissions[:read]
+            else
+              raise ArgumentError, "Unexpected permission for config: #{permission}"
+          end
+
         else
           raise ArgumentError, "Unexpected subject: #{subject}"
       end
@@ -59,11 +72,13 @@ module Bosh::Director
           # already allowed with initial expected_scope
         when :create_deployment
           expected_scope << add_bosh_admin_scopes(user_scopes)
-        when :read_events
+        when :read_events, :list_configs
           expected_scope << director_permissions[:read]
           expected_scope << add_bosh_team_scopes(user_scopes)
         when :read_releases, :list_deployments, :read_stemcells, :list_tasks
           expected_scope << director_permissions[:read]
+          expected_scope << add_bosh_admin_scopes(user_scopes)
+        when :update_configs
           expected_scope << add_bosh_admin_scopes(user_scopes)
         when :read, :upload_releases, :upload_stemcells
           expected_scope << director_permissions[permission]

--- a/src/bosh-director/spec/unit/db/migrations/director/20180114173605_add_team_id_to_configs_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/20180114173605_add_team_id_to_configs_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../../../../db_spec_helper'
+
+module Bosh::Director
+  describe 'add column to configs table' do
+    let(:db) {DBSpecHelper.db}
+    let(:migration_file) {'20180114173605_add_team_id_to_configs.rb'}
+
+    before do
+      DBSpecHelper.migrate_all_before(migration_file)
+      DBSpecHelper.migrate(migration_file)
+    end
+
+    it 'allows to save team_id' do
+      DBSpecHelper.migrate(migration_file)
+      expect(db[:configs].columns).to include(:team_id)
+
+      db[:configs] << {
+        name: 'config',
+        type: 'type',
+        content: '',
+        created_at: Time.now,
+        team_id: 1
+      }
+
+      expect(db[:configs].first[:team_id]).to eq 1
+    end
+
+    it 'allows team_id to be nil' do
+      DBSpecHelper.migrate(migration_file)
+      expect(db[:configs].columns).to include(:team_id)
+
+      db[:configs] << {
+        name: 'config',
+        type: 'type',
+        content: '',
+        created_at: Time.now,
+      }
+
+      expect(db[:configs].first[:team_id]).to be_nil
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/db/migrations/director/add_data_migration_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/add_data_migration_spec.rb
@@ -9,7 +9,7 @@ module Bosh::Director
       # populated with data. This test will fail every time a new migration script is added. Change
       # the file name below to the latest when a test is added.
       # Look at tests in this directory for similar examples: bosh-director/spec/unit/db/migrations/director
-      expect(latest_db_migration_file).to eq('20171201153629_remove_unused_template_columns.rb')
+      expect(latest_db_migration_file).to eq('20180114173605_add_team_id_to_configs.rb')
     end
   end
 end

--- a/src/bosh-director/spec/unit/models/config_spec.rb
+++ b/src/bosh-director/spec/unit/models/config_spec.rb
@@ -86,5 +86,18 @@ module Bosh::Director::Models
         expect(Bosh::Director::Models::Config.find_by_ids(nil)).to eq([])
       end
     end
+
+    describe '#teams' do
+      it 'returns teams array' do
+        team = Team.create(:name => 'dev')
+        Config.new(type: 'fake-cloud', content: 'v1', name: 'one', team_id: team.id).save
+        expect(Config.first.teams).to eq([team])
+      end
+
+      it 'returns empty teams when no team_id' do
+        Bosh::Director::Models::Config.new(type: 'fake-cloud', content: 'v1', name: 'one').save
+        expect(Bosh::Director::Models::Config.first.teams).to eq([])
+      end
+    end
   end
 end

--- a/src/bosh-director/spec/unit/permission_authorizer_spec.rb
+++ b/src/bosh-director/spec/unit/permission_authorizer_spec.rb
@@ -210,6 +210,67 @@ module Bosh::Director
           end
         end
 
+        describe 'checking list_configs rights' do
+          let(:acl_right) { :list_configs }
+          it 'allows bosh.read scope' do
+            expect(subject.is_granted?(acl_subject, acl_right, ['bosh.read'])).to eq(true)
+          end
+
+          it 'allows bosh.teams.X.read scope' do
+            expect(subject.is_granted?(acl_subject, acl_right, ['bosh.teams.anything.read'])).to eq(true)
+          end
+
+          it 'allows bosh.X.read scope' do
+            expect(subject.is_granted?(acl_subject, acl_right, ['bosh.fake-director-uuid.read'])).to eq(true)
+          end
+
+          it 'allows bosh.admin scope' do
+            expect(subject.is_granted?(acl_subject, acl_right, ['bosh.admin'])).to eq(true)
+          end
+
+          it 'allows bosh.teams.X.admin scope' do
+            expect(subject.is_granted?(acl_subject, acl_right, ['bosh.teams.anything.admin'])).to eq(true)
+          end
+
+          it 'allows bosh.X.admin scope' do
+            expect(subject.is_granted?(acl_subject, acl_right, ['bosh.fake-director-uuid.admin'])).to eq(true)
+          end
+
+          it 'denies others' do
+            expect(subject.is_granted?(acl_subject, acl_right, [
+              'bosh.unexpected-uuid.admin',
+              'bosh.unexpected-uuid.read',
+              'bosh.teams.security.unexpected',
+            ])).to eq(false)
+          end
+        end
+
+        describe 'checking update_configs rights' do
+          let(:acl_right) { :update_configs }
+          it 'allows bosh.admin scope' do
+            expect(subject.is_granted?(acl_subject, acl_right, ['bosh.admin'])).to eq(true)
+          end
+
+          it 'allows bosh.teams.X.admin scope' do
+            expect(subject.is_granted?(acl_subject, acl_right, ['bosh.teams.anything.admin'])).to eq(true)
+          end
+
+          it 'allows bosh.X.admin scope' do
+            expect(subject.is_granted?(acl_subject, acl_right, ['bosh.fake-director-uuid.admin'])).to eq(true)
+          end
+
+          it 'denies others' do
+            expect(subject.is_granted?(acl_subject, acl_right, [
+              'bosh.unexpected-uuid.admin',
+              'bosh.read',
+              'bosh.teams.anything.read',
+              'bosh.fake-director-uuid.read',
+              'bosh.unexpected-uuid.read',
+              'bosh.teams.security.unexpected',
+            ])).to eq(false)
+          end
+        end
+
         describe 'checking for list_tasks rights' do
           let(:acl_right) { :list_tasks }
           it_behaves_like :admin_read_team_admin_scopes
@@ -372,6 +433,78 @@ module Bosh::Director
             }.to raise_error ArgumentError, "Unexpected permission for deployment: #{acl_right}"
           end
         end
+      end
+
+      describe 'config' do
+          let(:acl_subject) {
+            team = Models::Team.make(name: 'security')
+
+            Models::Config.make(
+              content: 'some-yaml',
+              created_at: Time.now - 3.days,
+              team_id: team.id.to_s
+            )
+          }
+
+          describe 'admin rights' do
+            let(:acl_right) { :admin }
+
+            it 'allows global scopes' do
+              expect(subject.is_granted?(acl_subject, acl_right, [ 'bosh.admin' ])).to eq(true)
+            end
+
+            it 'allows director-specific scopes' do
+              expect(subject.is_granted?(acl_subject, acl_right, [ 'bosh.fake-director-uuid.admin' ])).to eq(true)
+            end
+
+            it 'allows team scope' do
+              expect(subject.is_granted?(acl_subject, acl_right, [ 'bosh.teams.security.admin' ])).to eq(true)
+            end
+
+            it 'denies others' do
+              expect(subject.is_granted?(acl_subject, acl_right, [
+                'bosh.unexpected-uuid.admin',   # other director-specific admin scope
+                'bosh.teams.fraud.admin',       # unrelated team specific admins
+                'bosh.teams.security.haha',     # team specific unsupported scope
+              ])).to eq(false)
+            end
+          end
+
+          describe 'read rights' do
+            let(:acl_right) { :read }
+
+            it 'allows global admin scope' do
+              expect(subject.is_granted?(acl_subject, acl_right, [ 'bosh.admin' ])).to eq(true)
+            end
+
+            it 'allows global read scope' do
+              expect(subject.is_granted?(acl_subject, acl_right, [ 'bosh.read' ])).to eq(true)
+            end
+
+            it 'allows director-specific admin scope' do
+              expect(subject.is_granted?(acl_subject, acl_right, [ 'bosh.fake-director-uuid.admin' ])).to eq(true)
+            end
+
+            it 'allows director-specific read scope' do
+              expect(subject.is_granted?(acl_subject, acl_right, [ 'bosh.fake-director-uuid.read' ])).to eq(true)
+            end
+
+            it 'allows team scope' do
+              expect(subject.is_granted?(acl_subject, acl_right, [ 'bosh.teams.security.admin' ])).to eq(true)
+            end
+
+            it 'allows team scope' do
+              expect(subject.is_granted?(acl_subject, acl_right, [ 'bosh.teams.security.read' ])).to eq(true)
+            end
+
+            it 'denies others' do
+              expect(subject.is_granted?(acl_subject, acl_right, [
+                'bosh.unexpected-uuid.admin',   # other director-specific admin scope
+                'bosh.teams.fraud.admin',       # unrelated team specific admins
+                'bosh.teams.security.haha',     # team specific unsupported scope
+              ])).to eq(false)
+            end
+          end
       end
 
       describe 'unexpected subject' do

--- a/src/spec/gocli/integration/cli_configs_spec.rb
+++ b/src/spec/gocli/integration/cli_configs_spec.rb
@@ -80,6 +80,73 @@ describe 'cli configs', type: :integration do
     end
   end
 
+  context 'when teams are used' do
+    with_reset_sandbox_before_each(user_authentication: 'uaa')
+
+    let(:production_env) {{'BOSH_CLIENT' => 'production_team', 'BOSH_CLIENT_SECRET' => 'secret'}}
+    let(:admin_env) {{'BOSH_CLIENT' => 'test', 'BOSH_CLIENT_SECRET' => 'secret'}}
+    let(:team_read_env){{'BOSH_CLIENT' => 'team-client-read-access', 'BOSH_CLIENT_SECRET' => 'team-secret'}}
+    let(:team_admin_env){{'BOSH_CLIENT' => 'team-client', 'BOSH_CLIENT_SECRET' => 'team-secret'}}
+
+    it 'shows configs of the same team only' do
+      bosh_runner.run("update-config production-type #{config.path}", client: production_env['BOSH_CLIENT'], client_secret: production_env['BOSH_CLIENT_SECRET'])
+      bosh_runner.run("update-config team-type #{config.path}", client: team_admin_env['BOSH_CLIENT'], client_secret: team_admin_env['BOSH_CLIENT_SECRET'])
+
+      production_configs = table(bosh_runner.run('configs', json: true, client: production_env['BOSH_CLIENT'],
+        client_secret: production_env['BOSH_CLIENT_SECRET']))
+      expect(production_configs.length).to eq(1)
+      expect(production_configs).to contain_exactly({'name'=>'default', 'teams'=>'', 'type'=>'production-type'})
+
+      team_configs = table(bosh_runner.run('configs', json: true, client: team_read_env['BOSH_CLIENT'],
+        client_secret: team_read_env['BOSH_CLIENT_SECRET']))
+      expect(team_configs.length).to eq(1)
+      expect(team_configs).to contain_exactly({'name'=>'default', 'teams'=>'', 'type'=>'team-type'})
+    end
+
+    it 'shows teams only for admin' do
+      bosh_runner.run("update-config production-type #{config.path}", client: production_env['BOSH_CLIENT'], client_secret: production_env['BOSH_CLIENT_SECRET'])
+      bosh_runner.run("update-config team-type #{config.path}", client: team_admin_env['BOSH_CLIENT'], client_secret: team_admin_env['BOSH_CLIENT_SECRET'])
+
+      configs = table(bosh_runner.run('configs', json: true, client: admin_env['BOSH_CLIENT'],
+        client_secret: admin_env['BOSH_CLIENT_SECRET']))
+      expect(configs.length).to eq(2)
+
+      expect(configs).to contain_exactly(
+        {"name"=>"default", "teams"=>"production_team", "type"=>"production-type"},
+        {"name"=>"default", "teams"=>"ateam", "type"=>"team-type"})
+
+      configs = table(bosh_runner.run('configs', json: true, client: team_admin_env['BOSH_CLIENT'],
+        client_secret: team_admin_env['BOSH_CLIENT_SECRET']))
+
+      expect(configs).to contain_exactly({'name'=>'default', 'teams'=>'', 'type'=>'team-type'})
+    end
+
+    it 'allows to create/delete team only for admin or team admin' do
+      output = bosh_runner.run("update-config team-type #{config.path}", failure_expected: true, client: team_read_env['BOSH_CLIENT'], client_secret: team_read_env['BOSH_CLIENT_SECRET'])
+      expect(output).to include('Retry: Post')
+
+      bosh_runner.run("update-config team-type --name=team-name1 #{config.path}", client: team_admin_env['BOSH_CLIENT'], client_secret: team_admin_env['BOSH_CLIENT_SECRET'])
+      bosh_runner.run("update-config team-type --name=team-name2 #{config.path}", client: team_admin_env['BOSH_CLIENT'], client_secret: team_admin_env['BOSH_CLIENT_SECRET'])
+
+      admin_configs = table(bosh_runner.run('configs', json: true, client: team_admin_env['BOSH_CLIENT'], client_secret: team_admin_env['BOSH_CLIENT_SECRET']))
+      expect(admin_configs.length).to eq(2)
+
+      expect(admin_configs).to contain_exactly(
+        {'name'=>'team-name1', 'teams'=>'', 'type'=>'team-type'},
+        {'name'=>'team-name2', 'teams'=>'', 'type'=>'team-type'}
+      )
+
+      output = bosh_runner.run("delete-config team-type --name=team-name1", failure_expected: true, client: team_read_env['BOSH_CLIENT'], client_secret: team_read_env['BOSH_CLIENT_SECRET'])
+      expect(output).to include('Require one of the scopes: bosh.admin, bosh.deadbeef.admin')
+
+      expect(bosh_runner.run('delete-config team-type --name=team-name1', client: admin_env['BOSH_CLIENT'], client_secret: admin_env['BOSH_CLIENT_SECRET'])).to include('Succeeded')
+      expect(bosh_runner.run('delete-config team-type --name=team-name2', client: team_admin_env['BOSH_CLIENT'], client_secret: team_admin_env['BOSH_CLIENT_SECRET'])).to include('Succeeded')
+
+      admin_configs = table(bosh_runner.run('configs', json: true, client: admin_env['BOSH_CLIENT'], client_secret: admin_env['BOSH_CLIENT_SECRET']))
+      expect(admin_configs.length).to eq(0)
+    end
+  end
+
   context 'can diff configs' do
     let(:other_config) {yaml_file('config.yml', Bosh::Spec::Deployments.manifest_errand_with_placeholders)}
 

--- a/src/spec/gocli/integration/cli_runtime_config_spec.rb
+++ b/src/spec/gocli/integration/cli_runtime_config_spec.rb
@@ -152,7 +152,7 @@ describe 'cli runtime config', type: :integration do
     configs = output['Tables'].first['Rows']
 
     expect(configs.count).to eq (1)
-    expect(configs.first).to eq('name' => 'default', 'type' => 'runtime')
+    expect(configs.first).to eq('name' => 'default', 'type' => 'runtime', 'teams' => '')
   end
 
   it 'shows no diff when uploading same unnamed runtime config as with generic config command' do


### PR DESCRIPTION
…s are affected by them (can see, can update, can list)

- admin and team admin can create/delete new configs
- admin, reader, team admin and team reader can list configs
- team admin and team reader can list only congis of the corresponding team
- admin can see teams for each config
- so far each config has information only about one team

[#154135425](https://www.pivotaltracker.com/story/show/154135425)

Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>