### PR TITLE
Refactor UpdateDeployment

### DIFF
--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -76,10 +76,8 @@ module Bosh::Director
 
       def prepare_deployment
         event_log_stage.advance_and_track('Preparing deployment') do
-          # that's where the link path is created
           create_network_stage(deployment_plan).perform unless dry_run?
 
-          # that's where the links resolver is created
           deployment_assembler.bind_models(
             is_deploy_action: deploy_action?,
             should_bind_new_variable_set: deploy_action?,

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -409,11 +409,6 @@ module Bosh::Director
             context 'even when network lifecycle is enabled' do
               before do
                 allow(Config).to receive(:network_lifecycle_enabled?).and_return true
-
-                # This is terrible, but the network logic really does not belong on this class
-                allow(job).to receive(:mark_orphaned_networks) do
-                  raise 'Should not get here'
-                end
               end
 
               it 'should not clean up the orphaned networks' do


### PR DESCRIPTION
I attempted to reduce the complexity of the #perform method by relying
on the class to encapsulate its dependencies.  Since this class is only
used to call #perform once, this is similar to extracting a method
object for the #perform method.  All unit tests pass.  I made all the
new methods private to prevent clients from calling them directly.  I
also made an attempt to order them by relevance, though I am open to
suggestions for reordering.  This class has a lot of responsibility and
in future refactorings it might be a good idea to break it up into
smaller objects with fewer responsibilities.

