### PR TITLE
Add flag to copy previous values

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
@@ -13,7 +13,7 @@ module Bosh::Director
       put '/:disk_cid/attachments' do
         deployment = Api::DeploymentManager.new.find_by_name(params[:deployment])
         job_queue = JobQueue.new
-        task = Bosh::Director::Jobs::AttachDisk.enqueue(current_user, deployment, params[:job], params[:instance_id], params[:disk_cid], params[:disk_properties] || 'default' , job_queue)
+        task = Bosh::Director::Jobs::AttachDisk.enqueue(current_user, deployment, params[:job], params[:instance_id], params[:disk_cid], params[:disk_properties], job_queue)
 
         redirect "/tasks/#{task.id}"
       end

--- a/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
@@ -13,7 +13,7 @@ module Bosh::Director
       put '/:disk_cid/attachments' do
         deployment = Api::DeploymentManager.new.find_by_name(params[:deployment])
         job_queue = JobQueue.new
-        task = Bosh::Director::Jobs::AttachDisk.enqueue(current_user, deployment, params[:job], params[:instance_id], params[:disk_cid], job_queue)
+        task = Bosh::Director::Jobs::AttachDisk.enqueue(current_user, deployment, params[:job], params[:instance_id], params[:disk_cid], params[:copy_previous] == 'true' , job_queue)
 
         redirect "/tasks/#{task.id}"
       end

--- a/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
@@ -13,7 +13,7 @@ module Bosh::Director
       put '/:disk_cid/attachments' do
         deployment = Api::DeploymentManager.new.find_by_name(params[:deployment])
         job_queue = JobQueue.new
-        task = Bosh::Director::Jobs::AttachDisk.enqueue(current_user, deployment, params[:job], params[:instance_id], params[:disk_cid], params[:copy_previous] == 'true' , job_queue)
+        task = Bosh::Director::Jobs::AttachDisk.enqueue(current_user, deployment, params[:job], params[:instance_id], params[:disk_cid], params[:copy] == 'true' , job_queue)
 
         redirect "/tasks/#{task.id}"
       end

--- a/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
@@ -13,7 +13,7 @@ module Bosh::Director
       put '/:disk_cid/attachments' do
         deployment = Api::DeploymentManager.new.find_by_name(params[:deployment])
         job_queue = JobQueue.new
-        task = Bosh::Director::Jobs::AttachDisk.enqueue(current_user, deployment, params[:job], params[:instance_id], params[:disk_cid], params[:copy] == 'true' , job_queue)
+        task = Bosh::Director::Jobs::AttachDisk.enqueue(current_user, deployment, params[:job], params[:instance_id], params[:disk_cid], params[:disk_properties] || 'default' , job_queue)
 
         redirect "/tasks/#{task.id}"
       end

--- a/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
@@ -8,16 +8,16 @@ module Bosh::Director
         :attach_disk
       end
 
-      def self.enqueue(username, deployment, job_name, instance_id, disk_cid, copy, job_queue)
-        job_queue.enqueue(username, Jobs::AttachDisk, "attach disk '#{disk_cid}' to '#{job_name}/#{instance_id}'", [deployment.name, job_name, instance_id, disk_cid, copy], deployment)
+      def self.enqueue(username, deployment, job_name, instance_id, disk_cid, disk_properties, job_queue)
+        job_queue.enqueue(username, Jobs::AttachDisk, "attach disk '#{disk_cid}' to '#{job_name}/#{instance_id}'", [deployment.name, job_name, instance_id, disk_cid, disk_properties], deployment)
       end
 
-      def initialize(deployment_name, job_name, instance_id, disk_cid, copy)
+      def initialize(deployment_name, job_name, instance_id, disk_cid, disk_properties)
         @deployment_name = deployment_name
         @job_name = job_name
         @instance_id = instance_id
         @disk_cid = disk_cid
-        @copy = copy
+        @disk_properties = disk_properties
         @size = 1
         @cloud_properties = {}
         @transactor = Transactor.new
@@ -61,7 +61,7 @@ module Bosh::Director
       def handle_previous_disk(instance)
         previous_persistent_disk = instance.managed_persistent_disk
         previous_persistent_disk.update(active: false)
-        if @copy == true
+        if @disk_properties == "copy"
           @size = previous_persistent_disk.size
           @cloud_properties = previous_persistent_disk.cloud_properties
         end

