### PR TITLE
Remove unnecessary job properties for Agent creds

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -411,10 +411,6 @@ properties:
     description: Username director uses to connect to blobstore used by simple blobstore plugin
   blobstore.director.password:
     description: Password director uses to connect to blobstore used by simple blobstore plugin
-  blobstore.agent.user:
-    description: Username agent uses to connect to blobstore used by simple blobstore plugin
-  blobstore.agent.password:
-    description: Password agent uses to connect to blobstore used by simple blobstore plugin
   blobstore.tls.cert.ca:
     description: CA Cert for TLS communcation with blobstore
   blobstore.enable_signed_urls:


### PR DESCRIPTION
### What is this change about?

Here we remove the `blobstore.agent.user` and `blobstore.agent.password` properties from the `director` job spec.

### Please provide contextual information.

The properties `blobstore.agent.user` and `blobstore.agent.password` are not used within the BOSH Director's code base.

This work is also consistent with the currently on-going PR #2323, where the Blobstore credentials (that are sent with the newly-extended `update_settings` NATS message) are coming from `agent.env.bosh.blobstores` director configuration.

The new “signed URLs” documentation also states that CPIs are sending the Blobstore credentials in the `env.bosh.blobstores` array.
https://bosh.io/docs/director-blobstore-signed-urls/#removing-blobstore-credentials-from-agent-vm

#### Related PRs:
- cloudfoundry/bosh-deployment#422

### What tests have you run against this PR?

Unit tests for the BOSH Release templates are passing, as executed with `(cd src && bundle exec rspec ../spec)`.

### How should this change be described in bosh release notes?

- Removed the unnecessary properties `blobstore.agent.user` and `blobstore.agent.password` from the `director` job.

### Does this PR introduce a breaking change?

With the verifications detailed above, this change is meant to be a no-op.

### Tag your pair, your PM, and/or team!

Co-Authored-By: @olivermautschke
