### PR TITLE
Send status information when advancing event logger tasks

### DIFF
--- a/src/bosh-director/lib/bosh/director/cloudcheck_helper.rb
+++ b/src/bosh-director/lib/bosh/director/cloudcheck_helper.rb
@@ -124,7 +124,7 @@ module Bosh::Director
             agent_client(instance_model.agent_id, instance_model.name),
             cleaner,
             @logger,
-            {}
+            {},
           ).apply(update_config, wait_for_running)
         end
 

--- a/src/bosh-director/lib/bosh/director/event_log.rb
+++ b/src/bosh-director/lib/bosh/director/event_log.rb
@@ -171,5 +171,9 @@ module Bosh::Director
         @stage.log_entry(task_entry)
       end
     end
+
+    class NullTask
+      def advance(delta, data = {}); end
+    end
   end
 end

--- a/src/bosh-director/lib/bosh/director/instance_group_updater.rb
+++ b/src/bosh-director/lib/bosh/director/instance_group_updater.rb
@@ -155,10 +155,14 @@ module Bosh::Director
     end
 
     def update_canary_instance(instance_plan, event_log_stage)
-      event_log_stage.advance_and_track("#{instance_plan.instance.model} (canary)") do
+      event_log_stage.advance_and_track(
+        "#{instance_plan.instance.model} (canary)",
+      ) do |task|
         with_thread_name("canary_update(#{instance_plan.instance.model})") do
-          InstanceUpdater.new_instance_updater(@ip_provider, @template_blob_cache, @dns_encoder, @link_provider_intents)
-            .update(instance_plan, canary: true)
+          InstanceUpdater.new_instance_updater(
+            @ip_provider, @template_blob_cache,
+            @dns_encoder, @link_provider_intents, task
+          ).update(instance_plan, canary: true)
         rescue Exception => e
           @logger.error("Error updating canary instance: #{e.inspect}\n#{e.backtrace.join("\n")}")
           raise
@@ -173,10 +177,14 @@ module Bosh::Director
     end
 
     def update_instance(instance_plan, event_log_stage)
-      event_log_stage.advance_and_track(instance_plan.instance.model.to_s) do
+      event_log_stage.advance_and_track(
+        instance_plan.instance.model.to_s,
+      ) do |task|
         with_thread_name("instance_update(#{instance_plan.instance.model})") do
-          InstanceUpdater.new_instance_updater(@ip_provider, @template_blob_cache, @dns_encoder, @link_provider_intents)
-            .update(instance_plan)
+          InstanceUpdater.new_instance_updater(
+            @ip_provider, @template_blob_cache, @dns_encoder,
+            @link_provider_intents, task
+          ).update(instance_plan)
         rescue Exception => e
           @logger.error("Error updating instance: #{e.inspect}\n#{e.backtrace.join("\n")}")
           raise

--- a/src/bosh-director/lib/bosh/director/instance_updater/state_applier.rb
+++ b/src/bosh-director/lib/bosh/director/instance_updater/state_applier.rb
@@ -7,10 +7,13 @@ module Bosh::Director
       @rendered_job_templates_cleaner = rendered_job_templates_cleaner
       @logger = logger
       @is_canary = options.fetch(:canary, false)
+      @task = options.fetch(:task, nil)
     end
 
     def apply(update_config, wait_for_running = true)
+      @task&.advance(10, status: 'installing packages')
       @instance.apply_vm_state(@instance_plan.spec)
+      @task&.advance(10, status: 'configuring jobs')
       @instance.update_templates(@instance_plan.templates)
       @rendered_job_templates_cleaner.clean
 
@@ -27,6 +30,7 @@ module Bosh::Director
         is_canary: @is_canary,
         wait_for_running: wait_for_running,
         logger: @logger,
+        task: @task,
       )
       @instance.update_state
     end

--- a/src/bosh-director/lib/bosh/director/instance_updater/state_applier.rb
+++ b/src/bosh-director/lib/bosh/director/instance_updater/state_applier.rb
@@ -7,13 +7,13 @@ module Bosh::Director
       @rendered_job_templates_cleaner = rendered_job_templates_cleaner
       @logger = logger
       @is_canary = options.fetch(:canary, false)
-      @task = options.fetch(:task, nil)
+      @task = options.fetch(:task, EventLog::NullTask.new)
     end
 
     def apply(update_config, wait_for_running = true)
-      @task&.advance(10, status: 'installing packages')
+      @task.advance(10, status: 'installing packages')
       @instance.apply_vm_state(@instance_plan.spec)
-      @task&.advance(10, status: 'configuring jobs')
+      @task.advance(10, status: 'configuring jobs')
       @instance.update_templates(@instance_plan.templates)
       @rendered_job_templates_cleaner.clean
 

