### PR TITLE
Allow DNS aliasing to custom link providers

### DIFF
--- a/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb
@@ -110,14 +110,8 @@ module Bosh::Director::Core::Templates
 
     def links_data(spec)
       provider_intents = @link_provider_intents.select do |provider_intent|
-        @links_provided.any? do |link_provided|
-          link_provided['name'] == provider_intent.original_name &&
-            link_provided['type'] == provider_intent.type
-        end
-      end
-
-      provider_intents = provider_intents.select do |provider_intent|
-        provider_intent.link_provider.instance_group == spec['name']
+        provider_intent.link_provider.instance_group == spec['name'] &&
+          provider_intent.link_provider.name == @name
       end
 
       data = provider_intents.map do |provider_intent|

--- a/src/bosh-director-core/spec/bosh/director/core/templates/job_template_renderer_spec.rb
+++ b/src/bosh-director-core/spec/bosh/director/core/templates/job_template_renderer_spec.rb
@@ -204,11 +204,15 @@ module Bosh::Director::Core::Templates
         end
 
         let(:provider1) do
-          double('provider1', instance_group: 'joao-da-silva')
+          double('provider1', instance_group: 'joao-da-silva', name: 'fake-job-name')
         end
 
         let(:provider2) do
           double('provider2', instance_group: 'bob-de-smith')
+        end
+
+        let(:provider3) do
+          double('provider3', instance_group: 'joao-da-silva', name: 'another-job-name')
         end
 
         let(:provider_intent) do
@@ -240,23 +244,8 @@ module Bosh::Director::Core::Templates
             original_name: 'dontcare',
             type: 'type3',
             group_name: 'yet-another-link-type3',
-            link_provider: provider1,
+            link_provider: provider3,
           )
-        end
-
-        let(:links_provided) do
-          [
-            {
-              'name' => 'db_link',
-              'type' => 'conn',
-              'properties' => [],
-            },
-            {
-              'name' => 'backup_db',
-              'type' => 'other',
-              'properties' => [],
-            },
-          ]
         end
 
         let(:link_provider_intents) { [provider_intent, another_provider_intent, yet_another_provider_intent] }

--- a/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
@@ -50,6 +50,7 @@ module Bosh::Director
         index_assigner,
         network_reservation_repository,
         @variables_interpolator,
+        @deployment_plan.link_provider_intents,
         'recreate' => @deployment_plan.recreate,
         'use_dns_addresses' => @deployment_plan.use_dns_addresses?,
         'use_short_dns_addresses' => @deployment_plan.use_short_dns_addresses?,

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan_factory.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan_factory.rb
@@ -2,7 +2,19 @@ module Bosh
   module Director
     module DeploymentPlan
       class InstancePlanFactory
-        def initialize(instance_repo, states_by_existing_instance, skip_drain_decider, index_assigner, network_reservation_repository, variables_interpolator, options = {})
+        # rubocop:disable Metrics/ParameterLists
+        def initialize(
+          instance_repo,
+          states_by_existing_instance,
+          skip_drain_decider,
+          index_assigner,
+          network_reservation_repository,
+          variables_interpolator,
+          link_provider_intents,
+          options = {}
+        )
+          # rubocop:enable Metrics/ParameterLists
+
           @instance_repo = instance_repo
           @skip_drain_decider = skip_drain_decider
           @recreate_deployment = options.fetch('recreate', false)
@@ -10,6 +22,7 @@ module Bosh
           @states_by_existing_instance = states_by_existing_instance
           @index_assigner = index_assigner
           @network_reservation_repository = network_reservation_repository
+          @link_provider_intents = link_provider_intents
           @use_dns_addresses = options.fetch('use_dns_addresses', false)
           @use_short_dns_addresses = options.fetch('use_short_dns_addresses', false)
           @use_link_dns_addresses = options.fetch('use_link_dns_addresses', false)
@@ -31,6 +44,7 @@ module Bosh
             use_short_dns_addresses: @use_short_dns_addresses,
             use_link_dns_addresses: @use_link_dns_addresses,
             variables_interpolator: @variables_interpolator,
+            link_provider_intents: @link_provider_intents,
           )
         end
 
@@ -52,6 +66,7 @@ module Bosh
             use_link_dns_addresses: @use_link_dns_addresses,
             tags: @tags,
             variables_interpolator: @variables_interpolator,
+            link_provider_intents: @link_provider_intents,
           )
         end
 
@@ -70,6 +85,7 @@ module Bosh
             use_link_dns_addresses: @use_link_dns_addresses,
             tags: @tags,
             variables_interpolator: @variables_interpolator,
