### PR TITLE
Respect serial and max_in_flight property

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/multi_instance_group_updater.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/multi_instance_group_updater.rb
@@ -47,15 +47,13 @@ module Bosh::Director
         serial_updater = SerialMultiInstanceGroupUpdater.new(@instance_group_updater_factory)
         parallel_updater = ParallelMultiInstanceGroupUpdater.new(@instance_group_updater_factory)
 
-        partition_jobs_by_serial(jobs).each do |jp|
+        BatchMultiInstanceGroupUpdater.partition_jobs_by_serial(jobs).each do |jp|
           updater = jp.first.update.serial? ? serial_updater : parallel_updater
           updater.run(base_job, ip_provider, jp)
         end
       end
 
-      private
-
-      def partition_jobs_by_serial(jobs)
+      def self.partition_jobs_by_serial(jobs)
         job_partitions = []
         last_partition = []
 

--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -1,3 +1,5 @@
+require_relative 'base_job'
+
 module Bosh::Director
   module Jobs
     class UpdateDeployment < BaseJob
@@ -59,6 +61,18 @@ module Bosh::Director
         handle_toplevel_exception(e, context)
       ensure
         lock_variable_set
+      end
+
+      def parse_manifest
+        deployment_manifest = Manifest.load_from_hash(manifest_hash, manifest_text, cloud_config_models, runtime_config_models)
+        planner_factory = DeploymentPlan::PlannerFactory.create(logger)
+
+        @deployment_plan = planner_factory.create_from_manifest(
+          deployment_manifest,
+          cloud_config_models,
+          runtime_config_models,
+          @options,
+        )
       end
 
       private
@@ -376,18 +390,6 @@ module Bosh::Director
 
       def notifier
         @notifier ||= DeploymentPlan::Notifier.new(deployment_name, Config.nats_rpc, logger)
-      end
-
-      def parse_manifest
-        deployment_manifest = Manifest.load_from_hash(manifest_hash, manifest_text, cloud_config_models, runtime_config_models)
-        planner_factory = DeploymentPlan::PlannerFactory.create(logger)
-
-        @deployment_plan = planner_factory.create_from_manifest(
-          deployment_manifest,
-          cloud_config_models,
-          runtime_config_models,
-          @options,
-        )
       end
 
       def links_manager

--- a/src/bosh-director/lib/bosh/director/models/deployment_problem.rb
+++ b/src/bosh-director/lib/bosh/director/models/deployment_problem.rb
@@ -40,8 +40,11 @@ module Bosh::Director::Models
     end
 
     def open?
-      state == "open"
+      state == 'open'
     end
 
+    def instance_problem?
+      handler.instance_problem?
+    end
   end
 end

--- a/src/bosh-director/lib/bosh/director/problem_handlers/base.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/base.rb
@@ -54,6 +54,8 @@ module Bosh::Director
       # Problem description
       def description; end
 
+      def instance_problem?; end
+
       def resolutions
         self.class.resolutions.map do |name|
           { :name => name.to_s, :plan => resolution_plan(name) }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/inactive_disk.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/inactive_disk.rb
@@ -33,6 +33,10 @@ module Bosh::Director
         "Disk #{disk_label} is inactive"
       end
 
+      def instance_problem?
+        false
+      end
+
       resolution :ignore do
         plan { 'Skip for now' }
         action { }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/invalid_problem.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/invalid_problem.rb
@@ -16,6 +16,10 @@ module Bosh::Director
         "Problem (#{@original_type} #{@resource_id}) is no longer valid: #{@error}"
       end
 
+      def instance_problem?
+        false
+      end
+
       resolution :close do
         plan { "Close problem" }
         action { }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/missing_disk.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/missing_disk.rb
@@ -28,6 +28,10 @@ module Bosh::Director
         "Disk #{disk_label} is missing"
       end
 
+      def instance_problem?
+        false
+      end
+
       resolution :ignore do
         plan { 'Skip for now' }
         action { }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/missing_vm.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/missing_vm.rb
@@ -38,6 +38,10 @@ module Bosh::Director
         end
         "VM for '#{@instance}'#{with_vm_cid} missing."
       end
+
+      def instance_problem?
+        true
+      end
     end
   end
 end

--- a/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
@@ -41,6 +41,10 @@ module Bosh::Director
         out
       end
 
+      def instance_problem?
+        false
+      end
+
       resolution :ignore do
         plan { "Ignore" }
         action { }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/unresponsive_agent.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/unresponsive_agent.rb
@@ -27,6 +27,10 @@ module Bosh::Director
         "VM for '#{@instance}'#{with_vm_cid} is not responding."
       end
 
+      def instance_problem?
+        true
+      end
+
       resolution :ignore do
         plan { 'Skip for now' }
         action { }

--- a/src/bosh-director/lib/bosh/director/problem_resolver.rb
+++ b/src/bosh-director/lib/bosh/director/problem_resolver.rb
@@ -1,5 +1,9 @@
+require_relative 'jobs/update_deployment'
+
 module Bosh::Director
   class ProblemResolver
+    include DeploymentPlan
+    include Jobs
 
     attr_reader :logger
 
