### PR TITLE
Speed up recursive chown

### DIFF
--- a/jobs/director/templates/pre-start.erb
+++ b/jobs/director/templates/pre-start.erb
@@ -8,7 +8,7 @@ DB_MUTUAL_TLS_PRIVATE_KEY=/var/vcap/jobs/director/config/db/client_private_key.k
 TMPDIR=/var/vcap/data/director/tmp
 
 mkdir -p $STORE_DIR
-chown -R vcap:vcap $STORE_DIR
+find $STORE_DIR \( -not -user vcap -or -not -group vcap \) -execdir chown vcap:vcap {} \+
 
 chmod -R 0640 $CONFIG_DIR
 find $CONFIG_DIR -type d | xargs -n1 chmod 0750


### PR DESCRIPTION
### What is this change about?

Only execute chown for files whose user or group is not already vcap.
$STORE_DIR stores all director tasks. With for example 300,000 files, before this change, this command takes multiple seconds until up to 30 minutes to complete depending on the persistent disk type used.
After this change, this command runs within less than 1 second.
This reduces downtime caused by bosh updates by seconds to minutes.

### What tests have you run against this PR?

There are no tests for pre start scripts? I just ran the command on a director and compared how long it takes before and after this change.

### Tag your pair, your PM, and/or team!
@voelzmo @friegger 

We were also discussing whether we even need the recursion?
Why not just `chown vcap:vcap $STORE_DIR`?
