### PR TITLE
[WIP] Add list persistent disks end point

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/disks_controller.rb
@@ -9,6 +9,12 @@ module Bosh::Director
         json_encode(orphan_json)
       end
 
+      get '/persistent_disks' do
+        content_type(:json)
+        disks_json = DiskManager.new(@logger).list_disks
+        json_encode(disks_json)
+      end
+
       # PUT /disks/disk_cid/attachments?deployment=foo&job=dea&instance_id=17f01a35-bf9c-4949-bcf2-c07a95e4df33
       put '/:disk_cid/attachments' do
         deployment = Api::DeploymentManager.new.find_by_name(params[:deployment])

--- a/src/bosh-director/lib/bosh/director/disk_manager.rb
+++ b/src/bosh-director/lib/bosh/director/disk_manager.rb
@@ -78,6 +78,20 @@ module Bosh::Director
       DeploymentPlan::Steps::UnmountDiskStep.new(disk).perform(step_report)
     end
 
+    def list_disks
+      Models::PersistentDisk.all.map do |disk|
+        {
+          'disk_cid' => disk.disk_cid,
+          'size' => disk.size,
+          'cpi' => disk.cpi,
+          'az' => disk.instance.availability_zone,
+          'deployment_name' => disk.instance.deployment.name,
+          'instance_name' => "#{disk.instance.job}/#{disk.instance.uuid}",
+          'cloud_properties' => disk.cloud_properties,
+        }
+      end
+    end
+
     private
 
     def step_report


### PR DESCRIPTION
### What is this change about?

This is useful for:
- debugging of disk issues. E.g. a disk, which is not attached
to any instance, but it appears in the IaaS console as bosh managed disk. Some CPIs added the
tagging of disks too late and there are disks, which don't have any tags.
- collect information for the disks managed by bosh. This information
could be used to calculate costs...

### Please provide contextual information.

`bosh disks` command can only list `orphaned` disks. It will be very useful to extend the command to list persistent disks in use also.

### What tests have you run against this PR?

X

### How should this change be described in bosh release notes?

X

### Does this PR introduce a breaking change?

no

### Tag your pair, your PM, and/or team!
X
