### PR TITLE
Improve description for director's job properties

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -429,10 +429,15 @@ properties:
 
   # Compiled Package Cache
   compiled_package_cache.provider:
-    description: Provider of the blobstore used for the compiled package cache
+    description: |
+      Provider of the blobstore used for the compiled package cache.
+      Possible values are: 'local', 's3' and 'gcs'.
+      A value of 'local' is implied (and thus optional) when blobstore_path is provided.
     default: 's3'
   compiled_package_cache.options.bucket_name:
-    description: AWS S3 Bucket used for the compiled package cache
+    description: AWS S3 or GCS Bucket used for the compiled package cache
+  compiled_package_cache.options.blobstore_path:
+    description: Local directory where blobs will be stored. Implies a provider of 'local'.
 
   compiled_package_cache.options.credentials_source:
     description:  AWS credentials (static / env_or_profile)


### PR DESCRIPTION
### What is this change about?

Here we improve the description for some director's job properties related to compiled package cache

### Please provide contextual information.

The property `provider` is actually unnecessary when `blobstore_path` is provided.

### What tests have you run against this PR?

Unit tests for the BOSH Release templates are passing, as executed with `(cd src && bundle exec rspec ../spec)`.

### How should this change be described in bosh release notes?

These minor changes should not be necessary to appear in the release notes.

### Does this PR introduce a breaking change?

No, this is definitely related to documentation only.

### Tag your pair, your PM, and/or team!

Co-Authored-By: @olivermautschke
