### PR TITLE
add chruby

### DIFF
--- a/ci/dockerfiles/main-ruby-go/install-ruby.sh
+++ b/ci/dockerfiles/main-ruby-go/install-ruby.sh
@@ -3,8 +3,20 @@
 set -e
 set -x
 
+CHRUBY_VER="0.3.9"
+CHRUBY_URL=https://github.com/postmodern/chruby/archive/v${CHRUBY_VER}.tar.gz
+
 RUBY_INSTALL_VER="0.8.1"
 RUBY_INSTALL_URL=https://github.com/postmodern/ruby-install/archive/v${RUBY_INSTALL_VER}.tar.gz
+
+echo "Installing chruby v${CHRUBY_VER}..."
+wget -O chruby-${CHRUBY_VER}.tar.gz https://github.com/postmodern/chruby/archive/v${CHRUBY_VER}.tar.gz
+tar -xzvf chruby-${CHRUBY_VER}.tar.gz
+cd chruby-${CHRUBY_VER}/
+scripts/setup.sh
+cd ..
+rm -rf chruby-${CHRUBY_VER}/
+rm chruby-${CHRUBY_VER}.tar.gz
 
 echo "Installing ruby-install v${RUBY_INSTALL_VER}..."
 wget -O ruby-install-${RUBY_INSTALL_VER}.tar.gz $RUBY_INSTALL_URL
@@ -22,6 +34,9 @@ install_ruby() {
     echo "Installing ruby $version..."
     ruby-install --jobs=2 --cleanup --system --sha256 "$sha" ruby "$version" -- --disable-install-rdoc
 
+    source /etc/profile.d/chruby.sh
+
+    chruby "ruby-$version"
     ruby -v
     gem update --system
 


### PR DESCRIPTION
add chruby to the main-ruby-go docker image.

it seems it was removed since we moved from the old-docker files