### PR TITLE
Director API will return both static & dynamic IPs

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -611,15 +611,21 @@ module Bosh::Director
       end
 
       def ips(vm)
+        manual_or_vip_ips(vm) + dynamic_ips(vm)
+      end
+
+      def manual_or_vip_ips(vm)
         return [] if vm.nil?
 
-        # For manual and vip networks
-        result = vm.ip_addresses.map { |ip| NetAddr::CIDR.create(ip.address).ip }
-
-        # For dynamic networks
-        result = vm.network_spec.map { |_, network| network['ip'] } if result.empty? && !vm.network_spec.empty?
-        result
+        vm.ip_addresses.map { |ip| NetAddr::CIDR.create(ip.address).ip }
       end
+
+      def dynamic_ips(vm)
+        return [] if vm.nil?
+
+        vm.network_spec.map { |_, network| network['ip'] }
+      end
+
     end
   end
 end

--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -611,7 +611,7 @@ module Bosh::Director
       end
 
       def ips(vm)
-        manual_or_vip_ips(vm) + dynamic_ips(vm)
+        manual_or_vip_ips(vm).concat(dynamic_ips(vm)).uniq
       end
 
       def manual_or_vip_ips(vm)

--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -605,27 +605,10 @@ module Bosh::Director
           'index' => instance.index,
           'id' => instance.uuid,
           'az' => instance.availability_zone,
-          'ips' => ips(vm),
+          'ips' => vm&.ips || [],
           'vm_created_at' => vm&.created_at&.utc&.iso8601,
         }
       end
-
-      def ips(vm)
-        manual_or_vip_ips(vm).concat(dynamic_ips(vm)).uniq
-      end
-
-      def manual_or_vip_ips(vm)
-        return [] if vm.nil?
-
-        vm.ip_addresses.map { |ip| NetAddr::CIDR.create(ip.address).ip }
-      end
-
-      def dynamic_ips(vm)
-        return [] if vm.nil?
-
-        vm.network_spec.map { |_, network| network['ip'] }
-      end
-
     end
   end
 end

--- a/src/bosh-director/lib/bosh/director/jobs/vm_state.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/vm_state.rb
@@ -64,7 +64,7 @@ module Bosh::Director
           cloud_properties: instance.cloud_properties_hash,
           disk_cid: instance.managed_persistent_disk_cid,
           disk_cids: instance.active_persistent_disks.collection.map { |d| d.model.disk_cid },
-          ips: ips(vm),
+          ips: vm&.ips || [],
           dns: dns_records,
           agent_id: vm&.agent_id,
           job_name: instance.job,
@@ -79,22 +79,6 @@ module Bosh::Director
           bootstrap: instance.bootstrap,
           ignore: instance.ignore,
         }
-      end
-
-      def ips(vm)
-        manual_or_vip_ips(vm).concat(dynamic_ips(vm)).uniq
-      end
-
-      def manual_or_vip_ips(vm)
-        return [] if vm.nil?
-
-        vm.ip_addresses.map { |ip| NetAddr::CIDR.create(ip.address).ip }
-      end
-
-      def dynamic_ips(vm)
-        return [] if vm.nil?
-
-        vm.network_spec.map { |_, network| network['ip'] }
       end
 
       def vm_details(vm)

--- a/src/bosh-director/lib/bosh/director/jobs/vm_state.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/vm_state.rb
@@ -82,15 +82,19 @@ module Bosh::Director
       end
 
       def ips(vm)
-        # For manual and vip networks
-        ip_addresses = vm&.ip_addresses || {}
-        result = ip_addresses.map {|ip| NetAddr::CIDR.create(ip.address).ip }
+        manual_or_vip_ips(vm).concat(dynamic_ips(vm)).uniq
+      end
 
