### PR TITLE
Use IO#readline_nonblock instead of IO#readline when reading output from CPI sub-processes.

### DIFF
--- a/src/bosh-director/lib/cloud/external_cpi.rb
+++ b/src/bosh-director/lib/cloud/external_cpi.rb
@@ -142,6 +142,8 @@ module Bosh::Clouds
             end
           rescue EOFError
             files.delete f
+          rescue IO::WaitReadable
+            # do nothing
           end
         end
         exit_status = wait_thr.value.exitstatus

--- a/src/bosh-director/lib/cloud/external_cpi.rb
+++ b/src/bosh-director/lib/cloud/external_cpi.rb
@@ -1,6 +1,28 @@
 require 'membrane'
 require 'open3'
 
+# Robbed from:
+# https://github.com/Homebrew/brew/blob/master/Library/Homebrew/extend/io.rb
+class IO
+  def readline_nonblock(sep = $INPUT_RECORD_SEPARATOR)
+    line = +""
+    buffer = +""
+
+    loop do
+      break if buffer == sep
+
+      read_nonblock(1, buffer)
+      line.concat(buffer)
+    end
+
+    line.freeze
+  rescue IO::WaitReadable, EOFError => e
+    raise e if line.empty?
+
+    line.freeze
+  end
+end
+
 module Bosh::Clouds
   class ExternalCpi
     # Raised when the external CPI executable returns an error unknown to director
@@ -110,7 +132,7 @@ module Bosh::Clouds
 
           readable = ready[0]
           readable.each do |f|
-            line = f.readline
+            line = f.readline_nonblock
             case f.fileno
             when stdout.fileno
               cpi_response.write(line)

--- a/src/bosh-director/spec/assets/bin/dummy_cpi
+++ b/src/bosh-director/spec/assets/bin/dummy_cpi
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+# Dummy cpi to test for a dealock scenario when a cpi sends an inclomplete line (missing line break) to STDOUT
+
+# Force the reading end to see incomplete line so that it blocks on 'readline' method
+# by $stdout.sync = true
+$stdout.sync = true
+$stdout.print('{"result":"OK","log":"LogMessage","error":null}')
+
+sleep 1
+
+# send a massive amount of output to fill the pipe buffer (64 KB) so that this script blocks on the next line
+$stderr.print('abcdefghijklmnopqrstuwxyz' * 100000)

--- a/src/bosh-director/spec/unit/cloud/external_cpi_response_wrapper_spec.rb
+++ b/src/bosh-director/spec/unit/cloud/external_cpi_response_wrapper_spec.rb
@@ -30,12 +30,12 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
     allow(stdout).to receive(:fileno).and_return(1)
 
     stdout_reponse_values = [cpi_response, nil, cpi_response, nil, cpi_response, nil]
-    allow(stdout).to receive(:readline) { stdout_reponse_values.shift || raise(EOFError) }
+    allow(stdout).to receive(:readline_nonblock) { stdout_reponse_values.shift || raise(EOFError) }
 
     allow(stderr).to receive(:fileno).and_return(2)
 
     stderr_reponse_values = [cpi_error, nil, cpi_error, nil, cpi_error, nil]
-    allow(stderr).to receive(:readline) { stderr_reponse_values.shift || raise(EOFError) }
+    allow(stderr).to receive(:readline_nonblock) { stderr_reponse_values.shift || raise(EOFError) }
   end
 
   before(:each) do


### PR DESCRIPTION


IO.#readline, being a blocking method, can cause a dealock when the cpi
sends output without a line break. We had such issues with azure cpi.

### What is this change about?

_Describe the change and why it's needed._

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What tests have you run against this PR?

_Include a comprehensive list of all tests run successfully._

### How should this change be described in bosh release notes?

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/bosh/releases) for examples._


### Does this PR introduce a breaking change?

_Does this introduce changes that would require operators to take care in order to upgrade without a failure?_

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
