### PR TITLE
🐞 BOSH cck / hm resurrector works with multi-CPI

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_spec.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_spec.rb
@@ -27,7 +27,7 @@ module Bosh::Director
           'networks' => instance_plan.network_settings_hash,
           'vm_type' => instance_group.vm_type&.spec,
           'vm_resources' => instance_group.vm_resources&.spec,
-          'stemcell' => instance_group.stemcell.spec,
+          'stemcell' => instance_group.stemcell.spec(instance.model.cpi),
           'env' => instance_group.env.spec,
           'packages' => instance_group.package_spec,
           'properties' => instance_group.properties,

--- a/src/bosh-director/lib/bosh/director/deployment_plan/stemcell.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/stemcell.rb
@@ -80,9 +80,9 @@ module Bosh::Director
         @models.first.sha1
       end
 
-      def spec
+      def spec(cpi = '')
         {
-          'name' => @name,
+          'name' => cpi_stemcell_name(cpi),
           'version' => @version,
         }
       end
@@ -103,6 +103,18 @@ module Bosh::Director
       end
 
       private
+
+      def cpi_stemcell_name(cpi)
+        # When bind_model has not been called fall back to default behaviour
+        return @name if @models.nil?
+
+        cpi_stemcell = @models.find { |model| model.cpi == cpi }
+
+        # when we can't find the stemcell, fall back to default behaviour
+        return @name if cpi_stemcell.nil?
+
+        cpi_stemcell.name
+      end
 
       def model_for_default_cpi
         stemcell = @models.find { |sc| sc.cpi.blank? }


### PR DESCRIPTION
Prior to this commit, `bosh cck` would sometimes fail on multi-CPI installations with a "Required stemcell ... not found for cpi" message.

This commit fixes that failure by selecting the stemcell appropriate for the particular CPI (rather than merely grabbing the first stemcell, which was the prior behavior).

An obvious question is, "why could `bosh deploy` find the correct stemcell, but `bosh cck` couldn't?" The answer is that `bosh deploy` follows a different codepath (deploy uses `CreateVmStep`).

Fixes, during `bosh cck` on a multi-CPI Director:
```
Task 41558 | 21:16:40 | Applying problem resolutions: VM for 'dummy-vsphere/812e9491-a615-465a-b975-5f0c044f7739 (0)' with cloud ID 'dummy-vsphere_sslipio_f41a348db816' is not responding. (unresponsive_agent 1945): Recreate VM without waiting for processes to start (00:00:21)
                     L Error: Required stemcell {"name"=>"bosh-aws-xen-hvm-ubuntu-bionic-go_agent", "version"=>"1.25"} not found for cpi vsphere, please upload again
```

### What is this change about?

`bosh cck` can fail on multi-CPI installations. For example, it may attempt to recreate a VM on vSphere with the AWS stemcell and fail with "Required stemcell {"name"=>"bosh-aws-xen-hvm-ubuntu-bionic-go_agent", "version"=>"1.25"} not found for cpi vsphere, please upload again"

### Please provide contextual information.

Fixes #2287 ("bosh cck / hm resurrector broken with multi-cpi and different stemcells (eg: vpshere and openstack)")

### What tests have you run against this PR?

I ran unit tests (`bundle exec rspec spec/unit`). There were two failures, but the same failures appeared on the pristine master branch, so I assumed it was okay.

I hot-patched a BOSH Director

### How should this change be described in bosh release notes?

bugfix: Multi-CPI BOSH cck / hm resurrector successfully recreates VMs by selecting the appropriate stemcell.

### Does this PR introduce a breaking change?

No, it does not introduce a breaking change. This change is backwards-compatible.

### Tag your pair, your PM, and/or team!

/cc @mariash 