-        # For dynamic networks
-        if result.empty? && vm && !vm.network_spec.empty?
-          result = vm&.network_spec&.map {|_, network| network['ip']}
-        end
-        result
+      def manual_or_vip_ips(vm)
+        return [] if vm.nil?
+
+        vm.ip_addresses.map { |ip| NetAddr::CIDR.create(ip.address).ip }
+      end
+
+      def dynamic_ips(vm)
+        return [] if vm.nil?
+
+        vm.network_spec.map { |_, network| network['ip'] }
       end
 
       def vm_details(vm)

--- a/src/bosh-director/lib/bosh/director/models/vm.rb
+++ b/src/bosh-director/lib/bosh/director/models/vm.rb
@@ -17,5 +17,17 @@ module Bosh::Director::Models
       spec ||= {}
       self.network_spec_json = JSON.dump(spec)
     end
+
+    def ips
+      manual_or_vip_ips.concat(dynamic_ips).uniq
+    end
+
+    def manual_or_vip_ips
+      ip_addresses.map { |ip| NetAddr::CIDR.create(ip.address).ip }
+    end
+
+    def dynamic_ips
+      network_spec.map { |_, network| network['ip'] }
+    end
   end
 end

--- a/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -1415,7 +1415,10 @@ module Bosh::Director
                 'cid' => 'cid',
                 'created_at' => time,
                 'instance_id' => instance.id,
-                'network_spec' => { 'network1' => { 'ip' => network_spec_ip } },
+                'network_spec' => {
+                  'network1' => { 'ip' => network_spec_ip },
+                  'network2' => { 'ip' => vip },
+                },
               }
 
               vm = Models::Vm.create(vm_params)


### PR DESCRIPTION
### What is this change about?

Related (closed) issue: https://github.com/cloudfoundry/bosh/issues/1908

(More info in commit message)

Currently when an instance is configured with both manual/vip and dynamic networks, the Director API returns IP addresses only from vip/manual networks, ignoring any IPs that have been allocated dynamically via the IaaS.

### Please provide contextual information.

As a user of the AWS CPI, I want to be able to have networks in my cloud config like:
```
networks:
  - name: public
    type: vip

  - name: internal
    type: dynamic
    subnets:
      - az: z1
        cloud_properties:
          subnet: subnet-123456
```

and then have an instance group like:

```
instance_groups:
  - name: my-instance
    instances: 1
    azs: [z1]
    networks:
      - name: public
        static_ips: [1.2.3.4]
      - name: internal
        default: [dns, gateway]
```

In this example my instance has two IP addresses, e.g. `10.0.0.10` (dynamically allocated by AWS) and `1.2.3.4` which is an AWS Elastic IP.

BOSH should:

1. display both of these IPs to me when I do `bosh instances` at the CLI, right now only `1.2.3.4` will be displayed
2. return both of these IPs to consumers of the BOSH API (including the CLI), so that things like the BOSH exporter can get dynamic internal IPs as well as external ones.

Currently a workaround exists for this, which is to configure all networks manually and replicate the CIDR ranges of the subnets defined in AWS in `manual` network definitions. This works, but in the case where the subnet is shared between BOSH and something else, BOSH expects to manage the whole range, and asks the CPI to use an address which is already in use (e.g. `Address 10.0.0.10 is in use` from the AWS CPI) - which is AFAICT the point of dynamic networks.

I have an even more concrete use case of why this is important but it is probably outside the purview of this PR.

### What tests have you run against this PR?

I have run the unit tests (`bundle exec rake spec:unit:director`)

Edit: I have deployed this to a real BOSH director running the AWS CPI and it works as expected.

### How should this change be described in bosh release notes?

> The Director will now return all IP addresses that are assigned to an instance, regardless of network type. Previously BOSH would return only IP addresses would only return IP addresses from manual/vip networks, if both dynamic and static networks were configured. Now all IP addresses are returned, statically defined IPs followed by dynamically defined IPs.

### Does this PR introduce a breaking change?

If there are API consumers which rely on only statically defined IP addresses being returned by the API then this will be disruptive, however this change does not affect the API schema.

### Tag your pair, your PM, and/or team!

Solo - this is my first PR to bosh so I might have done something egregious