### PR TITLE
Use BOSH-Context-ID on recreate command

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -102,6 +102,7 @@ module Bosh::Director
           latest_runtime_configs,
           deployment,
           options,
+          @current_context_id,
         )
         redirect "/tasks/#{task.id}"
       end
@@ -146,6 +147,7 @@ module Bosh::Director
           latest_runtime_configs,
           deployment,
           options,
+          @current_context_id,
         )
         redirect "/tasks/#{task.id}"
       end


### PR DESCRIPTION
### What is this change about?

BOSH-Context-ID is used by ODB in the Services Enablement team to tie together lifecycle errands for deploy and delete. Lifecycle errands now need to be run after a recreate, so we're making the controller send the context-id to the create-deployment method trigger from recreate.

White-space changes forced by rubocop.

### Please provide contextual information.

Required for the ODB recreate-all errand, used to update service instances behind a on-demand service broker. Previous related PR: #1531. Tracker link: https://www.pivotaltracker.com/story/show/160422367

### What tests have you run against this PR?

* All unit tests
* Manual deploy and recreate
* ODB contract tests using BOSH CLI lib to trigger recreate sending X-BOSH-Context-ID header

### How should this change be described in bosh release notes?

BOSH-Context-ID is now stored against a recreate task.

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@kirederik 
@pivotal-cf/services-enablement