### PR TITLE
Retry in sync_dns_scheduler if migration not finished

### DIFF
--- a/src/bosh-director/bin/bosh-director-sync-dns
+++ b/src/bosh-director/bin/bosh-director-sync-dns
@@ -23,13 +23,24 @@ dns_sync_broadcaster.prep
 
 %w(TERM INT QUIT).each do |signal|
   trap(signal) do
-    dns_sync_broadcaster.stop!
-    EM.stop
+    stop(signal)
   end
+end
+
+def stop(reason)
+  Bosh::Director::Config.logger.error("Shutting down bosh-director-sync-dns: #{reason}")
+  dns_sync_broadcaster.stop!
+  EM.stop
 end
 
 EventMachine.run do
   EM.defer do
-    Thread.new { dns_sync_broadcaster.start! }
+    Thread.new do
+      begin
+        dns_sync_broadcaster.start!
+      ensure
+        stop 'Thread terminated'
+      end
+    end
   end
 end

--- a/src/bosh-director/bin/bosh-director-sync-dns
+++ b/src/bosh-director/bin/bosh-director-sync-dns
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'bosh/director'
+require 'bosh/director/config'
 require 'bosh/director/sync_dns_scheduler'
 require 'bosh/director/agent_broadcaster'
 require 'bosh/director/dns/dns_version_converger'
@@ -18,14 +18,8 @@ opts.parse!(ARGV.dup)
 config_file ||= ::File.expand_path('../../config/bosh-director.yml', __FILE__)
 config = Bosh::Director::Config.load_file(config_file)
 
-Bosh::Director::App.new(config)
-
-dns_converger = Bosh::Director::DnsVersionConverger.new(
-  Bosh::Director::AgentBroadcaster.new,
-  Bosh::Director::Config.logger,
-  Bosh::Director::Config.max_threads
-)
-dns_sync_broadcaster = Bosh::Director::SyncDnsScheduler.new(dns_converger, 10)
+dns_sync_broadcaster = Bosh::Director::SyncDnsScheduler.new(config, 10)
+dns_sync_broadcaster.prep
 
 %w(TERM INT QUIT).each do |signal|
   trap(signal) do

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -519,6 +519,14 @@ module Bosh::Director
       logger
     end
 
+    def sync_dns_scheduler_logger
+      logger = Logging::Logger.new('SyncDnsScheduler')
+      logging_config = hash.fetch('logging', {})
+      logger.add_appenders(Logging.appenders.stdout('SyncDnsSchedulerIO', layout: ThreadFormatter.layout))
+      logger.level = Logging.levelify(logging_config.fetch('level', 'debug'))
+      logger
+    end
+
     def db
       Config.configure_db(hash['db'])
     end

--- a/src/bosh-director/lib/bosh/director/sync_dns_scheduler.rb
+++ b/src/bosh-director/lib/bosh/director/sync_dns_scheduler.rb
@@ -1,8 +1,25 @@
+require 'db_migrator'
+require 'optparse'
+require 'bosh/director/config'
+
 module Bosh::Director
   class SyncDnsScheduler
-    def initialize(dns_version_converger, interval)
-      @dns_version_converger = dns_version_converger
+    def initialize(config, interval)
+      @config = config
       @interval = interval
+    end
+
+    def prep
+      ensure_migrations
+
+      require 'bosh/director'
+      Bosh::Director::App.new(@config)
+
+      @dns_version_converger = Bosh::Director::DnsVersionConverger.new(
+        Bosh::Director::AgentBroadcaster.new,
+        Bosh::Director::Config.logger,
+        Bosh::Director::Config.max_threads,
+      )
     end
 
     def start!
@@ -22,6 +39,23 @@ module Bosh::Director
     end
 
     private
+
+    def ensure_migrations
+      if defined?(Bosh::Director::Models)
+        raise 'Bosh::Director::Models were loaded before ensuring migrations are current. '\
+              'Cowardly refusing to start sync dns scheduler.'
+      end
+
+      migrator = DBMigrator.new(@config.db, :director)
+      raise_migration_error unless migrator.finished?
+    end
+
+    def raise_migration_error
+      @config.sync_dns_scheduler_logger.error(
+        "Migrations not current during sync dns scheduler start after #{DBMigrator::MAX_MIGRATION_ATTEMPTS} attempts.",
+      )
+      raise "Migrations not current during sync dns scheduler start after #{DBMigrator::MAX_MIGRATION_ATTEMPTS} retries"
+    end
 
     def broadcast
       @dns_version_converger.update_instances_based_on_strategy

