### PR TITLE
Prestart director job without recursive chown on storage folder

### DIFF
--- a/jobs/director/templates/pre-start.erb
+++ b/jobs/director/templates/pre-start.erb
@@ -8,7 +8,7 @@ DB_MUTUAL_TLS_PRIVATE_KEY=/var/vcap/jobs/director/config/db/client_private_key.k
 TMPDIR=/var/vcap/data/director/tmp
 
 mkdir -p $STORE_DIR
-find $STORE_DIR \( -not -user vcap -or -not -group vcap \) -execdir chown vcap:vcap {} \+
+chown vcap:vcap $STORE_DIR
 
 chmod -R 0640 $CONFIG_DIR
 find $CONFIG_DIR -type d | xargs -n1 chmod 0750


### PR DESCRIPTION
### What is this change about?

Change director pre-start job to just `chown` the root store folder and do not do it recursively.

### Please provide contextual information.

On one of our landscapes we noticed that this usage of `find + chown` causes few minutes to complete. Before merging let discuss if this change could cause some implications.

### What tests have you run against this PR?

We have tested newly deployed bosh and an updated bosh with the change and it worked fine.

### How should this change be described in bosh release notes?

Not sure.

### Does this PR introduce a breaking change?

It should not.

### Tag your pair, your PM, and/or team!

@friegger @c0d1ngm0nk3y