@@ -7,8 +11,12 @@ module Bosh::Director
       @deployment = deployment
       @resolved_count = 0
       @resolution_error_logs = StringIO.new
-
-      #temp
+      update_deployment = UpdateDeployment.new(
+        @deployment.manifest,
+        @deployment.cloud_configs.map(&:id),
+        @deployment.runtime_configs.map(&:id),
+      )
+      @instance_groups = update_deployment.parse_manifest.instance_groups
       @event_log_stage = nil
       @logger = Config.logger
     end
@@ -27,20 +35,20 @@ module Bosh::Director
 
     def apply_resolutions(resolutions)
       @resolutions = resolutions
-      problems = Models::DeploymentProblem.where(id: resolutions.keys)
+      all_problems = Models::DeploymentProblem.where(id: resolutions.keys, deployment_id: @deployment.id).all
+      begin_stage('Applying problem resolutions', all_problems.size)
 
-      begin_stage('Applying problem resolutions', problems.count)
+      if Config.parallel_problem_resolution && all_problems.size > 1
+        ig_to_problems = problems_by_instance_group(all_problems)
 
-      if Config.parallel_problem_resolution
-        ThreadPool.new(max_threads: Config.max_threads).wrap do |pool|
-          problems.each do |problem|
-            pool.process do
-              process_problem(problem)
-            end
+        problems_serially_ordered_by_job(ig_to_problems) do |ig_problems, max_in_flight|
+          n_threads = [ig_problems.size, max_in_flight, Config.max_threads].min
+          parallel_each(n_threads, ig_problems) do |problem|
+            process_problem(problem)
           end
         end
       else
-        problems.each do |problem|
+        all_problems.each do |problem|
           process_problem(problem)
         end
       end
@@ -52,16 +60,65 @@ module Bosh::Director
 
     private
 
-    def process_problem(problem)
-      if problem.state != 'open'
-        reason = "state is '#{problem.state}'"
-        track_and_log("Ignoring problem #{problem.id} (#{reason})")
-      elsif problem.deployment_id != @deployment.id
-        reason = 'not a part of this deployment'
-        track_and_log("Ignoring problem #{problem.id} (#{reason})")
+    def parallel_each(n_threads, ary)
+      if n_threads > 1
+        ThreadPool.new(max_threads: n_threads).wrap do |pool|
+          ary.each do |entry|
+            pool.process do
+              yield entry
+            end
+          end
+        end
       else
-        apply_resolution(problem)
+        ary.each do |entry|
+          yield entry
+        end
       end
+    end
+
+    def process_problem(problem)
+      if problem.open?
+        apply_resolution(problem)
+      else
+        track_and_log("Ignoring problem #{problem.id} (state is '#{problem.state}')")
+      end
+    end
+
+    def problems_serially_ordered_by_job(ig_to_problems, &block)
+      BatchMultiInstanceGroupUpdater.partition_jobs_by_serial(@instance_groups).each do |jp|
+        igs_with_problems = []
+        jp.each { |ig| igs_with_problems << ig.name if ig_to_problems.key?(ig.name) }
+        n_threads = [igs_with_problems.size, Config.max_threads].min
+        parallel_each(jp.first.update.serial? ? 1 : n_threads, igs_with_problems) do |ig_name|
+          process_ig(ig_name, ig_to_problems[ig_name], block)
+        end
+      end
+    end
+
+    def process_ig(ig_name, problems, block)
+      instance_group = @instance_groups.find do |plan_ig|
+        plan_ig.name == ig_name
+      end
+      max_in_flight = instance_group.update.max_in_flight(problems.size)
+      block.call(problems, max_in_flight)
+    end
+
+    def problems_by_instance_group(problems)
+      instance_group_to_problems = {}
+      problems.each do |p|
+        begin
+          if p.instance_problem?
+            instance = Models::Instance.where(id: p.resource_id).first
+          else
+            disk = Models::PersistentDisk.where(id: p.resource_id).first
+            instance = Models::Instance.where(id: disk.instance_id).first if disk
+          end
+          (instance_group_to_problems[instance.job] ||= []) << p if instance
+        rescue StandardError => e
+          log_resolution_error(p, e)
+        end
+      end
+      instance_group_to_problems
     end
 
     def apply_resolution(problem)
@@ -84,8 +141,7 @@ module Bosh::Director
       problem.state = 'resolved'
       problem.save
       @resolved_count += 1
-
-    rescue => e
+    rescue StandardError => e
       log_resolution_error(problem, e)
     end
 

--- a/src/bosh-director/lib/bosh/director/problem_resolver.rb
+++ b/src/bosh-director/lib/bosh/director/problem_resolver.rb
@@ -84,7 +84,7 @@ module Bosh::Director
 
     def process_partitions(ig_partition_to_ig_names_with_problems, igs_to_problems)
       ig_partition_to_ig_names_with_problems.each do |ig_partition, igs_with_problems|
-        num_threads = ig_partition.first.update.serial? ? 1 : [igs_with_problems.size, Config.max_threads].min
+        num_threads = ig_partition.first.update.serial? ? 1 : igs_with_problems.size
 
         parallel_each(num_threads, igs_with_problems) do |ig_name|
           process_instance_group(ig_name, igs_to_problems[ig_name])
