### PR TITLE
Send custom tags in DataDog health monitor events

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/plugins/datadog.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/datadog.rb
@@ -94,6 +94,7 @@ module Bosh::Monitor
         [].tap do |tags|
           tags << "source:#{data[:source]}"
           tags << "deployment:#{data[:deployment]}"
+          custom_tags.each { |key, value| tags << "#{key}:#{value}" }
         end
       end
     end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
@@ -221,5 +221,36 @@ describe Bhm::Plugins::DataDog do
       alert = make_alert(severity: 4)
       subject.process(alert)
     end
+
+    context 'when custom tags are defined' do
+      let(:options) do
+        {
+          'api_key' => 'api_key',
+          'application_key' => 'application_key',
+          'custom_tags' => {
+            'customkey' => 'customvalue',
+            'customkey2' => 'customvalue2',
+          },
+        }
+      end
+
+      it 'includes the custom tags' do
+        custom_tags = %w[
+          customkey:customvalue
+          customkey2:customvalue2
+        ]
+
+        expect(EM).to receive(:defer).and_yield
+
+        expect(Dogapi::Event).to receive(:new) do |_, options|
+          expect(options[:tags]).to include(*custom_tags)
+        end
+
+        allow(dog_client).to receive(:emit_event)
+
+        alert = make_alert
+        subject.process(alert)
+      end
+    end
   end
 end


### PR DESCRIPTION
Extend the DataDog Health Monitor plugin to include custom tags when creating DataDog events for BOSH HM alerts

### What is this change about?

Before this change the DataDog Health Monitor plugin supported sending custom tags for metrics, but not events. This change also sends the same custom tag set whenever an event is generated due to a Health Monitor alert.

### Please provide contextual information.

Operators often use user-friendly names for their CloudFoundry deployments, which are set as custom tags in DataDog for the firehose, OS agent, etc. These tags are then used as filters in dashboards, monitors, incidents, the event stream, etc.

Attaching these custom tags to DataDog events created by the Health Monitor allows for consistent tagging across an entire foundry. 

Tags were added to DataDog metrics in https://github.com/cloudfoundry/bosh/pull/2077. 

### What tests have you run against this PR?

 - RSpec tests against the `bosh-monitor` folder
 
 - Created a development release and deployed a Director with DataDog `custom_tags` set as:

```
    custom_tags:
      custom_tag_1: hello
      custom_tag_2: world
```
Verified these tags are visible inside the DataDog event stream
<img width="997" alt="Screenshot 2021-07-11 at 17 42 05" src="https://user-images.githubusercontent.com/3462461/125203463-5aa66180-e270-11eb-9b60-8848df145515.png">

### How should this change be described in bosh release notes?

Custom tags can be attached to DataDog events generated by the Health Monitor

### Does this PR introduce a breaking change?

No