--- a/src/bosh-director/spec/unit/db_migrator_spec.rb
+++ b/src/bosh-director/spec/unit/db_migrator_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'db_migrator'
+
+module Bosh::Director
+  describe 'DBMigrator' do
+    subject(:migrator) { DBMigrator.new('db', 'test', {}, 0.01) }
+
+    describe '#finished?' do
+      it 'returns true if migration is already current' do
+        allow(migrator).to receive(:current?).once.and_return(true)
+        expect(migrator.finished?).to be(true)
+      end
+
+      it 'return true if migration is current after retrying' do
+        allow(migrator).to receive(:current?).twice.and_return(false, true)
+        expect(migrator.finished?).to be(true)
+      end
+
+      it 'returns false if migrations are never current' do
+        allow(migrator).to receive(:current?).exactly(DBMigrator::MAX_MIGRATION_ATTEMPTS).times.and_return(false)
+        expect(migrator.finished?).to be(false)
+      end
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/sync_dns_scheduler_spec.rb
+++ b/src/bosh-director/spec/unit/sync_dns_scheduler_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require 'db_migrator'
+require_relative '../../lib/bosh/director/sync_dns_scheduler'
+
+Models = Bosh::Director::Models
+module Kernel
+  alias original_require require
+  def require(path)
+    Bosh::Director.const_set(:Models, Models) if path == 'bosh/director' && !defined?(Bosh::Director::Models)
+    original_require(path)
+  end
+end
+
+module Bosh::Director
+  describe 'sync_dns_scheduler' do
+    subject(:sync_dns_scheduler) { SyncDnsScheduler.new(config, 0.01) }
+    let(:config_hash) do
+      SpecHelper.spec_get_director_config
+    end
+
+    let(:config) { Config.load_hash(config_hash) }
+    let(:dns_version_converger) { double(DnsVersionConverger) }
+
+    before do
+      Bosh::Director.send(:remove_const, :Models)
+    end
+
+    after do
+      require 'bosh/director'
+    end
+
+    describe 'migrations' do
+      let(:migrator) { instance_double(DBMigrator, current?: true) }
+      before do
+        allow(config).to receive(:db).and_return(double(:config_db))
+        allow(DBMigrator).to receive(:new).with(config.db, :director).and_return(migrator)
+      end
+
+      it 'starts up immediately if migrations have finished' do
+        allow(migrator).to receive(:finished?).and_return(true)
+        expect(sync_dns_scheduler).to receive(:ensure_migrations)
+        expect { sync_dns_scheduler.prep }.not_to raise_error
+      end
+
+      it 'raises error if migrations never finish' do
+        logger = double(Logging::Logger)
+        allow(config).to receive(:sync_dns_scheduler_logger).and_return(logger.tap { |l| allow(l).to receive(:error) })
+        allow(migrator).to receive(:finished?).and_return(false)
+
+        expect(logger).to receive(:error).with(
+          /Migrations not current during sync dns scheduler start after #{DBMigrator::MAX_MIGRATION_ATTEMPTS} attempts./,
+        )
+        expect do
+          sync_dns_scheduler.prep
+        end .to raise_error(
+          /Migrations not current during sync dns scheduler start after #{DBMigrator::MAX_MIGRATION_ATTEMPTS} retries/,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have to ensure that the migration has finshed succesfully in the
sync_dns_scheduler, before we can load the db Models. Otherwise the
sync-dns job gets into an inconsistent state since the db is still being
migrated or DB being upgraded.

[#164325756](https://www.pivotaltracker.com/story/show/164325756)

Co-authored-by: Sebastian Heid <sebastian.heid@sap.com>
Co-authored-by: Vladimir Videlov <vladimir.videlov@sap.com>
Co-authored-by: Denis Langer <denis.langer@sap.com>

### What is this change about?

Fix #2150 

### What tests have you run against this PR?

All unit and integration tests.
Also manually verified functionality by delaying the database migration by 30 seconds.

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!
@s4heid && @videlov && @langered 
