### PR TITLE
Added update feature to managed networks

### DIFF
--- a/src/bosh-director/db/migrations/director/20181024001616_add_subnet_metadata_to_subnets.rb
+++ b/src/bosh-director/db/migrations/director/20181024001616_add_subnet_metadata_to_subnets.rb
@@ -1,0 +1,9 @@
+Sequel.migration do
+  up do
+    alter_table(:subnets) do
+      add_column :predeployment_cloud_properties, String, null: false, default: '{}'
+      add_column :type, String, null: false, default: 'range'
+      add_column :netmask_bits, Integer, null: true
+    end
+  end
+end

--- a/src/bosh-director/db/migrations/migration_digests.json
+++ b/src/bosh-director/db/migrations/migration_digests.json
@@ -150,6 +150,7 @@
   "20181017210108_add_type_to_local_dns_encoded_instance_group": "c381ec9869bd19121f80f7a9c99213dbce55c680",
   "20181017233927_add_links_json_to_local_dns_record": "90ad875b1b9ab1aa665951c10a7c1b09076779e6",
   "20181019225226_rename_table_local_dns_encoded_instance_group": "b8a98f3b040a03f8ee30a39d5c9d3bd5102858fe",
+  "20181024001616_add_subnet_metadata_to_subnets": "5a0c5ece23485d734cf154a7122b26efae75105d",
   "20190104135624_add_update_completed_to_release_versions": "648645410ac265aa009e70d3a5cc6f403febde5f",
   "20190114153103_add_index_to_tasks": "50f68f6f1b0ce5765af6417a8b9bc0e1ffd5bb04",
   "20190313231924_remove_constraints_from_local_dns_blobs": "944bca2751c4c12680cbda63dfd35e7b15dac932",
@@ -160,3 +161,4 @@
   "20190325095716_remove_resurrection_paused": "546c855e7d2ee00a4f9867ab1d819847781a06de",
   "20190327222054_scale_dns_blob_version": "2460bacc06eae7368d9322a97bfe781a10c59d3f"
 }
+

--- a/src/bosh-director/lib/bosh/director/deployment_deleter.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_deleter.rb
@@ -48,6 +48,8 @@ module Bosh::Director
             if network.deployments.size == 1
               OrphanNetworkManager.new(Config.logger).orphan_network(network)
             end
+
+            remove_unused_subnets(deployment_model, network)
           end
         end
       end
@@ -55,6 +57,53 @@ module Bosh::Director
       event_log_stage.advance_and_track('Destroying deployment') do
         @logger.info('Destroying deployment')
         deployment_model.destroy
+      end
+    end
+
+    private
+
+    def unused_subnets(new_subnets, old_subnets)
+      old_subnets.select do |subnet|
+        new_subnets.find { |e| e['name'] == subnet.name }.nil?
+      end
+    end
+
+    def latest_cloud_config(deployment)
+      Models::Config.latest_set_for_teams('cloud', *deployment.teams).max(&:id).raw_manifest
+    end
+
+    def used_cloud_config_state(deployment)
+      latest = Models::Config.latest_set_for_teams('cloud', *deployment.teams).map(&:id).sort
+      if deployment.cloud_configs.empty?
+        'none'
+      elsif deployment.cloud_configs.map(&:id).sort == latest
+        'latest'
+      else
+        'outdated'
+      end
+    end
+
+    def delete_subnet(cloud_factory, subnet)
+      cpi = cloud_factory.get(subnet.cpi)
+      begin
+        @logger.info("deleting unused subnet #{subnet.name}")
+        cpi.delete_network(subnet.cid)
+      rescue StandardError => e
+        @logger.error("failed to delete subnet #{subnet.name}: #{e.message}")
+      end
+
+      subnet.destroy
+    end
+
+    def remove_unused_subnets(deployment_model, network)
+      other_deployments = network.deployments.delete_if { |x| x == deployment_model }
+      return if other_deployments.empty?
+      return unless other_deployments.all? { |deployment| used_cloud_config_state(deployment) == 'latest' }
+      cloud_config_hash = latest_cloud_config(other_deployments.first)
+      network_spec = cloud_config_hash['networks'].find { |x| x['name'] == network.name }
+      unused_subnets(network_spec['subnets'], network.subnets).each do |subnet|
+        cloud_factory = AZCloudFactory.create_with_latest_configs(deployment_model)
+        delete_subnet(cloud_factory, subnet)
       end
     end
   end

