### PR TITLE
Fix input for rake task fly:integration

### DIFF
--- a/src/bosh-dev/lib/bosh/dev/tasks/fly.rake
+++ b/src/bosh-dev/lib/bosh/dev/tasks/fly.rake
@@ -12,7 +12,7 @@ namespace :fly do
   # bundle exec rake fly:integration
   desc 'Fly integration gocli specs'
   task :integration do
-    execute('test-integration-gocli', '-p --inputs-from bosh/integration-postgres-gocli-sha2',
+    execute('test-integration-gocli', '-p --inputs-from bosh/integration-db-tls-postgres',
             DB: (ENV['DB'] || 'postgresql'), SPEC_PATH: (ENV['SPEC_PATH'] || nil))
   end
 


### PR DESCRIPTION
### What is this change about?

Fix rake task `fly:integration`

### Please provide contextual information.

Jobs in the main/bosh pipeline have been removed with commit:
https://github.com/cloudfoundry/bosh/commit/ffab4c71795011ddb017aba2e7405da43504f9ba. The rake task `fly:integration` used the removed job `integration-postgres-gocli-sha2`.

### What tests have you run against this PR?

we ran the rake task once 

### Tag your pair, your PM, and/or team!

Co-authored-by: Kai Hofstetter <kai.hofstetter@sap.com>