@@ -98,7 +98,7 @@ module Bosh::Director
       end
       max_in_flight = instance_group.update.max_in_flight(problems.size)
 
-      num_threads = [problems.size, max_in_flight, Config.max_threads].min
+      num_threads = [problems.size, max_in_flight].min
       parallel_each(num_threads, problems) do |problem|
         process_problem(problem)
       end

--- a/src/bosh-director/lib/bosh/director/problem_resolver.rb
+++ b/src/bosh-director/lib/bosh/director/problem_resolver.rb
@@ -1,24 +1,18 @@
-require_relative 'jobs/update_deployment'
-
 module Bosh::Director
   class ProblemResolver
     include DeploymentPlan
-    include Jobs
 
     attr_reader :logger
 
     def initialize(deployment)
-      @deployment = deployment
-      @resolved_count = 0
-      @resolution_error_logs = StringIO.new
-      update_deployment = UpdateDeployment.new(
-        @deployment.manifest,
-        @deployment.cloud_configs.map(&:id),
-        @deployment.runtime_configs.map(&:id),
-      )
-      @instance_groups = update_deployment.parse_manifest.instance_groups
       @event_log_stage = nil
       @logger = Config.logger
+      @deployment = deployment
+      deployment_plan = DeploymentPlan::PlannerFactory.create(logger).create_from_model(deployment)
+      @instance_groups = deployment_plan.instance_groups
+
+      @resolved_count = 0
+      @resolution_error_logs = StringIO.new
     end
 
     def begin_stage(stage_name, n_steps)

--- a/src/bosh-director/spec/spec_helper.rb
+++ b/src/bosh-director/spec/spec_helper.rb
@@ -221,6 +221,11 @@ module SpecHelper
     end
 
     def reset_database(example)
+      if example.metadata[:truncation_before_test]
+        @director_db_helper.truncate_db
+        @dns_db_helper.truncate_db
+      end
+
       if example.metadata[:truncation] && ENV.fetch('DB', 'sqlite') != 'sqlite'
         example.run
       else

--- a/src/bosh-director/spec/unit/problem_handlers/inactive_disk_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/inactive_disk_spec.rb
@@ -40,6 +40,10 @@ describe Bosh::Director::ProblemHandlers::InactiveDisk do
     expect(@handler.description).to eq("Disk 'disk-cid' (300M) for instance 'mysql_node/52C6C66A-6DF3-4D4E-9EB1-FFE63AD755D7 (3)' is inactive")
   end
 
+  it 'is not an instance problem' do
+    expect(@handler.instance_problem?).to be_falsey
+  end
+
   describe 'invalid states' do
     it 'is invalid if disk is gone' do
       @disk.destroy

--- a/src/bosh-director/spec/unit/problem_handlers/invalid_problem_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/invalid_problem_spec.rb
@@ -1,20 +1,19 @@
-require File.expand_path("../../../spec_helper", __FILE__)
+require File.expand_path('../../../spec_helper', __FILE__)
 
 describe Bosh::Director::ProblemHandlers::InvalidProblem do
-
   class ErrorHandler < Bosh::Director::ProblemHandlers::Base
     register_as :err
 
     def initialize(resource_id, data)
       super
-      handler_error("foobar")
+      handler_error('foobar')
     end
   end
 
-  it "is being used as a handler for problems that cannot represent themselves anymore" do
+  it 'is being used as a handler for problems that cannot represent themselves anymore' do
     handler = Bosh::Director::ProblemHandlers::Base.create_by_type(:err, 42, {})
     expect(handler).to be_kind_of(Bosh::Director::ProblemHandlers::InvalidProblem)
-    expect(handler.description).to eq("Problem (err 42) is no longer valid: foobar")
+    expect(handler.instance_problem?).to be_falsey
+    expect(handler.description).to eq('Problem (err 42) is no longer valid: foobar')
   end
-
 end

--- a/src/bosh-director/spec/unit/problem_handlers/missing_disk_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/missing_disk_spec.rb
@@ -32,6 +32,10 @@ describe Bosh::Director::ProblemHandlers::MissingDisk do
     expect(handler).to be_kind_of(Bosh::Director::ProblemHandlers::MissingDisk)
   end
 
+  it 'is not an instance problem' do
+    expect(handler.instance_problem?).to be_falsey
+  end
+
   it 'has well-formed description' do
     expect(handler.description).to eq("Disk 'disk-cid' (mysql_node/uuid-42, 300M) is missing")
   end

--- a/src/bosh-director/spec/unit/problem_handlers/missing_vm_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/missing_vm_spec.rb
@@ -67,6 +67,10 @@ module Bosh::Director
       expect(handler).to be_kind_of(described_class)
     end
 
+    it 'is an instance problem' do
+      expect(handler.instance_problem?).to be_truthy
+    end
+
     it 'should call recreate_vm_without_wait when set to auto' do
       allow(handler).to receive(:recreate_vm_without_wait)
       expect(handler).to receive(:recreate_vm_without_wait).with(instance)

