### PR TITLE
Enhancement for encryption of persistent storage.

### DIFF
--- a/src/bosh-director/lib/bosh/director/disk_manager.rb
+++ b/src/bosh-director/lib/bosh/director/disk_manager.rb
@@ -10,7 +10,10 @@ module Bosh::Director
     def update_persistent_disk(instance_plan)
       @logger.info('Updating persistent disk')
 
-      check_persistent_disk(instance_plan) unless has_multiple_persistent_disks?(instance_plan)
+      current_packages = instance_plan.instance.current_packages.to_s
+      if !current_packages["xcrypt"]
+        check_persistent_disk(instance_plan) unless has_multiple_persistent_disks?(instance_plan)
+      end
 
       return unless instance_plan.persistent_disk_changed?
 


### PR DESCRIPTION
### What is this change about?
For an encrypted storage partition, the mount convention is different. 

_Describe the change and why it's needed._
We were seeing issue during redeployment of the release which does encryption of the persistent disk and then mounts it. Therefore agent disk cid will be out of sync with cid stored with director. This bypasses that check to enable successful redeployment.

### Please provide contextual information.
We are implementing encryption of persistent storage which requires the filesystem to be mounted differently

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._
N/A

### What tests have you run against this PR?
N/A

_Include a comprehensive list of all tests run successfully._
We deployed an addon to allow encryption of persistent storage. We ran a sample application with encrypted partition and redeployed with encrypted partition.

### How should this change be described in bosh release notes?
Don't track cid if the persistent disk is encrypted

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/bosh/releases) for examples._
No operator intervention is required. Encryption will be implemented automatically once the proper addon is installed.

### Does this PR introduce a breaking change?
N/A

_Does this introduce changes that would require operators to take care in order to upgrade without a failure?_
No

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
@zts-bmetzger @zts-myankovskiy @zts-dshetty