--- a/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
@@ -8,16 +8,16 @@ module Bosh::Director
         :attach_disk
       end
 
-      def self.enqueue(username, deployment, job_name, instance_id, disk_cid, copy_previous, job_queue)
-        job_queue.enqueue(username, Jobs::AttachDisk, "attach disk '#{disk_cid}' to '#{job_name}/#{instance_id}'", [deployment.name, job_name, instance_id, disk_cid, copy_previous], deployment)
+      def self.enqueue(username, deployment, job_name, instance_id, disk_cid, copy, job_queue)
+        job_queue.enqueue(username, Jobs::AttachDisk, "attach disk '#{disk_cid}' to '#{job_name}/#{instance_id}'", [deployment.name, job_name, instance_id, disk_cid, copy], deployment)
       end
 
-      def initialize(deployment_name, job_name, instance_id, disk_cid, copy_previous)
+      def initialize(deployment_name, job_name, instance_id, disk_cid, copy)
         @deployment_name = deployment_name
         @job_name = job_name
         @instance_id = instance_id
         @disk_cid = disk_cid
-        @copy_previous = copy_previous
+        @copy = copy
         @size = 1
         @cloud_properties = {}
         @transactor = Transactor.new
@@ -61,7 +61,7 @@ module Bosh::Director
       def handle_previous_disk(instance)
         previous_persistent_disk = instance.managed_persistent_disk
         previous_persistent_disk.update(active: false)
-        if @copy_previous == true
+        if @copy == true
           @size = previous_persistent_disk.size
           @cloud_properties = previous_persistent_disk.cloud_properties
         end

--- a/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
@@ -8,15 +8,18 @@ module Bosh::Director
         :attach_disk
       end
 
-      def self.enqueue(username, deployment, job_name, instance_id, disk_cid, job_queue)
-        job_queue.enqueue(username, Jobs::AttachDisk, "attach disk '#{disk_cid}' to '#{job_name}/#{instance_id}'", [deployment.name, job_name, instance_id, disk_cid], deployment)
+      def self.enqueue(username, deployment, job_name, instance_id, disk_cid, copy_previous, job_queue)
+        job_queue.enqueue(username, Jobs::AttachDisk, "attach disk '#{disk_cid}' to '#{job_name}/#{instance_id}'", [deployment.name, job_name, instance_id, disk_cid, copy_previous], deployment)
       end
 
-      def initialize(deployment_name, job_name, instance_id, disk_cid)
+      def initialize(deployment_name, job_name, instance_id, disk_cid, copy_previous)
         @deployment_name = deployment_name
         @job_name = job_name
         @instance_id = instance_id
         @disk_cid = disk_cid
+        @copy_previous = copy_previous
+        @size = 1
+        @cloud_properties = {}
         @transactor = Transactor.new
         @disk_manager = DiskManager.new(logger)
         @orphan_disk_manager = OrphanDiskManager.new(logger)
@@ -58,6 +61,10 @@ module Bosh::Director
       def handle_previous_disk(instance)
         previous_persistent_disk = instance.managed_persistent_disk
         previous_persistent_disk.update(active: false)
+        if @copy_previous == true
+          @size = previous_persistent_disk.size
+          @cloud_properties = previous_persistent_disk.cloud_properties
+        end
 
         if instance.state == 'stopped'
           @disk_manager.detach_disk(previous_persistent_disk)
@@ -71,7 +78,7 @@ module Bosh::Director
         if orphan_disk
           disk = @orphan_disk_manager.unorphan_disk(orphan_disk, instance.id)
         else
-          disk = Models::PersistentDisk.create(disk_cid: @disk_cid, instance_id: instance.id, active: true, size: 1, cloud_properties: {})
+          disk = Models::PersistentDisk.create(disk_cid: @disk_cid, instance_id: instance.id, active: true, size: @size, cloud_properties: @cloud_properties)
         end
 
         if instance.state == 'stopped'

--- a/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
@@ -13,6 +13,7 @@ module Bosh::Director
     end
     let(:deployment_name) { 'fake_deployment_name' }
     let(:disk_cid) { 'fake_disk_cid' }
+    let(:copy_previous) { 'false' }
     let(:job_name) { 'job_name' }
     let(:instance_id) { 'fake_instance_id' }
     let(:event_manager) {Api::EventManager.new(true)}
