### PR TITLE
there are no required credentials sources for s3cli

### DIFF
--- a/src/bosh-director/lib/bosh/blobstore_client/s3cli_blobstore_client.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/s3cli_blobstore_client.rb
@@ -126,7 +126,8 @@ module Bosh::Blobstore
     end
 
     def required_credential_properties_list
-      []
+      return [] if @s3cli_options[:credentials_source] == 'env_or_profile'
+      %w[access_key_id secret_access_key] 
     end
 
     # @param [String] path path to file which will be stored in S3

--- a/src/bosh-director/lib/bosh/blobstore_client/s3cli_blobstore_client.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/s3cli_blobstore_client.rb
@@ -126,7 +126,7 @@ module Bosh::Blobstore
     end
 
     def required_credential_properties_list
-      %w[access_key_id secret_access_key]
+      []
     end
 
     # @param [String] path path to file which will be stored in S3

--- a/src/bosh-director/spec/unit/blobstore_client/s3cli_blobstore_client_spec.rb
+++ b/src/bosh-director/spec/unit/blobstore_client/s3cli_blobstore_client_spec.rb
@@ -19,7 +19,6 @@ module Bosh::Blobstore
           s3cli_path:        '/var/vcap/packages/s3cli/bin/s3cli'
       }
     end
-    
     let(:expected_config_file) { File.join(base_dir, 's3_blobstore_config-FAKE_UUID') }
     let(:success_exit_status) { instance_double('Process::Status', exitstatus: 0, success?: true) }
     let(:not_existed_exit_status) { instance_double('Process::Status', exitstatus: 3, success?: true) }
@@ -94,7 +93,6 @@ module Bosh::Blobstore
               Bosh::Director::BadConfig,
               'Inconsistent blobstore configuration: ["access_key_id", "secret_access_key"] are required'
             )
-          
         end
       end
 

--- a/src/bosh-director/spec/unit/blobstore_client/s3cli_blobstore_client_spec.rb
+++ b/src/bosh-director/spec/unit/blobstore_client/s3cli_blobstore_client_spec.rb
@@ -19,7 +19,7 @@ module Bosh::Blobstore
           s3cli_path:        '/var/vcap/packages/s3cli/bin/s3cli'
       }
     end
-
+    
     let(:expected_config_file) { File.join(base_dir, 's3_blobstore_config-FAKE_UUID') }
     let(:success_exit_status) { instance_double('Process::Status', exitstatus: 0, success?: true) }
     let(:not_existed_exit_status) { instance_double('Process::Status', exitstatus: 3, success?: true) }
@@ -67,6 +67,34 @@ module Bosh::Blobstore
 
         it 'should set `none` as credentials_source' do
           expect(JSON.parse(stored_config_file[0])["credentials_source"]).to eq("none")
+        end
+      end
+
+      context 'when using env_or_profile' do
+        let(:env_options) do
+          options.merge(
+            {
+              credentials_source: 'env_or_profile'
+            }
+          ).reject{|k, v| [:access_key_id, :secret_access_key].include? k}
+        end
+        it 'should allow access_key_id and secret_access_key to be unset' do
+          expect(described_class.new(env_options).validate!(env_options, 4)).to be_nil
+        end
+      end
+
+      context 'when not using env_or_profile' do
+        let(:bad_options) do
+          options.reject{|k, v| [:access_key_id, :secret_access_key].include? k}
+        end
+        it 'should require access_key_id and secret_access_key to be set' do
+          expect {
+            described_class.new(bad_options).validate!(bad_options, 4)
+          }.to raise_error(
+              Bosh::Director::BadConfig,
+              'Inconsistent blobstore configuration: ["access_key_id", "secret_access_key"] are required'
+            )
+          
         end
       end
 


### PR DESCRIPTION
### What is this change about?

This removes the required credentials settings for s3cli blobstores

### Please provide contextual information.

s3cli blobstores can use `static` or `env_or_profile` sources for credentials, and each has a different set of config keys. There is no set of credential properties that is required in all cases. In it's current form, the validation breaks deployments using `env_or_profile`.

An alternate fix I considered is to provide an override to the `validate` method for the s3cli blobstore that checks to make sure that either `credential_source` is set to `env_or_profile` or that `access_key_id` and `secret_access_key` are set - let me know if that's preferred and I can look at it.

### What tests have you run against this PR?

I ran `./scripts/test-unit` without no failures

### How should this change be described in bosh release notes?

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/bosh/releases) for examples._

### Does this PR introduce a breaking change?

no
### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
