### PR TITLE
Fix config rollback behavior.

### DIFF
--- a/src/bosh-director/lib/bosh/director/models/config.rb
+++ b/src/bosh-director/lib/bosh/director/models/config.rb
@@ -9,7 +9,7 @@ module Bosh
         end
 
         def self.latest_set(type)
-          find_by_ids(dataset.select { max(:id) }.where(type: type).group_by(:name)).reject(&:deleted)
+          find_by_ids(dataset.select { max(:id) }.where(type: type, deleted: false).group_by(:name))
         end
 
         def self.dataset_for_teams(*teams)
@@ -17,8 +17,9 @@ module Bosh
         end
 
         def self.latest_set_for_teams(type, *teams)
-          latest_config_ids_by_name = dataset_for_teams(*teams).select { max(:id) }.where(type: type).group_by(:name)
-          find_by_ids(latest_config_ids_by_name).reject(&:deleted)
+          latest_config_ids_by_name = dataset_for_teams(*teams).select { max(:id) }
+            .where(type: type, deleted: false).group_by(:name)
+          find_by_ids(latest_config_ids_by_name)
         end
 
         def self.find_by_ids(ids)


### PR DESCRIPTION
- Currently, if you add another version of an existing config (same name
  and type), then delete that config, when deploying, bosh won't find
  the prior config and will remove it from the deployment entirely. This
  is surprising behavior because bosh configs correctly lists the prior
  version. This commit fixes that behavior so that bosh will use the
  prior version configuration in this scenario.
[#179020742]

Signed-off-by: Rajan Agaskar <ragaskar@vmware.com>

### What is this change about?

_Describe the change and why it's needed._

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What tests have you run against this PR?

_Include a comprehensive list of all tests run successfully._

### How should this change be described in bosh release notes?

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/bosh/releases) for examples._


### Does this PR introduce a breaking change?

_Does this introduce changes that would require operators to take care in order to upgrade without a failure?_

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