@@ -27,12 +28,12 @@ module Bosh::Director
           'fake-username',
           Jobs::AttachDisk,
           "attach disk 'fake_disk_cid' to 'job_name/fake_instance_id'",
-          [deployment_name, job_name, instance_id, disk_cid], deployment)
-        Jobs::AttachDisk.enqueue('fake-username', deployment, job_name, instance_id, disk_cid, job_queue)
+          [deployment_name, job_name, instance_id, disk_cid, copy_previous], deployment)
+        Jobs::AttachDisk.enqueue('fake-username', deployment, job_name, instance_id, disk_cid, copy_previous, job_queue)
       end
     end
 
-    let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, disk_cid) }
+    let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, disk_cid, copy_previous) }
 
     describe '#perform' do
       let(:vm) { Models::Vm.make(cid: vm_cid, instance_id: instance_model.id) }
@@ -52,7 +53,8 @@ module Bosh::Director
             disk_cid: 'original-disk-cid',
             instance_id: instance_model.id,
             active: true,
-            size: 50)
+            size: 50,
+            cloud_properties: { "encrypted" => true })
         end
 
         it 'attaches the disk' do
@@ -82,8 +84,18 @@ module Bosh::Director
           expect(attach_disk_job.perform).to eq("attached disk 'fake_disk_cid' to 'job_name/fake_instance_id' in deployment 'fake_deployment_name'")
         end
 
+        context 'when copy_previous is set' do
+          let(:copy_previous) { true }
+          it 'sets the disk size and cloud_properties to that of previous persistent disk' do
+            attach_disk_job.perform
+            active_disks = instance_model.persistent_disks.select { |disk| disk.active }
+            expect(active_disks.first.size).to eq(50)
+            expect(active_disks.first.cloud_properties).to eq({ "encrypted" => true })
+          end
+        end
+
         context 'when the instance with the given instance id cannot be found' do
-          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, 'bogus', disk_cid) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, 'bogus', disk_cid, copy_previous) }
           it 'raises an error' do
             expect { attach_disk_job.perform }.to raise_error(AttachDiskErrorUnknownInstance,
                                                               "Instance 'job_name/bogus' in deployment 'fake_deployment_name' was not found")
@@ -91,7 +103,7 @@ module Bosh::Director
         end
 
         context 'when the instance with the given job name cannot be found' do
-          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, 'bogus', instance_id, disk_cid) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, 'bogus', instance_id, disk_cid, copy_previous) }
           it 'raises an error' do
             expect { attach_disk_job.perform }.to raise_error(AttachDiskErrorUnknownInstance,
                                                               "Instance 'bogus/fake_instance_id' in deployment 'fake_deployment_name' was not found")
@@ -99,7 +111,7 @@ module Bosh::Director
         end
 
         context 'when the instance with the given deployment name cannot be found' do
-          let(:attach_disk_job) { Jobs::AttachDisk.new('bogus', job_name, instance_id, disk_cid) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new('bogus', job_name, instance_id, disk_cid, copy_previous) }
           it 'raises an error' do
             expect { attach_disk_job.perform }.to raise_error(AttachDiskErrorUnknownInstance,
                                                               "Instance 'job_name/fake_instance_id' in deployment 'bogus' was not found")
@@ -160,7 +172,7 @@ module Bosh::Director
                 snapshot_created_at: Date.today)
           end
 
-          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, orphan_disk.disk_cid) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, orphan_disk.disk_cid, copy_previous) }
 
           before do
             attach_disk_job.perform

--- a/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
@@ -13,7 +13,7 @@ module Bosh::Director
     end
     let(:deployment_name) { 'fake_deployment_name' }
     let(:disk_cid) { 'fake_disk_cid' }
-    let(:copy) { 'false' }
+    let(:disk_properties) { 'default' }
     let(:job_name) { 'job_name' }
     let(:instance_id) { 'fake_instance_id' }
     let(:event_manager) {Api::EventManager.new(true)}
@@ -28,12 +28,12 @@ module Bosh::Director
           'fake-username',
           Jobs::AttachDisk,
           "attach disk 'fake_disk_cid' to 'job_name/fake_instance_id'",