--- a/src/bosh-director/spec/unit/problem_handlers/mount_info_mismatch_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/mount_info_mismatch_spec.rb
@@ -45,6 +45,10 @@ describe Bosh::Director::ProblemHandlers::MountInfoMismatch do
     expect(handler).to be_kind_of(Bosh::Director::ProblemHandlers::MountInfoMismatch)
   end
 
+  it 'is not an instance problem' do
+    expect(@handler.instance_problem?).to be_falsey
+  end
+
   it 'has description' do
     expect(@handler.description).to match(/Inconsistent mount information/)
     expect(@handler.description).to match(/Not mounted in any VM/)

--- a/src/bosh-director/spec/unit/problem_handlers/unresponsive_agent_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/unresponsive_agent_spec.rb
@@ -89,6 +89,10 @@ module Bosh::Director
       expect(handler).to be_kind_of(ProblemHandlers::UnresponsiveAgent)
     end
 
+    it 'is not an instance problem' do
+      expect(handler.instance_problem?).to be_truthy
+    end
+
     it 'has well-formed description' do
       expect(handler.description).to eq("VM for 'mysql_node/uuid-1 (0)' with cloud ID 'vm-cid' is not responding.")
     end

--- a/src/bosh-director/spec/unit/problem_resolver_spec.rb
+++ b/src/bosh-director/spec/unit/problem_resolver_spec.rb
@@ -9,12 +9,31 @@ module Bosh::Director
     let(:task) { Bosh::Director::Models::Task.make(id: 42, username: 'user') }
     let(:task_writer) { Bosh::Director::TaskDBWriter.new(:event_output, task.id) }
     let(:event_log) { Bosh::Director::EventLog::Log.new(task_writer) }
+    let(:update_deployment) { double }
+    let(:parallel_problem_resolution) { true }
+    let(:parallel_update_config) { instance_double('Bosh::Director::DeploymentPlan::UpdateConfig', serial?: false) }
+    let(:n_igs_with_problems) { 4 }
+    let(:n_problems_in_ig) { 3 }
+    let(:igs) do
+      igs = []
+      (1..n_igs_with_problems).each do |i|
+        igs << instance_double('Bosh::Director::DeploymentPlan::InstanceGroup', name: "ig-#{i}", update: parallel_update_config)
+      end
+      igs
+    end
+    let(:disk_igs) do
+      [instance_double('Bosh::Director::DeploymentPlan::InstanceGroup', name: 'disk-ig-1', update: parallel_update_config)]
+    end
+
     before(:each) do
       @deployment = Models::Deployment.make(name: 'mycloud')
-      @other_deployment = Models::Deployment.make(name: 'othercloud')
+
+      allow(Bosh::Director::Jobs::UpdateDeployment).to receive(:new).and_return(update_deployment)
+      allow(update_deployment).to receive_message_chain(:parse_manifest, :instance_groups).and_return(igs)
+
       allow(Bosh::Director::Config).to receive(:current_job).and_return(job)
       allow(Bosh::Director::Config).to receive(:event_log).and_return(event_log)
-      allow(Bosh::Director::Config).to receive(:parallel_problem_resolution).and_return(true)
+      allow(Bosh::Director::Config).to receive(:parallel_problem_resolution).and_return(parallel_problem_resolution)
 
       allow(Bosh::Director::CloudFactory).to receive(:create).and_return(cloud_factory)
       allow(cloud_factory).to receive(:get).with('', nil).and_return(cloud)
@@ -31,96 +50,201 @@ module Bosh::Director
                                      state: 'open')
     end
 
+    def test_instance_apply_resolutions
+      problem_resolutions = {}
+      (1..n_igs_with_problems).each do |n|
+        n_problems_in_ig.times do
+          instance = Models::Instance.make(job: "ig-#{n}", deployment_id: @deployment.id)
+          problem = Models::DeploymentProblem.make(
+            deployment_id: @deployment.id,
+            resource_id: instance.id,
+            type: 'missing_vm',
+            state: 'open',
+          )
+          problem_resolutions[problem.id.to_s] = 'recreate_vm'
+        end
+      end
+
+      resolver = make_resolver(@deployment)
+      problem_handler = ProblemHandlers::MissingVM.new(1, nil)
+      allow(ProblemHandlers::Base).to receive(:create_from_model).and_return(problem_handler)
+
+      expect(problem_handler).to receive(:recreate_vm).exactly(problem_resolutions.size).times
+      expect(resolver.apply_resolutions(problem_resolutions)).to eq([problem_resolutions.size, nil])
+      expect(Models::DeploymentProblem.filter(state: 'open').count).to eq(0)
+    end
+
     describe '#apply_resolutions' do
       context 'when execution succeeds' do
+        let(:max_threads) { 10 }
+        let(:max_in_flight) { 5 }
+
         before do
-          allow(Bosh::Director::Config).to receive(:max_threads).and_return(5)
+          allow(Bosh::Director::Config).to receive(:max_threads).and_return(max_threads)
+          allow(parallel_update_config).to receive(:max_in_flight).and_return(max_in_flight)
         end
+
         context 'when parallel resurrection is turned on' do
