### PR TITLE
systems with libyaml versions 02.0 > version < 0.2.5 would fail tests…

### DIFF
--- a/src/bosh-director/spec/unit/manifest/changeset_spec.rb
+++ b/src/bosh-director/spec/unit/manifest/changeset_spec.rb
@@ -770,7 +770,7 @@ module Bosh::Director
       end
 
       it 'does not error' do
-        extra_whitespace = YAML::LIBYAML_VERSION =~ /^0.2/ ? '' : ' '
+        extra_whitespace = Gem::Version.new(YAML::LIBYAML_VERSION) >= Gem::Version.new('0.2.5')  ? '' : ' '
         expect(changeset).to eq([
           ['service_catalog:', nil],
           ['  plans:', nil],
@@ -797,7 +797,7 @@ module Bosh::Director
         end
 
         it 'does not error' do
-          extra_whitespace = YAML::LIBYAML_VERSION =~ /^0.2/ ? '' : ' '
+          extra_whitespace = Gem::Version.new(YAML::LIBYAML_VERSION) >= Gem::Version.new('0.2.5')  ? '' : ' '
           expect(changeset).to eq([
             ['service_catalog:', nil],
             ['  plans:', nil],


### PR DESCRIPTION
…. 

### What is this change about?

The extra whitespace is added in 95ba1d1d8351d0da20711966d3893c7fc7705c73 was breaking tests on an ubuntu with libyaml version 0.2.2

### Please provide contextual information.

95ba1d1d8351d0da20711966d3893c7fc7705c73  introduced an additional whitespace into the test for libyaml versions starting with 0.2. the tests failed on an ubuntu wsl where ruby was using libyaml 0.2.2. I checked for the version of libyaml by installing it from  source and found that any version higher than 0.2x version < 0.2.5 would fail too starting from  version 0.2.4

### What tests have you run against this PR?

bundle exec rspec ./spec/unit/manifest/changeset_spec.rb

### How should this change be described in bosh release notes?

probably not at all as it fixes a test

### Does this PR introduce a breaking change?

no

### Tag your pair, your PM, and/or team!
@rkoster 
