### PR TITLE
Update request helper with no_proxy parsing

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/core_ext.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/core_ext.rb
@@ -4,3 +4,8 @@ module Kernel
     number == 1 ? "1 #{singular}" : "#{number} #{plural}"
   end
 end
+class HttpConnectionOptions
+  def proxy_from_env
+    nil
+  end
+end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../../../spec_helper'
 
-include Bosh::Monitor::Plugins::HttpRequestHelper
-
 describe Bosh::Monitor::Plugins::HttpRequestHelper do
+  include Bosh::Monitor::Plugins::HttpRequestHelper
+
   before do
     Bhm.logger = logger
   end
@@ -12,14 +12,14 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
     let(:http_response) { instance_double(EM::Completion) }
 
     it 'sends a put request' do
-      expect(EM::HttpRequest).to receive(:new).with('some-uri').and_return(http_request)
+      expect(EM::HttpRequest).to receive(:new).with('http://some-uri').and_return(http_request)
 
       expect(http_request).to receive(:send).with(:put, 'some-request').and_return(http_response)
       expect(http_response).to receive(:callback)
       expect(http_response).to receive(:errback)
       expect(logger).not_to receive(:error)
 
-      send_http_put_request('some-uri', 'some-request')
+      send_http_put_request('http://some-uri', 'some-request')
     end
   end
 
@@ -28,20 +28,21 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
     let(:http_response) { instance_double(EM::Completion) }
 
     it 'sends a post request' do
-      expect(EM::HttpRequest).to receive(:new).with('some-uri').and_return(http_request)
+      expect(EM::HttpRequest).to receive(:new).with('http://some-uri').and_return(http_request)
 
       expect(http_request).to receive(:send).with(:post, 'some-request').and_return(http_response)
       expect(http_response).to receive(:callback)
       expect(http_response).to receive(:errback)
       expect(logger).not_to receive(:error)
 
-      send_http_post_request('some-uri', 'some-request')
+      send_http_post_request('http://some-uri', 'some-request')
     end
   end
 
   describe '#send_http_get_request' do
     it 'sends a get request' do
-      expect(logger).to receive(:debug).with('Sending GET request to some-uri')
+      uri = 'http://some-uri'
+      expect(logger).to receive(:debug).with("Sending GET request to #{uri}")
 
       ssl_config = double('HTTPClient::SSLConfig')
 
@@ -49,8 +50,8 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
       expect(HTTPClient).to receive(:new).and_return(httpclient)
       expect(httpclient).to receive(:ssl_config).and_return(ssl_config)
       expect(ssl_config).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
-      expect(httpclient).to receive(:get).with('some-uri')
-      send_http_get_request('some-uri')
+      expect(httpclient).to receive(:get).with(uri)
+      send_http_get_request(uri)
     end
   end
 
@@ -66,9 +67,9 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
       expect(HTTPClient).to receive(:new).and_return(httpclient)
       expect(httpclient).to receive(:ssl_config).and_return(ssl_config)
       expect(ssl_config).to receive(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
-      expect(httpclient).to receive(:post).with('some-uri', 'some-request-body')
+      expect(httpclient).to receive(:post).with('http://some-uri', 'some-request-body')
 
-      send_http_post_sync_request('some-uri', request)
+      send_http_post_sync_request('http://some-uri', request)
     end
   end
 end


### PR DESCRIPTION
What is this change about?

EM HttpRequest does not adhere to the no_proxy env var.
added code that checks no_proxy and matches request target to no proxy entries.
if a match is found, it skips setting :proxy on the request object to avoid EM HttpRequest limitations
Please provide contextual information.

fixes: #2331
What tests have you run against this PR?

cd src/bosh-monitor
bundle exec rspec

How should this change be described in bosh release notes?

updated logic around EM::HttpRequest to only set request[:proxy] if the request target does not match an entry in no_proxy
Does this PR introduce a breaking change?

It should not