### PR TITLE
Fix bosh backup scripts for external DBs

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -19,7 +19,6 @@ templates:
   mime.types: config/mime.types
   config_server_ca.cert.erb: config/config_server_ca.cert
   uaa_server_ca.cert.erb: config/uaa_server_ca.cert
-  sync_dns_ctl.erb: bin/sync_dns_ctl
   bbr_backup.erb: bin/bbr/backup
   bbr_restore.erb: bin/bbr/restore
   nats_server_ca.pem.erb: config/nats_server_ca.pem

--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -19,8 +19,9 @@ templates:
   mime.types: config/mime.types
   config_server_ca.cert.erb: config/config_server_ca.cert
   uaa_server_ca.cert.erb: config/uaa_server_ca.cert
-  bbr_backup: bin/bbr/backup
-  bbr_restore: bin/bbr/restore
+  sync_dns_ctl.erb: bin/sync_dns_ctl
+  bbr_backup.erb: bin/bbr/backup
+  bbr_restore.erb: bin/bbr/restore
   nats_server_ca.pem.erb: config/nats_server_ca.pem
   nats_client_certificate.pem.erb: config/nats_client_certificate.pem
   nats_client_private_key.erb: config/nats_client_private_key

--- a/jobs/director/templates/bbr_backup.erb
+++ b/jobs/director/templates/bbr_backup.erb
@@ -31,4 +31,6 @@ export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
 export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/2.4.0
 
 /var/vcap/packages/director/bin/bosh-backup
+<% else %>
+echo "Skipping director backup because an external database is configured."
 <% end %>

--- a/jobs/director/templates/bbr_backup.erb
+++ b/jobs/director/templates/bbr_backup.erb
@@ -2,7 +2,7 @@
 
 set -eu
 
-<% if p('director.db.host').include? "127.0.0.1" %>
+<% if p('director.db.host') == "127.0.0.1" or p('director.db.host') == "localhost" or p('director.db.host') == "::1" %>
 if [ -z "$ARTIFACT_DIRECTORY" ]; then
   echo "\$ARTIFACT_DIRECTORY should not be empty! Refusing to back up." >&2
   exit 1

--- a/jobs/director/templates/bbr_backup.erb
+++ b/jobs/director/templates/bbr_backup.erb
@@ -2,7 +2,7 @@
 
 set -eu
 
-<% if p('director.db.host') == "127.0.0.1" or p('director.db.host') == "localhost" or p('director.db.host') == "::1" %>
+<% if p('director.db.host') == "127.0.0.1" || p('director.db.host') == "localhost" || p('director.db.host') == "::1" %>
 if [ -z "$ARTIFACT_DIRECTORY" ]; then
   echo "\$ARTIFACT_DIRECTORY should not be empty! Refusing to back up." >&2
   exit 1

--- a/jobs/director/templates/bbr_backup.erb
+++ b/jobs/director/templates/bbr_backup.erb
@@ -2,6 +2,7 @@
 
 set -eu
 
+<% if p('director.db.host').include? "127.0.0.1" %>
 if [ -z "$ARTIFACT_DIRECTORY" ]; then
   echo "\$ARTIFACT_DIRECTORY should not be empty! Refusing to back up." >&2
   exit 1
@@ -30,3 +31,4 @@ export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
 export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/2.4.0
 
 /var/vcap/packages/director/bin/bosh-backup
+<% end %>

--- a/jobs/director/templates/bbr_restore.erb
+++ b/jobs/director/templates/bbr_restore.erb
@@ -2,6 +2,7 @@
 
 set -e
 
+<% if p('director.db.host').include? "127.0.0.1" %>
 source /var/vcap/packages/ruby-2.4-r4/bosh/runtime.env
 PATH=$PATH:/var/vcap/jobs/director/bin
 
@@ -23,3 +24,4 @@ export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/2.4.0
 
 # BBR does not clean out the backup directory
 rm -rf $ARTIFACT_DIRECTORY/*
+<% end %>

--- a/jobs/director/templates/bbr_restore.erb
+++ b/jobs/director/templates/bbr_restore.erb
@@ -2,7 +2,7 @@
 
 set -e
 
-<% if p('director.db.host').include? "127.0.0.1" %>
+<% if p('director.db.host') == "127.0.0.1" or p('director.db.host') == "localhost" or p('director.db.host') == "::1" %>
 source /var/vcap/packages/ruby-2.4-r4/bosh/runtime.env
 PATH=$PATH:/var/vcap/jobs/director/bin
 

--- a/jobs/director/templates/bbr_restore.erb
+++ b/jobs/director/templates/bbr_restore.erb
@@ -2,7 +2,7 @@
 
 set -e
 
-<% if p('director.db.host') == "127.0.0.1" or p('director.db.host') == "localhost" or p('director.db.host') == "::1" %>
+<% if p('director.db.host') == "127.0.0.1" || p('director.db.host') == "localhost" || p('director.db.host') == "::1" %>
 source /var/vcap/packages/ruby-2.4-r4/bosh/runtime.env
 PATH=$PATH:/var/vcap/jobs/director/bin
 

--- a/jobs/director/templates/bbr_restore.erb
+++ b/jobs/director/templates/bbr_restore.erb
@@ -24,4 +24,6 @@ export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/2.4.0
 
 # BBR does not clean out the backup directory
 rm -rf $ARTIFACT_DIRECTORY/*
+<% else %>
+echo "Skipping director restore because an external database is configured."
 <% end %>


### PR DESCRIPTION
### What is this change about?

Changing the bosh directors backup script to produce an empty artifact when configured with an external DB

### Please provide contextual information.

When you configure your bosh director to use an external DB and attempt to backup using [bbr](https://github.com/cloudfoundry-incubator/bosh-backup-and-restore) it would produce an artifact that was invalid. This is due to the ruby gem used to create the backup artifact does not support external DB's, only internal. If you tried to restore with this artifact it would `succeed` falsely, leaving the director in a bad state. To negate this we want it to produce an empty backup artifact instead and for restore to no-op when configured with an external DB.

Story that discovered this issue: https://www.pivotaltracker.com/story/show/161379117
Story to fix this issue: https://www.pivotaltracker.com/story/show/162088113

### What tests have you run against this PR?

Manual testing with the following configuration:
`director.db.host` set to `localhost` - resulted in backup script being correctly templated
`director.db.host` set to `127.0.0.1` - resulted in backup script being correctly templated
`director.db.host` set to `<exteranl-db>` - resulted in backup script being templated empty (as desired)

### How should this change be described in bosh release notes?

Bug Fix- BOSH Director backup no longer produces an artifact when configured with an external DB

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@gmrodgers