--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -132,9 +132,6 @@ module Bosh::Director
 
             with_network_lock(network.name) do
               db_network = Bosh::Director::Models::Network.first(name: network.name)
-              # To actually remove the subnets, two conditions have to be met:
-              # 1) all deployments are upgraded to the latest cloud config
-              # 2) There are subnets in the database for that network that don't exist anymore in the manifest
               if db_network.deployments.all? { |deployment| used_cloud_config_state(deployment) == 'latest' }
                 unused_subnets(network.subnets, db_network.subnets).each do |subnet|
                   cloud_factory = AZCloudFactory.create_with_latest_configs(deployment_model)

--- a/src/bosh-director/lib/cloud/dummy.rb
+++ b/src/bosh-director/lib/cloud/dummy.rb
@@ -246,9 +246,9 @@ module Bosh
         File.write(file, network_info)
         addr_properties = {}
         if subnet_definition.key?('netmask_bits')
-          addr_properties['range'] = '192.168.10.0/24'
-          addr_properties['gateway'] = '192.168.10.1'
-          addr_properties['reserved'] = ['192.168.10.2']
+          addr_properties['range'] = '172.16.10.0/24'
+          addr_properties['gateway'] = '172.16.10.1'
+          addr_properties['reserved'] = ['172.16.10.2']
         end
 
         [network_id, addr_properties, { name: network_id }]

--- a/src/bosh-director/spec/unit/db/migrations/director/20181024001616_add_subnet_metadata_to_subnets_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/20181024001616_add_subnet_metadata_to_subnets_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../../../db_spec_helper'
+
+module Bosh::Director
+  describe 'add subnet metadata to subnets' do
+    let(:db) { DBSpecHelper.db }
+    let(:migration_file) { '20181024001616_add_subnet_metadata_to_subnets.rb' }
+
+    before do
+      DBSpecHelper.migrate_all_before(migration_file)
+      DBSpecHelper.migrate(migration_file)
+    end
+
+    it 'adds type, netmask_bits, and predeployment_cloud_properties to subnets' do
+      expect(db[:subnets].columns).to include(:type)
+      expect(db[:subnets].columns).to include(:predeployment_cloud_properties)
+      expect(db[:subnets].columns).to include(:netmask_bits)
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -36,6 +36,7 @@ module Bosh::Director
         end
       end
       let(:deployment_name) { 'deployment-name'}
+      let(:network_name) { 'network-name'}
 
       before do
         App.new(config)
@@ -59,6 +60,7 @@ module Bosh::Director
           )
         end
         let(:deployment_model) { Bosh::Director::Models::Deployment.make(name: deployment_name, manifest: '{}') }
+        let(:network_model) { Bosh::Director::Models::Network.make(name: network_name) }
         let(:planner) do
           instance_double(
             DeploymentPlan::Planner,
@@ -138,6 +140,7 @@ module Bosh::Director
               allow(config_server_client).to receive(:generate_values)
 
               allow(Models::Deployment).to receive(:find).with({name: 'deployment-name'}).and_return(deployment_model)
+
               allow(Time).to receive(:now).and_return(fixed_time)
               allow(deployment_model).to receive(:add_variable_set)
               allow(links_manager).to receive(:remove_unused_links)
@@ -196,6 +199,7 @@ module Bosh::Director
                   unorphanable,
                 ]
                 allow(deployment_model).to receive(:remove_network)
