### PR TITLE
Ensure JSON is emitted deterministically

### DIFF
--- a/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb
@@ -117,7 +117,7 @@ module Bosh::Director::Core::Templates
         }
       end
 
-      JSON.pretty_generate(data) + "\n"
+      JSON.pretty_generate(data.sort_by{|e| [e['name'], e['type'], e['group']]}) + "\n"
     end
   end
 end


### PR DESCRIPTION
So that we don't cause unnecessary instance update churn

### What is this change about?

It looks like an unintended side-effect of https://github.com/cloudfoundry/bosh/commit/39748765525aa13f084a27f0903c65671f978ff8 is that the `.bosh/links.json` file is now generated in what appears to be an unpredictable order.

This means that each deploy of a manifest will incorrectly think that each job has updated configuration, and thus drain, update config, and start the jobs again, which is inefficient.

### Please provide contextual information.

Fixes issue https://github.com/cloudfoundry/bosh/issues/2120 (I hope!).

### What tests have you run against this PR?

None yet, opening PR early as this is tricky to test (if you don't do much Ruby, which I don't), and probably fairly urgent as v268.5.0 (which inadvertently introduces this issue) was only just released.

### Does this PR introduce a breaking change?

No

