### PR TITLE
Make (most) tests transactional

### DIFF
--- a/src/.rubocop.yml
+++ b/src/.rubocop.yml
@@ -20,7 +20,7 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Max: 25
-  ExcludedMethods: [describe, context, let, it, chdir]
+  ExcludedMethods: [describe, context, let, it, chdir, shared_examples]
 
 Metrics/ClassLength:
   Max: 200

--- a/src/bosh-director/.rspec_parallel
+++ b/src/bosh-director/.rspec_parallel
@@ -1,0 +1,9 @@
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out /tmp/bosh_director_parallel_runtime_rspec.log
+--tag ~nginx
+--tag ~general_s3
+--tag ~aws_frankfurt_s3
+--tag ~aws_s3
+--tag ~general_gcs
+--tag ~davcli_integration
+--tag ~local_blobstore_integration

--- a/src/bosh-director/spec/blueprints.rb
+++ b/src/bosh-director/spec/blueprints.rb
@@ -98,17 +98,17 @@ module Bosh::Director::Models
   end
 
   Instance.blueprint do
-    deployment  { Deployment.make }
+    deployment
     job         { Sham.job }
     index       { Sham.index }
     state       { 'started' }
     uuid        { Sham.uuid }
-    variable_set { VariableSet.make }
+    variable_set
   end
 
   IpAddress.blueprint do
     address_str { NetAddr::CIDR.create(Sham.ip).to_i.to_s }
-    instance { Instance.make }
+    instance
     static { false }
     network_name { Sham.name }
     task_id { Sham.name }
@@ -129,11 +129,7 @@ module Bosh::Director::Models
   PersistentDisk.blueprint do
     active      { true }
     disk_cid    { Sham.disk_cid }
-    instance    do
-      is = Instance.make
-      vm = Vm.make(instance_id: is.id)
-      is.active_vm = vm
-    end
+    instance    { Vm.make(:active).instance }
   end
 
   Network.blueprint do
@@ -301,6 +297,10 @@ module Bosh::Director::Models
     cid      { Sham.vm_cid }
     agent_id { Sham.agent_id }
     created_at { Time.now }
+  end
+
+  Vm.blueprint(:active) do
+    active { true }
   end
 
   module Links

--- a/src/bosh-director/spec/spec_helper.rb
+++ b/src/bosh-director/spec/spec_helper.rb
@@ -217,7 +217,7 @@ module SpecHelper
     end
 
     def reset_database(example)
-      if example.metadata[:truncation]
+      if example.metadata[:truncation] && ENV.fetch('DB', 'sqlite') != 'sqlite'
         example.run
       else
         Sequel.transaction([@director_db, @dns_db], rollback: :always, auto_savepoint: true) do
@@ -227,7 +227,7 @@ module SpecHelper
 
       Bosh::Director::Config.db&.disconnect
 
-      return unless example.metadata[:truncation]
+      return unless example.metadata[:truncation] || ENV.fetch('DB', 'sqlite') == 'sqlite'
 
       @director_db_helper.truncate_db
       @dns_db_helper.truncate_db

--- a/src/bosh-director/spec/spec_helper.rb
+++ b/src/bosh-director/spec/spec_helper.rb
@@ -178,13 +178,13 @@ module SpecHelper
         @director_db_helper = nil
       end
 
-      if @dns_db
-        @dns_db.disconnect
-        @dns_db_helper.drop_db
+      return unless @dns_db
 
-        @dns_db = nil
-        @dns_db_helper = nil
-      end
+      @dns_db.disconnect
+      @dns_db_helper.drop_db
+
+      @dns_db = nil
+      @dns_db_helper = nil
     end
 
     def run_migrations

--- a/src/bosh-director/spec/unit/addon/addon_spec.rb
+++ b/src/bosh-director/spec/unit/addon/addon_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Bosh::Director
   module Addon
-    describe Addon do
+    describe Addon, truncation: true do
       subject(:addon) { Addon.new(addon_name, jobs, properties, includes, excludes) }
       let(:addon_name) { 'addon-name' }
       let(:jobs) do

--- a/src/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/events_controller_spec.rb
@@ -5,7 +5,7 @@ require 'bosh/director/api/controllers/events_controller'
 
 module Bosh::Director
   module Api
-    describe Controllers::EventsController do
+    describe Controllers::EventsController, truncation: true do
       include Rack::Test::Methods
 
       subject(:app) { linted_rack_app(described_class.new(config)) }

--- a/src/bosh-director/spec/unit/api/controllers/link_address_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/link_address_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rack/test'
 
 module Bosh::Director
   module Api
-    describe Controllers::LinkAddressController, truncation: true do
+    describe Controllers::LinkAddressController do
       include Rack::Test::Methods
 
       subject(:app) { described_class.new(config) }
@@ -75,16 +75,14 @@ module Bosh::Director
           end
 
           context 'when a single az is specified' do
-            before do
-              Models::LocalDnsEncodedAz.create(name: 'z1')
-              Models::LocalDnsEncodedAz.create(name: 'z2')
-            end
+            let!(:az1) { Models::LocalDnsEncodedAz.create(name: 'z1') }
+            let!(:az2) { Models::LocalDnsEncodedAz.create(name: 'z2') }
 
             it 'should return the address with the az information' do
               get "/?link_id=#{link.id}&azs[]=z1"
               expect(last_response.status).to eq(200)
               response = JSON.parse(last_response.body)
-              expect(response).to eq('address' => 'q-a1s0.ig-bar.baz.dep-foo.bosh')
+              expect(response).to eq('address' => "q-a#{az1.id}s0.ig-bar.baz.dep-foo.bosh")
             end
 
             context 'when the az is specified as not an array' do
@@ -98,16 +96,14 @@ module Bosh::Director
           end
 
           context 'when multiple azs are specified' do
-            before do
-              Models::LocalDnsEncodedAz.create(name: 'z1')
-              Models::LocalDnsEncodedAz.create(name: 'z2')
-            end
+            let!(:az1) { Models::LocalDnsEncodedAz.create(name: 'z1') }
+            let!(:az2) { Models::LocalDnsEncodedAz.create(name: 'z2') }
 
             it 'should return the address with the az information' do
               get "/?link_id=#{link.id}&azs[]=z1&azs[]=z2"
               expect(last_response.status).to eq(200)
               response = JSON.parse(last_response.body)
-              expect(response).to eq('address' => 'q-a1a2s0.ig-bar.baz.dep-foo.bosh')
+              expect(response).to eq('address' => "q-a#{az1.id}a#{az2.id}s0.ig-bar.baz.dep-foo.bosh")
             end
           end
 

--- a/src/bosh-director/spec/unit/api/controllers/link_address_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/link_address_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rack/test'
 
 module Bosh::Director
   module Api
-    describe Controllers::LinkAddressController do
+    describe Controllers::LinkAddressController, truncation: true do
       include Rack::Test::Methods
 
       subject(:app) { described_class.new(config) }

--- a/src/bosh-director/spec/unit/api/controllers/links_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/links_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rack/test'
 
 module Bosh::Director
   module Api
-    describe Controllers::LinksController do
+    describe Controllers::LinksController, truncation: true do
       include Rack::Test::Methods
 
       subject(:app) {described_class.new(config)}

--- a/src/bosh-director/spec/unit/api/controllers/releases_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/releases_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rack/test'
 
 module Bosh::Director
   module Api
-    describe Controllers::ReleasesController do
+    describe Controllers::ReleasesController, truncation: true do
       include Rack::Test::Methods
 
       subject(:app) { linted_rack_app(described_class.new(config)) }

--- a/src/bosh-director/spec/unit/api/controllers/tasks_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/tasks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rack/test'
 
 module Bosh::Director
   module Api
-    describe Controllers::TasksController, truncation: true do
+    describe Controllers::TasksController do
       include Rack::Test::Methods
 
       subject(:app) { linted_rack_app(described_class.new(config)) }
@@ -330,7 +330,7 @@ module Bosh::Director
               get "/#{task.id}"
               expect(last_response.status).to eq(200)
               task_json = JSON.parse(last_response.body)
-              expect(task_json['id']).to eq(1)
+              expect(task_json['id']).to eq(task.id)
               expect(task_json['state']).to eq('processed')
               expect(task_json['description']).to eq('fake-description')
             end

--- a/src/bosh-director/spec/unit/api/controllers/tasks_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/tasks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rack/test'
 
 module Bosh::Director
   module Api
-    describe Controllers::TasksController do
+    describe Controllers::TasksController, truncation: true do
       include Rack::Test::Methods
 
       subject(:app) { linted_rack_app(described_class.new(config)) }

--- a/src/bosh-director/spec/unit/api/event_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/event_manager_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Bosh::Director::Api::EventManager do
+describe Bosh::Director::Api::EventManager, truncation: true do
   let(:manager) { described_class.new(true) }
 
   describe '#create_event' do

--- a/src/bosh-director/spec/unit/api/event_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/event_manager_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Bosh::Director::Api::EventManager, truncation: true do
+describe Bosh::Director::Api::EventManager do
   let(:manager) { described_class.new(true) }
 
   describe '#create_event' do
@@ -13,20 +13,24 @@ describe Bosh::Director::Api::EventManager, truncation: true do
 
     context 'record_events is true' do
       it 'should create a new event model' do
-        expect {
-          manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment', :object_name => 'dep'})
-        }.to change {
-          Bosh::Director::Models::Event.count
-        }.from(0).to(1)
+        expect do
+          manager.create_event(user: 'user', action: 'action', object_type: 'deployment', object_name: 'dep')
+        end.to change { Bosh::Director::Models::Event.count }.from(0).to(1)
       end
 
       it 'allows to save specified timestamp' do