+                allow(job).to receive(:remove_unused_subnets)
                 allow(job).to receive(:with_network_lock) do |&block|
                   block.call
                 end
@@ -410,6 +414,7 @@ module Bosh::Director
 
             context 'even when network lifecycle is enabled' do
               before do
+                allow(job).to receive(:remove_unused_subnets)
                 allow(Config).to receive(:network_lifecycle_enabled?).and_return true
               end
 

--- a/src/spec/gocli/integration/network_lifecycle_spec.rb
+++ b/src/spec/gocli/integration/network_lifecycle_spec.rb
@@ -44,6 +44,16 @@ describe 'network lifecycle', type: :integration do
       manifest_hash['instance_groups'].first['instances'] = 1
       manifest_hash['instance_groups'].first['azs'] = ['z1']
       manifest_hash['instance_groups'].first['networks'] = [{ 'name' => 'a' }]
+      manifest_hash['instance_groups'] << {
+        'instances' => 1,
+        'azs' => ['z1'],
+        'networks' => [{ 'name' => 'a' }],
+        'name' => 'another_instance_group',
+        'jobs' => [{ 'name' => 'foobar', 'properties' => {} }],
+        'stemcell' => 'default',
+        'vm_type' => 'a',
+        'properties' => {},
+      }
     end
 
     context 'when deploying a manifest with a managed network' do
@@ -410,6 +420,512 @@ describe 'network lifecycle', type: :integration do
       expect(delete_network_invocations.count).to eq(3)
       networks = current_sandbox.cpi.network_cids
       expect(networks.count).to eq(0)
