### PR TITLE
Feature: Adding support for NATS/Blobstore cert rotation without recreating vms

### DIFF
--- a/src/bosh-director/bin/bosh-director-migrate
+++ b/src/bosh-director/bin/bosh-director-migrate
@@ -21,10 +21,12 @@ if config_file.nil?
 end
 
 config = Bosh::Director::Config.load_file(config_file)
+director_db = config.db
 # Configure the singleton for migrations that need access to this config. There does not appear
 # to be a way to pass additional data or objects into Sequel gem migrations.
-config.configure_evil_config_singleton!
-director_db = config.db
+if director_db.table_exists?(:releases)
+  config.configure_evil_config_singleton!
+end
 abort 'Director database config missing from config file' unless director_db
 dns_db = config.dns_db
 

--- a/src/bosh-director/bin/bosh-director-migrate
+++ b/src/bosh-director/bin/bosh-director-migrate
@@ -21,6 +21,9 @@ if config_file.nil?
 end
 
 config = Bosh::Director::Config.load_file(config_file)
+# Configure the singleton for migrations that need access to this config. There does not appear
+# to be a way to pass additional data or objects into Sequel gem migrations.
+config.configure_evil_config_singleton!
 director_db = config.db
 abort 'Director database config missing from config file' unless director_db
 dns_db = config.dns_db

--- a/src/bosh-director/db/migrations/director/20210902232124_add_blobstore_and_nats_shas_to_vms.rb
+++ b/src/bosh-director/db/migrations/director/20210902232124_add_blobstore_and_nats_shas_to_vms.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  up do
+    alter_table(:vms) do
+      add_column :blobstore_config_sha1, String, size: 50
+      add_column :nats_config_sha1, String, size: 50
+    end
+  end
+end

--- a/src/bosh-director/db/migrations/director/20210902232124_add_blobstore_and_nats_shas_to_vms.rb
+++ b/src/bosh-director/db/migrations/director/20210902232124_add_blobstore_and_nats_shas_to_vms.rb
@@ -4,5 +4,9 @@ Sequel.migration do
       add_column :blobstore_config_sha1, String, size: 50
       add_column :nats_config_sha1, String, size: 50
     end
+    self[:vms].update(
+      blobstore_config_sha1: Bosh::Director::Config.blobstore_config_fingerprint,
+      nats_config_sha1: Bosh::Director::Config.nats_config_fingerprint,
+    )
   end
 end

--- a/src/bosh-director/lib/bosh/blobstore_client/base.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/base.rb
@@ -141,6 +141,19 @@ module Bosh
         SecureRandom.uuid
       end
 
+      def redact_credentials(blobstore_hashes)
+        if signing_enabled?
+          blobstore_hashes.map do |blobstore_hash|
+            redacted_options = blobstore_hash.fetch('options', {}).reject do |key, _|
+              redacted_credential_properties_list.include?(key)
+            end
+            blobstore_hash.merge('options' => redacted_options)
+          end
+        else
+          blobstore_hashes
+        end
+      end
+
       def redacted_credential_properties_list
         # needs to be implemented in each subclass
         not_supported

--- a/src/bosh-director/lib/bosh/director/agent_client.rb
+++ b/src/bosh-director/lib/bosh/director/agent_client.rb
@@ -168,8 +168,8 @@ module Bosh::Director
       end
     end
 
-    def update_settings(certs, disk_associations)
-      safe_send_message(:update_settings, 'trusted_certs' => certs, 'disk_associations' => disk_associations)
+    def update_settings(settings)
+      safe_send_message(:update_settings, settings)
     end
 
     def run_script(script_name, options)

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -55,6 +55,7 @@ module Bosh::Director
       )
 
       attr_reader(
+        :blobstore_config_fingerprint,
         :config_server,
         :config_server_enabled,
         :db_config,
@@ -66,6 +67,7 @@ module Bosh::Director
         :nats_client_ca_private_key_path,
         :nats_client_certificate_path,
         :nats_client_private_key_path,
+        :nats_config_fingerprint,
         :record_events,
         :runtime,
       )
@@ -145,6 +147,11 @@ module Bosh::Director
         @nats_client_ca_certificate_path = config['nats']['client_ca_certificate_path']
         @nats_client_ca_private_key_path = config['nats']['client_ca_private_key_path']
         @nats_server_ca = File.read(@nats_server_ca_path)
