### PR TITLE
Update BOSH cck for CPI API V2 and mount the disk in case of reboot option

### DIFF
--- a/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
@@ -65,13 +65,11 @@ module Bosh::Director
         MetadataUpdater.build.update_disk_metadata(cloud_for_update_metadata, @disk, @disk.instance.deployment.tags)
         send_disk_hint_to_agent(disk_hint) if disk_hint
 
-        if reboot
-          reboot_vm(@instance)
-        else
-          agent_timeout_guard(@instance.vm_cid, @instance.agent_id, @instance.name) do |agent|
-            agent.mount_disk(@disk_cid)
-          end
+        agent_timeout_guard(@instance.vm_cid, @instance.agent_id, @instance.name) do |agent|
+          agent.mount_disk(@disk_cid)
         end
+
+        reboot_vm(@instance) if reboot
       end
 
       private

--- a/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
@@ -59,16 +59,26 @@ module Bosh::Director
       def reattach_disk(reboot = false)
         az_cloud_factory = AZCloudFactory.create_with_latest_configs(@instance.deployment)
         cloud_for_attach_disk = az_cloud_factory.get_for_az(@instance.availability_zone, @vm_stemcell_api_version)
-        cloud_for_attach_disk.attach_disk(@vm_cid, @disk_cid)
+        disk_hint = cloud_for_attach_disk.attach_disk(@vm_cid, @disk_cid)
 
         cloud_for_update_metadata = az_cloud_factory.get_for_az(@instance.availability_zone)
         MetadataUpdater.build.update_disk_metadata(cloud_for_update_metadata, @disk, @disk.instance.deployment.tags)
+        send_disk_hint_to_agent(disk_hint) if disk_hint
+
         if reboot
           reboot_vm(@instance)
         else
           agent_timeout_guard(@instance.vm_cid, @instance.agent_id, @instance.name) do |agent|
             agent.mount_disk(@disk_cid)
           end
+        end
+      end
+
+      private
+
+      def send_disk_hint_to_agent(disk_hint)
+        agent_timeout_guard(@instance.vm_cid, @instance.agent_id, @instance.name) do |agent|
+          agent.add_persistent_disk(@disk_cid, disk_hint)
         end
       end
     end

--- a/src/bosh-director/spec/unit/problem_handlers/mount_info_mismatch_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/mount_info_mismatch_spec.rb
@@ -93,7 +93,7 @@ describe Bosh::Director::ProblemHandlers::MountInfoMismatch do
             expect(az_cloud_factory).to receive(:get_for_az).with(@instance.availability_zone, 25).and_return(cloud)
             expect(az_cloud_factory).to receive(:get_for_az).with('az1').and_return(cloud_for_update_metadata)
             expect(@agent).to receive(:wait_until_ready)
-            expect(@agent).not_to receive(:mount_disk)
+            expect(@agent).to receive(:mount_disk)
             @handler.apply_resolution(:reattach_disk_and_reboot)
           end
 
@@ -104,6 +104,7 @@ describe Bosh::Director::ProblemHandlers::MountInfoMismatch do
             expect(az_cloud_factory).to receive(:get_for_az).with(@instance.availability_zone, 25).and_return(cloud)
             expect(az_cloud_factory).to receive(:get_for_az).with('az1').and_return(cloud_for_update_metadata)
             expect(@agent).to receive(:wait_until_ready)
+            expect(@agent).to receive(:mount_disk)
             expect_any_instance_of(Bosh::Director::MetadataUpdater).to receive(:update_disk_metadata)
               .with(cloud_for_update_metadata, @disk, hash_including(manifest['tags']))
             @handler.apply_resolution(:reattach_disk_and_reboot)
@@ -141,7 +142,7 @@ describe Bosh::Director::ProblemHandlers::MountInfoMismatch do
             expect(az_cloud_factory).to receive(:get_for_az).with('az1').and_return(cloud_for_update_metadata)
             expect(@agent).to receive(:wait_until_ready)
             expect(@agent).to receive(:add_persistent_disk).with(@disk.disk_cid, disk_hint)
-            expect(@agent).not_to receive(:mount_disk)
+            expect(@agent).to receive(:mount_disk)
 
             @handler.apply_resolution(:reattach_disk_and_reboot)
           end


### PR DESCRIPTION
### What is this change about?

This change adds CPI API V2 support to the BOSH `cck` command.
Also will mount the disk when BOSH `cck` with the option `reattach disk and reboot instance`
is executed.

### Please provide contextual information.

fixes #2139 
fixes #2138 

### What tests have you run against this PR?

Director Unit Tests and all ITs. Also manual tests has been executed.

