### PR TITLE
Speed up templating rendering

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_spec.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_spec.rb
@@ -140,7 +140,7 @@ module Bosh::Director
 
         template_hash = @full_spec.select {|k,v| keys.include?(k) }
 
-        template_hash['properties'] =  @variables_interpolator.interpolate_template_spec_properties(@full_spec['properties'], @full_spec['deployment'], @variable_set)
+        template_hash['properties'] =  @variables_interpolator.interpolate_template_spec_properties(@full_spec['properties'], @full_spec['deployment'], @instance.instance_group_name, @variable_set)
 
         template_hash['links'] = {}
 

--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -234,6 +234,7 @@ module Bosh::Director
               @variables_interpolator.interpolate_template_spec_properties(
                 instance_group.properties,
                 deployment_name,
+                instance_group.name,
                 current_variable_set,
               )
             end
@@ -251,7 +252,7 @@ module Bosh::Director
           instance_group_errors = []
 
           begin
-            @variables_interpolator.interpolate_template_spec_properties(instance_group.properties, deployment_name, current_variable_set)
+            @variables_interpolator.interpolate_template_spec_properties(instance_group.properties, deployment_name, instance_group.name, current_variable_set)
             unless instance_group&.env&.spec.nil?
               @variables_interpolator.interpolate_with_versioning(instance_group.env.spec, current_variable_set)
             end

--- a/src/bosh-director/spec/unit/config_server/variables_interpolator_spec.rb
+++ b/src/bosh-director/spec/unit/config_server/variables_interpolator_spec.rb
@@ -6,6 +6,7 @@ describe Bosh::Director::ConfigServer::VariablesInterpolator do
   let(:client_factory) { double(Bosh::Director::ConfigServer::ClientFactory) }
   let(:config_server_client) { instance_double(Bosh::Director::ConfigServer::ConfigServerClient) }
   let(:deployment_name) {'my_deployment_name'}
+  let(:instance_name) {'my_instance_name'}
 
   before do
     allow(Bosh::Director::ConfigServer::ClientFactory).to receive(:create).and_return(client_factory)
@@ -73,7 +74,7 @@ describe Bosh::Director::ConfigServer::VariablesInterpolator do
       expect(config_server_client).to receive(:interpolate_with_versioning).with(job_1_properties, given_variable_set).and_return(interpolated_job_1_properties)
       expect(config_server_client).to receive(:interpolate_with_versioning).with(job_2_properties, given_variable_set).and_return(interpolated_job_2_properties)
 
-      expect(subject.interpolate_template_spec_properties(properties_spec, deployment_name, given_variable_set)).to eq(interpolated_properties_spec)
+      expect(subject.interpolate_template_spec_properties(properties_spec, deployment_name, instance_name, given_variable_set)).to eq(interpolated_properties_spec)
     end
 
     it 'interpolates using the variable set passed in' do
@@ -82,19 +83,19 @@ describe Bosh::Director::ConfigServer::VariablesInterpolator do
       expect(config_server_client).to receive(:interpolate_with_versioning).with(job_1_properties, variable_set).and_return(interpolated_job_1_properties)
       expect(config_server_client).to receive(:interpolate_with_versioning).with(job_2_properties, variable_set).and_return(interpolated_job_2_properties)
 
-      expect(subject.interpolate_template_spec_properties(properties_spec, deployment_name, variable_set)).to eq(interpolated_properties_spec)
+      expect(subject.interpolate_template_spec_properties(properties_spec, deployment_name, instance_name, variable_set)).to eq(interpolated_properties_spec)
     end
 
     context 'when src hash is nil' do
       it 'returns the src as is' do
-        expect(subject.interpolate_template_spec_properties(nil, deployment_name, given_variable_set)).to eq(nil)
+        expect(subject.interpolate_template_spec_properties(nil, deployment_name, instance_name, given_variable_set)).to eq(nil)
       end
     end
 
     context 'when deployment name is nil' do
       it 'raises an error' do
         expect{
-          subject.interpolate_template_spec_properties(properties_spec, nil, given_variable_set)
+          subject.interpolate_template_spec_properties(properties_spec, nil, instance_name, given_variable_set)
         }.to raise_error(Bosh::Director::ConfigServerDeploymentNameMissing, "Deployment name missing while interpolating jobs' properties")
       end
     end