-          it 'resolves the problems parallel' do
-            test_apply_resolutions
-            expect(ThreadPool).to have_received(:new).with(max_threads: 5)
+          context 'when only one problem exists per instance group' do
+            let(:n_igs_with_problems) { 1 }
+            let(:n_problems_in_ig) { 1 }
+
+            it 'does not create a threadpool for processing the problem' do
+              test_instance_apply_resolutions
+              expect(ThreadPool).not_to have_received(:new)
+            end
+          end
+
+          context 'when max_threads is one' do
+            let(:max_threads) { 1 }
+
+            it 'does not create a threadpool for processing the problem' do
+              test_instance_apply_resolutions
+              expect(ThreadPool).not_to have_received(:new)
+            end
+          end
+
+          context 'when max_in_flight is one' do
+            let(:max_in_flight) { 1 }
+
+            it 'does not create a threadpool for processing the problem' do
+              test_instance_apply_resolutions
+              expect(ThreadPool).to have_received(:new).once.with(max_threads: n_igs_with_problems)
+            end
+          end
+
+          context 'when the number instances with problems is smaller than max_in_flight and max_threads' do
+            it 'respects number of instances with problems' do
+              test_instance_apply_resolutions
+              expect(ThreadPool).to have_received(:new).once.with(max_threads: n_igs_with_problems)
+              expect(ThreadPool).to have_received(:new).exactly(n_igs_with_problems).times.with(max_threads: n_problems_in_ig)
+            end
+          end
+
+          context 'when max_in_flight is smaller than the number of instances with problems and max_threads' do
+            let(:max_in_flight) { 2 }
+
+            it 'respects max_in_flight' do
+              test_instance_apply_resolutions
+              expect(ThreadPool).to have_received(:new).once.with(max_threads: n_igs_with_problems)
+              expect(ThreadPool).to have_received(:new).exactly(n_igs_with_problems).times.with(max_threads: max_in_flight)
+            end
+          end
+
+          context 'when max_threads is smaller than the number of instances with problems and max_in_flight' do
+            let(:max_threads) { 2 }
+            it 'respects max_threads' do
+              test_instance_apply_resolutions
+              expect(ThreadPool).to have_received(:new).exactly(1 + n_igs_with_problems).times.with(max_threads: max_threads)
+            end
+          end
+
+          context 'when serial is true for some instance groups' do
+            let(:serial_update_config) { instance_double('Bosh::Director::DeploymentPlan::UpdateConfig', serial?: true) }
+            let(:igs) do
+              [
+                instance_double('Bosh::Director::DeploymentPlan::InstanceGroup', name: 'ig-1', update: serial_update_config),
+                instance_double('Bosh::Director::DeploymentPlan::InstanceGroup', name: 'ig-2', update: parallel_update_config),
+                instance_double('Bosh::Director::DeploymentPlan::InstanceGroup', name: 'ig-3', update: parallel_update_config),
+                instance_double('Bosh::Director::DeploymentPlan::InstanceGroup', name: 'ig-4', update: serial_update_config),
+              ]
+            end
+            before do
+              allow(serial_update_config).to receive(:max_in_flight).and_return(max_in_flight)
+            end
+
+            it 'respects serial' do
+              test_instance_apply_resolutions
+              non_serial_igs_with_problems = 2
+              expect(ThreadPool).to have_received(:new).once.with(max_threads: non_serial_igs_with_problems)
+              expect(ThreadPool).to have_received(:new).exactly(
+                n_igs_with_problems,
+              ).times.with(max_threads: n_problems_in_ig)
+            end
           end
         end
 
         context 'when parallel resurrection is turned off' do
-          before do
-            allow(Bosh::Director::Config).to receive(:parallel_problem_resolution).and_return(false)
-          end
+          let(:parallel_problem_resolution) { false }
+
           it 'resolves the problems serial' do
-            test_apply_resolutions
+            test_instance_apply_resolutions
             expect(ThreadPool).not_to have_received(:new)
           end
         end
 
-        def test_apply_resolutions
-          disks = []
-          problems = []
+        context 'when instance group contains disk problems' do
+          let(:agent) { double('agent') }
 
-          agent = double('agent')
-          expect(agent).to receive(:list_disk).and_return([])
-          expect(cloud).to receive(:detach_disk).exactly(1).times
+          it 'can resolve persistent disk problems' do
+            disks = []
 
-          allow(AgentClient).to receive(:with_agent_id).and_return(agent)
+            expect(agent).to receive(:list_disk).and_return([])
+            expect(cloud).to receive(:detach_disk).exactly(1).times
+            allow(AgentClient).to receive(:with_agent_id).and_return(agent)
 
-          2.times do
-            disk = Models::PersistentDisk.make(active: false)
-            disks << disk
-            problems << inactive_disk(disk.id)
+            allow(update_deployment).to receive_message_chain(:parse_manifest, :instance_groups).and_return(disk_igs)
+            allow(Models::Instance).to receive(:make).and_return(
+              Models::Instance.make(job: 'disk-ig-1', deployment_id: @deployment.id),
+              Models::Instance.make(job: 'disk-ig-1', deployment_id: @deployment.id),
+            )
+
+            2.times do
+              disk = Models::PersistentDisk.make(active: false)
+              disks << disk
+              inactive_disk(disk.id)
+            end
+
+            resolver = make_resolver(@deployment)
+
+            expect(resolver).to receive(:track_and_log).with(
+              %r{Disk 'disk-cid-\d+' \(0M\) for instance 'disk-ig-\d+\/uuid-\d+ \(\d+\)' is inactive \(.*\): .*},
+            ).twice.and_call_original
+            expect(
+              resolver.apply_resolutions(
+                '1' => 'delete_disk',
+                '2' => 'ignore',
+              ),
+            ).to eq([2, nil])
+            expect(Models::PersistentDisk.find(id: disks[0].id)).to be_nil
+            expect(Models::PersistentDisk.find(id: disks[1].id)).not_to be_nil
+            expect(Models::DeploymentProblem.filter(state: 'open').count).to eq(0)
           end
