### PR TITLE
Reattach persistent disk if mismatch

### DIFF
--- a/src/bosh-director/spec/unit/disk_manager_spec.rb
+++ b/src/bosh-director/spec/unit/disk_manager_spec.rb
@@ -564,10 +564,14 @@ module Bosh::Director
         context 'when we still need disk' do
           let(:job_persistent_disk_size) { 100 }
 
-          it 'raises' do
-            expect do
-              disk_manager.update_persistent_disk(instance_plan)
-            end.to raise_error AgentDiskOutOfSync, "'job-name/my-uuid-1 (1)' has invalid disks: agent reports '' while director record shows 'disk123'"
+          it 're-attaches the disk' do
+            expect(logger).to receive(:warn).with(
+              "Agent of 'job-name/my-uuid-1 (1)' reports no disk while director record shows 'disk123'. " \
+              'Re-attaching existing persistent disk...',
+            )
+            expect(subject).to receive(:attach_disks_if_needed)
+
+            disk_manager.update_persistent_disk(instance_plan)
           end
         end
       end


### PR DESCRIPTION
If the agent reports no disk, but the director model includes a disk,
re-attach it.

see [#164276966](https://www.pivotaltracker.com/story/show/164276966) and https://github.com/cloudfoundry/bosh/issues/1869 for context

### What tests have you run against this PR?

Director unit tests and integration tests.

### Does this PR introduce a breaking change?

Nope.

### Tag your pair, your PM, and/or team!
@friegger @beyhan @langered 
