### PR TITLE
Remove caches from DnsEncoder in favor of DB

### DIFF
--- a/src/bosh-director/lib/bosh/director/dns/dns_encoder.rb
+++ b/src/bosh-director/lib/bosh/director/dns/dns_encoder.rb
@@ -1,11 +1,9 @@
 module Bosh::Director
   class DnsEncoder
-    def initialize(service_groups={}, az_hash={}, network_name_hash={}, instance_uuid_num_hash={}, short_dns_enabled=false)
+    def initialize(service_groups={}, az_hash={}, short_dns_enabled=false)
       @az_hash = az_hash
       @service_groups = service_groups
       @short_dns_enabled = short_dns_enabled
-      @network_name_hash = network_name_hash
-      @instance_uuid_num_hash = instance_uuid_num_hash
     end
 
     def encode_query(criteria)
@@ -42,7 +40,7 @@ module Bosh::Director
         return nil
       end
 
-      index = @instance_uuid_num_hash[uuid]
+      index = Models::Instance.where(uuid: uuid).get(:id)
       raise RuntimeError.new("Unknown instance UUID: '#{uuid}'") if index.nil?
       "#{index}"
     end
@@ -51,7 +49,7 @@ module Bosh::Director
       if network_name.nil?
         return nil
       end
-      index = @network_name_hash[network_name]
+      index = Models::LocalDnsEncodedNetwork.where(name: network_name).get(:id)
       raise RuntimeError.new("Unknown Network: '#{network_name}'") if index.nil?
       "#{index}"
     end

--- a/src/bosh-director/lib/bosh/director/dns/local_dns_encoder_manager.rb
+++ b/src/bosh-director/lib/bosh/director/dns/local_dns_encoder_manager.rb
@@ -13,16 +13,7 @@ module Bosh::Director
     end
 
     def self.create_dns_encoder(use_short_dns_names)
-      az_hash = {}
-      network_name_hash = {}
-
-      Models::LocalDnsEncodedAz.all.each do |item|
-        az_hash[item.name] = item.id.to_s
-      end
-
-      Models::LocalDnsEncodedNetwork.all.each do |item|
-        network_name_hash[item.name] = item.id.to_s
-      end
+      az_hash = Models::LocalDnsEncodedAz.as_hash(:name, :id)
 
       service_groups = {}
       Bosh::Director::Models::LocalDnsEncodedInstanceGroup.
@@ -38,12 +29,7 @@ module Bosh::Director
         }] = join_row[:id].to_s
       end
 
-      instance_uuids = {}
-      Bosh::Director::Models::Instance.each do |i|
-        instance_uuids[i.uuid] = i.id
-      end
-
-      Bosh::Director::DnsEncoder.new(service_groups, az_hash, network_name_hash, instance_uuids, use_short_dns_names)
+      Bosh::Director::DnsEncoder.new(service_groups, az_hash, use_short_dns_names)
     end
 
     def self.new_encoder_with_updated_index(plan)

--- a/src/bosh-director/spec/blueprints.rb
+++ b/src/bosh-director/spec/blueprints.rb
@@ -251,6 +251,11 @@ module Bosh::Director::Models
     version      { 1 }
   end
 
+  LocalDnsEncodedNetwork.blueprint do
+    id { 1 }
+    name { 'fake-network-1' }
+  end
+
   LocalDnsRecord.blueprint do
     ip          { Sham.ip }
     instance_id { Sham.instance_id }

--- a/src/bosh-director/spec/unit/dns/blobstore_dns_publisher_spec.rb
+++ b/src/bosh-director/spec/unit/dns/blobstore_dns_publisher_spec.rb
@@ -10,7 +10,6 @@ module Bosh::Director
           {instance_group: 'instance4', deployment: 'test-deployment'} => '4',
           {instance_group: 'instance2', deployment: 'test-deployment'} => '2'},
         { 'az1' => '1', 'az2' => '2'},
-        { 'net-name1' => 1, 'net-name2' => 2, 'net-name3' => 3}
       )
     end
     let(:blobstore) {  instance_double(Bosh::Blobstore::S3cliBlobstoreClient) }
@@ -24,6 +23,9 @@ module Bosh::Director
     let(:instance1) { Models::Instance.make(uuid: 'uuid1', index: 1) }
 
     before do
+      Models::LocalDnsEncodedNetwork.make(id: 1, name: 'net-name1')
+      Models::LocalDnsEncodedNetwork.make(id: 2, name: 'net-name2')
+      Models::LocalDnsEncodedNetwork.make(id: 3, name: 'net-name3')
       allow(Config).to receive(:root_domain).and_return(domain_name)
       allow(Config).to receive(:local_dns_include_index?).and_return(false)
       allow(agent_broadcaster).to receive(:sync_dns)

