### PR TITLE
Enable trim mode (<% -%>) for Template.render

### DIFF
--- a/src/bosh-template/lib/bosh/template/test/template.rb
+++ b/src/bosh-template/lib/bosh/template/test/template.rb
@@ -19,7 +19,7 @@ module Bosh::Template
 
         binding = Bosh::Template::EvaluationContext.new(sanitized_hash_with_spec, nil).get_binding
         raise "No such file at #{@template_path}" unless File.exist?(@template_path)
-        ERB.new(File.read(@template_path)).result(binding)
+        ERB.new(File.read(@template_path), safe_level = nil, trim_mode = "-").result(binding)
       end
 
       private


### PR DESCRIPTION
Enable trim mode for BOSH ERB templating if Template.render is been used.