### PR TITLE
custom tags may be attached to DataDog healthmonitor metrics

### DIFF
--- a/jobs/health_monitor/spec
+++ b/jobs/health_monitor/spec
@@ -185,6 +185,11 @@ properties:
     description: Health Monitor Application Key for DataDog
   hm.datadog.pagerduty_service_name:
     description: Service name to alert in PagerDuty upon HM events
+  hm.datadog.custom_tags:
+    description: Tags, as key/value pairs, to add to all metrics sent to DataDog.  See https://docs.datadoghq.com/tagging/
+    example: |
+      env: prod
+      region: eu
 
   # Send metrics to Graphite
   hm.graphite_enabled:

--- a/jobs/health_monitor/templates/health_monitor.yml.erb
+++ b/jobs/health_monitor/templates/health_monitor.yml.erb
@@ -188,6 +188,10 @@ if p('hm.datadog_enabled')
     datadog_plugin['options']['pagerduty_service_name'] = pagerduty_service_name
   end
 
+  if_p('hm.datadog.custom_tags') do |custom_tags|
+    datadog_plugin['options']['custom_tags'] = custom_tags
+  end
+
   params['plugins'] << datadog_plugin
 end
 

--- a/spec/health_monitor_templates_spec.rb
+++ b/spec/health_monitor_templates_spec.rb
@@ -232,6 +232,7 @@ describe 'health_monitor.yml.erb' do
                 'api_key' => 'abcdef',
                 'application_key' => 'dog-key',
                 'pagerduty_service_name' => 'pager-name',
+                'custom_tags' => { 'env' => 'prod', 'region' => 'eu' },
               },
             })
         end
@@ -245,6 +246,7 @@ describe 'health_monitor.yml.erb' do
           expect(plugin['options']['api_key']).to eq('abcdef')
           expect(plugin['options']['application_key']).to eq('dog-key')
           expect(plugin['options']['pagerduty_service_name']).to eq('pager-name')
+          expect(plugin['options']['custom_tags']).to eq('env' => 'prod', 'region' => 'eu')
         end
       end
 

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/datadog.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/datadog.rb
@@ -23,6 +23,10 @@ module Bosh::Monitor
         @dog_client = @pagerduty_service_name ? PagingDatadogClient.new(@pagerduty_service_name, client) : client
       end
 
+      def custom_tags
+        options['custom_tags'] || {}
+      end
+
       def process(event)
         case event
           when Bosh::Monitor::Events::Heartbeat
@@ -48,6 +52,7 @@ module Bosh::Monitor
         ]
 
         heartbeat.teams.each { |team| tags << "team:#{team}" }
+        custom_tags.each { |key, value| tags << "#{key}:#{value}" }
 
         dog_client.batch_metrics do
           heartbeat.metrics.each do |metric|

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe Bhm::Plugins::DataDog do
   let(:options) do
-    { 'api_key' => 'api_key', 'application_key' => 'application_key' }
+    { 'api_key' => 'api_key', 'application_key' => 'application_key', 'custom_tags' => { 'customkey' => 'customvalue', 'customkey2' => 'customvalue2' } }
   end
+
   subject { described_class.new(options) }
 
   let(:dog_client) { double('DataDog Client') }
@@ -96,6 +97,8 @@ describe Bhm::Plugins::DataDog do
           agent:deadbeef
           team:ateam
           team:bteam
+          customkey:customvalue
+          customkey2:customvalue2
       ]
       time = Time.now
       expect(dog_client).to receive(:emit_points).with('bosh.healthmonitor.system.load.1m', [[Time.at(time.to_i) , 0.2]], tags: tags)


### PR DESCRIPTION
### What is this change about?

DataDog allows tags to be attached to metrics.  BOSH healthmonitor attaches some tags, e.g. the deployment that originated the metric.  This is great.

But if you've got multiple directors, each with similar-looking deployments, all forwarding metrics to the same DataDog account, then all those metrics get mixed together: There isn't a straightforward way to distinguish metrics based on the originating director.  So, for example, it is tough to make a dashboard showing metrics from only one director, or to compare the same metrics across different directors.

This change allows an operator to set custom tags on the director, which get set on all metrics that the director emits.

This way, you can set different tags on different directors, and thus distinguish between those directors in your datadog dashboards.

### Please provide contextual information.

We've got [this story](https://www.pivotaltracker.com/story/show/161104272).  The only way we see to make it work today is to discover the director's `cid` value after it is deployed, and then populate our datadog templates with that dynamically-generated value.  The `cid` changes on every re-deploy of the director (which our CI pipelines do every night).   So that means we'd need to update our datadog templates after every deploy.  Not great.


### What tests have you run against this PR?

```
docker run --rm -it -e RUBY_VERSION=2.4.4 -e DB=sqlite -v $PWD/:/bosh-src bosh/main /bosh-src/ci/tasks/test-unit.sh
```

### How should this change be described in bosh release notes?

Maybe the commit message?

> Custom tags may be attached to DataDog healthmonitor metrics


### Does this PR introduce a breaking change?

No.