-
-          resolver = make_resolver(@deployment)
-
-          expect(resolver).to receive(:track_and_log).with(/Disk 'disk-cid-\d+' \(0M\) for instance 'job-\d+\/uuid-\d+ \(\d+\)' is inactive \(.*\): .*/).twice.and_call_original
-
-          expect(resolver.apply_resolutions(problems[0].id.to_s => 'delete_disk', problems[1].id.to_s => 'ignore'))
-            .to eq([2, nil])
-
-          expect(Models::PersistentDisk.find(id: disks[0].id)).to be_nil
-          expect(Models::PersistentDisk.find(id: disks[1].id)).not_to be_nil
-
-          expect(Models::DeploymentProblem.filter(state: 'open').count).to eq(0)
         end
 
-        it 'notices and logs extra resolutions' do
-          disks = (1..3).map { |_| Models::PersistentDisk.make(active: false) }
-
-          problems = [
-            inactive_disk(disks[0].id),
-            inactive_disk(disks[1].id),
-            inactive_disk(disks[2].id, @other_deployment.id),
-          ]
-
-          resolver1 = make_resolver(@deployment)
-          expect(resolver1.apply_resolutions(problems[0].id.to_s => 'ignore', problems[1].id.to_s => 'ignore')).to eq([2, nil])
-
-          resolver2 = make_resolver(@deployment)
-
-          messages = []
-          expect(resolver2).to receive(:track_and_log).exactly(3).times { |message| messages << message }
-          resolver2.apply_resolutions(
-            problems[0].id.to_s => 'ignore',
-            problems[1].id.to_s => 'ignore',
-            problems[2].id.to_s => 'ignore',
-            '9999999' => 'ignore',
-            '318' => 'do_stuff',
+        it 'logs already resolved problem' do
+          disk = Models::PersistentDisk.make
+          problem = Models::DeploymentProblem.make(
+            deployment_id: @deployment.id,
+            resource_id: disk.id,
+            type: 'inactive_disk',
+            state: 'resolved',
           )
+          resolver = make_resolver(@deployment)
+          expect(resolver).to receive(:track_and_log).once.with("Ignoring problem #{problem.id} (state is 'resolved')")
+          count, err_message = resolver.apply_resolutions(problem.id.to_s => 'delete_disk')
+          expect(count).to eq(0)
+          expect(err_message).to be_nil
+        end
 
-          expect(messages).to match_array([
-                                            "Ignoring problem #{problems[0].id} (state is 'resolved')",
-                                            "Ignoring problem #{problems[1].id} (state is 'resolved')",
-                                            "Ignoring problem #{problems[2].id} (not a part of this deployment)",
-                                          ])
+        it 'ignores non-existing problems' do
+          resolver = make_resolver(@deployment)
+          expect(
+            resolver.apply_resolutions(
+              '9999999' => 'ignore',
+              '318' => 'do_stuff',
+            ),
+          ).to eq([0, nil])
         end
       end
 
-      context 'when execution fails' do
-        it 'raises error and logs' do
-          backtrace = anything
-          disk = Models::PersistentDisk.make(active: false)
-          problem = inactive_disk(disk.id)
-          resolver = make_resolver(@deployment)
+      context 'when problem resolution fails' do
+        let(:backtrace) { anything }
+        let(:disk) { Models::PersistentDisk.make(active: false) }
+        let(:problem) { inactive_disk(disk.id) }
+        let(:resolver) { make_resolver(@deployment) }
 
+        it 'rescues ProblemHandlerError and logs' do
           expect(resolver).to receive(:track_and_log)
             .and_raise(Bosh::Director::ProblemHandlerError.new('Resolution failed'))
           expect(logger).to receive(:error).with("Error resolving problem '#{problem.id}': Resolution failed")
@@ -131,15 +255,8 @@ module Bosh::Director
           expect(error_message).to eq("Error resolving problem '#{problem.id}': Resolution failed")
           expect(count).to eq(1)
         end
-      end
 
-      context 'when execution fails because of other errors' do
-        it 'raises error and logs' do
-          backtrace = anything
-          disk = Models::PersistentDisk.make(active: false)
-          problem = inactive_disk(disk.id)
-          resolver = make_resolver(@deployment)
-
+        it 'rescues StandardError and logs' do
           expect(ProblemHandlers::Base).to receive(:create_from_model)
             .and_raise(StandardError.new('Model creation failed'))
           expect(logger).to receive(:error).with("Error resolving problem '#{problem.id}': Model creation failed")

--- a/src/bosh-director/spec/unit/problem_resolver_spec.rb
+++ b/src/bosh-director/spec/unit/problem_resolver_spec.rb
@@ -78,11 +78,9 @@ module Bosh::Director
 
     describe '#apply_resolutions' do
       context 'when execution succeeds' do
-        let(:max_threads) { 10 }
         let(:max_in_flight) { 5 }
 
         before do
-          allow(Bosh::Director::Config).to receive(:max_threads).and_return(max_threads)
           allow(parallel_update_config).to receive(:max_in_flight).and_return(max_in_flight)
         end
 
@@ -90,15 +88,6 @@ module Bosh::Director
           context 'when only one problem exists per instance group' do
             let(:num_problem_instance_groups) { 1 }
             let(:problems_per_instance_group) { 1 }
-
-            it 'does not create a threadpool for processing the problem' do
-              test_instance_apply_resolutions
-              expect(ThreadPool).not_to have_received(:new)
-            end
-          end
-
-          context 'when max_threads is one' do
-            let(:max_threads) { 1 }
 
             it 'does not create a threadpool for processing the problem' do
               test_instance_apply_resolutions
@@ -116,7 +105,7 @@ module Bosh::Director
             end
           end
 
-          context 'when the number instances with problems is smaller than max_in_flight and max_threads' do
+          context 'when the number instances with problems is smaller than max_in_flight' do
             it 'respects number of instances with problems' do
               test_instance_apply_resolutions
               expect(ThreadPool).to have_received(:new).once.with(max_threads: num_problem_instance_groups)
@@ -126,7 +115,7 @@ module Bosh::Director
             end
           end
 
-          context 'when max_in_flight is smaller than the number of instances with problems and max_threads' do
+          context 'when max_in_flight is smaller than the number of instances with problems' do
             let(:max_in_flight) { 2 }
 
             it 'respects max_in_flight' do
@@ -135,16 +124,6 @@ module Bosh::Director
               expect(ThreadPool).to have_received(:new)
                 .exactly(num_problem_instance_groups).times
                 .with(max_threads: max_in_flight)
-            end
-          end
-
-          context 'when max_threads is smaller than the number of instances with problems and max_in_flight' do
-            let(:max_threads) { 2 }
-            it 'respects max_threads' do
-              test_instance_apply_resolutions
-              expect(ThreadPool).to have_received(:new)
-                .exactly(1 + num_problem_instance_groups).times
-                .with(max_threads: max_threads)
             end
           end
 

--- a/src/bosh-director/spec/unit/problem_resolver_spec.rb
+++ b/src/bosh-director/spec/unit/problem_resolver_spec.rb
@@ -68,10 +68,8 @@ module Bosh::Director
       end
 
       resolver = make_resolver(@deployment)
-      problem_handler = ProblemHandlers::MissingVM.new(1, nil)
-      allow(ProblemHandlers::Base).to receive(:create_from_model).and_return(problem_handler)
+      allow_any_instance_of(ProblemHandlers::MissingVM).to receive(:apply_resolution).with('recreate_vm')
 
-      expect(problem_handler).to receive(:recreate_vm).exactly(problem_resolutions.size).times
       expect(resolver.apply_resolutions(problem_resolutions)).to eq([problem_resolutions.size, nil])
       expect(Models::DeploymentProblem.filter(state: 'open').count).to eq(0)
     end
@@ -164,7 +162,7 @@ module Bosh::Director
         context 'when instance group contains disk problems' do
           let(:agent) { double('agent') }
 
-          it 'can resolve persistent disk problems' do
+          it 'can resolve persistent disk problems', truncation_before_test: true do
             disks = []
 
             expect(agent).to receive(:list_disk).and_return([])

--- a/src/spec/gocli/integration/health_monitor/resurrector_spec.rb
+++ b/src/spec/gocli/integration/health_monitor/resurrector_spec.rb
@@ -59,4 +59,74 @@ describe 'resurrector', type: :integration, hm: true do
     disabled_instance.kill_agent
     expect(director.wait_for_vm('foobar', '0', 150, deployment_name: 'simple_disabled')).to be_nil
   end
+
+  it "respects 'serial' property" do
+    current_sandbox.reconfigure_health_monitor
+
+    deployment_hash = Bosh::Spec::NewDeployments.simple_manifest_with_instance_groups
+    deployment_hash['update']['serial'] = true
+    deployment_hash['update']['max_in_flight'] = 2
+
+    deployment_hash['instance_groups'][0]['instances'] = 2
+    deployment_hash['instance_groups'][0]['name'] = 'ig_1'
+
+    ig2 = {
+      name: 'ig_2',
+      jobs: [{ 'name' => 'foobar', 'release' => 'bosh-release' }],
+      instances: 2,
+    }
+    deployment_hash['instance_groups'][1] = Bosh::Spec::NewDeployments.simple_instance_group(ig2)
+
+    upload_cloud_config(cloud_config_hash: Bosh::Spec::NewDeployments.simple_cloud_config)
+    deploy_simple_manifest(manifest_hash: deployment_hash)
+
+    instances = director.instances
+    ig1_instances = instances.select { |i| i.instance_group_name == 'ig_1' }
+    ig2_instances = instances.select { |i| i.instance_group_name == 'ig_2' }
+
+    ig2_instances.each(&:kill_agent)
+    ig1_instances.each(&:kill_agent)
+
+    ig2_instances.each { |i| director.wait_for_vm('ig_2', i.index, 300) }
+    ig1_instances.each { |i| director.wait_for_vm('ig_1', i.index, 300) }
+
+    director.wait_for_resurrection_to_finish
+    resurrection_task = director.tasks.filter(
+      username: 'hm',
+      description: 'scan and fix',
+      state: 'done',
+    ).order(:id).first
+
+    expect(resurrection_task).to be_truthy
+    expect(resurrection_task[:event_output]).to match(/.*ig_1.*ig_1.*ig_1.*ig_1.*ig_2.*ig_2.*ig_2.*ig_2.*/m)
+  end
+
+  it "respects 'max_in_flight' property" do
+    current_sandbox.reconfigure_health_monitor
+
+    deployment_hash = Bosh::Spec::NewDeployments.simple_manifest_with_instance_groups
+    deployment_hash['update']['serial'] = false
+    deployment_hash['update']['max_in_flight'] = 2
+
+    deployment_hash['instance_groups'][0]['instances'] = 3
+    deployment_hash['instance_groups'][0]['name'] = 'ig_1'
+
+    upload_cloud_config(cloud_config_hash: Bosh::Spec::NewDeployments.simple_cloud_config)
+    deploy_simple_manifest(manifest_hash: deployment_hash)
+
+    instances = director.instances
+    ig1_instances = instances.select { |i| i.instance_group_name == 'ig_1' }
+    ig1_instances.each(&:kill_agent)
+    ig1_instances.each { |i| director.wait_for_vm('ig_1', i.index, 300) }
+
+    director.wait_for_resurrection_to_finish
+    resurrection_task = director.tasks.filter(
+      username: 'hm',
+      description: 'scan and fix',
+      state: 'done',
+    ).order(:id).first
+
+    expect(resurrection_task).to be_truthy
+    expect(resurrection_task[:event_output]).to match(/Applying.*started.*\n.*Applying.*started.*\n.*Applying.*finished/m)
+  end
 end

--- a/src/spec/gocli/integration/health_monitor/resurrector_spec.rb
+++ b/src/spec/gocli/integration/health_monitor/resurrector_spec.rb
@@ -97,7 +97,7 @@ describe 'resurrector', type: :integration, hm: true do
       state: 'done',
     ).order(:id).first
 
