### PR TITLE
update spacing for command

### DIFF
--- a/docs/workstation_setup.md
+++ b/docs/workstation_setup.md
@@ -13,7 +13,7 @@
 
 2. Install mysql (needed by the mysql2 gem)
 
-  `brew install mysql`
+    `brew install mysql`
 
 3. Setup & Start mysql (required for running integration tests with mysql)
     - start mysql as root


### PR DESCRIPTION
the brew command for `brew install mysql` was not aligned

### What is this change about?
format was off for `brew install mysql`. additional space needed to align text

_Describe the change and why it's needed._
added space in front of  `brew install mysql` to align with the rest of the document


### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What tests have you run against this PR?

_Include a comprehensive list of all tests run successfully._

### How should this change be described in bosh release notes?

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/bosh/releases) for examples._


### Does this PR introduce a breaking change?

_Does this introduce changes that would require operators to take care in order to upgrade without a failure?_

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
