### PR TITLE
Adds test-running and minimum Ruby version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ Cloud Foundry BOSH is an open source tool for release engineering, deployment, l
 ## Contributions
 
 Please read the [contributors' guide](https://github.com/cloudfoundry/bosh/blob/master/CONTRIBUTING.md)
+
+## Minimum software requirements
+
+Ruby 3.0.2 or later
+
+## Running the tests
+
+The code and all tests live in the `src` directory. All commands assume that `src` is your current working directory, and that `bundle install` has been run from that directory to install all required Ruby gems.
+
+### Unit Tests
+
+Either run `bundle exec rake unit:spec` or `bundle exec rake unit:spec:parallel`.
+
+The latter will run all unit tests, and should spread the load across all of the logical CPU cores that you have on your system.


### PR DESCRIPTION
This commit tells folks the minimum version of Ruby required to run the
tests (and -presumably- run the software under test), as well as how to
run the unit tests.

Because neither the CONTRIBUTING file, nor the README file currently
contain this information, I'm putting it in the README file.

Feel free to move the information to another file if that's more appropriate.