### PR TITLE
adding build chroot docker images

### DIFF
--- a/ci/dockerfiles/main-ubuntu-chroot/Dockerfile
+++ b/ci/dockerfiles/main-ubuntu-chroot/Dockerfile
@@ -1,10 +1,10 @@
-FROM bosh/main-ruby-go:xenial
+FROM bosh/main-ruby-go
 
 RUN apt-get update && apt-get install -y debootstrap
 RUN mkdir -p /tmp/ubuntu-chroot
 RUN debootstrap --arch amd64 xenial /tmp/ubuntu-chroot http://archive.ubuntu.com/ubuntu/ || true # debootstrap attempts to mount the proc which requires privileged. Hence continue and mount proc fs in entrypoint
 RUN cp /etc/passwd /tmp/ubuntu-chroot/etc/
-RUN sed 's/\([^:]*\):[^:]*:/\1:*:/' /etc/shadow | sudo tee /tmp/ubuntu-chroot/etc/shadow
+RUN sed 's/\([^:]*\):[^:]*:/\1:*:/' /etc/shadow | tee /tmp/ubuntu-chroot/etc/shadow
 RUN cp /etc/group /tmp/ubuntu-chroot/etc/
 RUN cp /etc/hosts /tmp/ubuntu-chroot/etc/ # avoid sudo warnings when it tries to resolve the chroot's hostname
 

--- a/ci/dockerfiles/main-ubuntu-chroot/Dockerfile
+++ b/ci/dockerfiles/main-ubuntu-chroot/Dockerfile
@@ -1,0 +1,18 @@
+FROM bosh/main-ruby-go:xenial
+
+RUN apt-get update && apt-get install -y debootstrap
+RUN mkdir -p /tmp/ubuntu-chroot
+RUN debootstrap --arch amd64 xenial /tmp/ubuntu-chroot http://archive.ubuntu.com/ubuntu/ || true # debootstrap attempts to mount the proc which requires privileged. Hence continue and mount proc fs in entrypoint
+RUN cp /etc/passwd /tmp/ubuntu-chroot/etc/
+RUN sed 's/\([^:]*\):[^:]*:/\1:*:/' /etc/shadow | sudo tee /tmp/ubuntu-chroot/etc/shadow
+RUN cp /etc/group /tmp/ubuntu-chroot/etc/
+RUN cp /etc/hosts /tmp/ubuntu-chroot/etc/ # avoid sudo warnings when it tries to resolve the chroot's hostname
+
+RUN echo /proc /tmp/ubuntu-chroot/proc none rbind 0 0 >> /etc/fstab
+RUN echo /dev /tmp/ubuntu-chroot/dev none rbind 0 0  >> /etc/fstab
+RUN echo /sys /tmp/ubuntu-chroot/sys none rbind 0 0 >> /etc/fstab
+RUN echo /tmp /tmp/ubuntu-chroot/tmp none rbind 0 0 >> /etc/fstab
+RUN echo /var/lib /tmp/ubuntu-chroot/var/lib none rbind 0 0 >> /etc/fstab
+
+ENV SHELLOUT_CHROOT_DIR /tmp/ubuntu-chroot
+ENV LC_ALL C

--- a/ci/dockerfiles/main-ubuntu-chroot/Dockerfile
+++ b/ci/dockerfiles/main-ubuntu-chroot/Dockerfile
@@ -1,10 +1,10 @@
 FROM bosh/main-ruby-go
 
-RUN apt-get update && apt-get install -y debootstrap
+RUN apt-get update && apt-get install -y debootstrap sudo
 RUN mkdir -p /tmp/ubuntu-chroot
 RUN debootstrap --arch amd64 xenial /tmp/ubuntu-chroot http://archive.ubuntu.com/ubuntu/ || true # debootstrap attempts to mount the proc which requires privileged. Hence continue and mount proc fs in entrypoint
 RUN cp /etc/passwd /tmp/ubuntu-chroot/etc/
-RUN sed 's/\([^:]*\):[^:]*:/\1:*:/' /etc/shadow | tee /tmp/ubuntu-chroot/etc/shadow
+RUN sed 's/\([^:]*\):[^:]*:/\1:*:/' /etc/shadow | sudo tee /tmp/ubuntu-chroot/etc/shadow
 RUN cp /etc/group /tmp/ubuntu-chroot/etc/
 RUN cp /etc/hosts /tmp/ubuntu-chroot/etc/ # avoid sudo warnings when it tries to resolve the chroot's hostname
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,6 +31,7 @@ groups:
   - name: docker
     jobs:
     - build-main-ruby-go
+    - build-main-ubuntu-chroot
     - build-main-postgres-9.4
     - build-main-postgres-10
     - build-main-mysql-5.7
@@ -739,6 +740,20 @@ jobs:
         get_params:
           skip_download: true
 
+  - name: build-main-ubuntu-chroot
+    public: true
+    serial: true
+    plan:
+      - get: bosh-src
+      - get: bosh-src-dockerfiles
+        trigger: true
+        passed: [build-main-ruby-go]
+      - put: main-ubuntu-chroot-image
+        params:
+          build: "bosh-src/ci/dockerfiles/main-ubuntu-chroot"
+        get_params:
+          skip_download: true
+
   - name: build-main-postgres-9.4
     public: true
     serial: true
@@ -1040,6 +1055,15 @@ resources:
     type: docker-image
     source:
       repository: bosh/main-ruby-go
+      tag: ((branch_name))
+      email: ((dockerhub_email))
+      username: ((dockerhub_username))
+      password: ((dockerhub_password))
+
+  - name: main-ubuntu-chroot-image
+    type: docker-image
+    source:
+      repository: bosh/main-ubuntu-chroot
       tag: ((branch_name))
       email: ((dockerhub_email))
       username: ((dockerhub_username))


### PR DESCRIPTION
the ubuntu-chroot docker images is used by the stemcell builder ci and the one that we reffered to was: https://github.com/cloudfoundry/bosh/blob/master/ci/old-docker/main-ubuntu-chroot/Dockerfile

this was still using the main-ruby-go:trusty and was not being build or updated.

this PR wil enable building the docker image again