### PR TITLE
Export path for psql binary for deprecated restore methods

### DIFF
--- a/jobs/director/templates/restore-db
+++ b/jobs/director/templates/restore-db
@@ -70,6 +70,7 @@ done
 if [ "$adapter" = 'postgres' ];then
     export PGPASSWORD=$pass
     export PGCLIENTENCODING=UTF8
+    export PATH="$PATH:/var/vcap/packages/postgres-9.4/bin"
 
     psql -U$db_su -h$host $db_name -c"drop schema public cascade; create schema public;"
     psql -U$db_su -h$host $db_name -c"grant all on schema public to $db_su; grant all on schema public to public;"


### PR DESCRIPTION
Such that calling https://github.com/cloudfoundry/bosh/blob/master/src/bosh-director/lib/bosh/director/api/controllers/restore_controller.rb#L7 for just restoring the DB with an existing dump still works.

Wdyt? Can we pull this in or should we rather remove this controller and action completely and tell people with this use-case to rely on their own scripts doing `scp` and `ssh -c`?