+            link_provider_intents: @link_provider_intents,
           )
         end
 

--- a/src/bosh-director/lib/bosh/director/links/links_parser.rb
+++ b/src/bosh-director/lib/bosh/director/links/links_parser.rb
@@ -65,9 +65,14 @@ module Bosh::Director::Links
             job_properties: job_properties,
             instance_group_name: instance_group_name,
           ),
+          process_release_providers(
+            current_release_template_model,
+            manifest_provides_links,
+            deployment_model,
+            instance_group_name,
+            job_properties,
+          ),
         )
-        errors.concat(process_release_providers(current_release_template_model, manifest_provides_links, deployment_model,
-                                                instance_group_name, job_properties))
 
         unless manifest_provides_links.empty?
           warning = 'Manifest defines unknown providers:'

--- a/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
@@ -54,6 +54,7 @@ module Bosh::Director
         allow(deployment_plan).to receive(:use_link_dns_names?).and_return(false)
         allow(deployment_plan).to receive(:randomize_az_placement?).and_return(false)
         allow(deployment_plan).to receive(:recreate_persistent_disks?).and_return(false)
+        allow(deployment_plan).to receive(:link_provider_intents).and_return([])
       end
 
       it 'should bind releases and their templates' do
@@ -128,6 +129,7 @@ module Bosh::Director
             anything,
             anything,
             anything,
+            anything,
             expected_options,
           ).and_call_original
           assembler.bind_models(tags: { 'key1' => 'value1' })
@@ -152,6 +154,7 @@ module Bosh::Director
               'use_link_dns_addresses' => false,
             }
             expect(DeploymentPlan::InstancePlanFactory).to receive(:new).with(
+              anything,
               anything,
               anything,
               anything,
@@ -185,6 +188,7 @@ module Bosh::Director
                 anything,
                 anything,
                 anything,
+                anything,
                 expected_options,
               ).and_call_original
               assembler.bind_models
@@ -209,6 +213,7 @@ module Bosh::Director
               'use_link_dns_addresses' => false,
             }
             expect(DeploymentPlan::InstancePlanFactory).to receive(:new).with(
+              anything,
               anything,
               anything,
               anything,

--- a/src/bosh-director/spec/unit/deployment_plan/instance_plan_factory_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_plan_factory_spec.rb
@@ -91,9 +91,12 @@ module Bosh::Director
           index_assigner,
           network_reservation_repository,
           variables_interpolator,
+          link_provider_intents,
           options,
         )
       end
+
+      let(:link_provider_intents) { [] }
 
       before do
         BD::Models::Stemcell.make(name: 'stemcell-name', version: '3.0.2', cid: 'sc-302')
@@ -152,6 +155,7 @@ module Bosh::Director
                 use_short_dns_addresses: false,
                 use_link_dns_addresses: false,
                 variables_interpolator: variables_interpolator,
+                link_provider_intents: [],
               )
               instance_plan_factory.obsolete_instance_plan(existing_instance_model)
             end
@@ -169,6 +173,7 @@ module Bosh::Director
                   use_short_dns_addresses: true,
                   use_link_dns_addresses: false,
                   variables_interpolator: variables_interpolator,
+                  link_provider_intents: [],
                 )
                 instance_plan_factory.obsolete_instance_plan(existing_instance_model)
               end
@@ -190,6 +195,7 @@ module Bosh::Director
                 use_dns_addresses: false,
                 use_link_dns_addresses: false,
                 variables_interpolator: variables_interpolator,
+                link_provider_intents: [],
               )
               instance_plan_factory.obsolete_instance_plan(existing_instance_model)
             end
@@ -227,6 +233,19 @@ module Bosh::Director
             end
           end
         end
+
+        context 'when there are link provider intents' do
+          let(:link_provider_intents) { double(:link_provider_intents) }
+
+          it 'passes them when creating an instance plan' do
+            expect(InstancePlan).to receive(:new).with(
+              include(
+                link_provider_intents: link_provider_intents,
+              ),
+            )
+            instance_plan_factory.obsolete_instance_plan(existing_instance_model)
+          end
+        end
       end
 
       describe '#desired_existing_instance_plan' do
@@ -246,6 +265,7 @@ module Bosh::Director
             use_link_dns_addresses: anything,
             tags: tags,
             variables_interpolator: variables_interpolator,
+            link_provider_intents: [],
           )
 
           instance_plan_factory.desired_existing_instance_plan(existing_instance_model, desired_instance)
@@ -267,6 +287,7 @@ module Bosh::Director
               use_short_dns_addresses: anything,
               use_link_dns_addresses: anything,
               variables_interpolator: anything,
