### PR TITLE
bugfix/remove compiled package cache from integration tests

### DIFF
--- a/src/bosh-director/spec/assets/test-director-config.yml
+++ b/src/bosh-director/spec/assets/test-director-config.yml
@@ -27,9 +27,6 @@ cpi_api_test_max_version: 2
 local_dns:
   enabled: false
   include_index: false
-  provider: local
-  options:
-    blobstore_path: /path/to/some/bucket
 snapshots:
   enabled: false
 scan_and_fix:

--- a/src/spec/integration/vm_types_and_stemcells_spec.rb
+++ b/src/spec/integration/vm_types_and_stemcells_spec.rb
@@ -168,7 +168,7 @@ describe 'vm_types and stemcells', type: :integration do
         deploy_simple_manifest(manifest_hash: manifest_hash_different_stemcell)
 
         new_create_vm_invocations = current_sandbox.cpi.invocations_for_method('create_vm')
-        expect(new_create_vm_invocations.count).to eq(create_vm_invocations.count + 1)
+        expect(new_create_vm_invocations.count).to eq(create_vm_invocations.count + 3)
       end
 
       context 'create-swap-delete' do


### PR DESCRIPTION
https://github.com/cloudfoundry/bosh/pull/2338 removed the compiled package cache but did not update integration tests. 

removes a full test that explicitly checks the compiled package cache

additionally updates another test that implicitly relied on the compiled package cache. According to bosh debug logs, it downloaded the packages from the cache on the second deployment of the test and therefore did not require to start
compilation vms on deploying the second stemcell. It now needs to create two additional vms for compilation after a stemcell switch.

