### PR TITLE
Allow custom scopes in local identity provider

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/local_identity_provider.rb
+++ b/src/bosh-director/lib/bosh/director/api/local_identity_provider.rb
@@ -26,15 +26,14 @@ module Bosh
             raise AuthenticationError
           end
 
-          LocalUser.new(*auth.credentials)
+          username, password = auth.credentials
+          scopes = @user_manager.user_scopes(username)
+
+          LocalUser.new(username, password, scopes)
         end
       end
 
-      class LocalUser < Struct.new(:username, :password)
-        def scopes
-          ['bosh.admin']
-        end
-
+      class LocalUser < Struct.new(:username, :password, :scopes)
         def username_or_client
           username
         end

--- a/src/bosh-director/lib/bosh/director/api/user/config_user_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/user/config_user_manager.rb
@@ -18,6 +18,12 @@ module Bosh::Director
         user['password'] == password
       end
 
+      def user_scopes(username)
+        user = @users.find { |u| u['name'] == username }
+        raise "User #{user} not found in ConfigUserManager" if user.nil?
+        return user.fetch('scopes', ['bosh.admin'])
+      end
+
       def delete_user(_)
         raise NotSupported
       end

--- a/src/bosh-director/spec/unit/api/user/config_user_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/user/config_user_manager_spec.rb
@@ -6,6 +6,7 @@ module Bosh::Director
     let(:users) do
       [
         {'name' => 'fake-user', 'password' => 'fake-pass'},
+        {'name' => 'fake-ro-user', 'password' => 'fake-pass', 'scopes' => [ 'bosh.read' ]},
         {'name' => '', 'password' => 'no-user'},
         {'name' => 'no-pass', 'password' => ''},
       ]
@@ -23,6 +24,18 @@ module Bosh::Director
 
       it 'should not authenticate users without password' do
         expect(user_manager.authenticate('no-pass', '')).to be(false)
+      end
+    end
+
+    describe :user_scopes do
+      it 'should return the scopes provided in the config' do
+        expect(user_manager.user_scopes('fake-ro-user')).to contain_exactly('bosh.read')
+      end
+      it 'should return bosh.admin if no scopes defined in config' do
+        expect(user_manager.user_scopes('fake-user')).to contain_exactly('bosh.admin')
+      end
+      it 'should raise error if user does not exist' do
+        expect{user_manager.user_scopes('unkown-user')}.to raise_error
       end
     end
   end


### PR DESCRIPTION
What is this change about?
----------------------------

We want to add readonly users for bosh for monitoring, but we do
not want to have to configure a full UAA for that.


What tests have you run against this PR?
--------------


```
bundle exec rspec \
    spec/unit/api/user/config_user_manager_spec.rb \
    spec/unit/api/local_identity_provider_spec.rb
```

How should this change be described in bosh release notes?
-----------

When using local authentication, local users can have an additonal
field `scopes` to allow override the assigned scopes. By default the
scope is still `bosh.admin`

Example:

    director:
      user_management:
        local:
          users:
            - name: admin
              password: admin123
            - name: hm
              password: hm123
            - name: prometheus
              password: prometheus123
              scopes: [bosh.read]

Does this PR introduce a breaking change?
-----

No

Tag your pair, your PM, and/or team!
-----

Gov UK PaaS team.