### PR TITLE
Parse cloud-configs in metrics server similar to deploy

### DIFF
--- a/src/bosh-director/lib/bosh/director/metrics_collector.rb
+++ b/src/bosh-director/lib/bosh/director/metrics_collector.rb
@@ -127,13 +127,8 @@ module Bosh
         @network_free_ips.set(0, labels: { name: canonicalize_to_prometheus('no-networks') })
         return if configs.empty?
 
-        parser = DeploymentPlan::CloudManifestParser.new(@logger)
-        networks = configs.map do |config|
-          parser.parse(YAML.safe_load(config.content)).networks
-        rescue Bosh::Director::DeploymentNoNetworks
-          # this config may not have networks, another might have some networks
-          []
-        end
+        consolidated_configs = Bosh::Director::CloudConfig::CloudConfigsConsolidator.new(configs)
+        networks = DeploymentPlan::CloudManifestParser.new(@logger).parse(consolidated_configs.raw_manifest).networks
         networks.flatten!
 
         return if networks.empty?

--- a/src/bosh-director/spec/unit/metrics_collector_spec.rb
+++ b/src/bosh-director/spec/unit/metrics_collector_spec.rb
@@ -194,42 +194,35 @@ module Bosh
             end
           end
 
-          context 'there are no networks defined in some cloud-config' do
-            before do
-              Models::Config.make(:cloud, name: 'yacc', content: YAML.dump(
-                'azs' => [az],
-                'vm_types' => [],
-                'disk_types' => [],
-                'vm_extensions' => [],
-                'networks' => [],
-                'compilation' => { 'az' => 'az-1', 'network' => manual_network_spec['name'], 'workers' => 3 },
-              ))
+          context 'missing values' do
+            context 'there are empty values defined in some cloud-config' do
+              before do
+                Models::Config.make(:cloud, name: 'yacc', content: YAML.dump(
+                  'azs' => [],
+                  'vm_types' => [],
+                  'disk_types' => [],
+                  'vm_extensions' => [],
+                  'networks' => [],
+                ))
+              end
+
+              it 'can still get metrics without errors' do
+                metrics_collector.start
+                metric = Prometheus::Client.registry.get(:bosh_networks_dynamic_ips_total)
+                expect(metric.get(labels: { name: 'my_manual_network' })).to eq(10)
+              end
             end
 
-            it 'can still get metrics without errors' do
-              metrics_collector.start
-              metric = Prometheus::Client.registry.get(:bosh_networks_dynamic_ips_total)
-              expect(metric.get(labels: { name: 'my_manual_network' })).to eq(10)
-            end
-          end
+            context 'there are no fields defined in some cloud-config' do
+              before do
+                Models::Config.make(:cloud, name: 'yacc', content: YAML.dump({}))
+              end
 
-          context 'there are no networks in any cloud-config' do
-            before do
-              Models::Config.all.each(&:delete)
-              Models::Config.make(:cloud, name: 'yacc', content: YAML.dump(
-                'azs' => [az],
-                'vm_types' => [],
-                'disk_types' => [],
-                'vm_extensions' => [],
-                'networks' => [],
-                'compilation' => { 'az' => 'az-1', 'network' => manual_network_spec['name'], 'workers' => 3 },
-              ))
-            end
-
-            it 'emits 0 for the metrics successfully' do
-              metrics_collector.start
-              metric = Prometheus::Client.registry.get(:bosh_networks_dynamic_ips_total)
-              expect(metric.get(labels: { name: 'no_networks' })).to eq(0)
+              it 'can still get metrics without errors' do
+                metrics_collector.start
+                metric = Prometheus::Client.registry.get(:bosh_networks_dynamic_ips_total)
+                expect(metric.get(labels: { name: 'my_manual_network' })).to eq(10)
+              end
             end
           end
         end


### PR DESCRIPTION
[#171408847](https://www.pivotaltracker.com/n/projects/956238/stories/171408847)

Co-authored-by: Beyhan Veli <beyhan.veli@sap.com>

### What is this change about?
Before each config would be validated individually which led to parsing
errors if one config missed a required field. Now similar to the deploy
flow cloud configs are consolidated before parsing.

### Please provide contextual information.

Issue: https://github.com/cloudfoundry/bosh/issues/2237

### What tests have you run against this PR?

Unit, ITs and manual

### How should this change be described in bosh release notes?

as a fix of https://github.com/cloudfoundry/bosh/issues/2237

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@beyhan 
@friegger 
