### PR TITLE
Stop eventmachine loop when error occurs

### DIFF
--- a/src/bosh-monitor/spec/unit/bosh/monitor/runner_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/runner_spec.rb
@@ -2,6 +2,7 @@ require_relative '../../../spec_helper'
 
 describe Bosh::Monitor::Runner do
   let(:runner) { Bosh::Monitor::Runner.new(sample_config) }
+  let(:logger) { instance_double(Logger) }
 
   let(:nats) { instance_double('NATS::IO::Client') }
 
@@ -12,6 +13,8 @@ describe Bosh::Monitor::Runner do
   let(:x509_cert_content) { 'client_cert' }
 
   before do
+    allow(Bhm).to receive(:logger).and_return(logger)
+
     runner
 
     allow(NATS::IO::Client).to receive(:new).and_return(nats)
@@ -22,9 +25,38 @@ describe Bosh::Monitor::Runner do
     allow(OpenSSL::X509::Certificate).to receive(:new)
     allow(File).to receive(:open).with(Bhm.mbus.client_private_key_path).and_return(rsa_key_content)
     allow(File).to receive(:open).with(Bhm.mbus.client_certificate_path).and_return(x509_cert_content)
+    allow(logger).to receive(:info)
   end
 
-  describe 'connect_to_mbus' do
+  describe '#handle_em_error' do
+    context 'when EM loop error occurs' do
+      let(:http_server) { instance_double(Thin::Server) }
+
+      before do
+        allow(Thin::Server).to receive(:new).and_return(http_server)
+        allow(http_server).to receive(:start!)
+
+        runner.start_http_server
+      end
+
+      it 'stops the HM server, stops the EM loop and logs the error' do
+        allow(EM).to receive(:stop_event_loop)
+        allow(http_server).to receive(:stop!)
+        allow(logger).to receive(:fatal)
+        error = StandardError.new('EM event loop exception')
+        error.set_backtrace(['backtrace'])
+
+        runner.handle_em_error(error)
+
+        expect(EM).to have_received(:stop_event_loop)
+        expect(http_server).to have_received(:stop!)
+        expect(logger).to have_received(:fatal).with('EM event loop exception')
+        expect(logger).to have_received(:fatal).with('backtrace')
+      end
+    end
+  end
+
+  describe '#connect_to_mbus' do
     it 'should connect using SSL' do
       expect(OpenSSL::PKey::RSA).to receive(:new).with(rsa_key_content).and_return(rsa_key)
       expect(OpenSSL::X509::Certificate).to receive(:new).with(x509_cert_content).and_return(x509_cert)
@@ -35,12 +67,10 @@ describe Bosh::Monitor::Runner do
     end
 
     context 'when NATS errors' do
-      let(:logger) { instance_double(Logger) }
       let(:custom_error) { 'Some error for nats://127.0.0.1:4222. Another error for nats://127.0.0.1:4222.' }
 
       before do
         allow(logger).to receive(:error)
-        allow(Bhm).to receive(:logger).and_return(logger)
 
         allow(nats).to receive(:on_error) do |&clbk|
           clbk.call(custom_error)
@@ -57,6 +87,7 @@ describe Bosh::Monitor::Runner do
 
         it 'shuts down the server' do
           expect(runner).to receive(:stop)
+
           runner.connect_to_mbus
         end
       end


### PR DESCRIPTION
### What is this change about?

Exceptions in the event loop of EM are puting the HM in a state,
where the HM server is stopped and also the periodic task,
which raised the exception is canceled. A partially running state
of HM doesn't make sense and it's better to stop the HM.
The HM doesn't have any state, which is lost if it's stopped and
the HM is started again by monit.


_Describe the change and why it's needed._

fixes #2262

### What tests have you run against this PR?

All unit tests
HM integration tests 
And manual tests


### Does this PR introduce a breaking change?

no
