### PR TITLE
Faster postgres restart after non clean shutdown

### DIFF
--- a/jobs/postgres-10/templates/pre-start.erb
+++ b/jobs/postgres-10/templates/pre-start.erb
@@ -78,3 +78,12 @@ if [[ -f /var/vcap/store/postgres-10/fresh ]] ; then
 
   rm /var/vcap/store/postgres-10/fresh
 fi
+
+# "bpm enforces its own locking around process operations to avoid race conditions"
+# from docs: https://bosh.io/docs/bpm/runtime/
+# so postmaster.pid is stale of it still exists
+# remove it to prevent running into:
+# FATAL:  lock file "postmaster.pid" already exists
+if [[ -f /var/vcap/store/postgres-10/postmaster.pid ]] ; then
+    rm /var/vcap/store/postgres-10/postmaster.pid
+fi


### PR DESCRIPTION
### What is this change about?

While investigating reports of bosh not being able to start after a `bosh create-env` update I found the following log lines in the postgres logs:
```
bosh/0:~# head -n 20 /var/vcap/sys/log/postgres-10/postgres-10.stderr.log
oid2name: could not connect to database postgres: could not connect to server: No such file or directory
        Is the server running locally and accepting
        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
2020-07-07 07:21:05 GMT FATAL:  lock file "postmaster.pid" already exists
2020-07-07 07:21:05 GMT HINT:  Is another postmaster (PID 13) running in data directory "/var/vcap/store/postgres-10"?
2020-07-07 07:26:49 GMT FATAL:  lock file "postmaster.pid" already exists
2020-07-07 07:26:49 GMT HINT:  Is another postmaster (PID 13) running in data directory "/var/vcap/store/postgres-10"?
2020-07-07 07:32:38 GMT FATAL:  lock file "postmaster.pid" already exists
2020-07-07 07:32:38 GMT HINT:  Is another postmaster (PID 13) running in data directory "/var/vcap/store/postgres-10"?
oid2name: could not connect to database postgres: could not connect to server: No such file or directory
        Is the server running locally and accepting
        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
2020-07-07 07:38:28 GMT LOG:  listening on IPv4 address "127.0.0.1", port 5432
```

Since postgres is managed via BPM, which ensures there is only one postgres instance running at any time, it is my belief that is safe to remove the postmaster.pid file in the pre-start hook.

### Please provide contextual information.
https://jira.eng.vmware.com/browse/PKS-3323

### What tests have you run against this PR?

Have deployed the changes in my local lab and killed the postgres processes multiple times while watching the logs.

### How should this change be described in bosh release notes?

speeding up postgres start after dirty shutdown

### Does this PR introduce a breaking change?
no