### PR TITLE
Speedup performance of job template rendering

### DIFF
--- a/src/bosh-template/lib/bosh/template/evaluation_context.rb
+++ b/src/bosh-template/lib/bosh/template/evaluation_context.rb
@@ -51,6 +51,17 @@ module Bosh
         @links = spec['links'] || {}
       end
 
+      def ==(other_object)
+        other_object.respond_to?('spec') &&
+          other_object.respond_to?('raw_properties') &&
+          other_object.respond_to?('name') &&
+          other_object.respond_to?('index') &&
+          @spec == other_object.spec &&
+          @raw_properties == other_object.raw_properties &&
+          @name == other_object.name &&
+          @index == other_object.index
+      end
+
       # @return [Binding] Template binding
       def get_binding
         binding.taint


### PR DESCRIPTION
### What is this change about?

Deploying a large number of instances comes with long rendering times of job templates. The reason behind the poor performance can be tracked down to the frequent initialization of the `EvaluationContext` for each template combined with frequent deep copies of the spec.

We discovered two hotspots in the [`JobTemplateRenderer`](https://github.com/cloudfoundry/bosh/blob/641ea9493cd4e32361d8496457f8cb33afc2175e/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb), which become very expensive with a growing number of instances. Those are the initialization of [`Bosh::Template::EvaluationContext`](https://github.com/cloudfoundry/bosh/blob/8fbf0457d48fbf6ab1223ef5e9134585cbf43f57/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb#L50) and the frequent usage of `Bosh::Common::DeepCopy.copy()` on the spec.

According to our benchmark tests we estimate that this change will speed up the job template rendering by factor ~3. Disclaimer: this has only been tested in a VBox environment with 1500 Zookeeper instances. 

### Please provide contextual information.

[Tracker story #163459423](https://www.pivotaltracker.com/story/show/163459423)

### What tests have you run against this PR?

We ran unit and integration tests on director concourse pipeline.

### How should this change be described in bosh release notes?

Improve job template rendering performance when deploying. 

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!

@friegger @voelzmo @mfine30 @KaiHofstetter @NautiluX @BeckerMax 