### PR TITLE
Strip individual deployment name for Puma metrics

### DIFF
--- a/src/bosh-director/bin/bosh-director
+++ b/src/bosh-director/bin/bosh-director
@@ -29,7 +29,7 @@ rack_app = Puma::Rack::Builder.app do
   use Rack::CommonLogger
   if config.metrics_server_enabled
     Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: '/var/vcap/store/director/metrics')
-    use Prometheus::Middleware::Collector
+    use Bosh::Director::CustomMiddlewareCollector
     use Prometheus::Middleware::Exporter
   end
 

--- a/src/bosh-director/lib/bosh/director.rb
+++ b/src/bosh-director/lib/bosh/director.rb
@@ -266,6 +266,7 @@ require 'bosh/director/api/route_configuration'
 
 require 'bosh/director/step_executor'
 require 'bosh/director/metrics_collector'
+require 'bosh/director/custom_middleware_collector'
 
 require 'common/common'
 

--- a/src/bosh-director/lib/bosh/director/custom_middleware_collector.rb
+++ b/src/bosh-director/lib/bosh/director/custom_middleware_collector.rb
@@ -1,0 +1,14 @@
+require 'prometheus/middleware/collector'
+
+module Bosh
+  module Director
+    class CustomMiddlewareCollector < Prometheus::Middleware::Collector
+      def strip_ids_from_path(path)
+        path
+          .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
+          .gsub(%r{/\d+(/|$)}, '/:id\\1')
+          .gsub(%r{/deployments/[a-z0-9_-]+(/|$)}, '/deployments/:deployment\\1')
+      end
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/custom_middleware_collector_spec.rb
+++ b/src/bosh-director/spec/unit/custom_middleware_collector_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Bosh::Director::CustomMiddlewareCollector do
+  before(:all) do
+    @cmc = Bosh::Director::CustomMiddlewareCollector.new(nil)
+  end
+
+  describe '#strip_ids_from_path' do
+    it 'strips uuids from path' do
+      expect(@cmc.strip_ids_from_path('/jobs/123e4567-e89b-12d3-a456-426614174000/logs')).to eq('/jobs/:uuid/logs')
+    end
+
+    it 'strips ids from path' do
+      expect(@cmc.strip_ids_from_path('/tasks/123/output')).to eq('/tasks/:id/output')
+    end
+
+    it 'strips deployment name from path' do
+      expect(@cmc.strip_ids_from_path('/deployments/dummy')).to eq('/deployments/:deployment')
+    end
+
+    it 'strips deployment name and uuids from path' do
+      expect(@cmc.strip_ids_from_path('/deployments/dummy/jobs/dummy/123e4567-e89b-12d3-a456-426614174000/logs')).to eq('/deployments/:deployment/jobs/dummy/:uuid/logs')
+    end
+
+    it 'do not strips if no match' do
+      expect(@cmc.strip_ids_from_path('/releases/abs-release')).to eq('/releases/abs-release')
+    end
+  end
+end


### PR DESCRIPTION
Fixes issue: https://github.com/cloudfoundry/bosh/issues/2271