+        nats_client_ca_certificate = File.read(@nats_client_ca_certificate_path)
+        nats_client_ca_private_key = File.read(@nats_client_ca_private_key_path)
+        @nats_config_fingerprint = Digest::SHA1.hexdigest("#{nats_client_ca_certificate}#{nats_client_ca_private_key}#{@nats_server_ca}")
+
+        @blobstore_config_fingerprint = Digest::SHA1.hexdigest(config.fetch('blobstore').to_s)
 
         @director_certificate_expiry_json_path = config['director_certificate_expiry_json_path']
 

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
@@ -290,6 +290,15 @@ module Bosh::Director
         false
       end
 
+      def nats_config_changed?
+        nats_config_fingerprint = Bosh::Director::Config.nats_config_fingerprint
+        if nats_config_fingerprint != @model.nats_config_sha1
+          log_changes(__method__, @model.nats_config_sha1, nats_config_fingerprint)
+          return true
+        end
+        false
+      end
+
       def vm_created?
         !@model.active_vm.nil?
       end

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
@@ -193,11 +193,11 @@ module Bosh::Director
         }
         if blobstore_config_changed?
           blobstore = App.instance.blobstores.blobstore
-          blobstore.validate!(env['bosh']['blobstores'].first.fetch('options', {}), @stemcell.api_version)
+          blobstore.validate!(Config.agent_env['blobstores'].first.fetch('options', {}), @stemcell.api_version)
           if blobstore.can_sign_urls?(@stemcell.api_version)
-            settings['blobstores'] = blobstore.redact_credentials(env['bosh']['blobstores'])
+            settings['blobstores'] = blobstore.redact_credentials(Config.agent_env['blobstores'])
           else
-            settings['blobstores'] = env['bosh']['blobstores']
+            settings['blobstores'] = Config.agent_env['blobstores']
           end
         end
 

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
@@ -281,6 +281,15 @@ module Bosh::Director
         changed
       end
 
+      def blobstore_config_changed?
+        blobstore_config_fingerprint = Bosh::Director::Config.blobstore_config_fingerprint
+        if blobstore_config_fingerprint != @model.blobstore_config_sha1
+          log_changes(__method__, @model.blobstore_config_sha1, blobstore_config_fingerprint)
+          return true
+        end
+        false
+      end
+
       def vm_created?
         !@model.active_vm.nil?
       end

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
@@ -86,6 +86,8 @@ module Bosh
           @changes << :state if state_changed?
           @changes << :dns if dns_changed?
           @changes << :trusted_certs if instance.trusted_certs_changed?
+          @changes << :blobstore_config if instance.blobstore_config_changed?
+          @changes << :nats_config if instance.nats_config_changed?
           @changes << :tags if tags_changed?
           @changes
         end

--- a/src/bosh-director/lib/bosh/director/deployment_plan/steps/create_vm_step.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/steps/create_vm_step.rb
@@ -98,8 +98,12 @@ module Bosh::Director
           env['bosh'] ||= {}
           env['bosh'] = Config.agent_env.merge(env['bosh'])
 
-          @blobstore.validate!(env['bosh'].fetch('blobstores', [{}]).first.fetch('options', {}), stemcell_api_version)
-          remove_blobstore_credentials(env) if @blobstore.can_sign_urls?(stemcell_api_version)
+          if env['bosh'].key?('blobstores')
+            @blobstore.validate!(env['bosh']['blobstores'].first.fetch('options', {}), stemcell_api_version)
+            if @blobstore.can_sign_urls?(stemcell_api_version)
+              env['bosh']['blobstores'] = @blobstore.redact_credentials(env['bosh']['blobstores'])
+            end
+          end
           env['bosh']['tags'] = @tags unless @tags.empty?
 
           if Config.nats_server_ca
@@ -177,14 +181,6 @@ module Bosh::Director
             }
           )
           event.id
-        end
-
-        def remove_blobstore_credentials(env)
-          env['bosh'].fetch('blobstores', [{}]).each do |blobstore|
-            blobstore.fetch('options', {}).reject! do |k, _|
-              @blobstore.redacted_credential_properties_list.include?(k)
-            end
-          end
         end
       end
     end

--- a/src/bosh-director/lib/bosh/director/deployment_plan/steps/create_vm_step.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/steps/create_vm_step.rb
@@ -93,7 +93,13 @@ module Bosh::Director
 
           cpi = cloud_factory.get_name_for_az(instance_model.availability_zone)
 
-          vm_options = { instance: instance_model, agent_id: agent_id, cpi: cpi }
+          vm_options = {
+            instance: instance_model,
+            agent_id: agent_id,
+            cpi: cpi,
+            blobstore_config_sha1: Config.blobstore_config_fingerprint,
+            nats_config_sha1: Config.nats_config_fingerprint,
+          }
 
           env['bosh'] ||= {}
           env['bosh'] = Config.agent_env.merge(env['bosh'])

--- a/src/bosh-director/lib/bosh/director/deployment_plan/steps/update_instance_settings_step.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/steps/update_instance_settings_step.rb
@@ -9,17 +9,7 @@ module Bosh::Director
         def perform(report)
           instance_model = @instance.model.reload
 
-          disk_associations = instance_model.active_persistent_disks.collection.reject do |disk|
-            disk.model.managed?
-          end
-
-          disk_associations.map! do |disk|
-            { 'name' => disk.model.name, 'cid' => disk.model.disk_cid }
-          end
-
-          vm = report.vm
-          AgentClient.with_agent_id(vm.agent_id, instance_model.name).update_settings(Config.trusted_certs, disk_associations)
-          vm.update(trusted_certs_sha1: ::Digest::SHA1.hexdigest(Config.trusted_certs))
+          @instance.update_instance_settings(report.vm)
 
           instance_model.update(cloud_properties: JSON.dump(@instance.cloud_properties))
         end

--- a/src/bosh-director/lib/bosh/director/instance_updater/recreate_handler.rb
+++ b/src/bosh-director/lib/bosh/director/instance_updater/recreate_handler.rb
@@ -36,7 +36,7 @@ module Bosh::Director
 
         attach_disks if instance_plan.needs_disk?
 
-        instance.update_instance_settings
+        instance.update_instance_settings(instance.model.active_vm)
       end
 
       def delete_create

--- a/src/bosh-director/lib/bosh/director/instance_updater/update_procedure.rb
+++ b/src/bosh-director/lib/bosh/director/instance_updater/update_procedure.rb
@@ -150,7 +150,7 @@ module Bosh::Director
         instance_report.vm = instance_plan.instance.model.active_vm
         @disk_manager.update_persistent_disk(instance_plan)
 
-        instance.update_instance_settings unless recreate
+        instance.update_instance_settings(instance.model.active_vm) unless recreate
       end
 
       # Full update drains jobs and starts them again

--- a/src/bosh-director/lib/bosh/director/models/instance.rb
+++ b/src/bosh-director/lib/bosh/director/models/instance.rb
@@ -183,6 +183,10 @@ module Bosh::Director::Models
       instance_active_vm.nil? ? ::Digest::SHA1.hexdigest('') : instance_active_vm.trusted_certs_sha1
     end
 
+    def blobstore_config_sha1
+      active_vm&.blobstore_config_sha1
+    end
+
     def stopped?
       state == 'stopped'
     end

--- a/src/bosh-director/lib/bosh/director/models/instance.rb
+++ b/src/bosh-director/lib/bosh/director/models/instance.rb
@@ -187,6 +187,10 @@ module Bosh::Director::Models
       active_vm&.blobstore_config_sha1
     end
 
+    def nats_config_sha1
+      active_vm&.nats_config_sha1
+    end
+
     def stopped?
       state == 'stopped'
     end

--- a/src/bosh-director/spec/unit/agent_client_spec.rb
+++ b/src/bosh-director/spec/unit/agent_client_spec.rb
@@ -146,28 +146,28 @@ module Bosh::Director
               'disk_associations' => [{ 'name' => 'zak', 'cid' => 'new-disk-cid' }],
             )
             allow(client).to receive(:get_task)
-            client.update_settings('these are the certificates', [{ 'name' => 'zak', 'cid' => 'new-disk-cid' }])
+            client.update_settings('trusted_certs' => 'these are the certificates', 'disk_associations' => [{ 'name' => 'zak', 'cid' => 'new-disk-cid' }])
           end
 
           it 'periodically polls the update settings task while it is running' do
             allow(client).to receive(:handle_message_with_retry).and_return task
             allow(client).to receive(:sleep).with(AgentClient::DEFAULT_POLL_INTERVAL)
             expect(client).to receive(:get_task).with('fake-agent_task_id')
-            client.update_settings('these are the certificates', [{ 'name' => 'zak', 'cid' => 'new-disk-cid' }])
+            client.update_settings('some-agent-setting' => 'value')
           end
 
           it 'is only a warning when the remote agent does not implement update_settings' do
             allow(client).to receive(:handle_method).and_raise(RpcRemoteException, 'unknown message update_settings')
 
             expect(Config.logger).to receive(:warn).with("Ignoring update_settings 'unknown message' error from the agent: #<Bosh::Director::RpcRemoteException: unknown message update_settings>")
-            expect { client.update_settings('no certs', 'no disks') }.to_not raise_error
+            expect { client.update_settings('some-agent-setting' => 'value') }.to_not raise_error
           end
 
           it 'still raises an exception for other RPC failures' do
             allow(client).to receive(:handle_method).and_raise(RpcRemoteException, 'random failure!')
 
             expect(client).to_not receive(:warning)
-            expect { client.update_settings('no certs', 'no disks') }.to raise_error(Bosh::Director::RpcRemoteException, /random failure!/)
+            expect { client.update_settings('some-agent-setting' => 'value') }.to raise_error(Bosh::Director::RpcRemoteException, /random failure!/)
           end
         end
 

--- a/src/bosh-director/spec/unit/db/migrations/director/20210902232124_add_blobstore_and_nats_shas_to_vms_spec.rb
+++ b/src/bosh-director/spec/unit/db/migrations/director/20210902232124_add_blobstore_and_nats_shas_to_vms_spec.rb
@@ -1,0 +1,36 @@
+require_relative '../../../../db_spec_helper'
+
+module Bosh::Director
+  describe '20210902232124_add_blobstore_and_nats_shas_to_vms.rb' do
+    let(:db) { DBSpecHelper.db }
+    let(:migration_file) { '20210902232124_add_blobstore_and_nats_shas_to_vms.rb' }
+    let(:created_at_time) { Time.now }
+
+    before do
+      DBSpecHelper.migrate_all_before(migration_file)
+
+      allow(Bosh::Director::Config).to receive(:blobstore_config_fingerprint).and_return('blobstore-sha')
+      allow(Bosh::Director::Config).to receive(:nats_config_fingerprint).and_return('nats-sha')
+    end
+
+    describe 'backfilling nats and blobstore sha1 data' do
+      it 'fills in the nats and blobstore sha1s for existing vms' do
+        db[:deployments] << { id: 1, name: 'some-deployment' }
+        db[:variable_sets] << { id: 1, deployment_id: 1, created_at: Time.now }
+        db[:instances] << { id: 1, job: 'some-job', index: 0, deployment_id: 1, state: 'running', variable_set_id: 1 }
+        db[:instances] << { id: 2, job: 'some-job', index: 1, deployment_id: 1, state: 'running', variable_set_id: 1 }
+        db[:vms] << { instance_id: 1 }
+        db[:vms] << { instance_id: 2 }
+
+        DBSpecHelper.migrate(migration_file)
+
+        vm1 = db[:vms].all[0]
+        vm2 = db[:vms].all[1]
+        expect(vm1[:blobstore_config_sha1]).to eq('blobstore-sha')
+        expect(vm1[:nats_config_sha1]).to eq('nats-sha')
+        expect(vm2[:blobstore_config_sha1]).to eq('blobstore-sha')
+        expect(vm2[:nats_config_sha1]).to eq('nats-sha')
+      end
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_plan_spec.rb
@@ -1734,6 +1734,18 @@ module Bosh::Director::DeploymentPlan
     end
 
     describe '#changes' do
+      before do
+        instance_model.active_vm.update(
+          blobstore_config_sha1: Bosh::Director::Config.blobstore_config_fingerprint,
+          nats_config_sha1: Bosh::Director::Config.nats_config_fingerprint,
+        )
+      end
+
+      it 'does not include nats_config or blobstore_config by default' do
+        expect(instance_plan.changes).to_not include(:nats_config)
+        expect(instance_plan.changes).to_not include(:blobstore_config)
+      end
+
       context 'when the spec_json is nil' do
         before do
           instance_plan.existing_instance.update(spec_json: nil)
@@ -1751,6 +1763,26 @@ module Bosh::Director::DeploymentPlan
 
         it 'should report changes' do
           expect(instance_plan.changes).to_not be_empty
+        end
+      end
+
+      context 'when theres a change to blobstore config' do
+        before do
+          instance_model.active_vm.update(blobstore_config_sha1: 'new-blobstore-config')
+        end
+
+        it 'includes blobstore_config' do
+          expect(instance_plan.changes).to include(:blobstore_config)
+        end
+      end
+
+      context 'when theres a change to nats config' do
+        before do
+          instance_model.active_vm.update(nats_config_sha1: 'new-nats-config')
+        end
+
+        it 'includes nats_config' do
+          expect(instance_plan.changes).to include(:nats_config)
         end
       end
     end

--- a/src/bosh-director/spec/unit/deployment_plan/instance_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_spec.rb
@@ -249,7 +249,7 @@ module Bosh::Director::DeploymentPlan
 
       describe 'when blobstore config has changed' do
         before do
-          allow(Bosh::Director::Config).to receive(:blobstore_config_fingerprint).and_return("new fingerprint")
+          allow(Bosh::Director::Config).to receive(:blobstore_config_fingerprint).and_return('new fingerprint')
         end
 
         it 'should return true' do
@@ -257,7 +257,7 @@ module Bosh::Director::DeploymentPlan
         end
 
         it 'should log the change reason' do
