### PR TITLE
Leverage the new BPM `shutdown_signal` feature in Postgres jobs

### DIFF
--- a/jobs/postgres-10/monit
+++ b/jobs/postgres-10/monit
@@ -1,5 +1,5 @@
 check process postgres
   with pidfile /var/vcap/sys/run/bpm/postgres-10/postgres-10.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start postgres-10" with timeout 300 seconds
-  stop program "/var/vcap/jobs/postgres-10/bin/bpm-stop-postgres"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop postgres-10"
   group vcap

--- a/jobs/postgres-10/spec
+++ b/jobs/postgres-10/spec
@@ -7,7 +7,6 @@ templates:
   create-database.erb: bin/create-database
   postgres.erb: bin/postgres
   postgresql.conf.erb: config/postgresql.conf
-  bpm-stop-postgres: bin/bpm-stop-postgres
 
 packages:
   - postgres-10

--- a/jobs/postgres-10/templates/bpm-stop-postgres
+++ b/jobs/postgres-10/templates/bpm-stop-postgres
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e -o pipefail
-
-postgres_pid=$(/var/vcap/packages/bpm/bin/bpm pid postgres-10)
-kill -s SIGINT "${postgres_pid}"
-
-/var/vcap/jobs/bpm/bin/bpm stop postgres-10

--- a/jobs/postgres-10/templates/bpm.yml
+++ b/jobs/postgres-10/templates/bpm.yml
@@ -3,6 +3,7 @@
 postgres_config = {
   "name" => "postgres-10",
   "executable" => "/var/vcap/jobs/postgres-10/bin/postgres",
+  "shutdown_signal" => "INT",
   "persistent_disk" => true,
   "limits" => {
     "open_files" => 65536,

--- a/jobs/postgres-9.4/monit
+++ b/jobs/postgres-9.4/monit
@@ -1,5 +1,5 @@
 check process postgres
   with pidfile /var/vcap/sys/run/bpm/postgres-9.4/postgres-9.4.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start postgres-9.4" with timeout 300 seconds
-  stop program "/var/vcap/jobs/postgres-9.4/bin/bpm-stop-postgres"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop postgres-9.4"
   group vcap

--- a/jobs/postgres-9.4/spec
+++ b/jobs/postgres-9.4/spec
@@ -7,7 +7,6 @@ templates:
   create-database.erb: bin/create-database
   postgres.erb: bin/postgres
   postgresql.conf.erb: config/postgresql.conf
-  bpm-stop-postgres: bin/bpm-stop-postgres
 
 packages:
   - postgres-9.4

--- a/jobs/postgres-9.4/templates/bpm-stop-postgres
+++ b/jobs/postgres-9.4/templates/bpm-stop-postgres
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e -o pipefail
-
-postgres_pid=$(/var/vcap/packages/bpm/bin/bpm pid postgres-9.4)
-kill -s SIGINT "${postgres_pid}"
-
-/var/vcap/jobs/bpm/bin/bpm stop postgres-9.4

--- a/jobs/postgres-9.4/templates/bpm.yml
+++ b/jobs/postgres-9.4/templates/bpm.yml
@@ -3,6 +3,7 @@
 postgres_config = {
   "name" => "postgres-9.4",
   "executable" => "/var/vcap/jobs/postgres-9.4/bin/postgres",
+  "shutdown_signal" => "INT",
   "persistent_disk" => true,
   "limits" => {
     "open_files" => 65536,

--- a/jobs/postgres/monit
+++ b/jobs/postgres/monit
@@ -1,5 +1,5 @@
 check process postgres
   with pidfile /var/vcap/sys/run/bpm/postgres/postgres.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start postgres" with timeout 300 seconds
-  stop program "/var/vcap/jobs/postgres/bin/bpm-stop-postgres"
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop postgres"
   group vcap

--- a/jobs/postgres/spec
+++ b/jobs/postgres/spec
@@ -7,7 +7,6 @@ templates:
   create-database.erb: bin/create-database
   postgres.erb: bin/postgres
   postgresql.conf.erb: config/postgresql.conf
-  bpm-stop-postgres: bin/bpm-stop-postgres
 
 packages:
   - postgres-13

--- a/jobs/postgres/templates/bpm-stop-postgres
+++ b/jobs/postgres/templates/bpm-stop-postgres
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -e -o pipefail
-
-postgres_pid=$(/var/vcap/packages/bpm/bin/bpm pid postgres)
-kill -s SIGINT "${postgres_pid}"
-
-/var/vcap/jobs/bpm/bin/bpm stop postgres

--- a/jobs/postgres/templates/bpm.yml
+++ b/jobs/postgres/templates/bpm.yml
@@ -3,6 +3,7 @@
 postgres_config = {
   "name" => "postgres",
   "executable" => "/var/vcap/jobs/postgres/bin/postgres",
+  "shutdown_signal" => "INT",
   "additional_volumes" => [
     {
       "path" => "/var/vcap/store/postgres-13",

--- a/spec/postgres_bpm_spec.rb
+++ b/spec/postgres_bpm_spec.rb
@@ -1,0 +1,49 @@
+require 'yaml'
+require 'bosh/template/evaluation_context'
+require_relative './template_example_group'
+
+shared_examples 'rendered postgres* bpm.yml' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '..')) }
+  let(:template) { job.template('config/bpm.yml') }
+
+  subject(:rendered_template) do
+    YAML.load(template.render(properties))
+  end
+
+  context 'with standard config' do
+    let(:properties) do
+      {
+        postgres: {
+          adapter: "postgres",
+          database: "bosh",
+          host: "127.0.0.1",
+          listen_address: "127.0.0.1",
+          password: "secret",
+          user: "postgres",
+        },
+      }
+    end
+
+    it 'should use SIGINT as shutdown signal' do
+      expect(rendered_template['processes'][0]).to include('shutdown_signal' => 'INT')
+    end
+  end
+end
+
+describe 'postgres job' do
+  it_should_behave_like 'rendered postgres* bpm.yml' do
+    let(:job) { release.job('postgres') }
+  end
+end
+
+describe 'postgres-10 job' do
+  it_should_behave_like 'rendered postgres* bpm.yml' do
+    let(:job) { release.job('postgres-10') }
+  end
+end
+
+describe 'postgres-9.4 job' do
+  it_should_behave_like 'rendered postgres* bpm.yml' do
+    let(:job) { release.job('postgres-9.4') }
+  end
+end


### PR DESCRIPTION


### What is this change about?

Now that BPM v1.1.14 is shipped and used in `bosh-deployment`, we can use the new `shutdown_signal` feature.

### Please provide contextual information.

- Using `SIGINT` to shutdown Postgres was recently implemented in: #2320
- The new BPM that ships with the `shutdown_signal` feature is out: https://github.com/cloudfoundry/bpm-release/releases/tag/v1.1.14
- This version has been adopted in `bosh-deployment`: https://github.com/cloudfoundry/bosh-deployment/blob/master/bosh.yml#L147-L150

### What tests have you run against this PR?

```
./scripts/test-unit-erb
```

### How should this change be described in bosh release notes?

- Refactored the Postgres jobs to leverage the new `shutdown_signal` feature provided by BPM v1.1.14+

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!

Solo-ed on this.