### PR TITLE
Resolve blobstore logging warning [#174649741]

### DIFF
--- a/jobs/blobstore/templates/bpm.yml
+++ b/jobs/blobstore/templates/bpm.yml
@@ -3,12 +3,21 @@
 blobstore_config = {
   "name" => "blobstore",
   "executable" => "/var/vcap/packages/nginx/sbin/nginx",
-  "args" => ["-c", "/var/vcap/jobs/blobstore/config/nginx.conf"],
+  "args" => [
+    "-c",
+    "/var/vcap/jobs/blobstore/config/nginx.conf",
+    "-p",
+    "/var/vcap/data/blobstore"
+  ],
+  "limits" => {
+    "open_files" => 8192
+  },
   "persistent_disk" => true,
   "ephemeral_disk" => true,
   "hooks" => {
     "pre_start" => "/var/vcap/jobs/blobstore/bin/pre-start",
   }
+
 }
 
 config = {

--- a/jobs/blobstore/templates/bpm.yml
+++ b/jobs/blobstore/templates/bpm.yml
@@ -14,6 +14,10 @@ blobstore_config = {
   },
   "persistent_disk" => true,
   "ephemeral_disk" => true,
+  "additional_volumes" => [{
+    "path" => "/var/vcap/sys/run/blobstore",
+    "writable" => true
+  }],
   "hooks" => {
     "pre_start" => "/var/vcap/jobs/blobstore/bin/pre-start",
   }

--- a/jobs/blobstore/templates/nginx.conf.erb
+++ b/jobs/blobstore/templates/nginx.conf.erb
@@ -1,6 +1,7 @@
 worker_processes <%= p('blobstore.nginx.workers') %>;
 daemon off;
 
+pid       /var/vcap/sys/run/blobstore/blobstore.pid;
 error_log /var/vcap/sys/log/blobstore/error.log warn;
 
 events {

--- a/jobs/blobstore/templates/nginx.conf.erb
+++ b/jobs/blobstore/templates/nginx.conf.erb
@@ -1,8 +1,7 @@
 worker_processes <%= p('blobstore.nginx.workers') %>;
 daemon off;
 
-error_log /var/vcap/sys/log/blobstore/error.log;
-pid       /var/vcap/data/blobstore/blobstore.pid;
+error_log /var/vcap/sys/log/blobstore/error.log warn;
 
 events {
   worker_connections 8192;

--- a/jobs/blobstore/templates/pre-start
+++ b/jobs/blobstore/templates/pre-start
@@ -3,3 +3,9 @@
 if [ -e /var/vcap/data/blobstore/backend.sock ]; then
   rm /var/vcap/data/blobstore/backend.sock
 fi
+
+# nginx looks for logs/error.log in prefix (-p) dir
+# symlink to default error location to keep flat log dir
+mkdir -p /var/vcap/data/blobstore/logs
+ln -sf /var/vcap/sys/log/blobstore/error.log \
+   /var/vcap/data/blobstore/logs/error.log


### PR DESCRIPTION
### What is this change about?

The blobstore log contained a warning which has confused people while debugging other blobstore issues.
The log line:
```
nginx: [alert] could not open error log file: open() "/var/vcap/packages/nginx/logs/error.log" failed (30: Read-only file system)
```
This was caused by the fact that the default prefix `/var/vcap/packages/nginx` was not writable.
By changing the prefix (using the `-p` flag) to `/var/vcap/data/blobstore` (which is writable), this issue was resolved.

This change also increases the log level to include warning.
Which resulted in the following log line:
```
 [warn] 6#0: 8192 worker_connections exceed open file resource limit: 1024
```
This was fixed by increasing the open_files limit via bpm to 8192.

While working on this I also noticed nginx was running in daemon mode (which makes sense under bpm).
However it still had a pid location configured which seemed unnecessary. 

### Please provide contextual information.

https://www.pivotaltracker.com/story/show/174649741

### What tests have you run against this PR?

Manual testing to verify warnings are ending up in the correct file:
```
==> /var/vcap/sys/log/blobstore/error.log <==
2020/09/18 10:08:33 [warn] 6#0: 8192 worker_connections exceed open file resource limit: 1024
```
This warning should not be displayed anymore after this PR is merged since the limit in bpm is increased.
Lowering the limit manually in the bpm config and restarting the blobstore should work.

### How should this change be described in bosh release notes?

Improved blobstore error logging

### Does this PR introduce a breaking change?

No