### PR TITLE
cloud_factory only parses azs

### DIFF
--- a/src/bosh-director/lib/bosh/director/cloud_factory.rb
+++ b/src/bosh-director/lib/bosh/director/cloud_factory.rb
@@ -1,6 +1,5 @@
 # Cloud factory looks up and instantiates clouds, either taken from the director config or from the cpi config.
 # To achieve this, it uses the parsed cpis from the cpi config.
-# For lookup based on availability zone, it additionally needs the cloud planner which contains the AZ -> CPI mapping from the cloud config.
 require 'bosh/director/validation_helper'
 
 module Bosh::Director
@@ -36,14 +35,6 @@ module Bosh::Director
       manifest_parser.parse(merged_cpi_configs_hash)
     end
 
-    def self.create_cloud_planner(cloud_configs, deployment_name = nil)
-      return nil unless CloudConfig::CloudConfigsConsolidator.have_cloud_configs?(cloud_configs)
-
-      global_network_resolver = DeploymentPlan::NullGlobalNetworkResolver.new
-      parser = DeploymentPlan::CloudManifestParser.new(Config.logger)
-      parser.parse(Api::CloudConfigManager.interpolated_manifest(cloud_configs, deployment_name), global_network_resolver, nil)
-    end
-
     def self.create_azs(cloud_configs, deployment_name = nil)
       return nil unless CloudConfig::CloudConfigsConsolidator.have_cloud_configs?(cloud_configs)
 
@@ -51,6 +42,8 @@ module Bosh::Director
       azs = Bosh::Director::DeploymentPlan::AvailabilityZone.parse(interpolated)
       Bosh::Director::DeploymentPlan::CloudPlanner.index_by_name(azs)
     end
+
+    private_class_method :create_azs
 
     def initialize(azs, parsed_cpi_config)
       @azs = azs

--- a/src/bosh-director/lib/bosh/director/deployment_plan/availability_zone.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/availability_zone.rb
@@ -3,13 +3,22 @@ module Bosh::Director
     class AvailabilityZone
       extend ValidationHelper
 
-      def self.parse(availability_zone_spec)
+      def self.parse(cloud_config)
+        azs = safe_property(cloud_config, 'azs', :class => Array, :optional => true, :default => [])
+        azs.map do |az|
+          parse_single(az)
+        end
+      end
+
+      def self.parse_single(availability_zone_spec)
         name = safe_property(availability_zone_spec, 'name', class: String)
         cloud_properties = safe_property(availability_zone_spec, 'cloud_properties', class: Hash, default: {})
         cpi = safe_property(availability_zone_spec, 'cpi', class: String, optional: true)
 
         new(name, cloud_properties, cpi)
       end
+
+      private_class_method :parse_single
 
       def initialize(name, cloud_properties, cpi=nil)
         @name = name

--- a/src/bosh-director/lib/bosh/director/deployment_plan/cloud_manifest_parser.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/cloud_manifest_parser.rb
@@ -35,10 +35,7 @@ module Bosh::Director
       private
 
       def parse_availability_zones(cloud_manifest)
-        availability_zones = safe_property(cloud_manifest, 'azs', :class => Array, :optional => true, :default => [])
-        parsed_availability_zones = availability_zones.map do |availability_zone|
-          AvailabilityZone.parse(availability_zone)
-        end
+        parsed_availability_zones = AvailabilityZone.parse(cloud_manifest)
 
         duplicates = detect_duplicates(parsed_availability_zones) { |az| az.name }
         unless duplicates.empty?


### PR DESCRIPTION
- Instead of parsing the whole cloud config cloud_factory
now parses only the azs, because only the azs are needed.
Especially network parsing was very expensive.

(#153991487)[https://www.pivotaltracker.com/story/show/153991487]

Co-authored-by: Felix Riegger <felix.riegger@sap.com>
Co-authored-by: Florian Nachtigall <florian.nachtigall@sap.com>
Co-authored-by: Sebastian Heid <sebastian.heid@sap.com>