### PR TITLE
Add logging around running a single Agenda in StepExecutor

### DIFF
--- a/src/bosh-director/lib/bosh/director/step_executor.rb
+++ b/src/bosh-director/lib/bosh/director/step_executor.rb
@@ -34,7 +34,10 @@ module Bosh::Director
     def run_agenda(agenda)
       @logger.info(agenda.info)
       agenda.steps.each do |step|
+        start_time = Time.now
+        @logger.debug("Agenda step #{step.class} started at: #{start_time}")
         step.perform(agenda.report)
+        @logger.debug("Agenda step #{step.class} finished after #{Time.now - start_time}s")
       end
     end
   end


### PR DESCRIPTION
To debug performance issues in production it might be useful to look at the run times of individual agenda steps.

If that is too much logging, is there a good way to make it configurable?