### PR TITLE
Add missing infinite connection retry option to hm template

### DIFF
--- a/jobs/health_monitor/templates/health_monitor.yml.erb
+++ b/jobs/health_monitor/templates/health_monitor.yml.erb
@@ -105,6 +105,7 @@ if p('hm.tsdb_enabled')
     'options' => {
       'host' => p('hm.tsdb.address'),
       'port' => p('hm.tsdb.port'),
+      'max_retries' => p('hm.tsdb.max_retries'),
     },
   }
 end
@@ -191,6 +192,7 @@ if p('hm.graphite_enabled')
     'options' => {
       'host' => p('hm.graphite.address'),
       'port' => p('hm.graphite.port'),
+      'max_retries' => p('hm.graphite.max_retries'),
     },
   }
 

--- a/spec/health_monitor_templates_spec.rb
+++ b/spec/health_monitor_templates_spec.rb
@@ -141,6 +141,7 @@ describe 'health_monitor.yml.erb' do
               'tsdb' => {
                 'address' => '127.0.0.91',
                 'port' => 4223,
+                'max_retries' => 1,
               },
             })
         end
@@ -153,6 +154,7 @@ describe 'health_monitor.yml.erb' do
           expect(plugin['events']).to be_a(Array)
           expect(plugin['options']['host']).to eq('127.0.0.91')
           expect(plugin['options']['port']).to eq(4223)
+          expect(plugin['options']['max_retries']).to eq(1)
         end
       end
 
@@ -259,6 +261,7 @@ describe 'health_monitor.yml.erb' do
                 'address' => '192.0.2.1',
                 'port' => 12345,
                 'prefix' => 'my-prefix',
+                'max_retries' => 1,
               },
             })
         end
@@ -272,6 +275,7 @@ describe 'health_monitor.yml.erb' do
           expect(plugin['options']['host']).to eq('192.0.2.1')
           expect(plugin['options']['port']).to eq(12345)
           expect(plugin['options']['prefix']).to eq('my-prefix')
+          expect(plugin['options']['max_retries']).to eq(1)
         end
       end
 


### PR DESCRIPTION
Fixes #2231
[#170700095](https://www.pivotaltracker.com/story/show/170700095)

### What is this change about?

Adds missing `max_retries` property to the `health_monitor.yml.erb ` template.

### Please provide contextual information.

Issue: https://github.com/cloudfoundry/bosh/issues/2231

### What tests have you run against this PR?

The unit tests and manual tests

