### PR TITLE
Adding the user_domain_name and project_domain_name as new parameters…

### DIFF
--- a/jobs/registry/spec
+++ b/jobs/registry/spec
@@ -108,11 +108,11 @@ properties:
   openstack.project:
      description: OpenStack project name (required for Keystone API version 3)
   openstack.domain:
-     description: OpenStack domain (required for Keystone API version 3)
+     description: OpenStack domain (required for Keystone API version 3, unless openstack.user_domain_name and openstack.project_domain_name are used)
   openstack.user_domain_name:
-     description: OpenStack user domain name (required for Keystone API version 3)
+     description: OpenStack user domain name (required for Keystone API version 3, unless openstack.domain is used)
   openstack.project_domain_name:
-     description: OpenStack project domain name (required for Keystone API version 3)
+     description: OpenStack project domain name (required for Keystone API version 3, unless openstack.domain is used)
   openstack.region:
     description: OpenStack region (optional)
   openstack.endpoint_type:

--- a/jobs/registry/spec
+++ b/jobs/registry/spec
@@ -109,6 +109,10 @@ properties:
      description: OpenStack project name (required for Keystone API version 3)
   openstack.domain:
      description: OpenStack domain (required for Keystone API version 3)
+  openstack.user_domain_name:
+     description: OpenStack user domain name (required for Keystone API version 3)
+  openstack.project_domain_name:
+     description: OpenStack project domain name (required for Keystone API version 3)
   openstack.region:
     description: OpenStack region (optional)
   openstack.endpoint_type:

--- a/jobs/registry/templates/registry.yml.erb
+++ b/jobs/registry/templates/registry.yml.erb
@@ -90,6 +90,12 @@
     if_p('openstack.domain') do |domain|
       cloud_params['openstack']['domain'] = domain
     end
+    if_p('openstack.user_domain_name') do |domain|
+      cloud_params['openstack']['user_domain_name'] = domain
+    end
+    if_p('openstack.project_domain_name') do |domain|
+      cloud_params['openstack']['project_domain_name'] = domain
+    end
     if_p('openstack.region') do |region|
       cloud_params['openstack']['region'] = region
     end

--- a/src/bosh-registry/lib/bosh/registry/instance_manager/openstack.rb
+++ b/src/bosh-registry/lib/bosh/registry/instance_manager/openstack.rb
@@ -27,6 +27,8 @@ module Bosh::Registry
           :openstack_tenant => @openstack_properties['tenant'],
           :openstack_project_name => @openstack_properties['project'],
           :openstack_domain_name => @openstack_properties['domain'],
+          :openstack_user_domain_name => @openstack_properties['user_domain_name'],
+          :openstack_project_domain_name => @openstack_properties['project_domain_name'],
           :openstack_region => @openstack_properties['region'],
           :openstack_endpoint_type => @openstack_properties['endpoint_type'],
           :connection_options => @openstack_properties['connection_options']
@@ -52,7 +54,7 @@ module Bosh::Registry
           end
 
         elsif is_v3? cloud_config['openstack']['auth_url']
-          unless cloud_config['openstack']['domain'] && cloud_config['openstack']['project']
+          unless (cloud_config['openstack']['domain'] && cloud_config['openstack']['project']) || (cloud_config['openstack']['user_domain_name'] && cloud_config['openstack']['project_domain_name'] && cloud_config['openstack']['project'])
             raise ConfigError, 'Invalid OpenStack configuration parameters'
           end
         end

--- a/src/bosh-registry/lib/bosh/registry/instance_manager/openstack.rb
+++ b/src/bosh-registry/lib/bosh/registry/instance_manager/openstack.rb
@@ -54,7 +54,10 @@ module Bosh::Registry
           end
 
         elsif is_v3? cloud_config['openstack']['auth_url']
-          unless (cloud_config['openstack']['domain'] && cloud_config['openstack']['project']) || (cloud_config['openstack']['user_domain_name'] && cloud_config['openstack']['project_domain_name'] && cloud_config['openstack']['project'])
+          unless (cloud_config['openstack']['domain'] && cloud_config['openstack']['project']) || 
+                 (cloud_config['openstack']['user_domain_name'] && 
+                  cloud_config['openstack']['project_domain_name'] && 
+                  cloud_config['openstack']['project'])
             raise ConfigError, 'Invalid OpenStack configuration parameters'
           end
         end

--- a/src/bosh-registry/spec/unit/bosh/registry/openstack/instance_manager_spec.rb
+++ b/src/bosh-registry/spec/unit/bosh/registry/openstack/instance_manager_spec.rb
@@ -48,6 +48,8 @@ describe Bosh::Registry::InstanceManager do
         openstack_tenant: nil,
         openstack_project_name: 'foo',
         openstack_domain_name: 'mydomain',
+        openstack_user_domain_name: nil,
+        openstack_project_domain_name: nil,
         openstack_region: '',
         openstack_endpoint_type: nil,
         connection_options: connection_options,


### PR DESCRIPTION
**### What is this change about?**
This pull request was tested in my local bosh deployment and intents to solve the issue https://github.com/cloudfoundry/bosh-openstack-cpi-release/issues/211 to support multiple domains in the openstack cpi, in the case the the users are configured with one domain and the projects have another domain associated. For these changes is necessary also the approval of another pull request in the bosh-openstack-cpi-release but it doesn't depend on it to work. Please refer to the pull request changes in the bosh-openstack-cpi-release to check the new parameters added.

Without the approval of this request, the new parameters in the bosh-openstack-cpi will not work, due to the registry service check for the presence on the openstack_domain parameters to validate the version v3, but this will not be the only case because the user_domain_name and the project_domain_name can also be present. This is why the domain parameter was changed from required to optional.

### Please provide contextual information.

Issue: https://github.com/cloudfoundry/bosh-openstack-cpi-release/issues/211

Pull Request in bosh-openstack-cpi: https://github.com/cloudfoundry/bosh-openstack-cpi-release/pull/236

### What tests have you run against this PR?

I have tested the changes deploying the modified releases in our local bosh deployment and tested the connection to Openstack. Was tested the vm creation, release upload, vm creation and deletion, check of the directors log and debug of access to the Openstack ensuring that everything can be stable.

Also was tested the user access with the user and project domain with the same value (using the parameter domain), and with a user and project with different values (using user_domain_name and the project_domain_name) 

### How should this change be described in bosh release notes?

feature
_Support of different domain names for user and the project to access an Openstack project, adding the user_domain_name and the project_domain_name parameters for the configuration to the Openstack plugin._
 

### Does this PR introduce a breaking change?

No. If the pull request of the bosh-openstack-cpi is not approved yet then if an operator tries to use the parameters, the creation or the deployment will fail.

_Does this introduce changes that would require operators to take care in order to upgrade without a failure?_
 If the operator wants to use the parameters added, the pull request of the openstack-cpi has to be approved. and released.

### Tag your pair, your PM, and/or team!
_andinod_