-        manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment', :object_name => 'dep', :timestamp => Time.at(1479673560)})
-        expect( Bosh::Director::Models::Event.first.timestamp.to_i).to eq(1479673560)
+        manager.create_event(
+          user: 'user',
+          action: 'action',
+          object_type: 'deployment',
+          object_name: 'dep',
+          timestamp: Time.at(1479673560),
+        )
+        expect(Bosh::Director::Models::Event.first.timestamp.to_i).to eq(1479673560)
       end
 
       it 'should write event to audit logger' do
-        event = manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment'})
+        event = manager.create_event(user: 'user', action: 'action', object_type: 'deployment')
 
         expect(audit_logger).to have_received(:info).with(JSON.generate(event.to_hash))
       end
@@ -36,21 +40,19 @@ describe Bosh::Director::Api::EventManager, truncation: true do
       let(:manager) { described_class.new(false) }
 
       it 'should not create a new event model' do
-        expect {
-          manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment', :object_name => 'dep'})
-        }.to_not change {
-          Bosh::Director::Models::Event.count
-        }
+        expect do
+          manager.create_event(user: 'user', action: 'action', object_type: 'deployment', object_name: 'dep')
+        end.to_not change { Bosh::Director::Models::Event.count }
       end
 
       it 'should not write event to audit logger' do
-        manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment'})
+        manager.create_event(user: 'user', action: 'action', object_type: 'deployment')
 
         expect(audit_logger).to_not have_received(:info)
       end
 
       it 'returns an empty event' do
-        event = manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment'})
+        event = manager.create_event(user: 'user', action: 'action', object_type: 'deployment')
 
         expect(event).to eq(Bosh::Director::Models::Event.new)
       end
@@ -60,114 +62,113 @@ describe Bosh::Director::Api::EventManager, truncation: true do
   describe '#event_to_hash' do
     it 'should not pass values are equal to nil' do
       Bosh::Director::Models::Event.make(
-          'user' => 'test',
-          'action' => 'create',
-          'object_type' => 'deployment',
-          'object_name' => 'depl1',
-          'error' => nil,
-          'task' => nil,
-          'deployment' => nil,
-          'instance' => nil,
-          'parent_id' => nil
+        'user' => 'test',
+        'action' => 'create',
+        'object_type' => 'deployment',
+        'object_name' => 'depl1',
+        'error' => nil,
+        'task' => nil,
+        'deployment' => nil,
+        'instance' => nil,
+        'parent_id' => nil,
       )
-      expect(manager.event_to_hash(Bosh::Director::Models::Event.first)).not_to include('error', 'task', 'deployment', 'instance', 'parent_id')
+      expect(manager.event_to_hash(Bosh::Director::Models::Event.first))
+        .not_to include('error', 'task', 'deployment', 'instance', 'parent_id')
     end
 
     it 'should pass ids as String' do
