### PR TITLE
Scan and fix request containing all missing VMs of deployment, resurrect VMs  in parallel

### DIFF
--- a/src/bosh-director/lib/bosh/director/problem_resolver.rb
+++ b/src/bosh-director/lib/bosh/director/problem_resolver.rb
@@ -31,16 +31,19 @@ module Bosh::Director
 
       begin_stage('Applying problem resolutions', problems.count)
 
-      problems.each do |problem|
-        if problem.state != 'open'
-          reason = "state is '#{problem.state}'"
-          track_and_log("Ignoring problem #{problem.id} (#{reason})")
-        elsif problem.deployment_id != @deployment.id
-          reason = 'not a part of this deployment'
-          track_and_log("Ignoring problem #{problem.id} (#{reason})")
-
-        else
-          apply_resolution(problem)
+      ThreadPool.new(max_threads: Config.max_threads).wrap do |pool|
+        problems.each do |problem|
+          pool.process do
+            if problem.state != 'open'
+              reason = "state is '#{problem.state}'"
+              track_and_log("Ignoring problem #{problem.id} (#{reason})")
+            elsif problem.deployment_id != @deployment.id
+              reason = 'not a part of this deployment'
+              track_and_log("Ignoring problem #{problem.id} (#{reason})")
+            else
+              apply_resolution(problem)
+            end
+          end
         end
       end
 

--- a/src/bosh-director/spec/unit/problem_resolver_spec.rb
+++ b/src/bosh-director/spec/unit/problem_resolver_spec.rb
@@ -51,6 +51,7 @@ module Bosh::Director
 
           resolver = make_resolver(@deployment)
 
+          expect(Bosh::Director::Config).to receive(:max_threads).and_return(5)
           expect(resolver).to receive(:track_and_log).with(/Disk 'disk-cid-\d+' \(0M\) for instance 'job-\d+\/uuid-\d+ \(\d+\)' is inactive \(.*\): .*/).twice.and_call_original
           expect(resolver.apply_resolutions({ problems[0].id.to_s => 'delete_disk', problems[1].id.to_s => 'ignore' })).to eq([2, nil])
 

--- a/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/events/alert.rb
@@ -1,7 +1,8 @@
 module Bosh::Monitor
   module Events
     class Alert < Base
