### PR TITLE
Changes to make spec:unit:parallel more useful

### DIFF
--- a/src/bosh-dev/lib/bosh/dev/test_runner.rb
+++ b/src/bosh-dev/lib/bosh/dev/test_runner.rb
@@ -3,35 +3,53 @@ require 'common/thread_pool'
 module Bosh::Dev
   class TestRunner
     def ruby(parallel: false)
+      error_happened = false
       log_dir = Dir.mktmpdir
       puts "Logging spec results in #{log_dir}"
+      test_output_lock = Mutex.new
 
       max_threads = ENV.fetch('BOSH_MAX_THREADS', 10).to_i
       null_logger = Logging::Logger.new('Ignored')
       Bosh::ThreadPool.new(max_threads: max_threads, logger: null_logger).wrap do |pool|
         unit_builds.each do |build|
           pool.process do
-            unit_exec(build, log_file: "#{log_dir}/#{build}.log", parallel: parallel)
+            test_return = unit_exec(build, log_file: "#{log_dir}/#{build}.log", parallel: parallel)
+            if test_return[:error] == true
+              error_happened = true
+            end
+            test_output_lock.synchronize {
+              puts test_return[:lines]
+            }
           end
         end
 
         pool.wait
       end
+
+      if error_happened
+        raise "Failed while running tests. See output above for more information."
+      end
     end
 
     def unit_exec(build, log_file: nil, parallel: false)
+      lines = []
       command = parallel ? unit_parallel(build, log_file) : unit_cmd(log_file)
 
       # inject command name so coverage results for each component don't clobber others
       if Kernel.system({'BOSH_BUILD_NAME' => build}, "cd #{build} && #{command}")
-        puts "----- BEGIN #{build}"
-        puts "            #{command}"
-        print File.read(log_file) if log_file && File.exists?(log_file)
-        puts "----- END   #{build}\n\n"
+        lines.append "----- BEGIN #{build}"
+        lines.append "            #{command}"
+        lines.append(File.read(log_file)) if log_file && File.exists?(log_file)
+        lines.append "----- END   #{build}\n\n"
+        return {:lines => lines, :error => false}
       else
-        error_message = "#{build} failed to build unit tests"
+        lines.append "----- BEGIN #{build}"
+        lines.append "            #{command}"
+        error_message = "#{build} failed to build or run unit tests"
         error_message += ": #{File.read(log_file)}" if log_file && File.exists?(log_file)
-        raise error_message
+        lines.append "            #{error_message}\n"
+        lines.append "----- END   #{build}\n\n"
+        return {:lines => lines, :error => true}
       end
     end
 
@@ -43,7 +61,7 @@ module Bosh::Dev
     end
 
     def unit_parallel(build_name, log_file = nil)
-      cmd = "parallel_test --type rspec --runtime-log /tmp/bosh_#{build_name}_parallel_runtime_rspec.log spec"
+      cmd = "parallel_test --test-options '--no-fail-fast' --type rspec --runtime-log /tmp/bosh_#{build_name}_parallel_runtime_rspec.log spec"
       cmd << " > #{log_file} 2>&1" if log_file
       cmd
     end

--- a/src/bosh-dev/spec/unit/bosh/dev/test_runner_spec.rb
+++ b/src/bosh-dev/spec/unit/bosh/dev/test_runner_spec.rb
@@ -38,13 +38,13 @@ module Bosh::Dev
     describe '#unit_parallel' do
       it 'builds an parallel_test command' do
         expect(runner.unit_parallel('rocket')).to eq(
-          'parallel_test --type rspec --runtime-log /tmp/bosh_rocket_parallel_runtime_rspec.log spec',
+          "parallel_test --test-options '--no-fail-fast' --type rspec --runtime-log /tmp/bosh_rocket_parallel_runtime_rspec.log spec",
         )
       end
 
       it 'redirects output if logfile passed' do
         expect(runner.unit_parallel('pumpkin', 'potato.log')).to eq(
-          'parallel_test --type rspec --runtime-log /tmp/bosh_pumpkin_parallel_runtime_rspec.log spec > potato.log 2>&1',
+          "parallel_test --test-options '--no-fail-fast' --type rspec --runtime-log /tmp/bosh_pumpkin_parallel_runtime_rspec.log spec > potato.log 2>&1",
         )
       end
     end
@@ -61,10 +61,11 @@ module Bosh::Dev
         runner.unit_exec(build)
       end
 
-      it 'raises an error if the command fails' do
+      it 'signals failure if the command fails' do
         allow(Kernel).to receive(:system).and_return(false)
 
-        expect { runner.unit_exec(build) }.to raise_error(/#{build} failed to build unit tests/)
+        retval = runner.unit_exec(build)
+        expect(retval[:error]).to equal(true)
       end
     end
 
@@ -75,7 +76,7 @@ module Bosh::Dev
         end
 
         it 'raises and error' do
-          expect { runner.ruby }.to raise_error(/failed to build unit tests/)
+          expect { runner.ruby }.to raise_error(/Failed while running tests. See output above for more information./)
         end
       end
 


### PR DESCRIPTION
This PR makes changes that make the `spec:unit:parallel` rake task more useful. Check the commit message for more information.

### What is this change about?, and please provide contextual information.

See the commit message for this information.

### What tests have you run against this PR?

I have run the `spec:unit:parallel` rake task. It now behaves as expected, and still will exit non-zero if any tests it ran failed, which should preserve its previous behavior.

I can think of no other tests that  can be reasonably run.

### How should this change be described in bosh release notes?

If you wish to include this information in the release notes, I would describe it as:

"Enhancement": Running the Bosh Director unit specs with the `spec:unit:parallel` rake task will no longer stop after the first failing test.

### Does this PR introduce a breaking change?

Not as far as I know.

### Tag your pair, your PM, and/or team!

This work was done solo.