### PR TITLE
Backfill rspec tests for UpdateDeployment 

### DIFF
--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -35,7 +35,7 @@ module Bosh::Director
           @event_log.warn_deprecated(warning)
           cloud_config_models = nil
         else
-          cloud_config_models = Bosh::Director::Models::Config.where(id: [@cloud_config_ids]).to_a
+          cloud_config_models = Bosh::Director::Models::Config.where(id: @cloud_config_ids).to_a
           if cloud_config_models.empty?
             logger.debug('No cloud config uploaded yet.')
           else
@@ -43,7 +43,7 @@ module Bosh::Director
           end
         end
 
-        runtime_config_models = Bosh::Director::Models::Config.where(id: [@runtime_config_ids]).to_a
+        runtime_config_models = Bosh::Director::Models::Config.where(id: @runtime_config_ids).to_a
         if runtime_config_models.empty?
           logger.debug("No runtime config uploaded yet.")
         else

--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -35,7 +35,7 @@ module Bosh::Director
           @event_log.warn_deprecated(warning)
           cloud_config_models = nil
         else
-          cloud_config_models = Bosh::Director::Models::Config.where(id: @cloud_config_ids).to_a
+          cloud_config_models = Bosh::Director::Models::Config.find_by_ids(@cloud_config_ids)
           if cloud_config_models.empty?
             logger.debug('No cloud config uploaded yet.')
           else
@@ -43,7 +43,7 @@ module Bosh::Director
           end
         end
 
-        runtime_config_models = Bosh::Director::Models::Config.where(id: @runtime_config_ids).to_a
+        runtime_config_models = Bosh::Director::Models::Config.find_by_ids(@runtime_config_ids)
         if runtime_config_models.empty?
           logger.debug("No runtime config uploaded yet.")
         else

--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -35,7 +35,7 @@ module Bosh::Director
           @event_log.warn_deprecated(warning)
           cloud_config_models = nil
         else
-          cloud_config_models = Bosh::Director::Models::Config.find_by_ids(@cloud_config_ids)
+          cloud_config_models = Bosh::Director::Models::Config.where(id: [@cloud_config_ids]).to_a
           if cloud_config_models.empty?
             logger.debug('No cloud config uploaded yet.')
           else
@@ -43,7 +43,7 @@ module Bosh::Director
           end
         end
 
-        runtime_config_models = Bosh::Director::Models::Config.find_by_ids(@runtime_config_ids)
+        runtime_config_models = Bosh::Director::Models::Config.where(id: [@runtime_config_ids]).to_a
         if runtime_config_models.empty?
           logger.debug("No runtime config uploaded yet.")
         else

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -330,14 +330,23 @@ module Bosh::Director
           end
 
           context 'when a cloud_config is passed in' do
-            let(:cloud_config_id) { Models::Config.make(:cloud).id }
+            let(:cloud_config)     { Models::Config.make(:cloud) }
+            let(:cloud_config_id)  { cloud_config.id }
+            let(:manifest_content) { YAML.dump ManifestHelper.default_deployment_manifest }
+
             it 'uses the cloud config' do
               expect(job.perform).to eq('/deployments/deployment-name')
+
+              expect(Manifest).to have_received(:load_from_hash)
+                .with(anything, anything, [cloud_config], anything)
+              expect(planner_factory).to have_received(:create_from_manifest)
+                .with(anything, [cloud_config], anything, anything)
             end
           end
 
           context 'when a runtime_config is passed in' do
-            let(:runtime_config_id) { Models::RuntimeConfig.make.id }
+            let(:runtime_config)     { Models::Config.make(:runtime) }
+            let(:runtime_config_ids) { [runtime_config.id] }
 
             before do
               allow(variables_interpolator).to receive(:interpolate_runtime_manifest)
@@ -345,6 +354,11 @@ module Bosh::Director
 
             it 'uses the runtime config' do
               expect(job.perform).to eq('/deployments/deployment-name')
+
+              expect(Manifest).to have_received(:load_from_hash)
+                .with(anything, anything, anything, [runtime_config])
+              expect(planner_factory).to have_received(:create_from_manifest)
+                .with(anything, anything, [runtime_config], anything)
             end
           end
 

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -90,7 +90,6 @@ module Bosh::Director
           allow(deployment_model).to receive(:current_variable_set).and_return(variable_set)
           allow(template_blob_cache).to receive(:clean_cache!)
           allow(DeploymentPlan::Assembler).to receive(:create).and_return(assembler)
-          allow(Bosh::Director::Models::Config).to receive(:find_by_ids).and_return([])
           allow(JobRenderer).to receive(:render_job_instances_with_cache).with(
             anything,
             template_blob_cache,

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -328,6 +328,17 @@ module Bosh::Director
             end
           end
 
+          context 'when there is no cloud_config' do
+            it 'passes nil where cloud_config would be passed' do
+              expect(job.perform).to eq('/deployments/deployment-name')
+
+              expect(Manifest).to have_received(:load_from_hash)
+                .with(anything, anything, nil, anything)
+              expect(planner_factory).to have_received(:create_from_manifest)
+                .with(anything, nil, anything, anything)
+            end
+          end
+
           context 'when a cloud_config is passed in' do
             let(:cloud_config)     { Models::Config.make(:cloud) }
             let(:cloud_config_id)  { cloud_config.id }


### PR DESCRIPTION
Previous description:

> Before this change, no matter what config IDs were being passed into
UpdateDeployment, it was using an empty array for the cloud config
models and runtime config models when preparing the update deployments.
This change adds test coverage for that code path and fixes the loading
of those models at the beginning of UpdateDeployment#perform.

Updated:
This PR backfills unit tests that were missing from the UpdateDeployment unit tests.