### PR TITLE
Add ability to supply link address in template test

### DIFF
--- a/src/bosh-template/lib/bosh/template/test/link.rb
+++ b/src/bosh-template/lib/bosh/template/test/link.rb
@@ -1,11 +1,12 @@
 module Bosh::Template::Test
   class Link
-    attr_reader :instances, :name, :properties
+    attr_reader :instances, :name, :properties, :address
 
-    def initialize(name:, instances: [], properties: {})
+    def initialize(name:, instances: [], properties: {}, address: nil)
       @instances = instances
       @name = name
       @properties = properties
+      @address = address
     end
 
     def to_h
@@ -13,6 +14,7 @@ module Bosh::Template::Test
         'instances' => instances.map(&:to_h),
         'name' => name,
         'properties' => properties,
+        'address' => address,
       }
     end
   end

--- a/src/bosh-template/spec/assets/template-test-release/jobs/web-server/templates/config.erb
+++ b/src/bosh-template/spec/assets/template-test-release/jobs/web-server/templates/config.erb
@@ -24,6 +24,7 @@
         'host' => db_link.instances.first.address,
         'port' => db_link.p('port'),
         'database' => db_link.p('name'),
+        'address' => db_link.address,
     }
   end
 

--- a/src/bosh-template/spec/assets/template-test-release/src/spec/config.erb_spec.rb
+++ b/src/bosh-template/spec/assets/template-test-release/src/spec/config.erb_spec.rb
@@ -135,7 +135,8 @@ module Bosh::Template::Test
                     'password' => 'asdf1234',
                     'port' => 4321,
                     'name' => 'webserverdb',
-                  }
+                  },
+                  address: 'primary-db.link.address.bosh',
                 )
               ]
               rendered_config = JSON.parse(template.render(merged_manifest_properties, consumes: links))
@@ -145,6 +146,7 @@ module Bosh::Template::Test
               expect(rendered_config['db']['password']).to eq('asdf1234')
               expect(rendered_config['db']['port']).to eq(4321)
               expect(rendered_config['db']['database']).to eq('webserverdb')
+              expect(rendered_config['db']['address']).to eq('primary-db.link.address.bosh')
             end
 
             context 'when the release does not consume the provided link' do


### PR DESCRIPTION
### What is this change about?

This change allows users to fake out 'link.address' when writing template rendering tests. Without this change, templates that contain 'link.address' cause the tests to fail during rendering.

### Please provide contextual information.

NA

### What tests have you run against this PR?

This test only changes the test folder of the bosh-template gem. The test folder contains classes that are only used when writing tests for a template. There is no change to the production template classes. Therefore, I've only ran the spec folder in the template-gem.

### How should this change be described in bosh release notes?

Improved template test support - 'link.address' can now be specified and verified in rendered templates.

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@christianang @xanderstrike @ameowlia @oozie 