### PR TITLE
Update deprected rubocop definition

### DIFF
--- a/src/.rubocop.yml
+++ b/src/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   - tmp/**/*
 
 # Layout
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
### What is this change about?
Executing rubocop in the bosh repo fails with the error:
  The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation

