### PR TITLE
Aborts errand run if instance(s) are stopped

### DIFF
--- a/src/bosh-director/lib/bosh/director/errand/errand_provider.rb
+++ b/src/bosh-director/lib/bosh/director/errand/errand_provider.rb
@@ -24,6 +24,18 @@ module Bosh::Director
       matcher = Errand::InstanceMatcher.new(requested_instances)
       instances, unmatched_filters = matcher.match(instances_from_db)
 
+      # Check if any of the instances are stopped because we don't know why an operator stopped an instance,
+      # maybe it might be colocated with other jobs to save time on rebooting vms but forgot it was stopped.
+      # Since we don't know why an instance is stopped, it is safer to error out.
+      stopped_instances = []
+      instances.each do |instance|
+        stopped_instances << "'#{instance.name}'" if instance.stopped?
+      end
+      unless stopped_instances.empty?
+        instance_string = stopped_instances.join(',')
+        raise RunErrandError, "Instance(s) #{instance_string} is stopped, unable to run errand. Maybe start vm?"
+      end
+
       event_log_stage.advance_and_track('Preparing deployment') do
         deployment_planner = @deployment_planner_provider.get_by_name(deployment_name, instances)
         dns_encoder = LocalDnsEncoderManager.create_dns_encoder(deployment_planner.use_short_dns_addresses?, deployment_planner.use_link_dns_names?)

--- a/src/bosh-director/spec/unit/errand/errand_provider_spec.rb
+++ b/src/bosh-director/spec/unit/errand/errand_provider_spec.rb
@@ -549,6 +549,27 @@ module Bosh::Director
           end
         end
 
+        context 'when there is a lifecycle: errand and instance is stopped' do
+          let(:instance_group) do
+            instance_double(DeploymentPlan::InstanceGroup,
+                            name: ig_name,
+                            jobs: [errand_job, non_errand_job],
+                            instances: [],
+                            errand?: true,
+                            needed_instance_plans: needed_instance_plans,
+                            bind_instances: nil)
+          end
+
+          let!(:instance_model) { Models::Instance.make(deployment: deployment_model, uuid: 'instance-uuid', state: 'stopped') }
+
+          it 'returns an error that instance is stopped' do
+            expect do
+              subject.get(deployment_name, ig_name, keep_alive, instance_slugs)
+            end.to raise_error(RunErrandError,
+                               "Instance(s) 'job-1/instance-uuid' is stopped, unable to run errand. Maybe start vm?")
+          end
+        end
+
         context 'when there is not a lifecycle: errand instance group with that name' do
           let(:instance_group) do
             instance_double(


### PR DESCRIPTION
A customer discovered a problem when running an errand on a VM that
was stopped with `bosh stop`. It is our understanding that Bosh will
never `stop` a VM automatically; this is a manual process that an
operator must perform.

Because we can't know why an operator stopped an instance that might
be used to run an errand, it's safer to just halt the planning process
and raise an error that informs the operator that manual intervention
is required.

We're not sure if this behavior is correct, thoughts?