-      CATEGORY_VM_HEALTH = "vm_health"
+      CATEGORY_VM_HEALTH = 'vm_health'.freeze
+      CATEGORY_DEPLOYMENT_HEALTH = 'deployment_health'.freeze
 
       # Considering Bosh::Agent::Alert
       SEVERITY_MAP = {

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
@@ -6,7 +6,7 @@ module Bosh::Monitor
     class Resurrector < Base
       include Bosh::Monitor::Plugins::HttpRequestHelper
 
-      def initialize(options={})
+      def initialize(options = {})
         super(options)
         director = @options['director']
         raise ArgumentError 'director options not set' unless director
@@ -20,11 +20,11 @@ module Bosh::Monitor
 
       def run
         unless EM.reactor_running?
-          logger.error("Resurrector plugin can only be started when event loop is running")
+          logger.error('Resurrector plugin can only be started when event loop is running')
           return false
         end
 
-        logger.info("Resurrector is running...")
+        logger.info('Resurrector is running...')
       end
 
       def process(alert)
@@ -50,7 +50,7 @@ module Bosh::Monitor
         end
 
         unless director_info
-          logger.error("(Resurrector) director is not responding with the status")
+          logger.error('(Resurrector) director is not responding with the status')
           return
         end
 
@@ -76,13 +76,13 @@ module Bosh::Monitor
           jobs_to_instances_resurrection_disabled = jobs_to_instances_resurrection_disabled.to_h
 
           unless jobs_to_instances_resurrection_enabled.empty?
-            payload = {'jobs' => jobs_to_instances_resurrection_enabled}
+            payload = { 'jobs' => jobs_to_instances_resurrection_enabled }
             request = {
               head: {
                 'Content-Type' => 'application/json',
-                'authorization' => auth_provider(director_info).auth_header
+                'authorization' => auth_provider(director_info).auth_header,
               },
-              body: JSON.dump(payload)
+              body: JSON.dump(payload),
             }
             url = @uri.dup
             url.path = "/deployments/#{deployment}/scan_and_fix"
@@ -143,7 +143,6 @@ module Bosh::Monitor
         end
         pretty_str.chomp(', ')
       end
-
     end
   end
 end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector_helper.rb
@@ -51,7 +51,7 @@ module Bosh::Monitor::Plugins
       end
 
       def record(agent_key, alert)
-        if alert.category == Bosh::Monitor::Events::Alert::CATEGORY_VM_HEALTH && UNHEALTHY.include?(alert.severity)
+        if UNHEALTHY.include?(alert.severity)
           @unhealthy_agents[agent_key] = alert.created_at
         end
       end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
@@ -12,24 +12,23 @@ module Bhm
     end
 
     context 'stubbed config' do
-
       before do
-        Bhm.config = {'director' => {}}
+        Bhm.config = { 'director' => {} }
 
         # Just use 2 loggers to test multiple agents without having to care
         # about stubbing delivery operations and providing well formed configs
-        Bhm.plugins = [{'name' => 'logger'}, {'name' => 'logger'}]
-        Bhm.intervals = OpenStruct.new(:agent_timeout => 10, :rogue_agent_alert => 10)
+        Bhm.plugins = [{ 'name' => 'logger' }, { 'name' => 'logger' }]
+        Bhm.intervals = OpenStruct.new(agent_timeout: 10, rogue_agent_alert: 10)
       end
 
       describe '#process_event' do
         context 'shutdown' do
           it 'shutdowns agent' do
-            instance_1 = Bhm::Instance.create({'id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator'})
-            instance_2 = Bhm::Instance.create({'id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'job' => 'nats'})
-            instance_3 = Bhm::Instance.create({'id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node'})
+            instance_1 = Bhm::Instance.create('id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator')
+            instance_2 = Bhm::Instance.create('id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'job' => 'nats')
+            instance_3 = Bhm::Instance.create('id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node')
 
-            manager.sync_deployments([{'name' => 'mycloud'}])
+            manager.sync_deployments([{ 'name' => 'mycloud' }])
             manager.sync_agents('mycloud', [instance_1, instance_2, instance_3])
 
             expect(manager.agents_count).to eq(3)
@@ -51,21 +50,19 @@ module Bhm
           end
 
           it 'processes a valid populated heartbeat message' do
-            instance1 = {'id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true}
+            instance1 = { 'id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true }
             cloud1 = [instance1]
-            manager.sync_deployments([{'name' => 'mycloud', 'teams' => ['ateam']}])
-            manager.sync_deployment_state({'name' => 'mycloud', 'teams' => ['ateam']}, cloud1)
+            manager.sync_deployments([{ 'name' => 'mycloud', 'teams' => ['ateam'] }])
+            manager.sync_deployment_state({ 'name' => 'mycloud', 'teams' => ['ateam'] }, cloud1)
 
             expect(event_processor).to receive(:process).with(
-                :heartbeat,
-                {
-                    'timestamp' => Integer,
-                    'agent_id' => '007',
-                    'deployment' => 'mycloud',
-                    'instance_id' => 'iuuid1',
-                    'job' => 'mutator',
-                    'teams' => ['ateam'],
-                }
+              :heartbeat,
+              'timestamp' => Integer,
+              'agent_id' => '007',
+              'deployment' => 'mycloud',
+              'instance_id' => 'iuuid1',
+              'job' => 'mutator',
+              'teams' => ['ateam'],
             )
 
             manager.process_event(:heartbeat, 'hm.agent.heartbeat.007')
@@ -81,37 +78,33 @@ module Bhm
 
           context 'when teams have changed between heartbeats' do
             it 'updates teams in heartbeat event' do
-              instance1 = {'id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true}
+              instance1 = { 'id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true }
               cloud1 = [instance1]
-              manager.sync_deployments([{'name' => 'mycloud', 'teams' => ['ateam']}])
-              manager.sync_deployment_state({'name' => 'mycloud', 'teams' => ['ateam']}, cloud1)
+              manager.sync_deployments([{ 'name' => 'mycloud', 'teams' => ['ateam'] }])
+              manager.sync_deployment_state({ 'name' => 'mycloud', 'teams' => ['ateam'] }, cloud1)
 
               expect(event_processor).to receive(:process).with(
-                  :heartbeat,
-                  {
-                      'timestamp' => Integer,
-                      'agent_id' => '007',
-                      'deployment' => 'mycloud',
-                      'instance_id' => 'iuuid1',
-                      'job' => 'mutator',
-                      'teams' => ['ateam'],
-                  }
+                :heartbeat,
+                'timestamp' => Integer,
+                'agent_id' => '007',
+                'deployment' => 'mycloud',
+                'instance_id' => 'iuuid1',
+                'job' => 'mutator',
+                'teams' => ['ateam'],
               )
 
               manager.process_event(:heartbeat, 'hm.agent.heartbeat.007')
 
-              manager.sync_deployment_state({'name' => 'mycloud', 'teams' => ['ateam', 'bteam']}, cloud1)
+              manager.sync_deployment_state({ 'name' => 'mycloud', 'teams' => %w[ateam bteam] }, cloud1)
 
               expect(event_processor).to receive(:process).with(
-                  :heartbeat,
-                  {
-                      'timestamp' => Integer,
-                      'agent_id' => '007',
-                      'deployment' => 'mycloud',
-                      'instance_id' => 'iuuid1',
-                      'job' => 'mutator',
-                      'teams' => ['ateam', 'bteam'],
-                  }
+                :heartbeat,
+                'timestamp' => Integer,
+                'agent_id' => '007',
+                'deployment' => 'mycloud',
+                'instance_id' => 'iuuid1',
+                'job' => 'mutator',
+                'teams' => %w[ateam bteam],
               )
 
               manager.process_event(:heartbeat, 'hm.agent.heartbeat.007')
@@ -122,31 +115,31 @@ module Bhm
         context 'bad alert' do
           it 'does not increment alerts_processed' do
             expect(event_processor).to receive(:process).at_least(:once).and_raise(Bosh::Monitor::InvalidEvent)
-            alert = JSON.dump({'id' => '778', 'severity' => -2, 'title' => nil, 'summary' => 'zbb', 'created_at' => Time.now.utc.to_i})
+            alert = JSON.dump('id' => '778', 'severity' => -2, 'title' => nil, 'summary' => 'zbb', 'created_at' => Time.now.utc.to_i)
 
-            expect {
+            expect do
               manager.process_event(:alert, 'hm.agent.alert.007', alert)
               manager.process_event(:alert, 'hm.agent.alert.007', alert)
-            }.to_not change(manager, :alerts_processed)
+            end.to_not change(manager, :alerts_processed)
           end
         end
 
         context 'good alert' do
           it 'increments alerts_processed' do
-            good_alert = JSON.dump({'id' => '778', 'severity' => 2, 'title' => 'zb', 'summary' => 'zbb', 'created_at' => Time.now.utc.to_i})
+            good_alert = JSON.dump('id' => '778', 'severity' => 2, 'title' => 'zb', 'summary' => 'zbb', 'created_at' => Time.now.utc.to_i)
 
-            expect {
+            expect do
               manager.process_event(:alert, 'hm.agent.alert.007', good_alert)
               manager.process_event(:alert, 'hm.agent.alert.007', good_alert)
-            }.to change(manager, :alerts_processed).by(2)
+            end.to change(manager, :alerts_processed).by(2)
           end
         end
       end
 
       describe '#sync_deployments' do
         it 'can sync deployments' do
-          deployment_1 = {'name' => 'deployment_1'}
-          deployment_2 = {'name' => 'deployment_2'}
+          deployment_1 = { 'name' => 'deployment_1' }
+          deployment_2 = { 'name' => 'deployment_2' }
           manager.sync_deployments([deployment_1, deployment_2])
 
           expect(manager.deployments_count).to eq(2)
@@ -156,23 +149,23 @@ module Bhm
         end
 
         it 'can sync deployments' do
-          instance1 = {'id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true}
-          instance2 = {'id' => 'iuuid2', 'agent_id' => '008', 'index' => '1', 'job' => 'nats', 'expects_vm' => true}
-          instance3 = {'id' => 'iuuid3', 'agent_id' => '009', 'index' => '2', 'job' => 'mysql_node', 'expects_vm' => true}
-          instance4 = {'id' => 'iuuid4', 'agent_id' => '010', 'index' => '52', 'job' => 'zb', 'expects_vm' => true}
+          instance1 = { 'id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true }
+          instance2 = { 'id' => 'iuuid2', 'agent_id' => '008', 'index' => '1', 'job' => 'nats', 'expects_vm' => true }
+          instance3 = { 'id' => 'iuuid3', 'agent_id' => '009', 'index' => '2', 'job' => 'mysql_node', 'expects_vm' => true }
+          instance4 = { 'id' => 'iuuid4', 'agent_id' => '010', 'index' => '52', 'job' => 'zb', 'expects_vm' => true }
 
           cloud1 = [instance1, instance2]
           cloud2 = [instance3, instance4]
-          manager.sync_deployments([{'name' => 'mycloud'}, {'name' => 'othercloud'}])
-          manager.sync_deployment_state({'name' => 'mycloud'}, cloud1)
-          manager.sync_deployment_state({'name' => 'othercloud'}, cloud2)
+          manager.sync_deployments([{ 'name' => 'mycloud' }, { 'name' => 'othercloud' }])
+          manager.sync_deployment_state({ 'name' => 'mycloud' }, cloud1)
+          manager.sync_deployment_state({ 'name' => 'othercloud' }, cloud2)
 
           expect(manager.deployments_count).to eq(2)
           expect(manager.agents_count).to eq(4)
           expect(manager.instances_count).to eq(4)
 
-          manager.sync_deployments([{'name' => 'mycloud'}]) # othercloud is gone
-          manager.sync_deployment_state({'name' => 'mycloud'}, cloud1)
+          manager.sync_deployments([{ 'name' => 'mycloud' }]) # othercloud is gone
+          manager.sync_deployment_state({ 'name' => 'mycloud' }, cloud1)
           expect(manager.deployments_count).to eq(1)
           expect(manager.agents_count).to eq(2)
           expect(manager.instances_count).to eq(2)
@@ -181,23 +174,23 @@ module Bhm
 
       describe '#sync_deployment_state' do
         it 'can sync deployment state' do
-          instance1 = {'id' => '007', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true}
-          instance2 = {'id' => '008', 'agent_id' => '008', 'index' => '0', 'job' => 'nats', 'expects_vm' => true}
-          instance3 = {'id' => '009', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node', 'expects_vm' => true}
+          instance1 = { 'id' => '007', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true }
+          instance2 = { 'id' => '008', 'agent_id' => '008', 'index' => '0', 'job' => 'nats', 'expects_vm' => true }
+          instance3 = { 'id' => '009', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node', 'expects_vm' => true }
 
           instances = [instance1, instance2]
-          manager.sync_deployments([{'name' => 'mycloud'}])
-          manager.sync_deployment_state({'name' => 'mycloud'}, instances)
+          manager.sync_deployments([{ 'name' => 'mycloud' }])
+          manager.sync_deployment_state({ 'name' => 'mycloud' }, instances)
           expect(manager.instances_count).to eq(2)
           expect(manager.agents_count).to eq(2)
 
-          manager.sync_deployments([{'name' => 'mycloud'}])
-          manager.sync_deployment_state({'name' => 'mycloud'}, instances - [instance1])
+          manager.sync_deployments([{ 'name' => 'mycloud' }])
+          manager.sync_deployment_state({ 'name' => 'mycloud' }, instances - [instance1])
           expect(manager.instances_count).to eq(1)
           expect(manager.agents_count).to eq(1)
 
-          manager.sync_deployments([{'name' => 'mycloud'}])
-          manager.sync_deployment_state({'name' => 'mycloud'}, [instance1, instance3])
+          manager.sync_deployments([{ 'name' => 'mycloud' }])
+          manager.sync_deployment_state({ 'name' => 'mycloud' }, [instance1, instance3])
           expect(manager.instances_count).to eq(2)
           expect(manager.agents_count).to eq(2)
         end
@@ -205,11 +198,11 @@ module Bhm
 
       describe '#get_agents_for_deployment' do
         it 'can provide agent information for a deployment' do
-          instance_1 = Bhm::Instance.create({'id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator'})
-          instance_2 = Bhm::Instance.create({'id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'job' => 'nats'})
-          instance_3 = Bhm::Instance.create({'id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node'})
+          instance_1 = Bhm::Instance.create('id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator')
+          instance_2 = Bhm::Instance.create('id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'job' => 'nats')
+          instance_3 = Bhm::Instance.create('id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node')
 
-          manager.sync_deployments([{'name' => 'mycloud'}])
+          manager.sync_deployments([{ 'name' => 'mycloud' }])
           manager.sync_agents('mycloud', [instance_1, instance_2, instance_3])
 
           agents = manager.get_agents_for_deployment('mycloud')
@@ -228,11 +221,11 @@ module Bhm
 
       describe '#get_deleted_agents_for_deployment' do
         it 'can provide agent information for a deployment' do
-          instance_1 = Bhm::Instance.create({'id' => 'iuuid1',  'index' => '0', 'job' => 'mutator', 'expects_vm' => true})
-          instance_2 = Bhm::Instance.create({'id' => 'iuuid2',  'index' => '0', 'job' => 'nats', 'expects_vm' => true})
-          instance_3 = Bhm::Instance.create({'id' => 'iuuid3',  'index' => '28', 'job' => 'mysql_node', 'expects_vm' => true})
+          instance_1 = Bhm::Instance.create('id' => 'iuuid1',  'index' => '0', 'job' => 'mutator', 'expects_vm' => true)
+          instance_2 = Bhm::Instance.create('id' => 'iuuid2',  'index' => '0', 'job' => 'nats', 'expects_vm' => true)
+          instance_3 = Bhm::Instance.create('id' => 'iuuid3',  'index' => '28', 'job' => 'mysql_node', 'expects_vm' => true)
 
-          manager.sync_deployments([{'name' => 'mycloud'}])
+          manager.sync_deployments([{ 'name' => 'mycloud' }])
           manager.sync_agents('mycloud', [instance_1, instance_2, instance_3])
 
           agents = manager.get_deleted_agents_for_deployment('mycloud')
@@ -249,14 +242,13 @@ module Bhm
         end
       end
 
-
       describe '#get_instances_for_deployment' do
         before do
-          manager.sync_deployments([{'name' => 'mycloud'}])
+          manager.sync_deployments([{ 'name' => 'mycloud' }])
         end
 
         it 'returns deployment instances' do
-          manager.sync_instances('mycloud', [{'id' => 'iuuid', 'job' => 'zb', 'index' => '0', 'expects_vm' => true}])
+          manager.sync_instances('mycloud', [{ 'id' => 'iuuid', 'job' => 'zb', 'index' => '0', 'expects_vm' => true }])
 
           expect(manager.get_instances_for_deployment('mycloud').size).to eq(1)
           manager.get_instances_for_deployment('mycloud').each do |instance|
@@ -270,35 +262,32 @@ module Bhm
       end
 
       describe '#analyze_agents' do
-
         before do
-          manager.sync_deployments([{'name' => 'mycloud'}])
+          manager.sync_deployments([{ 'name' => 'mycloud' }])
         end
 
         it 'can analyze agent' do
-          manager.sync_agents('mycloud', [Bhm::Instance.create({'id' => 'iuuid3', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator'})])
+          manager.sync_agents('mycloud', [Bhm::Instance.create('id' => 'iuuid3', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator')])
 
           expect(manager.analyze_agents).to eq(1)
         end
 
         it 'alerts on a timed out agent' do
-          manager.sync_agents('mycloud', [Bhm::Instance.create({'id' => 'some-sort-of-uuid', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator'})])
+          manager.sync_agents('mycloud', [Bhm::Instance.create('id' => 'some-sort-of-uuid', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator')])
 
           ts = Time.now
           allow(Time).to receive(:now).and_return(ts + Bhm.intervals.agent_timeout + 10)
 
           expect(event_processor).to receive(:process).with(
-              :alert,
-              {
-                  severity: 2,
-                  category: 'vm_health',
-                  source: 'mycloud: mutator(some-sort-of-uuid) [id=007, index=0, cid=]',
-                  title: '007 has timed out',
-                  created_at: anything,
-                  deployment: 'mycloud',
-                  job: 'mutator',
-                  instance_id: 'some-sort-of-uuid'
-              }
+            :alert,
+            severity: 2,
+            category: 'vm_health',
+            source: 'mycloud: mutator(some-sort-of-uuid) [id=007, index=0, cid=]',
+            title: '007 has timed out',
+            created_at: anything,
+            deployment: 'mycloud',
+            job: 'mutator',
+            instance_id: 'some-sort-of-uuid',
           )
 
           manager.analyze_agents
@@ -308,14 +297,14 @@ module Bhm
           expect(manager.analyze_agents).to eq(0)
 
           # 3 regular agents
-          instance_1 = Bhm::Instance.create({'id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job:' => 'mutator'})
-          instance_2 = Bhm::Instance.create({'id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'job:' => 'nats'})
-          instance_3 = Bhm::Instance.create({'id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node'})
+          instance_1 = Bhm::Instance.create('id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job:' => 'mutator')
+          instance_2 = Bhm::Instance.create('id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'job:' => 'nats')
+          instance_3 = Bhm::Instance.create('id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node')
 
           manager.sync_agents('mycloud', [instance_1, instance_2, instance_3])
           expect(manager.analyze_agents).to eq(3)
 
-          alert = JSON.dump({'id' => '778', 'severity' => 2, 'title' => 'zb', 'summary' => 'zbb', 'created_at' => Time.now.utc.to_i})
+          alert = JSON.dump('id' => '778', 'severity' => 2, 'title' => 'zb', 'summary' => 'zbb', 'created_at' => Time.now.utc.to_i)
 
           # Alert for already managed agent
           manager.process_event(:alert, 'hm.agent.alert.007', alert)
@@ -343,13 +332,12 @@ module Bhm
     end
 
     describe '#analyze_instance' do
-
       before do
-        manager.sync_deployments([{'name' => 'my_deployment'}])
+        manager.sync_deployments([{ 'name' => 'my_deployment' }])
       end
 
       it 'can analyze instance with vm' do
-        instance = {'id' => 'instance-uuid', 'agent_id' => '007', 'index' => '0', 'cid' => 'cuuid', 'job' => 'mutator', 'expects_vm' => true}
+        instance = { 'id' => 'instance-uuid', 'agent_id' => '007', 'index' => '0', 'cid' => 'cuuid', 'job' => 'mutator', 'expects_vm' => true }
         manager.sync_instances('my_deployment', [instance])
 
         expect(event_processor).to_not receive(:process)
@@ -358,7 +346,7 @@ module Bhm
 
       context 'when the instances expects a VM, and does not have one' do
         it 'sends an alert' do
-          instance = {'id' => 'instance-uuid', 'agent_id' => '007', 'index' => '0', 'cid' => nil, 'job' => 'mutator', 'expects_vm' => true}
+          instance = { 'id' => 'instance-uuid', 'agent_id' => '007', 'index' => '0', 'cid' => nil, 'job' => 'mutator', 'expects_vm' => true }
           manager.sync_instances('my_deployment', [instance])
 
           expect(event_processor).to receive(:process)
@@ -368,9 +356,8 @@ module Bhm
     end
 
     describe '#analyze_instances' do
-
       before do
-        manager.sync_deployments([{'name' => 'my_deployment'}])
+        manager.sync_deployments([{ 'name' => 'my_deployment' }])
       end
 
       it 'analyzes nothing for empty instances' do
@@ -379,8 +366,8 @@ module Bhm
       end
 
       it 'can analyze all instances' do
-        instance_data_1 = {'id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'cid' => 'cuuid', 'job:' => 'nats', 'expects_vm' => true}
-        instance_data_2 = {'id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'cid' => 'cuuid', 'job' => 'mysql_node', 'expects_vm' => true}
+        instance_data_1 = { 'id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'cid' => 'cuuid', 'job:' => 'nats', 'expects_vm' => true }
+        instance_data_2 = { 'id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'cid' => 'cuuid', 'job' => 'mysql_node', 'expects_vm' => true }
         manager.sync_instances('my_deployment', [instance_data_1, instance_data_2])
         expect(event_processor).to_not receive(:process)
 
@@ -388,20 +375,18 @@ module Bhm
       end
 
       it 'alerts on an instance without VM' do
-        instance = {'id' => 'instance-uuid', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true}
+        instance = { 'id' => 'instance-uuid', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'expects_vm' => true }
         manager.sync_instances('my_deployment', [instance])
         expect(event_processor).to receive(:process).with(
-            :alert,
-            {
-                severity: 2,
-                category: 'vm_health',
-                source: 'my_deployment: mutator(instance-uuid) [agent_id=007, index=0, cid=]',
-                title: 'instance-uuid has no VM',
-                created_at: anything,
-                deployment: 'my_deployment',
-                job: 'mutator',
-                instance_id: 'instance-uuid'
-            }
+          :alert,
+          severity: 2,
+          category: 'vm_health',
+          source: 'my_deployment: mutator(instance-uuid) [agent_id=007, index=0, cid=]',
+          title: 'instance-uuid has no VM',
+          created_at: anything,
+          deployment: 'my_deployment',
+          job: 'mutator',
+          instance_id: 'instance-uuid',
         )
 
         expect(manager.analyze_instances).to eq(1)
@@ -412,7 +397,7 @@ module Bhm
       let(:mock_nats) { double('nats') }
 
       before do
-        Bhm::config=Psych.load_file(sample_config)
+        Bhm.config = Psych.load_file(sample_config)
         allow(mock_nats).to receive(:subscribe)
         allow(Bhm).to receive(:nats).and_return(mock_nats)
         allow(EM).to receive(:schedule).and_yield
@@ -420,10 +405,8 @@ module Bhm
 
       it 'has the tsdb plugin' do
         expect(Bhm::Plugins::Tsdb).to receive(:new).with(
-            {
-              'host' => 'localhost',
-              'port' => 4242,
-            }
+          'host' => 'localhost',
+          'port' => 4242,
         ).and_call_original
 
         manager.setup_events
@@ -433,14 +416,14 @@ module Bhm
     context 'when loading plugin not found' do
       before do
         config = Psych.load_file(sample_config)
-        config['plugins'] << {'name' => 'joes_plugin_thing', 'events' => ['alerts', 'heartbeats']}
-        Bhm::config = config
+        config['plugins'] << { 'name' => 'joes_plugin_thing', 'events' => %w[alerts heartbeats] }
+        Bhm.config = config
       end
 
       it 'raises an error' do
-        expect {
+        expect do
           manager.setup_events
-        }.to raise_error(Bhm::PluginError, "Cannot find 'joes_plugin_thing' plugin")
+        end.to raise_error(Bhm::PluginError, "Cannot find 'joes_plugin_thing' plugin")
       end
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_helper_spec.rb
@@ -18,7 +18,7 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
         allow(Bhm).to receive_messages(instance_manager: instance_manager)
 
         alerts.times do |i|
-          alert = double(Bosh::Monitor::Events::Alert, created_at: Time.now, severity: :critical, category: Bosh::Monitor::Events::Alert::CATEGORY_VM_HEALTH)
+          alert = double(Bosh::Monitor::Events::Alert, created_at: Time.now, severity: :critical)
           tracker.record(build_key(i), alert)
         end
       end
@@ -80,9 +80,9 @@ module Bosh::Monitor::Plugins::ResurrectorHelper
 
         it 'excludes those alerts' do
           now = Time.now
-          tracker.record(build_key(0), double(Bosh::Monitor::Events::Alert, created_at: (now - 610), severity: :critical, category: Bosh::Monitor::Events::Alert::CATEGORY_VM_HEALTH))
-          tracker.record(build_key(1), double(Bosh::Monitor::Events::Alert, created_at: (now - 600), severity: :critical, category: Bosh::Monitor::Events::Alert::CATEGORY_VM_HEALTH))
-          tracker.record(build_key(2), double(Bosh::Monitor::Events::Alert, created_at: (now - 60), severity: :critical, category: Bosh::Monitor::Events::Alert::CATEGORY_VM_HEALTH))
+          tracker.record(build_key(0), double(Bosh::Monitor::Events::Alert, created_at: (now - 610), severity: :critical))
+          tracker.record(build_key(1), double(Bosh::Monitor::Events::Alert, created_at: (now - 600), severity: :critical))
+          tracker.record(build_key(2), double(Bosh::Monitor::Events::Alert, created_at: (now - 60), severity: :critical))
 
           state = tracker.state_for(deployment)
           expect(state).to be_meltdown


### PR DESCRIPTION
### What is this change about?

This PR is implementing parallel resurrection:
* Aggregated scan and fix request for all instances of a single deployment having missing VMs (see [tracker story](https://www.pivotaltracker.com/story/show/163648897))
* Resurrect in parallel (see [tracker story](https://www.pivotaltracker.com/story/show/163648915))

### Please provide contextual information.

see tracker stories

### What tests have you run against this PR?

Unit tests and integration tests ran green.
Manually tested that resurrection works on bosh lite.

### How should this change be described in bosh release notes?

see stories

### Does this PR introduce a breaking change?

Hopefully not: The instance_manager continues to raise all old alerts (i.e. alert per missing VM) in addition to the new deployment aggregated alert. The new alert lacks the alert attributes `job` and `instance_id` (and has the attribute `jobs_to_instance_ids` instead). However, we understand that all plugins can handle these missing attributes.

### Tag your pair, your PM, and/or team!
@friegger @langered @videlov @NautiluX 
