### PR TITLE
Bosh multiple resurrection support

### DIFF
--- a/src/bosh-director/lib/bosh/director/cloudcheck_helper.rb
+++ b/src/bosh-director/lib/bosh/director/cloudcheck_helper.rb
@@ -70,7 +70,7 @@ module Bosh::Director
           .create_for_instance_plan(
             instance_plan_to_create,
             planner.ip_provider,
-            Array(instance_model.managed_persistent_disk_cid),
+            Array(instance_model.active_persistent_disks.collection.map { |d| d.model.disk_cid}),
             instance_plan_to_create.tags,
             true,
           )

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan_from_db.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan_from_db.rb
@@ -57,7 +57,7 @@ module Bosh
         end
 
         def needs_disk?
-          @existing_instance.managed_persistent_disk_cid
+          @existing_instance.active_persistent_disks.collection.map { |d| d.model.disk_cid}
         end
 
         def templates


### PR DESCRIPTION
### What is this change about?

This PR is for the resurrection of VMs with multiple persistent disks.

Currently VMs with multiple persistent disks does not start after resurrection. 

### Please provide contextual information.

https://cloudfoundry.slack.com/archives/C02HPPYQ2/p1578339832051000

Resurrection of VMs with multiple disk in not working (#2253)

https://www.pivotaltracker.com/story/show/171919518

### What tests have you run against this PR?

Ran Director unit tests

Also tested the following scenarios with the changes in the Lab BOSH Director
1) Resurrection of VMs with no persistent disks
2) Resurrection of VMs with single persistent disk
3) Resurrection of VMs with single multiple persistent disks

### How should this change be described in bosh release notes?

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/bosh/releases) for examples._


### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