@@ -127,7 +128,7 @@ describe Bosh::Director::ConfigServer::VariablesInterpolator do
         EXPECTED
 
         expect {
-          subject.interpolate_template_spec_properties(properties_spec, deployment_name, anything)
+          subject.interpolate_template_spec_properties(properties_spec, deployment_name, instance_name, anything)
         }.to raise_error { |error|
           expect(error.message).to eq(expected_error_msg)
         }

--- a/src/bosh-director/spec/unit/deployment_plan/instance_spec_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_spec_spec.rb
@@ -239,7 +239,7 @@ module Bosh::Director::DeploymentPlan
       before do
         allow(Bosh::Director::ConfigServer::VariablesInterpolator).to receive(:new).and_return(variables_interpolator)
         allow(variables_interpolator).to receive(:interpolate_template_spec_properties)
-          .with(properties, 'fake-deployment', instance.desired_variable_set)
+          .with(properties, 'fake-deployment', instance.instance_group_name, instance.desired_variable_set)
           .and_return(properties)
         allow(variables_interpolator).to receive(:interpolate_link_spec_properties)
           .with(smurf_job_links, instance.desired_variable_set)
@@ -317,7 +317,7 @@ module Bosh::Director::DeploymentPlan
 
         it 'resolves properties and links properties' do
           expect(variables_interpolator).to receive(:interpolate_template_spec_properties)
-            .with(properties, 'fake-deployment', instance.desired_variable_set)
+            .with(properties, 'fake-deployment', instance.instance_group_name, instance.desired_variable_set)
             .and_return(resolved_properties)
           expect(variables_interpolator).to receive(:interpolate_link_spec_properties)
             .with(smurf_job_links, instance.desired_variable_set)

--- a/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_deployment_spec.rb
@@ -500,7 +500,7 @@ module Bosh::Director
             end
 
             it 'versions the variables in errands' do
-              expect(variables_interpolator).to receive(:interpolate_template_spec_properties).with(errand_properties, deployment_name, variable_set_1)
+              expect(variables_interpolator).to receive(:interpolate_template_spec_properties).with(errand_properties, deployment_name, errand_instance_group.name, variable_set_1)
               expect(variables_interpolator).to receive(:interpolate_link_spec_properties).with(job_1_links, variable_set_1)
               expect(variables_interpolator).to receive(:interpolate_link_spec_properties).with(job_2_links, variable_set_1)
 
@@ -508,7 +508,7 @@ module Bosh::Director
             end
 
             it 'versions the links in errands' do
-              allow(variables_interpolator).to receive(:interpolate_template_spec_properties).with(errand_properties, deployment_name, variable_set_1)
+              allow(variables_interpolator).to receive(:interpolate_template_spec_properties).with(errand_properties, deployment_name, errand_instance_group.name, variable_set_1)
               allow(variables_interpolator).to receive(:interpolate_link_spec_properties).with(job_1_links, variable_set_1)
               allow(variables_interpolator).to receive(:interpolate_link_spec_properties).with(job_2_links, variable_set_1)
 


### PR DESCRIPTION
Speed up template rendering by caching the properties of a given instance_group/job, in some cases you have alot of variables in credhub and rendering of properties templates is done for each instance in an instance_group and goes to credhub (which is cache by variable) so in the case of having 1k certs it takes 2~ seconds to render by the number of instances, in large production environments this causes a really slow template rendering.

This was tested with 200 instances in one instance group with 1k ca certs, this took 7:02 mins to render templates, with changes it goes down to 47 seconds. This will greatly help huge production environments with tons of credhub variables. 

Signed-off-by: Kenneth Lakin <klakin@vmware.com>