### PR TITLE
Test ERB rendered should set `trim_mode'

### DIFF
--- a/src/bosh-template/lib/bosh/template/test/template.rb
+++ b/src/bosh-template/lib/bosh/template/test/template.rb
@@ -19,7 +19,7 @@ module Bosh::Template
 
         binding = Bosh::Template::EvaluationContext.new(sanitized_hash_with_spec, nil).get_binding
         raise "No such file at #{@template_path}" unless File.exist?(@template_path)
-        ERB.new(File.read(@template_path), nil, '-').result(binding)
+        ERB.new(File.read(@template_path), safe_level = nil, trim_mode = '-').result(binding)
       end
 
       private

--- a/src/bosh-template/lib/bosh/template/test/template.rb
+++ b/src/bosh-template/lib/bosh/template/test/template.rb
@@ -19,7 +19,7 @@ module Bosh::Template
 
         binding = Bosh::Template::EvaluationContext.new(sanitized_hash_with_spec, nil).get_binding
         raise "No such file at #{@template_path}" unless File.exist?(@template_path)
-        ERB.new(File.read(@template_path)).result(binding)
+        ERB.new(File.read(@template_path), nil, '-').result(binding)
       end
 
       private

--- a/src/bosh-template/spec/assets/template-test-release/jobs/web-server/templates/config-with-nested.erb
+++ b/src/bosh-template/spec/assets/template-test-release/jobs/web-server/templates/config-with-nested.erb
@@ -6,4 +6,4 @@
 
   require 'json'
   JSON.dump(config)
-%>
+-%>

--- a/src/bosh-template/spec/assets/template-test-release/jobs/web-server/templates/config.erb
+++ b/src/bosh-template/spec/assets/template-test-release/jobs/web-server/templates/config.erb
@@ -29,4 +29,4 @@
 
   require 'json'
   JSON.dump(config)
-%>
+-%>


### PR DESCRIPTION
* Test template renderer now sets trim_mode to `-` in line with default
BOSH template renderer