### PR TITLE
add netcat for the use of ssh via proxy

### DIFF
--- a/ci/dockerfiles/main-ruby-go/Dockerfile
+++ b/ci/dockerfiles/main-ruby-go/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get install -y \
 	libcurl4-openssl-dev \
 	python3-pip \
 	sudo \
+	netcat-openbsd \
 	&& apt-get clean
 
 RUN pip3 install awscli


### PR DESCRIPTION
when using `BOSH_ALL_PROXY` we need a netcat version with `-x` option to ssh via proxy