-    expect(resurrection_task).to be_truthy
+    expect(resurrection_task.any?).to be_truthy
     expect(resurrection_task[:event_output]).to match(/.*ig_1.*ig_1.*ig_1.*ig_1.*ig_2.*ig_2.*ig_2.*ig_2.*/m)
   end
 
@@ -126,7 +126,7 @@ describe 'resurrector', type: :integration, hm: true do
       state: 'done',
     ).order(:id).first
 
-    expect(resurrection_task).to be_truthy
+    expect(resurrection_task.any?).to be_truthy
     expect(resurrection_task[:event_output]).to match(/Applying.*started.*\n.*Applying.*started.*\n.*Applying.*finished/m)
   end
 end

--- a/src/spec/support/director.rb
+++ b/src/spec/support/director.rb
@@ -143,6 +143,10 @@ module Bosh::Spec
       return output, !failed
     end
 
+    def tasks
+      @db[:tasks]
+    end
+
     def raw_task_events(task_id)
       result = @runner.run("task #{task_id} --raw")
       event_list = []
@@ -180,7 +184,7 @@ module Bosh::Spec
         resurrection_task = @db[:tasks].filter(
           username: 'hm',
           description: 'scan and fix',
-          state: 'processing'
+          state: 'processing',
         )
         return unless resurrection_task.any?
 


