### PR TITLE
cloud_factory only parses azs

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/cloud_manifest_parser.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/cloud_manifest_parser.rb
@@ -32,8 +32,6 @@ module Bosh::Director
         })
       end
 
-      private
-
       def parse_availability_zones(cloud_manifest)
         availability_zones = safe_property(cloud_manifest, 'azs', :class => Array, :optional => true, :default => [])
         parsed_availability_zones = availability_zones.map do |availability_zone|
@@ -47,6 +45,8 @@ module Bosh::Director
 
         parsed_availability_zones
       end
+
+      private
 
       def parse_networks(cloud_manifest, global_network_resolver, availability_zones)
         networks = safe_property(cloud_manifest, 'networks', :class => Array)


### PR DESCRIPTION
Instead of parsing the whole cloud config, cloud_factory
now parses only the azs, because only the azs are needed.
Especially network parsing was very expensive.

[#153991487](https://www.pivotaltracker.com/story/show/153991487)

This is a follow up to https://github.com/cloudfoundry/bosh/pull/1892.

@dpb587-pivotal, thanks for your feedback.
We came up with this new PR.
Would you mind having a look at this one and merge it if it's okay from your point of view?