### PR TITLE
Support batch function for ignore command

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/instance_ignore_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/instance_ignore_manager.rb
@@ -2,9 +2,17 @@ module Bosh::Director
   module Api
     class InstanceIgnoreManager
       def set_ignore_state_for_instance(deployment, instance_group_name, index_or_id, state)
-        instance = Api::InstanceManager.new.find_by_name(deployment, instance_group_name, index_or_id)
-        instance.ignore = state
-        instance.save
+        if index_or_id == "*"
+           instances = Api::InstanceManager.new.find_instances_by_job(deployment, instance_group_name)
+           instances.each do |instance|
+             instance.ignore = state
+             instance.save
+           end
+        else
+           instance = Api::InstanceManager.new.find_by_name(deployment, instance_group_name, index_or_id)
+           instance.ignore = state
+           instance.save
+        end
       end
     end
   end

--- a/src/bosh-director/lib/bosh/director/api/instance_lookup.rb
+++ b/src/bosh-director/lib/bosh/director/api/instance_lookup.rb
@@ -10,7 +10,15 @@ module Bosh::Director
         end
         instance
       end
-
+      
+      def by_job(deployment, job_name)
+        instances = Models::Instance.filter(deployment: deployment, job: job_name)
+        if instances.empty?
+          raise InstanceNotFound, "No instances matched,#{deployment.name}/#{job_name}"
+        end
+        instances
+      end
+      
       def by_attributes(deployment, job_name, job_index)
         # Postgres cannot coerce an empty string to integer, and fails on Models::Instance.find
         job_index = nil if job_index.is_a?(String) && job_index.empty?

--- a/src/bosh-director/lib/bosh/director/api/instance_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/instance_manager.rb
@@ -20,6 +20,10 @@ module Bosh::Director
           InstanceLookup.new.by_uuid(deployment, job, index_or_id)
         end
       end
+      
+      def find_instances_by_job(deployment, job)
+        InstanceLookup.new.by_job(deployment, job)
+      end
 
       def find_instances_by_deployment(deployment)
         InstanceLookup.new.by_deployment(deployment)


### PR DESCRIPTION
### What is this change about?
This PR add feature for ignore command 
https://bosh.io/docs/cli-v2/#ignore

It uses wildcard "*" to do batch job for all instances in an instance-group

bosh [GLOBAL-CLI-OPTIONS] ignore INSTANCE-GROUP/*
bosh [GLOBAL-CLI-OPTIONS] unignore INSTANCE-GROUP/*


`ubuntu@opsmgr-06-haas-59-pez-pivotal-io:~$ bosh -d service-instance_87465682-1da8-4fec-99ea-9863e8555eca vms
Using environment '10.193.71.11' as client 'ops_manager'

Task 53345. Done

Deployment 'service-instance_87465682-1da8-4fec-99ea-9863e8555eca'

Instance                                     Process State  AZ   IPs            VM CID                                   VM Type      Active
master/2f24225a-8ef2-4610-b6e6-a9f48df3ec56  running        az1  10.193.71.165  vm-4f607b94-733c-461d-a164-21889d9d9543  medium.disk  true
worker/8a77d684-4c16-48b5-afba-2e710fa00e20  running        az3  10.193.71.169  vm-ce0b4189-152e-49f7-ae21-c41682335eef  medium.disk  true
worker/94c6863e-b470-4a74-b568-f49d4f451e32  running        az2  10.193.71.168  vm-82c48d43-6c9b-4c12-b9c4-9384620cdbdf  medium.disk  true
worker/9cfb9c67-8c5b-4eb7-871f-1a234e5597a1  running        az1  10.193.71.167  vm-b525b25f-16b3-4a52-8c37-8dacb8e37ca0  medium.disk  true

4 vms

Succeeded
ubuntu@opsmgr-06-haas-59-pez-pivotal-io:~$
ubuntu@opsmgr-06-haas-59-pez-pivotal-io:~$ bosh -d service-instance_87465682-1da8-4fec-99ea-9863e8555eca ignore worker/*
Using environment '10.193.71.11' as client 'ops_manager'

Using deployment 'service-instance_87465682-1da8-4fec-99ea-9863e8555eca'

Succeeded
ubuntu@opsmgr-06-haas-59-pez-pivotal-io:~$ bosh -d service-instance_87465682-1da8-4fec-99ea-9863e8555eca unignore worker/*
Using environment '10.193.71.11' as client 'ops_manager'

Using deployment 'service-instance_87465682-1da8-4fec-99ea-9863e8555eca'

Succeeded
ubuntu@opsmgr-06-haas-59-pez-pivotal-io:~$`

### What tests have you run against this PR?

Will add unit tests, integration test, doc release shortly

### How should this change be described in bosh release notes?

It is a batch function for ignore command.

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
Just myself
