### PR TITLE
Respect max_in_flight and canaries in create deployment

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -405,6 +405,8 @@ module Bosh::Director
         options['recreate_persistent_disks'] = true if params['recreate_persistent_disks'] == 'true'
         options['skip_drain'] = params['skip_drain'] if params['skip_drain']
         options['fix'] = true if params['fix'] == 'true'
+        options['canaries'] = params[:canaries] if params['canaries']
+        options['max_in_flight'] = params[:max_in_flight] if params['max_in_flight']
         options['scopes'] = token_scopes
 
         # since authorizer does not look at manifest payload for deployment name

--- a/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -352,6 +352,28 @@ module Bosh::Director
             end
           end
 
+          context 'with the "canaries" param' do
+            it 'passes the parameter' do
+              expect_any_instance_of(DeploymentManager)
+                .to receive(:create_deployment)
+                .with(anything, anything, anything, anything, anything, hash_including('canaries' => '1'), anything)
+                .and_return(OpenStruct.new(id: 1))
+              post '/?canaries=1', spec_asset('test_conf.yaml'), 'CONTENT_TYPE' => 'text/yaml'
+              expect(last_response).to be_redirect
+            end
+          end
+
+          context 'with the "max-in-flight" param' do
+            it 'passes the parameter' do
+              expect_any_instance_of(DeploymentManager)
+                .to receive(:create_deployment)
+                .with(anything, anything, anything, anything, anything, hash_including('max_in_flight' => '1'), anything)
+                .and_return(OpenStruct.new(id: 1))
+              post '/?max_in_flight=1', spec_asset('test_conf.yaml'), 'CONTENT_TYPE' => 'text/yaml'
+              expect(last_response).to be_redirect
+            end
+          end
+
           context 'with the "recreate_persistent_disks" param' do
             it 'passes the parameter' do
               expect_any_instance_of(DeploymentManager)


### PR DESCRIPTION
### What is this change about?

The API endpoint for `bosh deploy` `POST /deployments` did not
respect the properties `max_in_flight` and `canaries`. Now
those properties are being propagated equivalent to the
`PUT /deployments/:deployment/jobs/:job` endpoint used in
`bosh start/restart/stop/recreate`.

### Please provide contextual information.

https://github.com/cloudfoundry/bosh/issues/2193

### What tests have you run against this PR?

Unit and integration tests

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!

@s4heid @mfine30 @friegger  