+              link_provider_intents: [],
             )
             instance_plan_factory.desired_existing_instance_plan(existing_instance_model, desired_instance)
           end
@@ -302,6 +323,7 @@ module Bosh::Director
                 use_short_dns_addresses: false,
                 use_link_dns_addresses: false,
                 variables_interpolator: variables_interpolator,
+                link_provider_intents: [],
               )
               instance_plan_factory.desired_existing_instance_plan(existing_instance_model, desired_instance)
             end
@@ -319,6 +341,7 @@ module Bosh::Director
                   use_short_dns_addresses: true,
                   use_link_dns_addresses: false,
                   variables_interpolator: anything,
+                  link_provider_intents: [],
                 )
                 instance_plan_factory.obsolete_instance_plan(existing_instance_model)
               end
@@ -342,9 +365,23 @@ module Bosh::Director
                 use_short_dns_addresses: false,
                 use_link_dns_addresses: false,
                 variables_interpolator: anything,
+                link_provider_intents: [],
               )
               instance_plan_factory.desired_existing_instance_plan(existing_instance_model, desired_instance)
             end
+          end
+        end
+
+        context 'when there are link provider intents' do
+          let(:link_provider_intents) { double(:link_provider_intents) }
+
+          it 'passes them when creating an instance plan' do
+            expect(InstancePlan).to receive(:new).with(
+              include(
+                link_provider_intents: link_provider_intents,
+              ),
+            )
+            instance_plan_factory.desired_existing_instance_plan(existing_instance_model, desired_instance)
           end
         end
       end
@@ -365,6 +402,7 @@ module Bosh::Director
             use_link_dns_addresses: anything,
             tags: tags,
             variables_interpolator: anything,
+            link_provider_intents: [],
           )
 
           instance_plan_factory.desired_new_instance_plan(desired_instance)
@@ -399,6 +437,7 @@ module Bosh::Director
                 use_short_dns_addresses: false,
                 use_link_dns_addresses: false,
                 variables_interpolator: anything,
+                link_provider_intents: [],
               )
               instance_plan_factory.desired_new_instance_plan(desired_instance)
             end
@@ -416,6 +455,7 @@ module Bosh::Director
                   use_short_dns_addresses: true,
                   use_link_dns_addresses: false,
                   variables_interpolator: anything,
+                  link_provider_intents: [],
                 )
                 instance_plan_factory.obsolete_instance_plan(existing_instance_model)
               end
@@ -438,9 +478,23 @@ module Bosh::Director
                 use_short_dns_addresses: false,
                 use_link_dns_addresses: false,
                 variables_interpolator: anything,
+                link_provider_intents: [],
               )
               instance_plan_factory.desired_new_instance_plan(desired_instance)
             end
+          end
+        end
+
+        context 'when there are link provider intents' do
+          let(:link_provider_intents) { double(:link_provider_intents) }
+
+          it 'passes them when creating an instance plan' do
+            expect(InstancePlan).to receive(:new).with(
+              include(
+                link_provider_intents: link_provider_intents,
+              ),
+            )
+            instance_plan_factory.desired_new_instance_plan(desired_instance)
           end
         end
       end

--- a/src/bosh-director/spec/unit/deployment_plan/instance_planner_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_planner_spec.rb
@@ -6,7 +6,20 @@ describe 'BD::DeploymentPlan::InstancePlanner' do
 
   subject(:instance_planner) { BD::DeploymentPlan::InstancePlanner.new(instance_plan_factory, logger) }
   let(:network_reservation_repository) { BD::DeploymentPlan::NetworkReservationRepository.new(deployment, logger) }
-  let(:instance_plan_factory) { BD::DeploymentPlan::InstancePlanFactory.new(instance_repo, {}, skip_drain_decider, index_assigner, network_reservation_repository, variables_interpolator, options) }
+
+  let(:instance_plan_factory) do
+    BD::DeploymentPlan::InstancePlanFactory.new(
+      instance_repo,
+      {},
+      skip_drain_decider,
+      index_assigner,
+      network_reservation_repository,
+      variables_interpolator,
+      [],
+      options,
+    )
+  end
+
   let(:index_assigner) { BD::DeploymentPlan::PlacementPlanner::IndexAssigner.new(deployment_model) }
   let(:options) do
     {}

--- a/src/bosh-director/spec/unit/deployment_plan/placement_planner/availability_zone_picker_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/placement_planner/availability_zone_picker_spec.rb
@@ -8,7 +8,18 @@ module Bosh::Director::DeploymentPlan
     let(:network_reservation_repository) { BD::DeploymentPlan::NetworkReservationRepository.new(instance_double(Bosh::Director::DeploymentPlan::Planner), logger) }
     let(:skip_drain_decider) { SkipDrain.new(true) }
     let(:variables_interpolator) { instance_double(Bosh::Director::ConfigServer::VariablesInterpolator) }