-          [deployment_name, job_name, instance_id, disk_cid, copy], deployment)
-        Jobs::AttachDisk.enqueue('fake-username', deployment, job_name, instance_id, disk_cid, copy, job_queue)
+          [deployment_name, job_name, instance_id, disk_cid, disk_properties], deployment)
+        Jobs::AttachDisk.enqueue('fake-username', deployment, job_name, instance_id, disk_cid, disk_properties, job_queue)
       end
     end
 
-    let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, disk_cid, copy) }
+    let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, disk_cid, disk_properties) }
 
     describe '#perform' do
       let(:vm) { Models::Vm.make(cid: vm_cid, instance_id: instance_model.id) }
@@ -84,8 +84,8 @@ module Bosh::Director
           expect(attach_disk_job.perform).to eq("attached disk 'fake_disk_cid' to 'job_name/fake_instance_id' in deployment 'fake_deployment_name'")
         end
 
-        context 'when copy is set' do
-          let(:copy) { true }
+        context 'when disk_properties is set to copy' do
+          let(:disk_properties) { 'copy' }
           it 'sets the disk size and cloud_properties to that of previous persistent disk' do
             attach_disk_job.perform
             active_disks = instance_model.persistent_disks.select { |disk| disk.active }
@@ -95,7 +95,7 @@ module Bosh::Director
         end
 
         context 'when the instance with the given instance id cannot be found' do
-          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, 'bogus', disk_cid, copy) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, 'bogus', disk_cid, disk_properties) }
           it 'raises an error' do
             expect { attach_disk_job.perform }.to raise_error(AttachDiskErrorUnknownInstance,
                                                               "Instance 'job_name/bogus' in deployment 'fake_deployment_name' was not found")
@@ -103,7 +103,7 @@ module Bosh::Director
         end
 
         context 'when the instance with the given job name cannot be found' do
-          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, 'bogus', instance_id, disk_cid, copy) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, 'bogus', instance_id, disk_cid, disk_properties) }
           it 'raises an error' do
             expect { attach_disk_job.perform }.to raise_error(AttachDiskErrorUnknownInstance,
                                                               "Instance 'bogus/fake_instance_id' in deployment 'fake_deployment_name' was not found")
@@ -111,7 +111,7 @@ module Bosh::Director
         end
 
         context 'when the instance with the given deployment name cannot be found' do
-          let(:attach_disk_job) { Jobs::AttachDisk.new('bogus', job_name, instance_id, disk_cid, copy) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new('bogus', job_name, instance_id, disk_cid, disk_properties) }
           it 'raises an error' do
             expect { attach_disk_job.perform }.to raise_error(AttachDiskErrorUnknownInstance,
                                                               "Instance 'job_name/fake_instance_id' in deployment 'bogus' was not found")
@@ -172,7 +172,7 @@ module Bosh::Director
                 snapshot_created_at: Date.today)
           end
 
-          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, orphan_disk.disk_cid, copy) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, orphan_disk.disk_cid, disk_properties) }
 
           before do
             attach_disk_job.perform

--- a/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
@@ -13,7 +13,7 @@ module Bosh::Director
     end
     let(:deployment_name) { 'fake_deployment_name' }
     let(:disk_cid) { 'fake_disk_cid' }
-    let(:disk_properties) { 'default' }
+    let(:disk_properties) { '' }
     let(:job_name) { 'job_name' }
     let(:instance_id) { 'fake_instance_id' }
     let(:event_manager) {Api::EventManager.new(true)}
@@ -94,8 +94,8 @@ module Bosh::Director
           end
         end
 
-        context 'when disk_properties is set to default' do
-          let(:disk_properties) { 'default' }
+        context 'when disk_properties is not sent' do
+          let(:disk_properties) { '' }
           it 'sets the disk size to 1 so it is migrated to the desired size next deploy' do
             attach_disk_job.perform
             active_disks = instance_model.persistent_disks.select { |disk| disk.active }

--- a/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
@@ -94,6 +94,16 @@ module Bosh::Director
           end
         end
 
+        context 'when disk_properties is set to default' do
+          let(:disk_properties) { 'default' }
+          it 'sets the disk size to 1 so it is migrated to the desired size next deploy' do
+            attach_disk_job.perform
+            active_disks = instance_model.persistent_disks.select { |disk| disk.active }
+            expect(active_disks.first.size).to eq(1)
+            expect(active_disks.first.cloud_properties).to eq({})
+          end
+        end
+
         context 'when the instance with the given instance id cannot be found' do
           let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, 'bogus', disk_cid, disk_properties) }
           it 'raises an error' do