--- a/src/bosh-director/lib/bosh/director/instance_updater/update_procedure.rb
+++ b/src/bosh-director/lib/bosh/director/instance_updater/update_procedure.rb
@@ -15,7 +15,8 @@ module Bosh::Director
                      links_manager,
                      ip_provider,
                      dns_state_updater,
-                     logger)
+                     logger,
+                     task)
         @instance = instance
         @instance_plan = instance_plan
         @options = options
@@ -31,6 +32,7 @@ module Bosh::Director
         @logger = logger
         @action = calculate_action
         @context = calculate_context
+        @task = task
       end
 
       def to_proc
@@ -88,6 +90,7 @@ module Bosh::Director
           agent,
           RenderedJobTemplatesCleaner.new(instance.model, @blobstore, @logger),
           @logger,
+          task: @task,
           canary: options[:canary],
         )
         state_applier.apply(instance_plan.desired_instance.instance_group.update)
@@ -164,7 +167,8 @@ module Bosh::Director
 
       def stop
         stop_intent = deleting_vm? ? :delete_vm : :keep_vm
-        Stopper.stop(intent: stop_intent, instance_plan: instance_plan, target_state: instance.state, logger: @logger)
+        Stopper.stop(intent: stop_intent, instance_plan: instance_plan,
+                     target_state: instance.state, logger: @logger, task: @task)
       end
 
       def deleting_vm?

--- a/src/bosh-director/lib/bosh/director/starter.rb
+++ b/src/bosh-director/lib/bosh/director/starter.rb
@@ -34,7 +34,7 @@ module Bosh::Director
 
       def parse_optional(args)
         wait_for_running = args.fetch(:wait_for_running, true)
-        task = args.fetch(:task, nil)
+        task = args.fetch(:task, EventLog::NullTask.new)
         logger = args.fetch(:logger, Config.logger)
         is_canary = args.fetch(:is_canary, false)
         [wait_for_running, task, logger, is_canary]
@@ -42,19 +42,19 @@ module Bosh::Director
 
       def run_pre_start(instance, agent_client, task, logger)
         logger.info("Running pre-start for #{instance}")
-        task&.advance(10, status: 'executing pre-start')
+        task.advance(10, status: 'executing pre-start')
         agent_client.run_script('pre-start', {})
       end
 
       def start_jobs(instance, agent_client, task, logger)
         logger.info("Starting instance #{instance}")
-        task&.advance(20, status: 'starting jobs')
+        task.advance(20, status: 'starting jobs')
         agent_client.start
       end
 
       def run_post_start(instance, agent_client, task, logger)
         logger.info("Running post-start for #{instance}")
-        task&.advance(10, status: 'executing post-start')
+        task.advance(10, status: 'executing post-start')
         agent_client.run_script('post-start', {})
       end
 

--- a/src/bosh-director/lib/bosh/director/stopper.rb
+++ b/src/bosh-director/lib/bosh/director/stopper.rb
@@ -4,7 +4,7 @@ module Bosh::Director
       def stop(
         instance_plan:,
         target_state:,
-        task: false,
+        task: EventLog::NullTask.new,
         logger: Config.logger,
         intent: :keep_vm
       )
@@ -16,23 +16,23 @@ module Bosh::Director
 
         if instance_plan.skip_drain
           logger.info("Skipping pre-stop and drain for '#{instance_model}'")
-          task&.advance(10, status: 'skipped pre-stop & drain')
+          task.advance(10, status: 'skipped pre-stop & drain')
         else
           logger.info("Running pre-stop for #{instance_model}")
-          task&.advance(5, status: 'executing pre-stop')
+          task.advance(5, status: 'executing pre-stop')
           agent_client.run_script('pre-stop', 'env' => pre_stop_env(intent))
 
           logger.info("Running drain for #{instance_model}")
-          task&.advance(5, status: 'executing drain')
+          task.advance(5, status: 'executing drain')
           perform_drain(instance_plan, target_state, instance_model, agent_client, logger)
         end
 
         logger.info("Stopping instance #{instance_model}")
-        task&.advance(20, status: 'stopping jobs')
+        task.advance(20, status: 'stopping jobs')
         agent_client.stop
 
         logger.info("Running post-stop for #{instance_model}")
-        task&.advance(10, status: 'executing post-stop')
+        task.advance(10, status: 'executing post-stop')
         agent_client.run_script('post-stop', {})
       end
 

--- a/src/bosh-director/lib/bosh/director/stopper.rb
+++ b/src/bosh-director/lib/bosh/director/stopper.rb
@@ -4,6 +4,7 @@ module Bosh::Director
       def stop(
         instance_plan:,
         target_state:,
+        task: false,
         logger: Config.logger,
         intent: :keep_vm
       )
