### PR TITLE
Lock releases individually to reduce lock contention on deploy

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
@@ -97,8 +97,8 @@ module Bosh::Director
     # @return [void]
     def bind_releases
       releases = @deployment_plan.releases
-      with_release_locks(releases.map(&:name)) do
-        releases.each do |release|
+      releases.each do |release|
+        with_release_lock(release.name) do
           release.bind_model
         end
       end

--- a/src/bosh-director/lib/bosh/director/deployment_plan/stages/package_compile_stage.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/stages/package_compile_stage.rb
@@ -115,7 +115,6 @@ module Bosh::Director
 
               @counter_mutex.synchronize { @compilations_performed += 1 }
             end
-
             task.use_compiled_package(compiled_package)
           end
         end

--- a/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
@@ -66,7 +66,8 @@ module Bosh::Director
         expect(r1).to receive(:bind_templates)
         expect(r2).to receive(:bind_templates)
 
-        expect(assembler).to receive(:with_release_locks).with(['r1', 'r2']).and_yield
+        expect(assembler).to receive(:with_release_lock).with('r1').and_yield
+        expect(assembler).to receive(:with_release_lock).with('r2').and_yield
         assembler.bind_models
       end
 


### PR DESCRIPTION
We're seeing a number of deployment failures when we make several deployments simultaneously if those deployments all consume the same release, along the lines of:

`Error: Failed to acquire lock for lock:release:consul`

We believe that locking releases individually during `bind_model` will reduce the contention on these locks.

Thanks!

@henryaj and @tinygrasshopper