--- a/src/bosh-director/spec/unit/dns/dns_encoder_spec.rb
+++ b/src/bosh-director/spec/unit/dns/dns_encoder_spec.rb
@@ -2,13 +2,12 @@ require 'spec_helper'
 
 module Bosh::Director
   describe DnsEncoder do
-    subject { described_class.new(service_groups, az_hash, network_name_hash, instance_uuid_num_hash, short_dns_enabled) }
+    subject { described_class.new(service_groups, az_hash, short_dns_enabled) }
     let(:az_hash) {}
-    let(:network_name_hash) { {default_network => '1'} }
-    let(:instance_uuid_num_hash) { {'uuid-1' => '1'} }
     let(:short_dns_enabled) { false }
     let(:instance_group) { 'potato-group' }
     let(:default_network) { 'potato-net' }
+    let(:default_network_id) { 1 }
     let(:deployment_name) { 'fake-deployment' }
     let(:root_domain) { 'sub.bosh' }
     let(:specific_query) { {} }
@@ -29,6 +28,11 @@ module Bosh::Director
         deployment:     'fake-deployment',
       } => 7,
     }}
+
+    before(:each) do
+      Models::LocalDnsEncodedNetwork.make(id: default_network_id, name: default_network)
+      Models::Instance.make(id: 1, uuid: 'uuid-1')
+    end
 
     describe '#encode_query' do
       context 'no filters' do
@@ -127,8 +131,12 @@ module Bosh::Director
         end
 
         describe 'encoding network filter' do
-          let(:network_name_hash) { {'network1' => '4', 'network2' => '3'} }
           let(:default_network) { 'network1' }
+          let(:default_network_id) { 4 }
+          before(:each) do
+            Models::LocalDnsEncodedNetwork.make(id: 3, name: 'network2')
+          end
+
           context 'default_network is set' do
             it 'includes an n# code' do
               expect(subject.encode_query(criteria)).to eq('q-n4s0.q-g3.sub.bosh')
@@ -167,11 +175,13 @@ module Bosh::Director
     end
 
     describe '#num_for_uuid' do
-      let(:instance_uuid_num_hash) { { 'uuid1' => '1', 'uuid2' => '2' } }
+      before(:each) do
+        Models::Instance.make(id: 2, uuid: 'uuid-2')
+      end
 
       it 'matches if found' do
-        expect(subject.num_for_uuid('uuid1')).to eq('1')
-        expect(subject.num_for_uuid('uuid2')).to eq('2')
+        expect(subject.num_for_uuid('uuid-1')).to eq('1')
+        expect(subject.num_for_uuid('uuid-2')).to eq('2')
       end
 
       it 'raises exception if not found' do
@@ -205,11 +215,14 @@ module Bosh::Director
     end
 
     describe '#id_for_network' do
-      let(:network_name_hash) { { 'nw1' => '1', 'nw2' => '2' } }
+      before(:each) do
+        Models::LocalDnsEncodedNetwork.make(id: 10, name: 'nw1')
+        Models::LocalDnsEncodedNetwork.make(id: 20, name: 'nw2')
+      end
 
       it 'matches if found' do
-        expect(subject.id_for_network('nw1')).to eq('1')
-        expect(subject.id_for_network('nw2')).to eq('2')
+        expect(subject.id_for_network('nw1')).to eq('10')
+        expect(subject.id_for_network('nw2')).to eq('20')
       end
 
       it 'raises exception if not found' do

--- a/src/bosh-director/spec/unit/dns/dns_records_spec.rb
+++ b/src/bosh-director/spec/unit/dns/dns_records_spec.rb
@@ -14,6 +14,12 @@ module Bosh::Director
     let(:dns_encoder) { DnsEncoder.new(groups_hash, az_hash, network_name_hash) }
     let(:dns_records) { DnsRecords.new(version, include_index_records, dns_encoder) }
 
+    before(:each) do
+      network_name_hash.each do |name, id|
+        Models::LocalDnsEncodedNetwork.make(id: id, name: name)
+      end
+    end
+
     describe '#to_json' do
       context 'with records' do
         before do


### PR DESCRIPTION
DnsEncoder is instantiated often. Creating it once and passing it along,
via InstancePlan, as discussed in #1847, does not work. This is because it needs to get updated, i.e.
after instance creation.

Therefore we removed two of the caches, 'Instance uuid to name' and the one
for 'network name to id'. Thus we avoid two full table scans on every
instantiation.

[#153991487](https://www.pivotaltracker.com/story/show/153991487)

There are some numbers on the time it takes with and without the cache in the tracker story.