@@ -15,18 +16,23 @@ module Bosh::Director
 
         if instance_plan.skip_drain
           logger.info("Skipping pre-stop and drain for '#{instance_model}'")
+          task&.advance(10, status: 'skipped pre-stop & drain')
         else
           logger.info("Running pre-stop for #{instance_model}")
+          task&.advance(5, status: 'executing pre-stop')
           agent_client.run_script('pre-stop', 'env' => pre_stop_env(intent))
 
           logger.info("Running drain for #{instance_model}")
+          task&.advance(5, status: 'executing drain')
           perform_drain(instance_plan, target_state, instance_model, agent_client, logger)
         end
 
         logger.info("Stopping instance #{instance_model}")
+        task&.advance(20, status: 'stopping jobs')
         agent_client.stop
 
         logger.info("Running post-stop for #{instance_model}")
+        task&.advance(10, status: 'executing post-stop')
         agent_client.run_script('post-stop', {})
       end
 

--- a/src/bosh-director/spec/unit/instance_group_updater_spec.rb
+++ b/src/bosh-director/spec/unit/instance_group_updater_spec.rb
@@ -26,7 +26,8 @@ module Bosh::Director
 
     before do
       allow(Bosh::Director::InstanceUpdater).to receive(:new_instance_updater)
-        .with(ip_provider, template_blob_cache, dns_encoder, link_provider_intents)
+        .with(ip_provider, template_blob_cache, dns_encoder,
+              link_provider_intents, kind_of(Bosh::Director::EventLog::Task))
         .and_return(canary_updater, changed_updater, unchanged_updater)
 
       Models::Deployment.make(name: 'test-deployment', manifest: manifest)
@@ -441,7 +442,9 @@ module Bosh::Director
 
         before do
           allow(Bosh::Director::InstanceUpdater).to receive(:new_instance_updater)
-            .with(ip_provider, template_blob_cache, dns_encoder, link_provider_intents)
+            .with(ip_provider, template_blob_cache, dns_encoder,
+                  link_provider_intents,
+                  kind_of(Bosh::Director::EventLog::Task))
             .and_return(canary_updater, changed_updater)
         end
 

--- a/src/bosh-director/spec/unit/instance_updater/update_procedure_spec.rb
+++ b/src/bosh-director/spec/unit/instance_updater/update_procedure_spec.rb
@@ -18,6 +18,7 @@ module Bosh::Director
           ip_provider,
           dns_state_updater,
           logger,
+          task,
         )
       end
 
@@ -56,6 +57,7 @@ module Bosh::Director
       let(:tags) { {} }
       let(:metadata_updater) { instance_double(MetadataUpdater, update_vm_metadata: nil, update_disk_metadata: nil) }
       let(:persistent_disk) { nil }
+      let(:task) { instance_double('Bosh::Director::EventLog::Task') }
 
       let(:rendered_templates_persistor) do
         instance_double(RenderedTemplatesPersister, persist: nil)

--- a/src/bosh-director/spec/unit/instance_updater_spec.rb
+++ b/src/bosh-director/spec/unit/instance_updater_spec.rb
@@ -15,9 +15,15 @@ module Bosh::Director
     let(:needs_shutting_down) { false }
     let(:event) { Models::Event.make }
     let(:link_provider_intents) { [] }
-    let(:updater) { InstanceUpdater.new_instance_updater(ip_provider, template_blob_cache, dns_encoder, link_provider_intents) }
+    let(:updater) do
+      InstanceUpdater.new_instance_updater(
+        ip_provider, template_blob_cache, dns_encoder,
+        link_provider_intents, task
+      )
+    end
     let(:vm_creator) { instance_double(VmCreator) }
     let(:agent_client) { instance_double(AgentClient) }
+    let(:task) { instance_double('Bosh::Director::EventLog::Task') }
     let(:credentials) do
       { 'user' => 'secret' }
     end


### PR DESCRIPTION
This PR addresses: https://www.pivotaltracker.com/n/projects/956238/stories/168179623

### What tests have you run against this PR?

Has passed rspec unit tests
Have also performed manual deploy to verify compatibility with current bosh cli, as well with up coming PR for cli changes (without those changes the cli will ignore these `in_progress` events).

### How should this change be described in bosh release notes?

Fine-grain process log on CLI during instance update

### Does this PR introduce a breaking change?

No, these changes should be backward compatible. These events are ignored by the current cli:
https://github.com/cloudfoundry/bosh-cli/blob/master/ui/task/event.go#L86-L88