-    let(:instance_plan_factory) { InstancePlanFactory.new(instance_repo, {}, skip_drain_decider, index_assigner, network_reservation_repository, variables_interpolator, 'randomize_az_placement' => randomize_az_placement) }
+    let(:instance_plan_factory) do
+      InstancePlanFactory.new(
+        instance_repo,
+        {},
+        skip_drain_decider,
+        index_assigner,
+        network_reservation_repository,
+        variables_interpolator,
+        [],
+        'randomize_az_placement' => randomize_az_placement,
+      )
+    end
     let(:index_assigner) { PlacementPlanner::IndexAssigner.new(deployment_model) }
     let(:deployment_model) { Bosh::Director::Models::Deployment.make }
     let(:test_random_tie_strategy) { PlacementPlanner::TieStrategy::RandomWins }

--- a/src/bosh-director/spec/unit/deployment_plan/placement_planner/plan_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/placement_planner/plan_spec.rb
@@ -6,7 +6,19 @@ module Bosh::Director::DeploymentPlan
     let(:network_planner) { NetworkPlanner::Planner.new(logger) }
     let(:network_reservation_repository) { BD::DeploymentPlan::NetworkReservationRepository.new(deployment, logger) }
     let(:variables_interpolator) { instance_double(Bosh::Director::ConfigServer::VariablesInterpolator) }
-    let(:instance_plan_factory) { InstancePlanFactory.new(instance_repo, {}, SkipDrain.new(true), index_assigner, network_reservation_repository, variables_interpolator) }
+
+    let(:instance_plan_factory) do
+      InstancePlanFactory.new(
+        instance_repo,
+        {},
+        SkipDrain.new(true),
+        index_assigner,
+        network_reservation_repository,
+        variables_interpolator,
+        [],
+      )
+    end
+
     let(:index_assigner) { PlacementPlanner::IndexAssigner.new(deployment_model) }
     let(:instance_repo) { Bosh::Director::DeploymentPlan::InstanceRepository.new(network_reservation_repository, logger, variables_interpolator) }
     let(:instance_plans) do

--- a/src/bosh-director/spec/unit/deployment_plan/placement_planner/static_ips_availability_zone_picker_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/placement_planner/static_ips_availability_zone_picker_spec.rb
@@ -17,7 +17,19 @@ module Bosh::Director::DeploymentPlan
     let(:index_assigner) { PlacementPlanner::IndexAssigner.new(deployment_model) }
     let(:instance_repo) { Bosh::Director::DeploymentPlan::InstanceRepository.new(network_reservation_repository, logger, variables_interpolator) }
     let(:instance_plans) { zone_picker.place_and_match_in(desired_instances, existing_instances) }
-    let(:instance_plan_factory) { InstancePlanFactory.new(instance_repo, {}, SkipDrain.new(true), index_assigner, network_reservation_repository, variables_interpolator) }
+
+    let(:instance_plan_factory) do
+      InstancePlanFactory.new(
+        instance_repo,
+        {},
+        SkipDrain.new(true),
+        index_assigner,
+        network_reservation_repository,
+        variables_interpolator,
+        [],
+      )
+    end
+
     let(:network_planner) { NetworkPlanner::Planner.new(logger) }
     let(:network_reservation_repository) { BD::DeploymentPlan::NetworkReservationRepository.new(planner, logger) }
     let(:planner) { planner_factory.create_from_manifest(manifest, cloud_configs, [], {}) }

--- a/src/spec/gocli/integration/links/dns_alias_spec.rb
+++ b/src/spec/gocli/integration/links/dns_alias_spec.rb
@@ -22,7 +22,7 @@ describe 'Aliasing links to DNS addresses', type: :integration do
     deploy_simple_manifest(manifest_hash: manifest)
   end
 
-  context 'when configuring aliases to links' do
+  context 'when configuring aliases to release links' do
     let(:instances) { director.instances }
 
     let(:cloud_config) do
@@ -145,6 +145,139 @@ describe 'Aliasing links to DNS addresses', type: :integration do
           },
         ],
       )
