### PR TITLE
Add unit tests for EvaluationContext.== operator

### DIFF
--- a/src/bosh-template/lib/bosh/template/evaluation_context.rb
+++ b/src/bosh-template/lib/bosh/template/evaluation_context.rb
@@ -51,15 +51,11 @@ module Bosh
         @links = spec['links'] || {}
       end
 
-      def ==(other_object)
-        other_object.respond_to?('spec') &&
-          other_object.respond_to?('raw_properties') &&
-          other_object.respond_to?('name') &&
-          other_object.respond_to?('index') &&
-          @spec == other_object.spec &&
-          @raw_properties == other_object.raw_properties &&
-          @name == other_object.name &&
-          @index == other_object.index
+      def ==(other)
+        public_members = %w[spec raw_properties name index properties]
+        public_members.all? do |member|
+          other.respond_to?(member) && send(member) == other.send(member)
+        end
       end
 
       # @return [Binding] Template binding


### PR DESCRIPTION
### What is this change about?

* Also compare the `properties` member
* Add tests that modify member variables
* Add test to ensure new public properties are noticed when they are
added. The test acts as a reminder to not forget to add new properties
to the == operator

### Please provide contextual information.

This is a Follow-up to https://github.com/cloudfoundry/bosh/pull/2147
See also [tracker story](https://www.pivotaltracker.com/story/show/163459423)

### What tests have you run against this PR?

bosh unit and integration tests

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@NautiluX @dpb587-pivotal 
