### PR TITLE
fix MySQL library path

### DIFF
--- a/jobs/director/templates/worker_ctl.erb
+++ b/jobs/director/templates/worker_ctl.erb
@@ -14,7 +14,7 @@ LD_LIBRARY_PATH=/var/vcap/packages/libpq/lib:$LD_LIBRARY_PATH
 
 # MySQL
 PATH=/var/vcap/packages/mysql/bin:$PATH
-LD_LIBRARY_PATH=/var/vcap/packages/mysql/lib/mysql:$LD_LIBRARY_PATH
+LD_LIBRARY_PATH=/var/vcap/packages/mysql/lib/mariadb:$LD_LIBRARY_PATH
 
 source /var/vcap/jobs/director/env
 


### PR DESCRIPTION
### What is this change about?

This change fixes the LD_LIBRARY_PATH used my the mysql2 connector. Since the bump of mariadb-connector to 3.1.11 the directory has been renamed from mysql to mariadb.

### Please provide contextual information.

This fix resolves the error resulting in the stacktrace
```
/var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `require': LoadError: libmariadb.so.3: cannot open shared object file: No such file or directory - /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/mysql2-0.5.3/lib/mysql2/mysql2.so (Sequel::AdapterNotFound)
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `block in require'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:291:in `load_dependency'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `require'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/mysql2-0.5.3/lib/mysql2.rb:36:in `<top (required)>'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `require'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `block in require'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:291:in `load_dependency'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `require'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/sequel-5.16.0/lib/sequel/adapters/mysql2.rb:3:in `<top (required)>'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `require'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `block in require'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:291:in `load_dependency'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/activesupport-6.0.3.1/lib/active_support/dependencies.rb:324:in `require'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/sequel-5.16.0/lib/sequel/database/connecting.rb:88:in `load_adapter'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/sequel-5.16.0/lib/sequel/database/connecting.rb:17:in `adapter_class'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/sequel-5.16.0/lib/sequel/database/connecting.rb:45:in `connect'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/sequel-5.16.0/lib/sequel/core.rb:121:in `connect'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/bosh-director-0.0.0/lib/bosh/director/config.rb:346:in `configure_db'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/bosh-director-0.0.0/lib/bosh/director/config.rb:541:in `db'
        from /var/vcap/data/packages/director/1c6f338650b301aa70c525324db1a243cd0e3fd8/gem_home/ruby/2.6.0/gems/bosh-director-0.0.0/bin/bosh-director-migrate:24:in `<top (required)>'
        from /var/vcap/packages/director/bin/bosh-director-migrate:29:in `load'
        from /var/vcap/packages/director/bin/bosh-director-migrate:29:in `<main>'
```
