### PR TITLE
Copy size and cloud properties to new disk

### DIFF
--- a/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
@@ -17,6 +17,8 @@ module Bosh::Director
         @job_name = job_name
         @instance_id = instance_id
         @disk_cid = disk_cid
+        @size = 1
+        @cloud_properties = {}
         @transactor = Transactor.new
         @disk_manager = DiskManager.new(logger)
         @orphan_disk_manager = OrphanDiskManager.new(logger)
@@ -58,6 +60,8 @@ module Bosh::Director
       def handle_previous_disk(instance)
         previous_persistent_disk = instance.managed_persistent_disk
         previous_persistent_disk.update(active: false)
+        @size = previous_persistent_disk.size
+        @cloud_properties = previous_persistent_disk.cloud_properties
 
         if instance.state == 'stopped'
           @disk_manager.detach_disk(previous_persistent_disk)
@@ -71,7 +75,7 @@ module Bosh::Director
         if orphan_disk
           disk = @orphan_disk_manager.unorphan_disk(orphan_disk, instance.id)
         else
-          disk = Models::PersistentDisk.create(disk_cid: @disk_cid, instance_id: instance.id, active: true, size: 1, cloud_properties: {})
+          disk = Models::PersistentDisk.create(disk_cid: @disk_cid, instance_id: instance.id, active: true, size: @size, cloud_properties: @cloud_properties)
         end
 
         if instance.state == 'stopped'

--- a/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
@@ -50,7 +50,8 @@ module Bosh::Director
             disk_cid: 'original-disk-cid',
             instance_id: instance_model.id,
             active: true,
-            size: 50)
+            size: 50,
+            cloud_properties: { "encrypted" => true })
         end
 
         it 'attaches the disk' do
@@ -60,10 +61,11 @@ module Bosh::Director
           expect(active_disks.first.disk_cid).to eq(disk_cid)
         end
 
-        it 'sets the disk size to 1 so it is migrated to the desired size next deploy' do
+        it 'sets the disk size and cloud_properties to that of previous persistent disk' do
           attach_disk_job.perform
           active_disks = instance_model.persistent_disks.select { |disk| disk.active }
-          expect(active_disks.first.size).to eq(1)
+          expect(active_disks.first.size).to eq(50)
+          expect(active_disks.first.cloud_properties).to eq({ "encrypted" => true })
         end
 
         it 'marks the pre existing active persistent disk as inactive and orphans it' do


### PR DESCRIPTION
Set PersistentDisk with the actual size of the disk attached.
Also update the cloud properties as reported by the cpi.
This prevents unnecessary copy of disk after a disk attach.

Issue: cloudfoundry/bosh#1900