### PR TITLE
Support specification of multiple include and exclude rules on addons

### DIFF
--- a/src/bosh-director/lib/bosh/director/errors.rb
+++ b/src/bosh-director/lib/bosh/director/errors.rb
@@ -306,6 +306,7 @@ module Bosh::Director
   AddonIncompleteFilterStemcellSection = err(530005)
   AddonDeploymentFilterNotAllowed = err(530006)
   RuntimeConfigParseError = err(530006)
+  AddonSingleAndArrayFilter = err(530007)
 
   # Config server errors
   ConfigServerFetchError = err(540001)

--- a/src/spec/support/deployments.rb
+++ b/src/spec/support/deployments.rb
@@ -278,21 +278,72 @@ module Bosh::Spec
       })
     end
 
-    def self.runtime_config_with_addon_excludes
-      runtime_config_with_addon.merge({
+    def self.runtime_config_with_addon_includes_section
+      runtime_config_with_addon.merge(
         'addons' => [
           {
             'name' => 'addon1',
-            'jobs' => [{'name' => 'dummy_with_properties', 'release' => 'dummy2'}],
-            'properties' => {'dummy_with_properties' => {'echo_value' => 'prop_value'}},
+            'jobs' => [
+              { 'name' => 'dummy_with_properties', 'release' => 'dummy2' },
+            ],
+            'properties' => { 'dummy_with_properties' => { 'echo_value' => 'prop_value' } },
+            'includes' => [
+              {
+                'deployments' => ['dep2'],
+              },
+              {
+                'jobs' => [
+                  { 'name' => 'foobar', 'release' => 'bosh-release' },
+                ],
+              },
+            ],
+          },
+        ],
+      )
+    end
+
+    def self.runtime_config_with_addon_excludes_section
+      runtime_config_with_addon.merge(
+        'addons' => [
+          {
+            'name' => 'addon1',
+            'jobs' => [
+              { 'name' => 'dummy_with_properties', 'release' => 'dummy2' },
+            ],
+            'properties' => { 'dummy_with_properties' => { 'echo_value' => 'prop_value' } },
+            'excludes' => [
+              {
+                'deployments' => ['dep2'],
+              },
+              {
+                'jobs' => [
+                  { 'name' => 'foobar', 'release' => 'bosh-release' },
+                ],
+              },
+            ],
+          },
+        ],
+      )
+    end
+
+    def self.runtime_config_with_addon_excludes
+      runtime_config_with_addon.merge(
+        'addons' => [
+          {
+            'name' => 'addon1',
+            'jobs' => [
+              { 'name' => 'dummy_with_properties', 'release' => 'dummy2' },
+            ],
+            'properties' => { 'dummy_with_properties' => { 'echo_value' => 'prop_value' } },
             'exclude' => {
               'deployments' => ['dep1'],
               'jobs' => [
-                {'name'=> 'foobar', 'release' => 'bosh-release'}
-              ]
-            }
-          }]
-        })
+                { 'name' => 'foobar', 'release' => 'bosh-release' },
+              ],
+            },
+          },
+        ],
+      )
     end
 
     def self.runtime_config_with_addon_includes_stemcell_os


### PR DESCRIPTION
- includes and excludes sections can be specified with OR condition for subsections
- includes cannot exist with include
- excludes cannot exist with exclude

[#155198006](https://www.pivotaltracker.com/story/show/155198006)
Signed-off-by: Konstantin Maksimov <kmaksimov@ru.ibm.com>