### PR TITLE
Pre fetch agent

### DIFF
--- a/src/bosh-director/lib/bosh/director/dns/dns_version_converger.rb
+++ b/src/bosh-director/lib/bosh/director/dns/dns_version_converger.rb
@@ -3,9 +3,9 @@ module Bosh::Director
 
     ONLY_OUT_OF_DATE_SELECTOR = lambda do |current_version, logger|
       logger.info('Selected strategy: ONLY_OUT_OF_DATE_SELECTOR')
-      Models::Instance.inner_join(:vms, Sequel.qualify('vms', 'instance_id') => Sequel.qualify('instances', 'id'))
+      Config.db[:instances].inner_join(:vms, Sequel.qualify('vms', 'instance_id') => Sequel.qualify('instances', 'id'))
         .left_outer_join(:agent_dns_versions, Sequel.qualify('agent_dns_versions', 'agent_id') => Sequel.qualify('vms', 'agent_id'))
-        .select_append(Sequel.expr(Sequel.qualify('vms','agent_id')).as(:agent_id))
+        .select_append(Sequel.expr(Sequel.qualify('vms','agent_id')).as(:fetched_agent_id))
         .select_append(Sequel.expr(Sequel.qualify('instances','id')).as(:id))
         .where { Sequel.expr(Sequel.qualify('vms','active') => true) }
         .where { Sequel.expr(Sequel.qualify('instances','compilation') => false) }
@@ -14,8 +14,9 @@ module Bosh::Director
 
     ALL_INSTANCES_WITH_VMS_SELECTOR = lambda do |_, logger|
       logger.info('Selected strategy: ALL_INSTANCES_WITH_VMS_SELECTOR')
-      Models::Instance.inner_join(:vms, Sequel.qualify('vms', 'instance_id') => Sequel.qualify('instances', 'id'))
+      Config.db[:instances].inner_join(:vms, Sequel.qualify('vms', 'instance_id') => Sequel.qualify('instances', 'id'))
         .select_append(Sequel.expr(Sequel.qualify('instances','id')).as(:id))
+        .select_append(Sequel.expr(Sequel.qualify('vms','agent_id')).as(:fetched_agent_id))
         .where { Sequel.expr(Sequel.qualify('vms', 'active') => true) }
         .where { Sequel.expr(Sequel.qualify('instances', 'compilation') => false) }
     end

--- a/src/bosh-director/spec/unit/agent_broadcaster_spec.rb
+++ b/src/bosh-director/spec/unit/agent_broadcaster_spec.rb
@@ -67,7 +67,7 @@ module Bosh::Director
         agent_broadcast = AgentBroadcaster.new
         instances = agent_broadcast.filter_instances(vm_being_created_cid)
 
-        expect(instances.map(&:id)).to eq [instance.id]
+        expect(instances.map {|i| i[:id]}).to eq [instance[:id]]
       end
     end
 
@@ -124,7 +124,7 @@ module Bosh::Director
             blk.call({'value' => 'synced'})
           end.and_return('instance-2-req-id')
 
-          agent_broadcast.sync_dns([instance1, instance2], 'fake-blob-id', 'fake-sha1', 1)
+          agent_broadcast.sync_dns(agent_broadcast.filter_instances(nil), 'fake-blob-id', 'fake-sha1', 1)
 
           expect(Models::AgentDnsVersion.all.length).to eq(2)
         end
@@ -156,7 +156,7 @@ module Bosh::Director
               agent
             end
 
-            agent_broadcast.sync_dns(instances, 'fake-blob-id', 'fake-sha1', 1)
+            agent_broadcast.sync_dns(agent_broadcast.filter_instances(nil), 'fake-blob-id', 'fake-sha1', 1)
 
             expect(Models::AgentDnsVersion.all.length).to eq(1)
           end
@@ -178,7 +178,7 @@ module Bosh::Director
 
         context 'when there are no prior existing records for the instances' do
           it 'will create new records for the instances' do
-            agent_broadcast.sync_dns(instances, 'fake-blob-id', 'fake-sha1', 42)
+            agent_broadcast.sync_dns(agent_broadcast.filter_instances(nil), 'fake-blob-id', 'fake-sha1', 42)
 
             expect(Models::AgentDnsVersion.all.length).to eq(1)
             expect(Models::AgentDnsVersion.all[0].dns_version).to equal(42)
@@ -191,7 +191,7 @@ module Bosh::Director
           end
 
           it 'will update records for the instances' do
-            agent_broadcast.sync_dns(instances, 'fake-blob-id', 'fake-sha1', 42)
+            agent_broadcast.sync_dns(agent_broadcast.filter_instances(nil), 'fake-blob-id', 'fake-sha1', 42)
 
             expect(Models::AgentDnsVersion.all.length).to eq(1)
             expect(Models::AgentDnsVersion.all[0].dns_version).to equal(42)
@@ -213,7 +213,7 @@ module Bosh::Director
           end
 
           it 'will still be able to update the AgentDnsVersion records' do
-            agent_broadcast.sync_dns(instances, 'fake-blob-id', 'fake-sha1', 42)
+            agent_broadcast.sync_dns(agent_broadcast.filter_instances(nil), 'fake-blob-id', 'fake-sha1', 42)
 
             expect(Models::AgentDnsVersion.all[0].dns_version).to equal(42)
           end
@@ -250,7 +250,7 @@ module Bosh::Director
               agent
             end.once
 
-            agent_broadcast.sync_dns(instances, 'fake-blob-id', 'fake-sha1', 1)
+            agent_broadcast.sync_dns(agent_broadcast.filter_instances(nil), 'fake-blob-id', 'fake-sha1', 1)
 
             expect(Models::AgentDnsVersion.all.length).to eq(1)
           end
@@ -274,7 +274,7 @@ module Bosh::Director
             agent
           end
 
-          agent_broadcast.sync_dns([instance1], 'fake-blob-id', 'fake-sha1', 1)
+          agent_broadcast.sync_dns(agent_broadcast.filter_instances('id-2'), 'fake-blob-id', 'fake-sha1', 1)
         end
       end
     end


### PR DESCRIPTION
### What is this change about?
Pre-fetch the `agent_id` for all instances selected for a dns update to avoid unnecessary DB requests. Previously, much time was spent in the `agent_broadcaster#sync_dns` method, which is even logged at the end of the method:
```
INFO -- DirectorJobRunner: agent_broadcaster: sync_dns: attempted 1619 agents in 53211ms (555 successful, 0 failed, 1167 unresponsive)
```

Even for 1600 VMs, this method should not take 53 seconds, but rather 10 seconds + `x`, for `x` in the range of ms.

### Please provide contextual information.
There were thousands of DB requests logged like 
```
DirectorJobRunner: (0.000409s) (conn: 47449216593120) SELECT * FROM "vms" WHERE (("instance_id" = 3683) AND ("active" IS TRUE)) LIMIT 1
```
because each access to `instance.agent_id` triggers a request like this. This was called during the regular 10-second `sync-dns` job as well as during all forced syncs during the update of instances.

### What tests have you run against this PR?
`bundle exec rake spec:unit`
Deploy with a Director dev release.

### How should this change be described in bosh release notes?
Probably not release note relevant?

### Does this PR introduce a breaking change?
no

### Tag your pair, your PM, and/or team!
/cc @cloudfoundry/cf-bosh-europe 