--- a/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/attach_disk_spec.rb
@@ -13,7 +13,7 @@ module Bosh::Director
     end
     let(:deployment_name) { 'fake_deployment_name' }
     let(:disk_cid) { 'fake_disk_cid' }
-    let(:copy_previous) { 'false' }
+    let(:copy) { 'false' }
     let(:job_name) { 'job_name' }
     let(:instance_id) { 'fake_instance_id' }
     let(:event_manager) {Api::EventManager.new(true)}
@@ -28,12 +28,12 @@ module Bosh::Director
           'fake-username',
           Jobs::AttachDisk,
           "attach disk 'fake_disk_cid' to 'job_name/fake_instance_id'",
-          [deployment_name, job_name, instance_id, disk_cid, copy_previous], deployment)
-        Jobs::AttachDisk.enqueue('fake-username', deployment, job_name, instance_id, disk_cid, copy_previous, job_queue)
+          [deployment_name, job_name, instance_id, disk_cid, copy], deployment)
+        Jobs::AttachDisk.enqueue('fake-username', deployment, job_name, instance_id, disk_cid, copy, job_queue)
       end
     end
 
-    let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, disk_cid, copy_previous) }
+    let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, disk_cid, copy) }
 
     describe '#perform' do
       let(:vm) { Models::Vm.make(cid: vm_cid, instance_id: instance_model.id) }
@@ -84,8 +84,8 @@ module Bosh::Director
           expect(attach_disk_job.perform).to eq("attached disk 'fake_disk_cid' to 'job_name/fake_instance_id' in deployment 'fake_deployment_name'")
         end
 
-        context 'when copy_previous is set' do
-          let(:copy_previous) { true }
+        context 'when copy is set' do
+          let(:copy) { true }
           it 'sets the disk size and cloud_properties to that of previous persistent disk' do
             attach_disk_job.perform
             active_disks = instance_model.persistent_disks.select { |disk| disk.active }
@@ -95,7 +95,7 @@ module Bosh::Director
         end
 
         context 'when the instance with the given instance id cannot be found' do
-          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, 'bogus', disk_cid, copy_previous) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, 'bogus', disk_cid, copy) }
           it 'raises an error' do
             expect { attach_disk_job.perform }.to raise_error(AttachDiskErrorUnknownInstance,
                                                               "Instance 'job_name/bogus' in deployment 'fake_deployment_name' was not found")
@@ -103,7 +103,7 @@ module Bosh::Director
         end
 
         context 'when the instance with the given job name cannot be found' do
-          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, 'bogus', instance_id, disk_cid, copy_previous) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, 'bogus', instance_id, disk_cid, copy) }
           it 'raises an error' do
             expect { attach_disk_job.perform }.to raise_error(AttachDiskErrorUnknownInstance,
                                                               "Instance 'bogus/fake_instance_id' in deployment 'fake_deployment_name' was not found")
@@ -111,7 +111,7 @@ module Bosh::Director
         end
 
         context 'when the instance with the given deployment name cannot be found' do
-          let(:attach_disk_job) { Jobs::AttachDisk.new('bogus', job_name, instance_id, disk_cid, copy_previous) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new('bogus', job_name, instance_id, disk_cid, copy) }
           it 'raises an error' do
             expect { attach_disk_job.perform }.to raise_error(AttachDiskErrorUnknownInstance,
                                                               "Instance 'job_name/fake_instance_id' in deployment 'bogus' was not found")
@@ -172,7 +172,7 @@ module Bosh::Director
                 snapshot_created_at: Date.today)
           end
 
-          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, orphan_disk.disk_cid, copy_previous) }
+          let(:attach_disk_job) { Jobs::AttachDisk.new(deployment_name, job_name, instance_id, orphan_disk.disk_cid, copy) }
 
           before do
             attach_disk_job.perform


### PR DESCRIPTION
If the disk attached is not already an orphaned bosh disk,
attach_disk currently sets the size of disk as 1 and the cloud_properties empty.
Introduced an option `copy` which if true copies the size
and cloud properties of the previous disk for the new attached disk.

https://github.com/cloudfoundry/bosh/issues/1900