-          allow(instance_model).to receive(:blobstore_config_sha1).and_return("old fingerprint")
+          allow(instance_model).to receive(:blobstore_config_sha1).and_return('old fingerprint')
           expect(logger).to receive(:debug)
             .with('blobstore_config_changed? changed '\
                   'FROM: old fingerprint '\
@@ -273,6 +273,41 @@ module Bosh::Director::DeploymentPlan
 
         it 'should return false' do
           expect(instance.blobstore_config_changed?).to be(false)
+        end
+      end
+    end
+
+    describe '#nats_config_changed?' do
+      before do
+        instance.bind_existing_instance_model(instance_model)
+      end
+
+      describe 'when nats config has changed' do
+        before do
+          allow(Bosh::Director::Config).to receive(:nats_config_fingerprint).and_return('new fingerprint')
+        end
+
+        it 'should return true' do
+          expect(instance.nats_config_changed?).to be(true)
+        end
+
+        it 'should log the change reason' do
+          allow(instance_model).to receive(:nats_config_sha1).and_return('old fingerprint')
+          expect(logger).to receive(:debug)
+            .with('nats_config_changed? changed '\
+                  'FROM: old fingerprint '\
+                  'TO: new fingerprint')
+          instance.nats_config_changed?
+        end
+      end
+
+      describe 'when nats config has not changed' do
+        before do
+          allow(Bosh::Director::Config).to receive(:nats_config_fingerprint).and_return(instance_model.blobstore_config_sha1)
+        end
+
+        it 'should return false' do
+          expect(instance.nats_config_changed?).to be(false)
         end
       end
     end

--- a/src/bosh-director/spec/unit/deployment_plan/instance_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_spec.rb
@@ -242,6 +242,41 @@ module Bosh::Director::DeploymentPlan
       end
     end
 
+    describe '#blobstore_config_changed?' do
+      before do
+        instance.bind_existing_instance_model(instance_model)
+      end
+
+      describe 'when blobstore config has changed' do
+        before do
+          allow(Bosh::Director::Config).to receive(:blobstore_config_fingerprint).and_return("new fingerprint")
+        end
+
+        it 'should return true' do
+          expect(instance.blobstore_config_changed?).to be(true)
+        end
+
+        it 'should log the change reason' do
+          allow(instance_model).to receive(:blobstore_config_sha1).and_return("old fingerprint")
+          expect(logger).to receive(:debug)
+            .with('blobstore_config_changed? changed '\
+                  'FROM: old fingerprint '\
+                  'TO: new fingerprint')
+          instance.blobstore_config_changed?
+        end
+      end
+
+      describe 'when blobstore config has not changed' do
+        before do
+          allow(Bosh::Director::Config).to receive(:blobstore_config_fingerprint).and_return(instance_model.blobstore_config_sha1)
+        end
+
+        it 'should return false' do
+          expect(instance.blobstore_config_changed?).to be(false)
+        end
+      end
+    end
+
     describe '#cloud_properties_changed?' do
       let(:instance_model) do
         model = Bosh::Director::Models::Instance.make(deployment: deployment)

--- a/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
@@ -188,8 +188,8 @@ module Bosh
             allow(cloud).to receive(:set_vm_metadata)
             allow(DeleteVmStep).to receive(:new).and_return(delete_vm_step)
             allow(App).to receive_message_chain(:instance, :blobstores, :blobstore).and_return(blobstore)
-            allow(blobstore).to receive(:can_sign_urls?).and_return(false)
             allow(blobstore).to receive(:validate!)
+            allow(blobstore).to receive(:redact_credentials).and_return([])
           end
 
           it 'sets vm on given report' do
@@ -323,7 +323,7 @@ module Bosh
             end
           end
 
-          context 'when the blobstore is configured to use signed urls' do
+          context 'with a blobstore config' do
             let(:agent_env_hash) do
               {
                 'blobstores' => [{
@@ -336,31 +336,36 @@ module Bosh
               }
             end
             before do
-              allow(blobstore).to receive(:can_sign_urls?).and_return(true)
-              allow(blobstore).to receive(:redacted_credential_properties_list).and_return(%w[my-key my-key-id])
               allow(Config).to receive(:agent_env).and_return(agent_env_hash)
-              allow(cloud_factory).to receive(:get).with('cpi1', stemcell_api_version).and_return(cloud_wrapper)
+              allow(blobstore).to receive(:redact_credentials).and_return('redacted-credentials')
+              # allow(cloud_factory).to receive(:get).with('cpi1', stemcell_api_version).and_return(cloud_wrapper)
             end
 
-            it 'validates blobstore configuration' do
-              expect(blobstore).to receive(:validate!).with(agent_env_hash['blobstores'].first['options'], anything)
-              allow(cloud_wrapper).to receive(:create_vm).and_return(create_vm_response)
-              subject.perform(report)
-            end
+            context 'and the blobstore is configured to use signed urls' do
+              before do
+                allow(blobstore).to receive(:can_sign_urls?).and_return(true)
+              end
 
-            it 'does not send blobstore credentials to the agent' do
-              expect(cloud_wrapper).to receive(:create_vm).with(
-                kind_of(String),
-                'stemcell-id', { 'ram' => '2gb' },
-                network_settings,
-                disks,
-                'bosh' => {
-                  'group' => expected_group,
-                  'groups' => expected_groups,
-                  'blobstores' => [{ 'options' => { 'allowed-key' => 'baz' } }],
-                }
-              ).and_return(create_vm_response)
-              subject.perform(report)
+              it 'validates blobstore configuration' do
+                expect(blobstore).to receive(:validate!).with(agent_env_hash['blobstores'].first['options'], anything)
+                allow(cloud_wrapper).to receive(:create_vm).and_return(create_vm_response)
+                subject.perform(report)
+              end
+
+              it 'does not send blobstore credentials to the agent' do
+                expect(cloud_wrapper).to receive(:create_vm).with(
+                  kind_of(String),
+                  'stemcell-id', { 'ram' => '2gb' },
+                  network_settings,
+                  disks,
+                  'bosh' => {
+                    'group' => expected_group,
+                    'groups' => expected_groups,
+                    'blobstores' => 'redacted-credentials',
+                  }
+                ).and_return(create_vm_response)
+                subject.perform(report)
+              end
             end
 
             context 'and the agent is unable to use signed urls' do
@@ -368,7 +373,7 @@ module Bosh
                 allow(blobstore).to receive(:can_sign_urls?).and_return(false)
               end
 
-              it 'still sends blobstore credentials to the agent' do
+              it 'sends blobstore credentials to the agent' do
                 expect(cloud_wrapper).to receive(:create_vm).with(
                   kind_of(String),
                   'stemcell-id', { 'ram' => '2gb' },

--- a/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
@@ -261,7 +261,13 @@ module Bosh
             ).and_return(create_vm_response)
 
             expect(agent_client).to receive(:wait_until_ready)
-            expect(Models::Vm).to receive(:create).with(hash_including(cid: 'new-vm-cid', instance: instance_model, stemcell_api_version: nil))
+            expect(Models::Vm).to receive(:create).with(hash_including(
+              cid: 'new-vm-cid',
+              instance: instance_model,
+              stemcell_api_version: nil,
+              blobstore_config_sha1: Config.blobstore_config_fingerprint,
+              nats_config_sha1: Config.nats_config_fingerprint
+            ))
 
             subject.perform(report)
           end

--- a/src/bosh-director/spec/unit/instance_updater/recreate_handler_spec.rb
+++ b/src/bosh-director/spec/unit/instance_updater/recreate_handler_spec.rb
@@ -29,7 +29,7 @@ module Bosh::Director
         end
 
         let(:instance) do
-          double(
+          instance_double(
             Instance,
             model: instance_model,
             update_instance_settings: true,
@@ -108,7 +108,7 @@ module Bosh::Director
             end
 
             it 'updates instance settings' do
-              expect(instance).to have_received(:update_instance_settings)
+              expect(instance).to have_received(:update_instance_settings).with(instance.model.active_vm)
             end
 
             context 'when it needs a disk' do

--- a/src/bosh-director/spec/unit/instance_updater/update_procedure_spec.rb
+++ b/src/bosh-director/spec/unit/instance_updater/update_procedure_spec.rb
@@ -466,7 +466,7 @@ module Bosh::Director
 
               it 'does not recreate the vm' do
                 expect(recreate_handler).to_not have_received(:perform)
-                expect(instance).to have_received(:update_instance_settings)
+                expect(instance).to have_received(:update_instance_settings).with(instance.model.active_vm)
               end
             end
           end

--- a/src/bosh-director/spec/unit/models/instance_spec.rb
+++ b/src/bosh-director/spec/unit/models/instance_spec.rb
@@ -375,6 +375,7 @@ module Bosh::Director::Models
           agent_id: 'my-agent-id',
           cid: 'my-cid',
           trusted_certs_sha1: 'trusted-sha',
+          blobstore_config_sha1: 'blobstore-config',
           instance_id: subject.id,
           cpi: 'my-cpi'
         )
@@ -411,6 +412,12 @@ module Bosh::Director::Models
           expect(subject.trusted_certs_sha1).to eq('trusted-sha')
         end
       end
+
+      describe 'blobstore_config_sha1' do
+        it 'returns active vms blobstore_config_sha1' do
+          expect(subject.blobstore_config_sha1).to eq('blobstore-config')
+        end
+      end
     end
 
     context 'without active vm' do
@@ -442,6 +449,12 @@ module Bosh::Director::Models
       describe 'trusted_certs_sha1' do
         it 'returns sha1 digest of empty string' do
           expect(subject.trusted_certs_sha1).to eq(::Digest::SHA1.hexdigest(''))
+        end
+      end
+
+      describe 'blobstore_config_sha1' do
+        it 'returns nil' do
+          expect(subject.blobstore_config_sha1).to be_nil
         end
       end
     end

--- a/src/bosh-director/spec/unit/models/instance_spec.rb
+++ b/src/bosh-director/spec/unit/models/instance_spec.rb
@@ -376,6 +376,7 @@ module Bosh::Director::Models
           cid: 'my-cid',
           trusted_certs_sha1: 'trusted-sha',
           blobstore_config_sha1: 'blobstore-config',
+          nats_config_sha1: 'nats-config',
           instance_id: subject.id,
           cpi: 'my-cpi'
         )
@@ -418,6 +419,12 @@ module Bosh::Director::Models
           expect(subject.blobstore_config_sha1).to eq('blobstore-config')
         end
       end
+
+      describe 'nats_config_sha1' do
+        it 'returns active vms nats_config_sha1' do
+          expect(subject.nats_config_sha1).to eq('nats-config')
+        end
+      end
     end
 
     context 'without active vm' do
@@ -455,6 +462,12 @@ module Bosh::Director::Models
       describe 'blobstore_config_sha1' do
         it 'returns nil' do
           expect(subject.blobstore_config_sha1).to be_nil
+        end
+      end
+
+      describe 'nats_config_sha1' do
+        it 'returns nil' do
+          expect(subject.nats_config_sha1).to be_nil
         end
       end
     end


### PR DESCRIPTION
Currently rotating nats or blobstore certs, vms need to be recreated so BOSH agent can get the new certs. 

This was proposed https://github.com/cloudfoundry/bosh/discussions/2309 and is the PR for the changes on the director side