-      Bosh::Director::Models::Event.make(
-          'parent_id' => 2,
-          'user' => 'test',
-          'action' => 'create',
-          'object_type' => 'deployment',
-          'object_name' => 'depl1',
+      event = Bosh::Director::Models::Event.make(
+        'parent_id' => 2,
+        'user' => 'test',
+        'action' => 'create',
+        'object_type' => 'deployment',
+        'object_name' => 'depl1',
       )
-      expect(manager.event_to_hash(Bosh::Director::Models::Event.first)).to include('id' => '1', 'parent_id' => '2')
+      expect(manager.event_to_hash(Bosh::Director::Models::Event.first)).to include('id' => event.id.to_s, 'parent_id' => '2')
     end
   end
 
   describe '#remove_old_events' do
     def make_n_events(num_events)
-      num_events.times do |i|
+      num_events.times do |_i|
         Bosh::Director::Models::Event.make
       end
     end
 
     context 'when there are fewer than `max_events` events in the database' do
-      before {
+      before do
         make_n_events(2)
-      }
+      end
 
       it 'keeps all events in the database' do
-        expect {
+        expect do
           manager.remove_old_events
-        }.not_to change {
-          Bosh::Director::Models::Event.count
-        }
+        end.not_to change { Bosh::Director::Models::Event.count }
       end
     end
 
     context 'when there are exactly `max_events` events in the database' do
-      before {
+      before do
         make_n_events(3)
-      }
+      end
 
       it 'keeps all events in the database' do
-        expect {
+        expect do
           manager.remove_old_events(3)
-        }.not_to change {
-          Bosh::Director::Models::Event.count
-        }
+        end.not_to change { Bosh::Director::Models::Event.count }
       end
     end
 
     context 'when there is one more than `max_events` events in the database' do
-      before {
+      before do
         make_n_events(4)
-      }
+      end
 
       it 'keeps the latest `max_events` events in the database' do
-        expect {
+        expect do
           manager.remove_old_events(3)
-        }.to change {
+        end.to change {
           Bosh::Director::Models::Event.count
         }.from(4).to(3)
       end
     end
 
     context 'when there are 10 more than `max_events` events in the database' do
-      before {
+      before do
         make_n_events(13)
-      }
+      end
 
       it 'keeps the latest `max_events` events in the database' do
-        expect {
+        expect do
           manager.remove_old_events(3)
-        }.to change {
+        end.to change {
           Bosh::Director::Models::Event.count
         }.from(13).to(3)
       end
 
       it 'does not duplicate ids (no reuse of deleted ids)' do
         manager.remove_old_events(3)
-        manager.create_event({:user => 'user', :action => 'action', :object_type => 'deployment', :object_name => 'dep'})
-        expect(Bosh::Director::Models::Event.order{Sequel.asc(:id)}.last.id).to eq(14)
+        previous_id = Bosh::Director::Models::Event.order { Sequel.asc(:id) }.last.id
+        manager.create_event(user: 'user', action: 'action', object_type: 'deployment', object_name: 'dep')
+        expect(Bosh::Director::Models::Event.order { Sequel.asc(:id) }.last.id).to be > previous_id
       end
     end
 
     context 'when there is `parent_id` from dataset to remove' do
-      before {
+      let(:parent_id) { Bosh::Director::Models::Event.last.id - 5 }
+      before do
         make_n_events(10)
-        Bosh::Director::Models::Event.make(parent_id: 5, action: 'action', object_type: 'type')
+        Bosh::Director::Models::Event.make(parent_id: parent_id, action: 'action', object_type: 'type')
         make_n_events(2)
-      }
+      end
 
       it 'keeps the events started from `parent_id` in the database' do
-        expect {
+        expect do
           manager.remove_old_events(3)
-        }.to change {
+        end.to change {
           Bosh::Director::Models::Event.count
         }.from(13).to(9)
-        expect(Bosh::Director::Models::Event.order{Sequel.desc(:id)}.last.id).to eq(5)
+        expect(Bosh::Director::Models::Event.order { Sequel.desc(:id) }.last.id).to eq(parent_id)
       end
     end
   end

--- a/src/bosh-director/spec/unit/api/links_api_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/links_api_manager_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Api::LinksApiManager do
+  describe Api::LinksApiManager, truncation: true do
     let(:link_serial_id) { 42 }
     let(:deployment) { Models::Deployment.create(name: 'test_deployment', manifest: YAML.dump('foo' => 'bar'), links_serial_id: link_serial_id) }
     let(:instance_group) { 'instance_group' }

--- a/src/bosh-director/spec/unit/api/task_remover_spec.rb
+++ b/src/bosh-director/spec/unit/api/task_remover_spec.rb
@@ -3,7 +3,7 @@ require 'fakefs/spec_helpers'
 require 'bosh/director/api/task_remover'
 
 module Bosh::Director::Api
-  describe TaskRemover do
+  describe TaskRemover, truncation: true do
     include FakeFS::SpecHelpers
 
     def make_n_tasks(num_tasks, type = default_type)

--- a/src/bosh-director/spec/unit/cloud/external_cpi_response_wrapper_spec.rb
+++ b/src/bosh-director/spec/unit/cloud/external_cpi_response_wrapper_spec.rb
@@ -32,7 +32,6 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
     it 'should raise error' do
       expect { call_cpi_method }.to raise_error(error_type, error_msg)
     end
-
   end
 
   def self.it_calls_cpi_method(method, *arguments)
@@ -50,22 +49,22 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
     it 'should call cpi binary with correct arguments' do
       stub_const('ENV', 'TMPDIR' => '/some/tmp')
 
-      expected_env = {'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp'}
+      expected_env = { 'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp' }
       expected_cmd = '/path/to/fake-cpi/bin/cpi'
       arguments << additional_expected_args unless additional_expected_args.nil?
       expected_stdin = %({"method":"#{method}","arguments":#{arguments.to_json},"context":{"director_uuid":"fake-director-uuid","request_id":"cpi-fake-request-id"},"api_version":#{cpi_api_version}})
 
       expect(Open3).to receive(:capture3).with(expected_env, expected_cmd, stdin_data: expected_stdin, unsetenv_others: true)
-      call_cpi_method
+      expect(call_cpi_method).to eq(expected_response)
     end
 
     context 'if properties from cpi config are given' do
-      let(:director_uuid) {'fake-director-uuid'}
-      let(:request_id) {'cpi-fake-request-id'}
-      let(:cpi_config_properties) { {'key1' => {'nestedkey1' => 'nestedvalue1'}, 'key2' => 'value2'} }
+      let(:director_uuid) { 'fake-director-uuid' }
+      let(:request_id) { 'cpi-fake-request-id' }
+      let(:cpi_config_properties) { { 'key1' => { 'nestedkey1' => 'nestedvalue1' }, 'key2' => 'value2' } }
       let(:options) do
         {
-          properties_from_cpi_config: cpi_config_properties
+          properties_from_cpi_config: cpi_config_properties,
         }
       end
       let(:cloud) { Bosh::Clouds::ExternalCpi.new('/path/to/fake-cpi/bin/cpi', director_uuid, logger, options) }
@@ -73,21 +72,14 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
       it 'passes the properties in context to the cpi' do
         stub_const('ENV', 'TMPDIR' => '/some/tmp')
 
-        expected_env = {'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp'}
+        expected_env = { 'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp' }
         expected_cmd = '/path/to/fake-cpi/bin/cpi'
-        context = {'director_uuid' => director_uuid, 'request_id' => request_id}.merge(cpi_config_properties)
+        context = { 'director_uuid' => director_uuid, 'request_id' => request_id }.merge(cpi_config_properties)
         expected_stdin = %({"method":"#{method}","arguments":#{arguments.to_json},"context":#{context.to_json},"api_version":#{cpi_api_version}})
-
-        expect(Open3).to receive(:capture3).with(expected_env, expected_cmd, stdin_data: expected_stdin, unsetenv_others: true)
-        call_cpi_method
-      end
-
-      it 'logs requests and responses with request id' do
-        stub_const('ENV', 'TMPDIR' => '/some/tmp')
-
         lines = []
         allow(logger).to receive(:debug) { |line| lines << line }
 
+        expect(Open3).to receive(:capture3).with(expected_env, expected_cmd, stdin_data: expected_stdin, unsetenv_others: true)
         call_cpi_method
         expect(lines[0]).to start_with "[external-cpi] [#{request_id}] request"
         expect(lines[1]).to start_with "[external-cpi] [#{request_id}] response"
@@ -96,30 +88,30 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
       it 'redacts properties from cpi config in logs' do
         stub_const('ENV', 'TMPDIR' => '/some/tmp')
 
-        expected_env = {'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp'}
+        expected_env = { 'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp' }
         expected_cmd = '/path/to/fake-cpi/bin/cpi'
-        context = {'director_uuid' => director_uuid, 'request_id' => request_id}.merge(cpi_config_properties)
+        context = { 'director_uuid' => director_uuid, 'request_id' => request_id }.merge(cpi_config_properties)
         redacted_context = {
-            'director_uuid' => director_uuid,
-            'request_id' => request_id,
-            'key1' => '<redacted>',
-            'key2' => '<redacted>'
+          'director_uuid' => director_uuid,
+          'request_id' => request_id,
+          'key1' => '<redacted>',
+          'key2' => '<redacted>',
         }
 
         expected_arguments = arguments.clone
         if method == :create_vm
-          expected_arguments[2] = {'cloud' => '<redacted>'}
+          expected_arguments[2] = { 'cloud' => '<redacted>' }
           expected_arguments[3] = redacted_network_settings
           expected_arguments[5] = {
             'bosh' => {
               'group' => 'my-group',
               'groups' => ['my-first-group'],
-              'password' => '<redacted>'
+              'password' => '<redacted>',
             },
-            'other' => '<redacted>'
+            'other' => '<redacted>',
           }
         elsif method == :create_disk
-          expected_arguments[1] = {'type' => '<redacted>'}
+          expected_arguments[1] = { 'type' => '<redacted>' }
         end
 
         expected_stdin = %({"method":"#{method}","arguments":#{arguments.to_json},"context":#{context.to_json},"api_version":#{cpi_api_version}})
@@ -132,12 +124,12 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
     end
 
     context 'when stemcell api_version is given' do
-      let(:director_uuid) {'fake-director-uuid'}
-      let(:request_id) {'cpi-fake-request-id'}
+      let(:director_uuid) { 'fake-director-uuid' }
+      let(:request_id) { 'cpi-fake-request-id' }
       let(:stemcell_api_version) { 5 }
       let(:options) do
         {
-          stemcell_api_version: stemcell_api_version
+          stemcell_api_version: stemcell_api_version,
         }
       end
 
@@ -153,39 +145,26 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
       it 'puts api_version in context passed to cpi and logs it in CPI logs' do
         stub_const('ENV', 'TMPDIR' => '/some/tmp')
 
-        expected_env = {'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp'}
+        expected_env = { 'PATH' => '/usr/sbin:/usr/bin:/sbin:/bin', 'TMPDIR' => '/some/tmp' }
         expected_cmd = '/path/to/fake-cpi/bin/cpi'
         context = {
           'director_uuid' => director_uuid,
           'request_id' => request_id,
           'vm' => {
             'stemcell' => {
-              'api_version' => 5
-            }
-          }
+              'api_version' => 5,
+            },
+          },
         }
         expected_stdin = %({"method":"#{method}","arguments":#{arguments.to_json},"context":#{context.to_json},"api_version":#{cpi_api_version}})
-        expect(logger).to receive(:debug).with(/api_version/)
-
-        expect(Open3).to receive(:capture3).with(expected_env, expected_cmd, stdin_data: expected_stdin, unsetenv_others: true)
-        call_cpi_method
-      end
-
-      it 'logs requests and responses with request id' do
-        stub_const('ENV', 'TMPDIR' => '/some/tmp')
-
         lines = []
         allow(logger).to receive(:debug) { |line| lines << line }
 
+        expect(Open3).to receive(:capture3).with(expected_env, expected_cmd, stdin_data: expected_stdin, unsetenv_others: true)
         call_cpi_method
+
         expect(lines[0]).to start_with "[external-cpi] [#{request_id}] request"
         expect(lines[1]).to start_with "[external-cpi] [#{request_id}] response"
-      end
-    end
-
-    describe 'result' do
-      it 'returns result' do
-        expect(call_cpi_method).to eq(expected_response)
       end
     end
 
@@ -195,18 +174,14 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
       it 'saves the log and stderr in task cpi log' do
         call_cpi_method
         expect(File.read(cpi_log_path)).to eq('fake-logfake-stderr-data')
-      end
-
-      it 'adds to existing file if for a given task several cpi requests were made' do
-        subject.public_send(method, *arguments)
-        subject.public_send(method, *arguments)
+        call_cpi_method
         expect(File.read(cpi_log_path)).to eq('fake-logfake-stderr-datafake-logfake-stderr-data')
       end
 
       context 'when no stderr' do
-        before {
+        before do
           allow(Open3).to receive(:capture3).and_return(cpi_response, nil, 0)
-        }
+        end
 
         it 'saves the log in task cpi log' do
           call_cpi_method
@@ -235,9 +210,9 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
       before { allow(File).to receive(:executable?).with('/path/to/fake-cpi/bin/cpi').and_return(false) }
 
       it 'raises MessageHandlerError' do
-        expect {
+        expect do
           call_cpi_method
-        }.to raise_error(
+        end.to raise_error(
           Bosh::Clouds::ExternalCpi::NonExecutable,
           "Failed to run cpi: '/path/to/fake-cpi/bin/cpi' is not executable",
         )
@@ -260,16 +235,7 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
 
         it 'raises an error constructed from error response' do
           expect { call_cpi_method }.to raise_error(error_class, /CPI error '#{error_type}' with message '#{message}' in '#{method}' CPI method/)
-        end
-
-        it 'saves log and stderr' do
-          begin
-            call_cpi_method
-          rescue
-            expect(File.read(cpi_log_path)).to eq('fake-logfake-stderr-data')
-          else
-            fail 'It should throw exception'
-          end
+          expect(File.read(cpi_log_path)).to eq('fake-logfake-stderr-data')
         end
       end
 
@@ -287,9 +253,9 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
         end
 
         it 'raises an error constructed from error response' do
-          expect {
+          expect do
             call_cpi_method
-          }.to raise_error do |error|
+          end.to raise_error do |error|
             expect(error.class).to eq(error_class)
             expect(error.message).to eq("CPI error '#{error_class}' with message 'fake-error-message' in '#{method}'"\
               " CPI method (CPI request ID: 'cpi-fake-request-id')")
@@ -360,7 +326,7 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
     let(:cloud) { instance_double(Bosh::Clouds::ExternalCpi).as_null_object }
 
     it 'raises an exception if the CPI API version is not supported' do
-      expect{ Bosh::Clouds::ExternalCpiResponseWrapper.new(cloud, 100) }.to raise_error(Bosh::Clouds::NotSupported)
+      expect { Bosh::Clouds::ExternalCpiResponseWrapper.new(cloud, 100) }.to raise_error(Bosh::Clouds::NotSupported)
     end
   end
 
@@ -370,23 +336,23 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
     describe '#create_vm' do
       let(:redacted_network_settings) { nil }
       let(:instance_cid) { 'i-0478554' }
-      let(:networks) {
+      let(:networks) do
         {
           'private' => {
             'type' => 'manual',
             'netmask' => '255.255.255.0',
             'gateway' => '10.230.13.1',
             'ip' => '10.230.13.6',
-            'default' => [ 'dns', 'gateway' ],
-            'cloud_properties' => { 'net_id' => 'd29fdb0d-44d8-4e04-818d-5b03888f8eaa' }
+            'default' => %w[dns gateway],
+            'cloud_properties' => { 'net_id' => 'd29fdb0d-44d8-4e04-818d-5b03888f8eaa' },
           },
           'public' => {
             'type' => 'vip',
             'ip' => '173.101.112.104',
-            'cloud_properties' => {}
-          }
+            'cloud_properties' => {},
+          },
         }
-      }
+      end
       let(:cpi_response) { JSON.dump(result: [instance_cid, networks], error: nil, log: 'fake-log') }
       let(:expected_response) { [instance_cid, networks] }
 
@@ -394,17 +360,15 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
         :create_vm,
         'fake-agent-id',
         'fake-stemcell-cid',
-        {'cloud' => 'props'},
+        { 'cloud' => 'props' },
         nil,
         ['fake-disk-cid'],
-        {
-          'bosh' => {
-            'group' => 'my-group',
-            'groups' => ['my-first-group'],
-            'password' => 'my-secret-password'
-          },
-          'other' => 'value'
-        }
+        'bosh' => {
+          'group' => 'my-group',
+          'groups' => ['my-first-group'],
+          'password' => 'my-secret-password',
+        },
+        'other' => 'value',
       )
 
       context 'when network settings hash cloud properties is absent' do
@@ -414,10 +378,10 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
               'type' => 'manual',
               'ip' => '10.10.0.2',
               'netmask' => '255.255.255.0',
-              'default' => ['dns', 'gateway'],
+              'default' => %w[dns gateway],
               'dns' => ['10.10.0.2'],
-              'gateway' => '10.10.0.1'
-            }
+              'gateway' => '10.10.0.1',
+            },
           }
         end
 
@@ -425,26 +389,24 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
           :create_vm,
           'fake-agent-id',
           'fake-stemcell-cid',
-          {'cloud' => 'props'},
+          { 'cloud' => 'props' },
           {
             'net' => {
               'type' => 'manual',
               'ip' => '10.10.0.2',
               'netmask' => '255.255.255.0',
-              'default' => ['dns', 'gateway'],
+              'default' => %w[dns gateway],
               'dns' => ['10.10.0.2'],
-              'gateway' => '10.10.0.1'
-            }
+              'gateway' => '10.10.0.1',
+            },
           },
           ['fake-disk-cid'],
-          {
-            'bosh' => {
-              'group' => 'my-group',
-              'groups' => ['my-first-group'],
-              'password' => 'my-secret-password'
-            },
-            'other' => 'value'
-          }
+          'bosh' => {
+            'group' => 'my-group',
+            'groups' => ['my-first-group'],
+            'password' => 'my-secret-password',
+          },
+          'other' => 'value',
         )
       end
     end
@@ -474,7 +436,7 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
       end
 
       context('#create_stemcell') do
-        it_calls_cpi_method(:create_stemcell, 'fake-stemcell-image-path', {'cloud' => 'props'})
+        it_calls_cpi_method(:create_stemcell, 'fake-stemcell-image-path', 'cloud' => 'props')
       end
 
       context('#delete_stemcell') do
@@ -503,15 +465,15 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
       end
 
       context('#set_vm_metadata') do
-        it_calls_cpi_method(:set_vm_metadata, 'fake-vm-cid', {'metadata' => 'hash'})
+        it_calls_cpi_method(:set_vm_metadata, 'fake-vm-cid', 'metadata' => 'hash')
       end
 
       context('#set_disk_metadata') do
-        it_calls_cpi_method(:set_disk_metadata, 'fake-disk-cid', {'metadata' => 'hash'})
+        it_calls_cpi_method(:set_disk_metadata, 'fake-disk-cid', 'metadata' => 'hash')
       end
 
       context('#create_disk') do
-        it_calls_cpi_method(:create_disk, 100_000, {'type' => 'gp2'}, 'fake-vm-cid')
+        it_calls_cpi_method(:create_disk, 100_000, { 'type' => 'gp2' }, 'fake-vm-cid')
       end
 
       context('#has_disk') do
@@ -558,37 +520,35 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
     describe '#create_vm' do
       let(:cpi_response) { JSON.dump(result: 'fake-result', error: nil, log: 'fake-log') }
       let(:redacted_network_settings) { nil }
-      let(:expected_response) { ["fake-result"] }
+      let(:expected_response) { ['fake-result'] }
 
       it_calls_cpi_method(
         :create_vm,
         'fake-agent-id',
         'fake-stemcell-cid',
-        {'cloud' => 'props'},
+        { 'cloud' => 'props' },
         nil,
         ['fake-disk-cid'],
-        {
-          'bosh' => {
-            'group' => 'my-group',
-            'groups' => ['my-first-group'],
-            'password' => 'my-secret-password'
-          },
-          'other' => 'value'
-        }
+        'bosh' => {
+          'group' => 'my-group',
+          'groups' => ['my-first-group'],
+          'password' => 'my-secret-password',
+        },
+        'other' => 'value',
       )
 
       context 'when network settings hash cloud properties is absent' do
-        let(:expected_response) { ["fake-result"] }
+        let(:expected_response) { ['fake-result'] }
         let(:redacted_network_settings) do
           {
             'net' => {
               'type' => 'manual',
               'ip' => '10.10.0.2',
               'netmask' => '255.255.255.0',
-              'default' => ['dns', 'gateway'],
+              'default' => %w[dns gateway],
               'dns' => ['10.10.0.2'],
-              'gateway' => '10.10.0.1'
-            }
+              'gateway' => '10.10.0.1',
+            },
           }
         end
 
@@ -596,26 +556,24 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
           :create_vm,
           'fake-agent-id',
           'fake-stemcell-cid',
-          {'cloud' => 'props'},
+          { 'cloud' => 'props' },
           {
             'net' => {
               'type' => 'manual',
               'ip' => '10.10.0.2',
               'netmask' => '255.255.255.0',
-              'default' => ['dns', 'gateway'],
+              'default' => %w[dns gateway],
               'dns' => ['10.10.0.2'],
-              'gateway' => '10.10.0.1'
-            }
+              'gateway' => '10.10.0.1',
+            },
           },
           ['fake-disk-cid'],
-          {
-            'bosh' => {
-              'group' => 'my-group',
-              'groups' => ['my-first-group'],
-              'password' => 'my-secret-password'
-            },
-            'other' => 'value'
-          }
+          'bosh' => {
+            'group' => 'my-group',
+            'groups' => ['my-first-group'],
+            'password' => 'my-secret-password',
+          },
+          'other' => 'value',
         )
       end
     end
@@ -630,75 +588,75 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
       let(:cpi_response) { JSON.dump(result: 'fake-result', error: nil, log: 'fake-log') }
       let(:expected_response) { 'fake-result' }
 
-      context("#current_vm_id") do
+      context('#current_vm_id') do
         it_calls_cpi_method(:current_vm_id)
       end
 
-      context("#create_stemcell") do
-        it_calls_cpi_method(:create_stemcell, 'fake-stemcell-image-path', {'cloud' => 'props'})
+      context('#create_stemcell') do
+        it_calls_cpi_method(:create_stemcell, 'fake-stemcell-image-path', 'cloud' => 'props')
       end
 
-      context("#delete_stemcell") do
+      context('#delete_stemcell') do
         it_calls_cpi_method(:delete_stemcell, 'fake-stemcell-cid')
       end
 
-      context("#delete_vm") do
+      context('#delete_vm') do
         it_calls_cpi_method(:delete_vm, 'fake-vm-cid')
       end
 
-      context("#has_vm") do
+      context('#has_vm') do
         it_calls_cpi_method(:has_vm, 'fake-vm-cid')
       end
 
-      context("#reboot_vm") do
+      context('#reboot_vm') do
         it_calls_cpi_method(:reboot_vm, 'fake-vm-cid')
       end
 
-      context("#set_vm_metadata") do
-        it_calls_cpi_method(:set_vm_metadata, 'fake-vm-cid', {'metadata' => 'hash'})
+      context('#set_vm_metadata') do
+        it_calls_cpi_method(:set_vm_metadata, 'fake-vm-cid', 'metadata' => 'hash')
       end
 
-      context("#set_disk_metadata") do
-        it_calls_cpi_method(:set_disk_metadata, 'fake-disk-cid', {'metadata' => 'hash'})
+      context('#set_disk_metadata') do
+        it_calls_cpi_method(:set_disk_metadata, 'fake-disk-cid', 'metadata' => 'hash')
       end
 
-      context("#create_disk") do
-        it_calls_cpi_method(:create_disk, 100_000, {'type' => 'gp2'}, 'fake-vm-cid')
+      context('#create_disk') do
+        it_calls_cpi_method(:create_disk, 100_000, { 'type' => 'gp2' }, 'fake-vm-cid')
       end
 
-      context("#has_disk") do
+      context('#has_disk') do
         it_calls_cpi_method(:has_disk, 'fake-disk-cid')
       end
 
-      context("#delete_disk") do
+      context('#delete_disk') do
         it_calls_cpi_method(:delete_disk, 'fake-disk-cid')
       end
 
-      context("#detach_disk") do
+      context('#detach_disk') do
         it_calls_cpi_method(:detach_disk, 'fake-vm-cid', 'fake-disk-cid')
       end
 
-      context("#snapshot_disk") do
+      context('#snapshot_disk') do
         it_calls_cpi_method(:snapshot_disk, 'fake-disk-cid')
       end
 
-      context("#delete_snapshot") do
+      context('#delete_snapshot') do
         it_calls_cpi_method(:delete_snapshot, 'fake-snapshot-cid')
       end
 
-      context("#resize_disk") do
+      context('#resize_disk') do
         it_calls_cpi_method(:resize_disk, 'fake-disk-cid', 1024)
       end
 
-      context("#get_disks") do
+      context('#get_disks') do
         it_calls_cpi_method(:get_disks, 'fake-vm-cid')
       end
 
-      context("#ping") do
+      context('#ping') do
         it_calls_cpi_method(:ping)
       end
 
-      context("#info") do
+      context('#info') do
         it_calls_cpi_method(:info)
       end
     end

--- a/src/bosh-director/spec/unit/config_server/client_spec.rb
+++ b/src/bosh-director/spec/unit/config_server/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director::ConfigServer
-  describe ConfigServerClient do
+  describe ConfigServerClient, truncation: true do
     subject(:client) { ConfigServerClient.new(http_client, director_name, logger) }
     let(:director_name) { 'smurf_director_name' }
     let(:deployment_name) { 'deployment_name' }

--- a/src/bosh-director/spec/unit/config_server/client_spec.rb
+++ b/src/bosh-director/spec/unit/config_server/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director::ConfigServer
-  describe ConfigServerClient, truncation: true do
+  describe ConfigServerClient do
     subject(:client) { ConfigServerClient.new(http_client, director_name, logger) }
     let(:director_name) { 'smurf_director_name' }
     let(:deployment_name) { 'deployment_name' }
@@ -1472,35 +1472,35 @@ module Bosh::Director::ConfigServer
               client.generate_values(variables_obj, deployment_name)
             end.to change { Bosh::Director::Models::Event.count }.from(0).to(3)
 
-            event_1 = Bosh::Director::Models::Event.first
-            expect(event_1.user).to eq('user')
-            expect(event_1.action).to eq('create')
-            expect(event_1.object_type).to eq('variable')
-            expect(event_1.object_name).to eq('/smurf_director_name/deployment_name/placeholder_a')
-            expect(event_1.task).to eq(task_id.to_s)
-            expect(event_1.deployment).to eq(deployment_name)
-            expect(event_1.instance).to eq(nil)
-            expect(event_1.context).to eq('id' => 1, 'name' => '/smurf_director_name/deployment_name/placeholder_a')
+            event1 = Bosh::Director::Models::Event.order(:id).first
+            expect(event1.user).to eq('user')
+            expect(event1.action).to eq('create')
+            expect(event1.object_type).to eq('variable')
+            expect(event1.object_name).to eq('/smurf_director_name/deployment_name/placeholder_a')
+            expect(event1.task).to eq(task_id.to_s)
+            expect(event1.deployment).to eq(deployment_name)
+            expect(event1.instance).to eq(nil)
+            expect(event1.context).to eq('id' => 1, 'name' => '/smurf_director_name/deployment_name/placeholder_a')
 
-            event_2 = Bosh::Director::Models::Event.order(:id)[2]
-            expect(event_2.user).to eq('user')
-            expect(event_2.action).to eq('create')
-            expect(event_2.object_type).to eq('variable')
-            expect(event_2.object_name).to eq('/smurf_director_name/deployment_name/placeholder_b')
-            expect(event_2.task).to eq(task_id.to_s)
-            expect(event_2.deployment).to eq(deployment_name)
-            expect(event_2.instance).to eq(nil)
-            expect(event_2.context).to eq('id' => 2, 'name' => '/smurf_director_name/deployment_name/placeholder_b')
+            event2 = Bosh::Director::Models::Event.order(:id).all[1]
+            expect(event2.user).to eq('user')
+            expect(event2.action).to eq('create')
+            expect(event2.object_type).to eq('variable')
+            expect(event2.object_name).to eq('/smurf_director_name/deployment_name/placeholder_b')
+            expect(event2.task).to eq(task_id.to_s)
+            expect(event2.deployment).to eq(deployment_name)
+            expect(event2.instance).to eq(nil)
+            expect(event2.context).to eq('id' => 2, 'name' => '/smurf_director_name/deployment_name/placeholder_b')
 
-            event_3 = Bosh::Director::Models::Event.order(:id)[3]
-            expect(event_3.user).to eq('user')
-            expect(event_3.action).to eq('create')
-            expect(event_3.object_type).to eq('variable')
-            expect(event_3.object_name).to eq('/placeholder_c')
-            expect(event_3.task).to eq(task_id.to_s)
-            expect(event_3.deployment).to eq(deployment_name)
-            expect(event_3.instance).to eq(nil)
-            expect(event_3.context).to eq('id' => 3, 'name' => '/placeholder_c')
+            event3 = Bosh::Director::Models::Event.order(:id).all[2]
+            expect(event3.user).to eq('user')
+            expect(event3.action).to eq('create')
+            expect(event3.object_type).to eq('variable')
+            expect(event3.object_name).to eq('/placeholder_c')
+            expect(event3.task).to eq(task_id.to_s)
+            expect(event3.deployment).to eq(deployment_name)
+            expect(event3.instance).to eq(nil)
+            expect(event3.context).to eq('id' => 3, 'name' => '/placeholder_c')
           end
 
           context 'when variable options contains a CA key' do

--- a/src/bosh-director/spec/unit/db/migrations/director/20170503205545_change_id_local_dns_to_bigint_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/20170503205545_change_id_local_dns_to_bigint_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../db_spec_helper'
 
 module Bosh::Director
-  describe 'change id from int to bigint on local_dns_blob' do
+  describe 'change id from int to bigint on local_dns_blob', truncation: true do
     let(:db) { DBSpecHelper.db }
     let(:migration_file) { '20170503205545_change_id_local_dns_to_bigint.rb' }
 

--- a/src/bosh-director/spec/unit/db/migrations/director/20170815175515_change_variable_ids_to_bigint_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/20170815175515_change_variable_ids_to_bigint_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../../../db_spec_helper'
 
 module Bosh::Director
-  describe 'change id from int to bigint variable_sets & variables' do
+  describe 'change id from int to bigint variable_sets & variables', truncation: true do
     let(:db) { DBSpecHelper.db }
     let(:migration_file) { '20170815175515_change_variable_ids_to_bigint.rb' }
     let(:some_time) do

--- a/src/bosh-director/spec/unit/deployment_plan/compilation_instance_pool_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/compilation_instance_pool_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
 module Bosh::Director
-  describe DeploymentPlan::CompilationInstancePool do
+  describe DeploymentPlan::CompilationInstancePool, truncation: true do
     subject(:compilation_instance_pool) do
       DeploymentPlan::CompilationInstancePool.new(
         instance_reuser,

--- a/src/bosh-director/spec/unit/deployment_plan/compilation_instance_pool_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/compilation_instance_pool_spec.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
 module Bosh::Director
-  describe DeploymentPlan::CompilationInstancePool, truncation: true do
+  describe DeploymentPlan::CompilationInstancePool do
     subject(:compilation_instance_pool) do
       DeploymentPlan::CompilationInstancePool.new(
         instance_reuser,
@@ -224,7 +224,7 @@ module Bosh::Director
         expect(event1.instance).to eq('compilation-deadbeef/instance-uuid-1')
 
         event2 = Bosh::Director::Models::Event.order(:id).last
-        expect(event2.parent_id).to eq(1)
+        expect(event2.parent_id).to eq(event1.id)
         expect(event2.user).to eq('user')
         expect(event2.action).to eq('create')
         expect(event2.object_type).to eq('instance')

--- a/src/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
@@ -37,7 +37,7 @@ RSpec::Matchers.define :log_persistent_disk_change do |expected|
 end
 
 module Bosh::Director::DeploymentPlan
-  describe InstancePlan, truncation: true do
+  describe InstancePlan do
     subject(:instance_plan) do
       InstancePlan.new(
         existing_instance: existing_instance,
@@ -1360,6 +1360,7 @@ module Bosh::Director::DeploymentPlan
           instance_group_spec['persistent_disk_pool'] = 'disk_a'
           instance_group_spec
         end
+
         before do
           persistent_disk = BD::Models::PersistentDisk.make(size: 42, cloud_properties: { 'new' => 'properties' })
           instance_plan.instance.model.add_persistent_disk(persistent_disk)
@@ -1723,7 +1724,7 @@ module Bosh::Director::DeploymentPlan
             )
             expect(logger).to log_dns_change(from: [], to: [{
               ip: '192.168.1.3',
-              instance_id: 4,
+              instance_id: instance_model.id,
               az: nil,
               network: 'a',
               deployment: 'simple',
@@ -1757,14 +1758,14 @@ module Bosh::Director::DeploymentPlan
                 instance_group: nil,
                 network: nil,
                 deployment: nil,
-                instance_id: 4,
+                instance_id: instance_model.id,
                 agent_id: nil,
                 domain: nil,
                 links: [],
               }],
               to: [{
                 ip: '192.168.1.3',
-                instance_id: 4,
+                instance_id: instance_model.id,
                 az: nil,
                 network: 'a',
                 deployment: 'simple',
@@ -1858,7 +1859,7 @@ module Bosh::Director::DeploymentPlan
         it 'enumerates instance group properties and link properties' do
           properties = subject.instance_group_properties
           expect(properties).to eq(
-            instance_id: 4,
+            instance_id: instance_model.id,
             az: nil,
             deployment: 'simple',
             agent_id: 'active-vm-agent-id',
@@ -1904,7 +1905,7 @@ module Bosh::Director::DeploymentPlan
           properties = subject.instance_group_properties
 
           expect(properties).to eq(
-            instance_id: 4,
+            instance_id: instance_model.id,
             az:  nil,
             deployment: 'simple',
             agent_id: 'active-vm-agent-id',

--- a/src/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
@@ -37,7 +37,7 @@ RSpec::Matchers.define :log_persistent_disk_change do |expected|
 end
 
 module Bosh::Director::DeploymentPlan
-  describe InstancePlan do
+  describe InstancePlan, truncation: true do
     subject(:instance_plan) do
       InstancePlan.new(
         existing_instance: existing_instance,

--- a/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
@@ -5,7 +5,7 @@ module Bosh
   module Director
     module DeploymentPlan
       module Steps
-        describe CreateVmStep, truncation: true do
+        describe CreateVmStep do
           subject { CreateVmStep.new(instance_plan, agent_broadcaster, disks, tags, use_existing) }
 
           let(:use_existing) { false }
@@ -295,8 +295,8 @@ module Bosh
             expect(event1.deployment).to eq(instance_model.deployment.name)
             expect(event1.instance).to eq(instance_model.name)
 
-            event2 = Models::Event.order(:id)[2]
-            expect(event2.parent_id).to eq(1)
+            event2 = Models::Event.order(:id).all[1]
+            expect(event2.parent_id).to eq(event1.id)
             expect(event2.user).to eq('user')
             expect(event2.action).to eq('create')
             expect(event2.object_type).to eq('vm')
@@ -312,7 +312,7 @@ module Bosh
               subject.perform(report)
             end.to raise_error Bosh::Clouds::VMCreationFailed
 
-            event2 = Models::Event.order(:id)[2]
+            event2 = Models::Event.order(:id).all[1]
             expect(event2.error).to eq('Bosh::Clouds::VMCreationFailed')
           end
 

--- a/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
@@ -5,7 +5,7 @@ module Bosh
   module Director
     module DeploymentPlan
       module Steps
-        describe CreateVmStep do
+        describe CreateVmStep, truncation: true do
           subject { CreateVmStep.new(instance_plan, agent_broadcaster, disks, tags, use_existing) }
 
           let(:use_existing) { false }

--- a/src/bosh-director/spec/unit/disk_manager_spec.rb
+++ b/src/bosh-director/spec/unit/disk_manager_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Bosh::Director::DiskManager do
+  describe Bosh::Director::DiskManager, truncation: true do
     subject(:disk_manager) { DiskManager.new(logger) }
 
     let(:cloud) { instance_double(Bosh::Clouds::ExternalCpi) }

--- a/src/bosh-director/spec/unit/disk_manager_spec.rb
+++ b/src/bosh-director/spec/unit/disk_manager_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Bosh::Director::DiskManager, truncation: true do
+  describe Bosh::Director::DiskManager do
     subject(:disk_manager) { DiskManager.new(logger) }
 
     let(:cloud) { instance_double(Bosh::Clouds::ExternalCpi) }
@@ -344,8 +344,8 @@ module Bosh::Director
           expect(event1.deployment).to eq(instance_model.deployment.name)
           expect(event1.instance).to eq(instance_model.name)
 
-          event2 = Bosh::Director::Models::Event.order(:id)[2]
-          expect(event2.parent_id).to eq(1)
+          event2 = Bosh::Director::Models::Event.order(:id).all[1]
+          expect(event2.parent_id).to eq(event1.id)
           expect(event2.user).to eq('user')
           expect(event2.action).to eq('create')
           expect(event2.object_type).to eq('disk')
@@ -361,7 +361,7 @@ module Bosh::Director
             disk_manager.update_persistent_disk(instance_plan)
           end.to raise_error Exception, 'error'
 
-          event2 = Bosh::Director::Models::Event.order(:id)[2]
+          event2 = Bosh::Director::Models::Event.order(:id).all[1]
           expect(event2.error).to eq('error')
         end
 

--- a/src/bosh-director/spec/unit/dns/blobstore_dns_publisher_spec.rb
+++ b/src/bosh-director/spec/unit/dns/blobstore_dns_publisher_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe BlobstoreDnsPublisher do
+  describe BlobstoreDnsPublisher, truncation: true do
     include IpUtil
 
     subject(:dns) { BlobstoreDnsPublisher.new(-> { blobstore }, domain_name, agent_broadcaster, logger) }

--- a/src/bosh-director/spec/unit/dns/local_dns_encoder_manager_spec.rb
+++ b/src/bosh-director/spec/unit/dns/local_dns_encoder_manager_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe LocalDnsEncoderManager do
+  describe LocalDnsEncoderManager, truncation: true do
     subject { described_class }
 
     describe '.persist_az_names' do

--- a/src/bosh-director/spec/unit/dns/local_dns_repo_spec.rb
+++ b/src/bosh-director/spec/unit/dns/local_dns_repo_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe LocalDnsRepo do
+  describe LocalDnsRepo, truncation: true do
     subject(:local_dns_repo) { LocalDnsRepo.new(logger, root_domain) }
     let(:deployment_model) { Models::Deployment.make(name: 'bosh.1') }
     let(:root_domain) { 'bosh1.tld' }

--- a/src/bosh-director/spec/unit/dns/local_dns_repo_spec.rb
+++ b/src/bosh-director/spec/unit/dns/local_dns_repo_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe LocalDnsRepo, truncation: true do
+  describe LocalDnsRepo do
     subject(:local_dns_repo) { LocalDnsRepo.new(logger, root_domain) }
     let(:deployment_model) { Models::Deployment.make(name: 'bosh.1') }
     let(:root_domain) { 'bosh1.tld' }
@@ -167,7 +167,7 @@ module Bosh::Director
           expect(diff.obsolete).to be_empty
           expect(diff.missing).to eq([{
             ip: '9876',
-            instance_id: 1,
+            instance_id: instance_model.id,
             az: 'az1',
             network: 'net-name-2',
             deployment: 'bosh.1',
@@ -420,7 +420,7 @@ module Bosh::Director
           expect do
             local_dns_repo.update_for_instance(instance_plan)
           end.to change { Models::LocalDnsRecord.max(:id) }.by(1)
-          expect(Models::LocalDnsRecord.all.map(&:id)).to contain_exactly(1, 2, 3)
+          expect(Models::LocalDnsRecord.count).to eq(3)
         end
 
         it 'inserts a record for the new network and ip' do

--- a/src/bosh-director/spec/unit/event_log_spec.rb
+++ b/src/bosh-director/spec/unit/event_log_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'timecop'
 
-describe Bosh::Director::EventLog::Log, truncation: true do
+describe Bosh::Director::EventLog::Log do
   subject(:event_log) { described_class.new(task_db_writer) }
 
   let(:task_db_writer) { Bosh::Director::TaskDBWriter.new(column_name, task.id) }
@@ -22,15 +22,16 @@ describe Bosh::Director::EventLog::Log, truncation: true do
     expect(events.map { |e| e['state'] }).to eq(['started', 'started', 'finished', 'finished'])
   end
 
-  it 'supports tracking parallel events without being thread safe' +
-     '(since stages can start in the middle of other stages)', truncation: true, :if => ENV.fetch('DB', 'sqlite') != 'sqlite' do
+  it 'supports tracking parallel events without being thread safe' \
+     '(since stages can start in the middle of other stages)',
+     truncation: true, if: ENV.fetch('DB', 'sqlite') != 'sqlite' do
     stage = event_log.begin_stage(:prepare, 5)
     threads = []
 
     5.times do |i|
       threads << Thread.new do
-        sleep(rand()/5)
-        stage.advance_and_track(i) { sleep(rand()/5) }
+        sleep(rand / 5)
+        stage.advance_and_track(i) { sleep(rand / 5) }
       end
     end
 

--- a/src/bosh-director/spec/unit/event_log_spec.rb
+++ b/src/bosh-director/spec/unit/event_log_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'timecop'
 
-describe Bosh::Director::EventLog::Log do
+describe Bosh::Director::EventLog::Log, truncation: true do
   subject(:event_log) { described_class.new(task_db_writer) }
 
   let(:task_db_writer) { Bosh::Director::TaskDBWriter.new(column_name, task.id) }

--- a/src/bosh-director/spec/unit/instance_deleter_spec.rb
+++ b/src/bosh-director/spec/unit/instance_deleter_spec.rb
@@ -150,7 +150,7 @@ module Bosh::Director
           expect(event1.instance).to eq('fake-job-name/my-uuid-1')
 
           event2 = Bosh::Director::Models::Event.order(:id).last
-          expect(event2.parent_id).to eq(1)
+          expect(event2.parent_id).to eq(event1.id)
           expect(event2.user).to eq(task.username)
           expect(event2.action).to eq('delete')
           expect(event2.object_type).to eq('instance')

--- a/src/bosh-director/spec/unit/job_queue_spec.rb
+++ b/src/bosh-director/spec/unit/job_queue_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'bosh/director/job_queue'
 
 module Bosh::Director
-  describe JobQueue do
+  describe JobQueue, truncation: true do
     class FakeJob < Jobs::BaseJob
       def self.job_type
         :snow

--- a/src/bosh-director/spec/unit/jobs/base_job_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/base_job_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Jobs::BaseJob, truncation: true do
+  describe Jobs::BaseJob do
     let(:tasks_dir) { Dir.mktmpdir }
-    let(:task_dir) { File.join(tasks_dir, 'tasks', task_id.to_s) }
+    let(:task_dir) { File.join(tasks_dir, 'tasks', Sham.uuid) }
     before { allow(Config).to receive(:base_dir).and_return(tasks_dir) }
     before { allow(Config).to receive(:cloud_options).and_return({}) }
-    before { allow(Config).to receive(:runtime).and_return({'instance' => 'name/id', 'ip' => '127.0.127.0'}) }
+    before { allow(Config).to receive(:runtime).and_return('instance' => 'name/id', 'ip' => '127.0.127.0') }
 
     describe 'described_class.job_type' do
       it 'should complain that the method is not implemented' do
@@ -21,9 +21,9 @@ module Bosh::Director
         end
       end
 
-      task = Models::Task.make(:id => task_id, :output => task_dir)
+      task = Models::Task.make(output: task_dir)
 
-      testjob_class.perform(task_id, 'workername1')
+      testjob_class.perform(task.id, 'workername1')
 
       task.refresh
       expect(task.state).to eq('done')
@@ -34,14 +34,14 @@ module Bosh::Director
 
     it 'should propagate the worker name to job runner' do
       testjob_class = Class.new(Jobs::BaseJob) do
-        define_method :perform do ; end
+        define_method(:perform) {}
       end
 
-      Models::Task.make(:id => task_id, :output => task_dir)
+      task = Models::Task.make(output: task_dir)
 
       expect(Bosh::Director::JobRunner).to receive(:new).with(anything, anything, 'workername1').and_call_original
 
-      testjob_class.perform(task_id, 'workername1')
+      testjob_class.perform(task.id, 'workername1')
     end
 
     it 'should pass on the rest of the arguments to the actual job' do
@@ -55,13 +55,13 @@ module Bosh::Director
         end
       end
 
-      task = Models::Task.make(:output => task_dir)
+      task = Models::Task.make(output: task_dir)
 
-      testjob_class.perform(task_id, 'workername1', 'a', [:b], {:c => 5})
+      testjob_class.perform(task.id, 'workername1', 'a', [:b], c: 5)
 
       task.refresh
       expect(task.state).to eq('done')
-      expect(JSON.parse(task.result)).to eq(['a', ['b'], {'c' => 5}])
+      expect(JSON.parse(task.result)).to eq(['a', ['b'], { 'c' => 5 }])
     end
 
     it 'should record the error when there is an exception' do
@@ -71,9 +71,9 @@ module Bosh::Director
         end
       end
 
-      task = Models::Task.make(:id => task_id, :output => task_dir)
+      task = Models::Task.make(output: task_dir)
 
-      testjob_class.perform(1, 'workername1')
+      testjob_class.perform(task.id, 'workername1')
 
       task.refresh
       expect(task.state).to eq('error')
@@ -83,7 +83,7 @@ module Bosh::Director
     it 'should raise an exception when the task was not found' do
       testjob_class = Class.new(Jobs::BaseJob) do
         define_method :perform do
-          fail
+          raise
         end
       end
 
@@ -91,20 +91,18 @@ module Bosh::Director
     end
 
     it 'should cancel task' do
-      task = Models::Task.make(:id => 1, :output => task_dir,
-                               :state => 'cancelling')
+      task = Models::Task.make(output: task_dir, state: 'cancelling')
 
-      described_class.perform(1, 'workername1')
+      described_class.perform(task.id, 'workername1')
       task.refresh
       expect(task.state).to eq('cancelled')
       expect(Config.logger).to be_a_kind_of(Logging::Logger)
     end
 
     it 'should cancel timeout-task' do
-      task = Models::Task.make(:id => task_id, :output => task_dir,
-                               :state => 'timeout')
+      task = Models::Task.make(output: task_dir, state: 'timeout')
 
-      described_class.perform(task_id, 'workername1')
+      described_class.perform(task.id, 'workername1')
       task.refresh
       expect(task.state).to eq('cancelled')
       expect(Config.logger).to be_a_kind_of(Logging::Logger)

--- a/src/bosh-director/spec/unit/jobs/base_job_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/base_job_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Jobs::BaseJob do
-    let(:task_id) { 1 }
+  describe Jobs::BaseJob, truncation: true do
     let(:tasks_dir) { Dir.mktmpdir }
     let(:task_dir) { File.join(tasks_dir, 'tasks', task_id.to_s) }
     before { allow(Config).to receive(:base_dir).and_return(tasks_dir) }

--- a/src/bosh-director/spec/unit/jobs/cloud_check/apply_resolutions_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/cloud_check/apply_resolutions_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Jobs::CloudCheck::ApplyResolutions do
+  describe Jobs::CloudCheck::ApplyResolutions, truncation: true do
     before do
       Models::Deployment.make(name: 'deployment')
       allow(ProblemResolver).to receive_messages(new: resolver)

--- a/src/bosh-director/spec/unit/jobs/cloud_check/apply_resolutions_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/cloud_check/apply_resolutions_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Jobs::CloudCheck::ApplyResolutions, truncation: true do
+  describe Jobs::CloudCheck::ApplyResolutions do
     before do
       Models::Deployment.make(name: 'deployment')
       allow(ProblemResolver).to receive_messages(new: resolver)
@@ -21,7 +21,7 @@ module Bosh::Director
     end
     let(:job) { described_class.new('deployment', resolutions) }
     let(:resolver) { instance_double('Bosh::Director::ProblemResolver') }
-    let(:deployment) { Models::Deployment[1] }
+    let(:deployment) { Models::Deployment.first }
 
     describe '#perform' do
       context 'when resolution succeeds' do

--- a/src/bosh-director/spec/unit/jobs/cloud_check/scan_and_fix_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/cloud_check/scan_and_fix_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Jobs::CloudCheck::ScanAndFix, truncation: true do
+  describe Jobs::CloudCheck::ScanAndFix do
     let!(:deployment) { Models::Deployment.make(name: 'deployment') }
     let(:jobs) { [%w[job1 job1index0], %w[job1 job1index1], %w[job2 job2index0]] }
     let(:resolutions) do
@@ -177,7 +177,7 @@ module Bosh::Director
     describe '#resolutions' do
       it 'only lists resolutions for jobs whose state is either "unresponsive_agent" or "missing_vm"' do
         res = scan_and_fix.resolutions(jobs)
-        expect(res).to eq('1' => :recreate_vm, '2' => :recreate_vm)
+        expect(res).to eq(resolutions)
       end
 
       context 'when a VM is ignored' do
@@ -185,7 +185,7 @@ module Bosh::Director
 
         it 'should not list it as a resolution' do
           res = scan_and_fix.resolutions(jobs)
-          expect(res).to eq('1' => :recreate_vm)
+          expect(res).to eq(Models::DeploymentProblem.all[0].id.to_s => :recreate_vm)
         end
       end
     end

--- a/src/bosh-director/spec/unit/jobs/delete_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/delete_deployment_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Jobs::DeleteDeployment do
+  describe Jobs::DeleteDeployment, truncation: true do
     include Support::FakeLocks
     before { fake_locks }
 

--- a/src/bosh-director/spec/unit/jobs/delete_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/delete_deployment_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Jobs::DeleteDeployment, truncation: true do
+  describe Jobs::DeleteDeployment do
     include Support::FakeLocks
     before { fake_locks }
 
@@ -59,7 +59,7 @@ module Bosh::Director
       expect(event1.timestamp).to eq(Time.now)
 
       event2 = Bosh::Director::Models::Event.order(:id).last
-      expect(event2.parent_id).to eq(1)
+      expect(event2.parent_id).to eq(event1.id)
       expect(event2.user).to eq(task.username)
       expect(event2.action).to eq('delete')
       expect(event2.object_type).to eq('deployment')

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Bosh::Director
   module Jobs
-    describe UpdateDeployment do
+    describe UpdateDeployment, truncation: true do
       subject(:job) do
         UpdateDeployment.new(manifest_content, cloud_config_id, runtime_config_ids, options).tap do |obj|
           allow(obj).to receive(:task_id).and_return(task.id)

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Bosh::Director
   module Jobs
-    describe UpdateDeployment, truncation: true do
+    describe UpdateDeployment do
       subject(:job) do
         UpdateDeployment.new(manifest_content, cloud_config_id, runtime_config_ids, options).tap do |obj|
           allow(obj).to receive(:task_id).and_return(task.id)
@@ -618,7 +618,7 @@ module Bosh::Director
             expect(event_1.timestamp).to eq(Time.now)
 
             event_2 = Models::Event.order(:id).last
-            expect(event_2.parent_id).to eq(1)
+            expect(event_2.parent_id).to eq(event_1.id)
             expect(event_2.user).to eq(task.username)
             expect(event_2.object_type).to eq('deployment')
             expect(event_2.deployment).to eq('deployment-name')

--- a/src/bosh-director/spec/unit/jobs/update_release_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_release_spec.rb
@@ -3,7 +3,7 @@ require 'support/release_helper'
 require 'digest'
 
 module Bosh::Director
-  describe Jobs::UpdateRelease, truncation: true do
+  describe Jobs::UpdateRelease do
     before do
       allow(Bosh::Director::Config).to receive(:verify_multidigest_path).and_return('some/path')
       allow(App).to receive_message_chain(:instance, :blobstores, :blobstore).and_return(blobstore)
@@ -791,7 +791,7 @@ module Bosh::Director
         expect(rv.templates.map { |t| t.version }).to match_array(%w(0.2-dev 33 666))
       end
 
-      it 'performs the rebase if same release is being rebased twice', truncation: true, :if => ENV.fetch('DB', 'sqlite') != 'sqlite' do
+      it 'performs the rebase if same release is being rebased twice', if: ENV.fetch('DB', 'sqlite') != 'sqlite' do
         allow(Config).to receive_message_chain(:current_job, :username).and_return('username')
         task = Models::Task.make(state: 'processing')
         allow(Config).to receive_message_chain(:current_job, :task_id).and_return(task.id)

--- a/src/bosh-director/spec/unit/jobs/update_release_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_release_spec.rb
@@ -3,7 +3,7 @@ require 'support/release_helper'
 require 'digest'
 
 module Bosh::Director
-  describe Jobs::UpdateRelease do
+  describe Jobs::UpdateRelease, truncation: true do
     before do
       allow(Bosh::Director::Config).to receive(:verify_multidigest_path).and_return('some/path')
       allow(App).to receive_message_chain(:instance, :blobstores, :blobstore).and_return(blobstore)

--- a/src/bosh-director/spec/unit/lock_spec.rb
+++ b/src/bosh-director/spec/unit/lock_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe Lock, truncation: true, :if => ENV.fetch('DB', 'sqlite') != 'sqlite' do
+  describe Lock, truncation: true, if: ENV.fetch('DB', 'sqlite') != 'sqlite' do
     let!(:task) { Models::Task.make(state: 'processing') }
     before do
       allow(Config).to receive_message_chain(:current_job, :username).and_return('current-user')

--- a/src/bosh-director/spec/unit/models/config_spec.rb
+++ b/src/bosh-director/spec/unit/models/config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director::Models
-  describe Config, truncation: true do
+  describe Config do
     let(:config_model) { Config.make(content: "---\n{key : value}") }
 
     describe '#raw_manifest' do
@@ -184,7 +184,7 @@ module Bosh::Director::Models
             [global_cloud_config.id, red_team_cloud_config.id, blue_team_runtime_config.id],
             red_team,
           )
-        end.to raise_error(Sequel::NoMatchingRow, /Failed to find ID: 6/)
+        end.to raise_error(Sequel::NoMatchingRow, /Failed to find ID: #{blue_team_runtime_config.id}/)
       end
     end
 

--- a/src/bosh-director/spec/unit/models/config_spec.rb
+++ b/src/bosh-director/spec/unit/models/config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director::Models
-  describe Config do
+  describe Config, truncation: true do
     let(:config_model) { Config.make(content: "---\n{key : value}") }
 
     describe '#raw_manifest' do

--- a/src/bosh-director/spec/unit/models/event_spec.rb
+++ b/src/bosh-director/spec/unit/models/event_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director::Models
-  describe Event do
+  describe Event, truncation: true do
     it 'should save bigint ids' do
       expect {
         Event.make('id' => 9223372036854775807, 'parent_id' => 9223372036854775806)

--- a/src/bosh-director/spec/unit/models/link_consumer_intent_spec.rb
+++ b/src/bosh-director/spec/unit/models/link_consumer_intent_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'bosh/director/models/variable'
 
 module Bosh::Director::Models::Links
-  describe LinkConsumerIntent, truncation: true do
+  describe LinkConsumerIntent do
     let(:consumer) { LinkConsumer.create(deployment: deployment, name: 'test', type: 'job') }
     let(:deployment) { Bosh::Director::Models::Deployment.create(name: 'test') }
     let(:subject) { LinkConsumerIntent.create(link_consumer: consumer, original_name: 'test', type: 'db') }
@@ -15,10 +15,9 @@ module Bosh::Director::Models::Links
     end
 
     context '#target_link_id' do
-      before do
-        Link.create(name: 'link', link_consumer_intent: subject, link_content: '{}')
-        Link.create(name: 'link', link_consumer_intent: subject, link_content: '{}')
-      end
+      let!(:link1) { Link.create(name: 'link', link_consumer_intent: subject, link_content: '{}') }
+      let!(:link2) { Link.create(name: 'link', link_consumer_intent: subject, link_content: '{}') }
+
       it 'should return the target link id defined in the metadata' do
         subject.metadata = { explicit_link: true, target_link_id: 5 }.to_json
         subject.save
@@ -27,7 +26,7 @@ module Bosh::Director::Models::Links
 
       context 'when there is no metadata' do
         it 'should return fallback link id' do
-          expect(subject.target_link_id).to eq(2)
+          expect(subject.target_link_id).to eq(link2.id)
         end
       end
 
@@ -35,7 +34,7 @@ module Bosh::Director::Models::Links
         it 'should return fallback link id' do
           subject.metadata = { explicit_link: true }.to_json
           subject.save
-          expect(subject.target_link_id).to eq(2)
+          expect(subject.target_link_id).to eq(link2.id)
         end
       end
     end

--- a/src/bosh-director/spec/unit/models/link_consumer_intent_spec.rb
+++ b/src/bosh-director/spec/unit/models/link_consumer_intent_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'bosh/director/models/variable'
 
 module Bosh::Director::Models::Links
-  describe LinkConsumerIntent do
+  describe LinkConsumerIntent, truncation: true do
     let(:consumer) { LinkConsumer.create(deployment: deployment, name: 'test', type: 'job') }
     let(:deployment) { Bosh::Director::Models::Deployment.create(name: 'test') }
     let(:subject) { LinkConsumerIntent.create(link_consumer: consumer, original_name: 'test', type: 'db') }

--- a/src/bosh-director/spec/unit/models/persistent_disk_spec.rb
+++ b/src/bosh-director/spec/unit/models/persistent_disk_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director::Models
-  describe PersistentDisk do
+  describe PersistentDisk, truncation: true do
     subject(:persistent_disk) { described_class.make }
 
     describe 'cloud_properties' do

--- a/src/bosh-director/spec/unit/models/persistent_disk_spec.rb
+++ b/src/bosh-director/spec/unit/models/persistent_disk_spec.rb
@@ -1,14 +1,12 @@
 require 'spec_helper'
 
 module Bosh::Director::Models
-  describe PersistentDisk, truncation: true do
+  describe PersistentDisk do
     subject(:persistent_disk) { described_class.make }
 
     describe 'cloud_properties' do
       let(:disk_cloud_properties) do
-        {
-          'fake-cloud-property-key' => 'fake-cloud-property-value'
-        }
+        { 'fake-cloud-property-key' => 'fake-cloud-property-value' }
       end
 
       it 'updates cloud_properties' do

--- a/src/bosh-director/spec/unit/problem_handlers/inactive_disk_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/inactive_disk_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
-describe Bosh::Director::ProblemHandlers::InactiveDisk, truncation: true do
+describe Bosh::Director::ProblemHandlers::InactiveDisk do
   def make_handler(disk_id, data = {})
     Bosh::Director::ProblemHandlers::InactiveDisk.new(disk_id, data)
   end

--- a/src/bosh-director/spec/unit/problem_handlers/inactive_disk_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/inactive_disk_spec.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
-describe Bosh::Director::ProblemHandlers::InactiveDisk do
-
+describe Bosh::Director::ProblemHandlers::InactiveDisk, truncation: true do
   def make_handler(disk_id, data = {})
     Bosh::Director::ProblemHandlers::InactiveDisk.new(disk_id, data)
   end

--- a/src/bosh-director/spec/unit/problem_resolver_spec.rb
+++ b/src/bosh-director/spec/unit/problem_resolver_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe ProblemResolver, truncation: true do
+  describe ProblemResolver do
     let(:event_manager) { Bosh::Director::Api::EventManager.new(true)}
     let(:job) {instance_double(Bosh::Director::Jobs::BaseJob, username: 'user', task_id: task.id, event_manager: event_manager)}
     let(:cloud_factory) { instance_double(Bosh::Director::CloudFactory) }
@@ -101,12 +101,12 @@ module Bosh::Director
 
           expect(resolver).to receive(:track_and_log)
                                   .and_raise(Bosh::Director::ProblemHandlerError.new('Resolution failed'))
-          expect(logger).to receive(:error).with("Error resolving problem '1': Resolution failed")
+          expect(logger).to receive(:error).with("Error resolving problem '#{problem.id}': Resolution failed")
           expect(logger).to receive(:error).with(backtrace)
 
           count, error_message = resolver.apply_resolutions({ problem.id.to_s => 'ignore' })
 
-          expect(error_message).to eq("Error resolving problem '1': Resolution failed")
+          expect(error_message).to eq("Error resolving problem '#{problem.id}': Resolution failed")
           expect(count).to eq(1)
         end
       end
@@ -120,12 +120,12 @@ module Bosh::Director
 
           expect(ProblemHandlers::Base).to receive(:create_from_model)
                                                .and_raise(StandardError.new('Model creation failed'))
-          expect(logger).to receive(:error).with("Error resolving problem '1': Model creation failed")
+          expect(logger).to receive(:error).with("Error resolving problem '#{problem.id}': Model creation failed")
           expect(logger).to receive(:error).with(backtrace)
 
           count, error_message = resolver.apply_resolutions({ problem.id.to_s => 'ignore' })
 
-          expect(error_message).to eq("Error resolving problem '1': Model creation failed")
+          expect(error_message).to eq("Error resolving problem '#{problem.id}': Model creation failed")
           expect(count).to eq(0)
         end
       end

--- a/src/bosh-director/spec/unit/problem_resolver_spec.rb
+++ b/src/bosh-director/spec/unit/problem_resolver_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Bosh::Director
-  describe ProblemResolver do
+  describe ProblemResolver, truncation: true do
     let(:event_manager) { Bosh::Director::Api::EventManager.new(true)}
     let(:job) {instance_double(Bosh::Director::Jobs::BaseJob, username: 'user', task_id: task.id, event_manager: event_manager)}
     let(:cloud_factory) { instance_double(Bosh::Director::CloudFactory) }


### PR DESCRIPTION
Some time in the past we changed everything to be incidentally truncating the director's database after each unit test. While this generates a completely consistent running environment for the test, it causes the entire suite to slow quite a bit down.

With the changes in this PR I was able to get units to run in about 15 minutes (as opposed to over 1h currently)