### PR DESCRIPTION
### What is this change about?

Before this change, the resolution of detected problems by a scan and fix task was scheduled in parallel across all instance groups in a deployment. After this change, `max_in_flight` and `serial` are considered.

**Question**: Why does the regular deploy flow [not consider](https://github.com/cloudfoundry/bosh/blob/c73c7e6636a895b6315739ecad18fd8fc2228b56/src/bosh-director/lib/bosh/director/deployment_plan/multi_instance_group_updater.rb#L29) the [`max_threads`](https://bosh.io/jobs/director?source=github.com/cloudfoundry/bosh#p%3ddirector.max_threads) property during the update instance step although it is considered in the create vm step, c.f. [step_executor](https://github.com/cloudfoundry/bosh/blob/c73c7e6636a895b6315739ecad18fd8fc2228b56/src/bosh-director/lib/bosh/director/step_executor.rb#L15).

In this implementation, resurrection of instances also considers `max_threads` from the director config for the update instance step. This is the only difference between resurrection and the standard deploy flow and it would be nice if both would be aligned.

### Please provide contextual information.

[#165062729](https://www.pivotaltracker.com/story/show/165062729) and discussion in https://github.com/cloudfoundry/bosh/pull/2157#issuecomment-476132012

### What tests have you run against this PR?

Unit and integration tests.

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!

@friegger, @mfine30, @beyhan 
