### PR TITLE
Restrict the IaaS-native persistent disk resize to disk growing only

### DIFF
--- a/docs/workstation_setup.md
+++ b/docs/workstation_setup.md
@@ -86,7 +86,23 @@
     cd ~/workspace/bosh/src
     bundle install
     ```
-    
+
+    If ever you hit some compilation issues with the `thin` Gem
+    about “implicit function declarations”, try installing it manually with
+    the following compilation flag:
+
+    ```
+    gem install thin -v '1.7.2' -- --with-cflags="-Wno-error=implicit-function-declaration"
+    ```
+
+    If ever you hit some linker issues like “_ld: library not found
+    for -lssl_” when installing the `mysql2` Gem, try installing it manually
+    with the following linker flags:
+
+    ```
+    gem install mysql2 -v '0.5.3' -- --with-ldflags="-L/usr/local/opt/openssl@1.1/lib"
+    ```
+
 10. Download `bosh-agent` dependency:
     ```
     cd ~/workspace/bosh/src

--- a/src/bosh-director/lib/bosh/director/deployment_plan/persistent_disk_collection.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/persistent_disk_collection.rb
@@ -144,6 +144,15 @@ module Bosh::Director
           cloud_properties == other.cloud_properties &&
             size != other.size && name == other.name
         end
+
+        def is_bigger_than?(other)
+          unless other.is_a? PersistentDisk
+            raise Exception, 'Cannot compare persistent disk size to anything
+                              that is not a persistent disk.'
+          end
+
+          size >= other.size
+        end
       end
 
       class NewPersistentDisk < PersistentDisk

--- a/src/bosh-director/lib/bosh/director/deployment_plan/persistent_disk_collection.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/persistent_disk_collection.rb
@@ -147,8 +147,7 @@ module Bosh::Director
 
         def is_bigger_than?(other)
           unless other.is_a? PersistentDisk
-            raise Exception, 'Cannot compare persistent disk size to anything
-                              that is not a persistent disk.'
+            raise Exception, 'Cannot compare persistent disk size to anything that is not a persistent disk.'
           end
 
           size >= other.size

--- a/src/bosh-director/lib/bosh/director/disk_manager.rb
+++ b/src/bosh-director/lib/bosh/director/disk_manager.rb
@@ -32,7 +32,7 @@ module Bosh::Director
 
         @logger.info("CPI resize disk enabled: #{Config.enable_cpi_resize_disk}")
 
-        if use_cpi_resize_disk?(old_disk, new_disk)
+        if use_iaas_native_disk_resize?(old_disk, new_disk)
           resize_disk(instance_plan, new_disk, old_disk)
         else
           update_disk(instance_plan, new_disk, old_disk)
@@ -84,8 +84,12 @@ module Bosh::Director
       DeploymentPlan::Stages::Report.new
     end
 
-    def use_cpi_resize_disk?(old_disk, new_disk)
-      Config.enable_cpi_resize_disk && new_disk && new_disk.size_diff_only?(old_disk) && new_disk.managed?
+    def use_iaas_native_disk_resize?(old_disk, new_disk)
+      Config.enable_cpi_resize_disk &&
+        new_disk &&
+        new_disk.managed? &&
+        new_disk.size_diff_only?(old_disk) &&
+        new_disk.is_bigger_than?(old_disk)
     end
 
     def add_event(action, deployment_name, instance_name, object_name = nil, parent_id = nil, error = nil)

--- a/src/bosh-director/spec/unit/deployment_plan/persistent_disk_collection_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/persistent_disk_collection_spec.rb
@@ -349,6 +349,44 @@ module Bosh::Director
           end
         end
       end
+
+      describe '#is_bigger_than?' do
+        let(:new_disk) { new_disk = PersistentDiskCollection::PersistentDisk.new('', {}, 10) }
+
+        context 'when other thing is not a disk' do
+          it 'raises an error' do
+            old_disk = {}
+
+            expect {
+              new_disk.is_bigger_than?(old_disk)
+            }.to raise_error(/Cannot compare persistent disk size to anything that is not a persistent disk/)
+          end
+        end
+
+        context 'when the size is bigger' do
+          it 'is true' do
+            old_disk = PersistentDiskCollection::PersistentDisk.new('', {}, 5)
+
+            expect(new_disk.is_bigger_than?(old_disk)).to eq(true)
+          end
+        end
+
+        context 'when the size is equal' do
+          it 'is true' do
+            old_disk = PersistentDiskCollection::PersistentDisk.new('', {}, 10)
+
+            expect(new_disk.is_bigger_than?(old_disk)).to eq(true)
+          end
+        end
+
+        context 'when the size is smaller' do
+          it 'is false' do
+            old_disk = PersistentDiskCollection::PersistentDisk.new('', {}, 15)
+
+            expect(new_disk.is_bigger_than?(old_disk)).to eq(false)
+          end
+        end
+      end
     end
   end
 end

--- a/src/spec/support/integration_example_group.rb
+++ b/src/spec/support/integration_example_group.rb
@@ -416,9 +416,9 @@ module IntegrationSandboxHelpers
 
   def prepare_sandbox
     cleanup_client_sandbox_dir
+    setup_home_dir
     setup_test_release_dir
     setup_bosh_work_dir
-    setup_home_dir
     Thread.current[:sandbox] ||= Bosh::Dev::Sandbox::Main.from_env
   end
 
@@ -472,6 +472,7 @@ module IntegrationSandboxHelpers
   def setup_home_dir
     FileUtils.mkdir_p(ClientSandbox.home_dir)
     ENV['HOME'] = ClientSandbox.home_dir
+    `git config --global init.defaultBranch "master"`
   end
 
   def cleanup_client_sandbox_dir


### PR DESCRIPTION
### What is this change about?

Here we limit the native disk resize to the “disk growing” feature only, having the disk shrinking fallback to classical disk migration algorithm.

Other improvements also included in this PR:
- Updated the documentation with hints for some difficulties I've met while setting up my workstation.
- Fixed Git hints complaining about missing Git config for `init.defaultBranch`, which were cluttering the output for integration tests.

### Please provide contextual information.

This story is a dependency of cloudfoundry/bosh-agent#244.

### What tests have you run against this PR?

Unit tests are passing. I'm currently trying to run the integration tests, this is work-in-progress.

### How should this change be described in bosh release notes?

🔗  Improvements
- IaaS-native disk resize, when supported by CPI, will now properly happen only when growing disk. This is due

### Does this PR introduce a breaking change?

No, the IaaS-native disk resize is a fairly new feature that is not supported by CPIs, to my knowledge. The AWS CPI would be the first to support this, and the PR is pending, waiting for cloudfoundry/bosh-agent#244 to be merged.

### Tag your pair, your PM, and/or team!
Sure, but I've worked alone on this.