+    end
+
+    context 'update network' do
+      let(:dummysubnet1) do
+        {
+          'azs' => ['z1'],
+          'name' => 'dummysubnet1',
+          'range' => '192.168.10.0/24',
+          'gateway' => '192.168.10.1',
+          'cloud_properties' => { 't0_id' => '123456' },
+          'dns' => ['8.8.8.8'],
+        }
+      end
+
+      let(:dummysubnet2) do
+        {
+          'azs' => ['z1'],
+          'name' => 'dummysubnet2',
+          'range' => '192.168.20.0/24',
+          'gateway' => '192.168.20.1',
+          'cloud_properties' => { 't0_id' => '123456' },
+          'dns' => ['8.8.8.8'],
+        }
+      end
+
+      let(:dummysubnet3) do
+        {
+          'azs' => ['z1'],
+          'name' => 'dummysubnet3',
+          'netmask_bits' => 24,
+          'cloud_properties' => { 't0_id' => '123456' },
+          'dns' => ['8.8.8.8'],
+        }
+      end
+
+      let(:dummysubnet4) do
+        {
+          'azs' => ['z1'],
+          'name' => 'dummysubnet4',
+          'range' => '192.168.40.0/24',
+          'gateway' => '192.168.40.1',
+          'cloud_properties' => { 't0_id' => '123456' },
+          'dns' => ['8.8.8.8'],
+        }
+      end
+
+      let(:dummysubnet5) do
+        {
+          'azs' => ['z1'],
+          'name' => 'dummysubnet5',
+          'netmask_bits' => 16,
+          'cloud_properties' => { 't0_id' => '123456' },
+          'dns' => ['8.8.8.8'],
+        }
+      end
+
+      it 'should create network in the iaas when subnets are added in cloud config' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'] << dummysubnet2
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(2)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(2)
+      end
+
+      it 'should delete network in the iaas when subnets are removed from cloud config' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet2],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].delete_at(1)
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(1)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(2)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(1)
+        # check that another deploy doesnt cause any more network deletions
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        expect(delete_network_invocations.count).to eq(1)
+      end
+
+      it 'should not delete network in the iaas when other deployments are outdated' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet2],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        manifest_hash['name'] = 'another-deployment'
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].delete_at(1)
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(2)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(2)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(0)
+      end
+
+      it 'should delete network in the iaas when all deployments are updated' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet2],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        first_deployment_name = manifest_hash['name']
+        manifest_hash['name'] = 'another-deployment'
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        manifest_hash['name'] = 'another-deployment-2'
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].delete_at(1)
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(0)
+
+        bosh_runner.run('delete-deployment', deployment_name: first_deployment_name)
+
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(0)
+
+        manifest_hash['name'] = 'another-deployment'
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(1)
+      end
+
+      it 'should update modified subnets' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet2],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].last['subnets'].last['gateway'] = '192.168.30.1'
+        cloud_config_hash['networks'].last['subnets'].last['range'] = '192.168.30.0/24'
+        cloud_config_hash['networks'].last['subnets'].first['dns'] = ['1.1.1.1']
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(2)
+        exp_create_network_input = [
+          {
+            'type' => 'manual',
+            'range' => '192.168.10.0/24',
+            'gateway' => '192.168.10.1',
+            'cloud_properties' => { 'a' => 'b', 't0_id' => '123456' },
+          },
+          {
+            'type' => 'manual',
+            'range' => '192.168.20.0/24',
+            'gateway' => '192.168.20.1',
+            'cloud_properties' => { 'a' => 'b', 't0_id' => '123456' },
+          },
+          {
+            'type' => 'manual',
+            'range' => '192.168.30.0/24',
+            'gateway' => '192.168.30.1',
+            'cloud_properties' => { 'a' => 'b', 't0_id' => '123456' },
+          },
+        ]
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(3)
+        create_network_invocations.each do |subnet_invocation|
+          cpi_input = subnet_invocation.inputs['subnet_definition']
+          idx = exp_create_network_input.index(cpi_input)
+          expect(idx).to be_truthy
+          exp_create_network_input.delete_at(idx)
+        end
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(1)
+      end
+
+      it 'should recreate subnet when modified from range definition to size definition' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].first['netmask_bits'] = 24
+        cloud_config_hash['networks'].first['subnets'].first.delete('gateway')
+        cloud_config_hash['networks'].first['subnets'].first.delete('range')
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(1)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(2)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(1)
+      end
+
+      it 'should recreate subnet when modified from size definition to range definition' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet3],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].first['gateway'] = '192.168.10.1'
+        cloud_config_hash['networks'].first['subnets'].first['range'] = '192.168.10.0/24'
+        cloud_config_hash['networks'].first['subnets'].first.delete('netmask_bits')
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(1)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(2)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(1)
+      end
+
+      it 'should recreate subnet when modified from one size definition to another' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet3],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].first['netmask_bits'] = 16
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(1)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(2)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(1)
+      end
+
+      it 'should not recreate subnet when dns is modified' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet3],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].first['dns'] = ['1.1.1.1']
+        cloud_config_hash['networks'].first['subnets'].last['dns'] = ['2.2.2.2']
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(2)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(2)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(0)
+      end
+
+      it 'should recreate subnets when cloud properties are modified' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet3],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].first['range'] = '192.168.50.0/24'
+        cloud_config_hash['networks'].first['subnets'].first['gateway'] = '192.168.50.1'
+        cloud_config_hash['networks'].first['subnets'].first['cloud_properties'] = { 't0_id' => '987654' }
+        cloud_config_hash['networks'].first['subnets'].last['cloud_properties'] = { 't0_id' => '34534' }
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(2)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(4)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(2)
+      end
+
+      it 'should not support adding new subnets that overlap with current subnets' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet2],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].first['name'] = 'new subnet'
+        cloud_config_hash['networks'].first['subnets'].first['range'] = '192.168.10.0/26'
+        cloud_config_hash['networks'].first['subnets'].first['gateway'] = '192.168.10.2'
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        expect do
+          deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        end.to raise_error
+      end
+
+      it 'should not support modifying a current subnet with an overlapping subnet' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet2],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].first['range'] = '192.168.10.0/26'
+        cloud_config_hash['networks'].first['subnets'].first['gateway'] = '192.168.10.2'
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        expect do
+          deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        end.to raise_error
+      end
+
+      it 'should detect changes for subnet name only [range defined]' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet2],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].first['name'] = 'dummy-subnet-name-change'
+        cloud_config_hash['networks'].first['subnets'].last['name'] = 'dummy-subnet2-name-change'
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(2)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(0)
+      end
+
+      it 'subnet-name only changes should still recreate a [size defined] subnet' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet3],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['subnets'].first['name'] = 'another-dummy-subnet-name-change'
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(2)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(1)
+      end
+
+      it 'should handle transferring a network from managed to unmanaged' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].first['managed'] = false
+        cloud_config_hash['networks'].first['subnets'].first['name'] = 'another-dummy-subnet-name-change'
+        cloud_config_hash['networks'].first['subnets'].first['range'] = '192.168.50.0/24'
+        cloud_config_hash['networks'].first['subnets'].first['gateway'] = '192.168.50.1'
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(1)
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(0)
+      end
+
+      it 'should add, remove, and update modified subnets' do
+        cloud_config_hash['networks'] = [{
+          'name' => 'a',
+          'type' => 'manual',
+          'managed' => true,
+          'subnets' => [dummysubnet1, dummysubnet2],
+        }]
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_from_scratch(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        cloud_config_hash['networks'].last['subnets'].last['gateway'] = '192.168.30.1'
+        cloud_config_hash['networks'].last['subnets'].last['range'] = '192.168.30.0/24'
+        cloud_config_hash['networks'].last['subnets'][0] = dummysubnet4
+
+        upload_cloud_config(cloud_config_hash: cloud_config_hash)
+        deploy_simple_manifest(cloud_config_hash: cloud_config_hash, manifest_hash: manifest_hash)
+
+        networks = current_sandbox.cpi.network_cids
+        expect(networks.count).to eq(2)
+        exp_create_network_input = [
+          {
+            'type' => 'manual',
+            'range' => '192.168.10.0/24',
+            'gateway' => '192.168.10.1',
+            'cloud_properties' => { 'a' => 'b', 't0_id' => '123456' },
+          },
+          {
+            'type' => 'manual',
+            'range' => '192.168.20.0/24',
+            'gateway' => '192.168.20.1',
+            'cloud_properties' => { 'a' => 'b', 't0_id' => '123456' },
+          },
+          {
+            'type' => 'manual',
+            'range' => '192.168.30.0/24',
+            'gateway' => '192.168.30.1',
+            'cloud_properties' => { 'a' => 'b', 't0_id' => '123456' },
+          },
+          {
+            'type' => 'manual',
+            'range' => '192.168.40.0/24',
+            'gateway' => '192.168.40.1',
+            'cloud_properties' => { 'a' => 'b', 't0_id' => '123456' },
+          },
+        ]
+        create_network_invocations = current_sandbox.cpi.invocations_for_method('create_network')
+        expect(create_network_invocations.count).to eq(4)
+        create_network_invocations.each do |subnet_invocation|
+          cpi_input = subnet_invocation.inputs['subnet_definition']
+          idx = exp_create_network_input.index(cpi_input)
+          expect(idx).to be_truthy
+          exp_create_network_input.delete_at(idx)
+        end
+        delete_network_invocations = current_sandbox.cpi.invocations_for_method('delete_network')
+        expect(delete_network_invocations.count).to eq(2)
+      end
     end
   end
 end


### PR DESCRIPTION
### What is this change about?

This allows managed networks to be updated in the cloud config. Currently, managed networks are only allowed to be created and deleted. But once a managed network is created, there is no way to update the subnets of that particular network (adding, removing, or updating existing subnets). This PR introduces this feature.

### What tests have you run against this PR?

Unit tests, Integration test, and I manually tested the update process.

### Does this PR introduce a breaking change?

No

The changes in this PR are based on the following document
https://docs.google.com/document/d/1E72c5tetQkxXd0zRIpmFQVE2aQ-_kEPMs11bmrCkb5Q/edit?usp=sharing