### PR TITLE
[Discuss] Update setup doc to include agent installation

### DIFF
--- a/docs/workstation_setup.md
+++ b/docs/workstation_setup.md
@@ -87,6 +87,12 @@
     cd ~/workspace/bosh/src
     bundle install
     ```
+    
+10. Download `bosh-agent` dependency:
+    ```
+    cd ~/workspace/bosh/src
+    rake spec:integration:download_bosh_agent
+    ```
 
 ## Issues
 


### PR DESCRIPTION
### What is this change about?

Updating bosh docs for work station setup.

### Please provide contextual information.

[Discuss] Currently we are not specifying `bosh-agent` install as part of setup steps. But if you try to `rake spec:integration:install_dependencies` as mentioned in the later steps it will fail. So we can add it as part of setup step

```
go/src/github.com/cloudfoundry/bosh-agent/bin/build
rake aborted!
Command failed with status (127): [go/src/github.com/cloudfoundry/bosh-agent/...]
/Users/pivotal/gdey/bosh/src/bosh-dev/lib/bosh/dev/tasks/spec.rake:116:in `compile_dependencies'
/Users/pivotal/gdey/bosh/src/bosh-dev/lib/bosh/dev/tasks/spec.rake:55:in `block (4 levels) in <top (required)>'
/Users/pivotal/gdey/bosh/src/bosh-dev/lib/bosh/dev/tasks/spec.rake:37:in `open'
/Users/pivotal/gdey/bosh/src/bosh-dev/lib/bosh/dev/tasks/spec.rake:37:in `block (3 levels) in <top (required)>'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/cli/exec.rb:74:in `load'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/cli/exec.rb:28:in `run'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/cli.rb:424:in `exec'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/cli.rb:27:in `dispatch'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/cli.rb:18:in `start'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/exe/bundle:30:in `block in <top (required)>'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/Users/pivotal/.gem/ruby/2.4.4/gems/bundler-1.16.4/exe/bundle:22:in `<top (required)>'
/Users/pivotal/.gem/ruby/2.4.4/bin/bundle:23:in `load'
/Users/pivotal/.gem/ruby/2.4.4/bin/bundle:23:in `<main>'
Tasks: TOP => spec:integration:install_dependencies
(See full trace by running task with --trace)
```
### What tests have you run against this PR?

NA

### How should this change be described in bosh release notes?

NA

### Does this PR introduce a breaking change?

NA

### Tag your pair, your PM, and/or team!

solo han