+    end
+  end
+
+  context 'when configuring aliases to custom provided links' do
+    let(:instances) { director.instances }
+
+    let(:cloud_config) do
+      cloud_config_hash = Bosh::Spec::NewDeployments.simple_cloud_config
+      cloud_config_hash['azs'] = [{ 'name' => 'z1' }]
+      cloud_config_hash['networks'].first['subnets'].first['az'] = 'z1'
+      cloud_config_hash['compilation']['az'] = 'z1'
+      cloud_config_hash['networks'] << {
+        'name' => 'manual-network',
+        'type' => 'manual',
+        'subnets' => [
+          { 'range' => '10.10.0.0/24',
+            'gateway' => '10.10.0.1',
+            'az' => 'z1' },
+        ],
+      }
+      cloud_config_hash['networks'] << {
+        'name' => 'dynamic-network',
+        'type' => 'dynamic',
+        'subnets' => [{ 'az' => 'z1' }],
+      }
+
+      cloud_config_hash
+    end
+
+    let(:manifest) do
+      manifest = Bosh::Spec::NewDeployments.simple_manifest_with_instance_groups
+      manifest['instance_groups'] = [
+        first_provider_instance_group,
+        second_provider_instance_group,
+      ]
+      manifest
+    end
+
+    let(:first_provider_instance_group) do
+      spec = Bosh::Spec::NewDeployments.simple_instance_group(
+        name: 'mysql',
+        jobs: [
+          {
+            'name' => 'database',
+            'custom_provider_definitions' => [
+              {
+                'name' => 'my-custom-link',
+                'type' => 'my-custom-link-type',
+              },
+            ],
+            'provides' => {
+              'my-custom-link' => {
+                'aliases' => [
+                  {
+                    'domain' => 'my-service.my-domain',
+                    'health_filter' => 'all',
+                    'initial_health_check' => 'synchronous',
+                    'placeholder_type' => 'uuid',
+                  },
+                ],
+              },
+            },
+          },
+          {
+            'name' => 'provider',
+            'provides' => {
+              'provider' => {
+                'aliases' => [
+                  { 'domain' => 'provider-service.my-domain' },
+                ],
+              },
+            },
+          },
+        ],
+        instances: 1,
+      )
+      spec['azs'] = ['z1']
+      spec['networks'] = [{ 'name' => 'manual-network' }]
+      spec
+    end
+
+    let(:second_provider_instance_group) do
+      spec = Bosh::Spec::NewDeployments.simple_instance_group(
+        name: 'yoursql',
+        jobs: [{
+          'name' => 'database',
+          'provides' => {
+            'db' => {
+              'as' => 'mydb',
+              'aliases' => second_provider_aliases,
+            },
+          },
+        }],
+        instances: 1,
+      )
+      spec['azs'] = ['z1']
+      spec['networks'] = [{ 'name' => 'manual-network' }]
+      spec
+    end
+
+    let(:second_provider_aliases) do
+      [
+        { 'domain' => 'texas.my-domain', 'health_filter' => 'all' },
+        { 'domain' => 'my-service.my-domain' },
+      ]
+    end
+
+    it 'provides the alias' do
+      # links.json
+      first_provider_instance = director.find_instance(instances, 'mysql', '0')
+      first_provider_database_links = JSON.parse(
+        first_provider_instance.read_job_template('database', '.bosh/links.json'),
+      )
+      first_provider_provider_links = JSON.parse(
+        first_provider_instance.read_job_template('provider', '.bosh/links.json'),
+      )
+
+      expect(first_provider_database_links).to include(
+        'name' => 'my-custom-link', 'type' => 'my-custom-link-type', 'group' => '3',
+      )
+      expect(first_provider_provider_links).to_not include(
+        'name' => 'my-custom-link', 'type' => 'my-custom-link-type', 'group' => '3',
+      )
+
+      # records.json
+      group_id_index = first_provider_instance.dns_records['record_keys'].index 'group_ids'
+
+      first_provider_record_info = first_provider_instance.dns_records['record_infos'][0]
+      expect(first_provider_record_info[group_id_index]).to match(include('3'))
+
+      second_provider_instance = director.find_instance(instances, 'yoursql', '0')
+      second_provider_record_info = second_provider_instance.dns_records['record_infos'][1]
+      expect(second_provider_record_info[group_id_index]).to_not match(include('3'))
     end
   end
 end


### PR DESCRIPTION
### What is this change about?

Previously we were filtering links.json and records.json files using job
template definitions. This prevented use of custom link providers when
aliasing to links. This change enables that use case by instead using
link provider intents as a starting point, which include both kinds of
links (custom and release-defined).

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/164964453

### What tests have you run against this PR?

All integration tests and unit tests (including the new ones) pass.

### How should this change be described in bosh release notes?

This could be described as a bugfix for using aliases to custom link providers.

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!

cc: @mgadiya @SocalNick @aashah 