### PR TITLE
Cleanup of Postgres pre-start code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ src/parallel_runtime_rspec.log
 
 cscope.out
 .starscope.db
+/src/vendor/cache/extensions/x86_64-darwin-21

--- a/jobs/postgres-10/templates/bpm.yml
+++ b/jobs/postgres-10/templates/bpm.yml
@@ -8,9 +8,6 @@ postgres_config = {
   "limits" => {
     "open_files" => 65536,
   },
-  "hooks" => {
-    "pre_start" => "/var/vcap/jobs/postgres-10/bin/pre-start",
-  }
 }
 
 config = {

--- a/jobs/postgres-10/templates/pre-start.erb
+++ b/jobs/postgres-10/templates/pre-start.erb
@@ -5,10 +5,10 @@ set -eu
 PACKAGE_DIR=/var/vcap/packages/postgres-10
 PACKAGE_DIR_OLD=/var/vcap/packages/postgres-9.4
 
-STORE_DIR=/var/vcap/store
+PERSISTENT_DISK_DIR=/var/vcap/store
 
-DATA_DIR=$STORE_DIR/postgres-10
-DATA_DIR_OLD=$STORE_DIR/postgres-9.4
+STORE_DIR=${PERSISTENT_DISK_DIR}/postgres-10
+STORE_DIR_OLD=${PERSISTENT_DISK_DIR}/postgres-9.4
 
 USER='<%= p("postgres.user") %>'
 
@@ -26,38 +26,38 @@ fi
 
 # We cannot kill the following conditional
 # because initdb is very picky about looking at an empty dir
-if [ ! -d $DATA_DIR ] || [ ! -f $DATA_DIR/postgresql.conf ]; then
-  mkdir -p $DATA_DIR
-  chown vcap:vcap $DATA_DIR
+if [ ! -d ${STORE_DIR} ] || [ ! -f ${STORE_DIR}/postgresql.conf ]; then
+  mkdir -p "${STORE_DIR}"
+  chown vcap:vcap "${STORE_DIR}"
 
   # initdb creates data directories
-  su - vcap -c "$PACKAGE_DIR/bin/initdb -E utf8 -D $DATA_DIR"
+  su - vcap -c "${PACKAGE_DIR}/bin/initdb -E utf8 -D ${STORE_DIR}"
 
-  touch /var/vcap/store/postgres-10/fresh
+  touch "${STORE_DIR}/fresh"
 
   if [ $? != 0 ]; then
     echo "ERROR: Unable to Initialize Postgres DB"
     exit 1
   fi
 
-  echo "host all $USER 0.0.0.0/0 md5" >> $DATA_DIR/pg_hba.conf
+  echo "host all $USER 0.0.0.0/0 md5" >> "${STORE_DIR}/pg_hba.conf"
 
-  mkdir -p $DATA_DIR/pg_log
-  chown vcap:vcap $DATA_DIR/pg_log
+  mkdir -p "${STORE_DIR}/pg_log"
+  chown vcap:vcap "${STORE_DIR}/pg_log"
 fi
 
-if [[ -f /var/vcap/store/postgres-10/fresh ]] ; then
-  if [[ -d /var/vcap/store/postgres-9.4 ]] ; then
+if [[ -f ${STORE_DIR}/fresh ]] ; then
+  if [[ -d ${STORE_DIR_OLD} ]] ; then
     echo "checking status of postgres-9.4..."
-    if ! ${PACKAGE_DIR_OLD}/bin/pg_controldata "${DATA_DIR_OLD}" | grep -E "Database cluster state:\s+shut down"; then
+    if ! "${PACKAGE_DIR_OLD}/bin/pg_controldata" "${STORE_DIR_OLD}" | grep -E "Database cluster state:\s+shut down"; then
       echo "postgres-9.4 did not shut down cleanly"
       echo "repairing postgres-9.4. cluster state..."
 
-      su - vcap -c "$PACKAGE_DIR_OLD/bin/postgres -D $DATA_DIR_OLD" &
+      su - vcap -c "${PACKAGE_DIR_OLD}/bin/postgres -D ${STORE_DIR_OLD}" &
       postgres_pid=$!
 
       count=0
-      while ! ${PACKAGE_DIR_OLD}/bin/pg_isready -t 30 -U postgres; do
+      while ! "${PACKAGE_DIR_OLD}/bin/pg_isready" -t 30 -U postgres; do
         echo "waiting for postgres-9.4 to start..."
         sleep 1
         count=$(( count + 1 ))
@@ -72,17 +72,17 @@ if [[ -f /var/vcap/store/postgres-10/fresh ]] ; then
     fi
 
     echo "copying contents of postgres-9.4 to postgres-10 for postgres upgrade..."
-    su - vcap -c "/var/vcap/packages/postgres-10/bin/pg_upgrade \
-      --old-bindir=$PACKAGE_DIR_OLD/bin \
-      --new-bindir=$PACKAGE_DIR/bin \
-      --old-datadir=$DATA_DIR_OLD \
-      --new-datadir=$DATA_DIR"
+    su - vcap -c "${PACKAGE_DIR}/bin/pg_upgrade \
+      --old-bindir=${PACKAGE_DIR_OLD}/bin \
+      --new-bindir=${PACKAGE_DIR}/bin \
+      --old-datadir=${STORE_DIR_OLD} \
+      --new-datadir=${STORE_DIR}"
 
     echo "successfully upgraded from postgres-9.4"
-    rm -rf '/var/vcap/store/postgres-9'
+    rm -rf "${STORE_DIR_OLD}"
   fi
 
-  rm /var/vcap/store/postgres-10/fresh
+  rm "${STORE_DIR}/fresh"
 fi
 
 # "bpm enforces its own locking around process operations to avoid race conditions"
@@ -90,6 +90,6 @@ fi
 # so postmaster.pid is stale of it still exists
 # remove it to prevent running into:
 # FATAL:  lock file "postmaster.pid" already exists
-if [[ -f /var/vcap/store/postgres-10/postmaster.pid ]] ; then
-    rm /var/vcap/store/postgres-10/postmaster.pid
+if [[ -f ${STORE_DIR}/postmaster.pid ]] ; then
+    rm "${STORE_DIR}/postmaster.pid"
 fi

--- a/jobs/postgres-10/templates/pre-start.erb
+++ b/jobs/postgres-10/templates/pre-start.erb
@@ -26,7 +26,7 @@ fi
 
 # We cannot kill the following conditional
 # because initdb is very picky about looking at an empty dir
-if [ ! -d ${STORE_DIR} ] || [ ! -f ${STORE_DIR}/postgresql.conf ]; then
+if [[ ! -d ${STORE_DIR} || ! -f ${STORE_DIR}/postgresql.conf ]]; then
   mkdir -p "${STORE_DIR}"
   chown vcap:vcap "${STORE_DIR}"
 

--- a/jobs/postgres-10/templates/pre-start.erb
+++ b/jobs/postgres-10/templates/pre-start.erb
@@ -48,29 +48,6 @@ fi
 
 if [[ -f ${STORE_DIR}/fresh ]] ; then
   if [[ -d ${STORE_DIR_OLD} ]] ; then
-    echo "checking status of postgres-9.4..."
-    if ! "${PACKAGE_DIR_OLD}/bin/pg_controldata" "${STORE_DIR_OLD}" | grep -E "Database cluster state:\s+shut down"; then
-      echo "postgres-9.4 did not shut down cleanly"
-      echo "repairing postgres-9.4. cluster state..."
-
-      su - vcap -c "${PACKAGE_DIR_OLD}/bin/postgres -D ${STORE_DIR_OLD}" &
-      postgres_pid=$!
-
-      count=0
-      while ! "${PACKAGE_DIR_OLD}/bin/pg_isready" -t 30 -U postgres; do
-        echo "waiting for postgres-9.4 to start..."
-        sleep 1
-        count=$(( count + 1 ))
-        if [ $count -ge 120 ]; then
-          echo "timed out waiting for postgres-9.4 to start"
-          exit 1
-        fi
-      done
-
-      kill "${postgres_pid}"
-      wait "${postgres_pid}"
-    fi
-
     echo "copying contents of postgres-9.4 to postgres-10 for postgres upgrade..."
     su - vcap -c "${PACKAGE_DIR}/bin/pg_upgrade \
       --old-bindir=${PACKAGE_DIR_OLD}/bin \

--- a/jobs/postgres/templates/bpm.yml
+++ b/jobs/postgres/templates/bpm.yml
@@ -9,17 +9,10 @@ postgres_config = {
       "path" => "/var/vcap/store/postgres-13",
       "writable" => true,
     },
-    {
-      "path" => "/var/vcap/store/postgres-10",
-      "writable" => true,
-    },
   ],
   "limits" => {
     "open_files" => 65536,
   },
-  "hooks" => {
-    "pre_start" => "/var/vcap/jobs/postgres/bin/pre-start",
-  }
 }
 
 config = {

--- a/jobs/postgres/templates/pre-start.erb
+++ b/jobs/postgres/templates/pre-start.erb
@@ -5,10 +5,10 @@ set -eu
 PACKAGE_DIR=/var/vcap/packages/postgres-13
 PACKAGE_DIR_OLD=/var/vcap/packages/postgres-10
 
-STORE_DIR=/var/vcap/store
+PERSISTENT_DISK_DIR=/var/vcap/store
 
-DATA_DIR=$STORE_DIR/postgres-13
-DATA_DIR_OLD=$STORE_DIR/postgres-10
+STORE_DIR=${PERSISTENT_DISK_DIR}/postgres-13
+STORE_DIR_OLD=${PERSISTENT_DISK_DIR}/postgres-10
 
 USER='<%= p("postgres.user") %>'
 
@@ -21,40 +21,40 @@ fi
 
 # We cannot kill the following conditional
 # because initdb is very picky about looking at an empty dir
-if [ ! -d $DATA_DIR ] || [ ! -f $DATA_DIR/postgresql.conf ]; then
-  mkdir -p $DATA_DIR
-  chown vcap:vcap $DATA_DIR
+if [ ! -d ${STORE_DIR} ] || [ ! -f ${STORE_DIR}/postgresql.conf ]; then
+  mkdir -p "${STORE_DIR}"
+  chown vcap:vcap "${STORE_DIR}"
 
   # initdb creates data directories
-  su - vcap -c "$PACKAGE_DIR/bin/initdb -E utf8 -D $DATA_DIR"
+  su - vcap -c "${PACKAGE_DIR}/bin/initdb -E utf8 -D ${STORE_DIR}"
 
-  touch /var/vcap/store/postgres-13/fresh
+  touch "${STORE_DIR}/fresh"
 
   if [ $? != 0 ]; then
     echo "ERROR: Unable to Initialize Postgres DB"
     exit 1
   fi
 
-  echo "host all $USER 0.0.0.0/0 md5" >> $DATA_DIR/pg_hba.conf
+  echo "host all ${USER} 0.0.0.0/0 md5" >> "${STORE_DIR}/pg_hba.conf"
 
-  mkdir -p $DATA_DIR/pg_log
-  chown vcap:vcap $DATA_DIR/pg_log
+  mkdir -p "${STORE_DIR}/pg_log"
+  chown vcap:vcap "${STORE_DIR}/pg_log"
 fi
 
-if [[ -f /var/vcap/store/postgres-13/fresh ]] ; then
-  if [[ -d /var/vcap/store/postgres-10 ]] ; then
+if [[ -f ${STORE_DIR}/fresh ]] ; then
+  if [[ -d ${STORE_DIR_OLD} ]] ; then
     echo "copying contents of postgres-10 to postgres-13 for postgres upgrade..."
-    su - vcap -c "$PACKAGE_DIR/bin/pg_upgrade \
-      --old-bindir=$PACKAGE_DIR_OLD/bin \
-      --new-bindir=$PACKAGE_DIR/bin \
-      --old-datadir=$DATA_DIR_OLD \
-      --new-datadir=$DATA_DIR"
+    su - vcap -c "${PACKAGE_DIR}/bin/pg_upgrade \
+      --old-bindir=${PACKAGE_DIR_OLD}/bin \
+      --new-bindir=${PACKAGE_DIR}/bin \
+      --old-datadir=${STORE_DIR_OLD} \
+      --new-datadir=${STORE_DIR}"
 
     echo "successfully upgraded from postgres-10"
-    rm -rf '/var/vcap/store/postgres-10'
+    rm -rf "${STORE_DIR_OLD}"
   fi
 
-  rm /var/vcap/store/postgres-13/fresh
+  rm "${STORE_DIR}/fresh"
 fi
 
 # "bpm enforces its own locking around process operations to avoid race conditions"
@@ -62,6 +62,6 @@ fi
 # so postmaster.pid is stale if it still exists
 # remove it to prevent running into:
 # FATAL:  lock file "postmaster.pid" already exists
-if [[ -f /var/vcap/store/postgres-13/postmaster.pid ]] ; then
-    rm /var/vcap/store/postgres-13/postmaster.pid
+if [[ -f ${STORE_DIR}/postmaster.pid ]] ; then
+    rm "${STORE_DIR}/postmaster.pid"
 fi

--- a/jobs/postgres/templates/pre-start.erb
+++ b/jobs/postgres/templates/pre-start.erb
@@ -21,7 +21,7 @@ fi
 
 # We cannot kill the following conditional
 # because initdb is very picky about looking at an empty dir
-if [ ! -d ${STORE_DIR} ] || [ ! -f ${STORE_DIR}/postgresql.conf ]; then
+if [[ ! -d ${STORE_DIR} || ! -f ${STORE_DIR}/postgresql.conf ]]; then
   mkdir -p "${STORE_DIR}"
   chown vcap:vcap "${STORE_DIR}"
 

--- a/jobs/postgres/templates/pre-start.erb
+++ b/jobs/postgres/templates/pre-start.erb
@@ -14,8 +14,8 @@ USER='<%= p("postgres.user") %>'
 
 sysctl -w "kernel.shmmax=67108864"
 
-if [[ -d /var/vcap/store/postgres-9 ]]; then
-  echo "Please use a previous bosh release version (271.x or lower) to migrate data from postgres-9 to postgres-10."
+if [[ -d /var/vcap/store/postgres-9.4 ]]; then
+  echo "Please use a previous bosh release version (271.x or lower) to migrate data from postgres-9.4 to postgres-10."
   exit 1
 fi
 


### PR DESCRIPTION
Hello dear Bosh fellows,

Turns out the Postgres `pre-start` scripts were executed twice: first by Bosh Agent as `root` on the VM with no restrictions, second inside the BPM context. This issue comes from commit 4ab31932f in the first place, maybe due to lack of review.

When fixing this unnecessary duplicate execution of `pre-start` scripts, then mounting the old persistent store directory with BPM is no more necessary. This is useful to prevent an empty `postgres-10` directory to re-appear at every startup, only because it is declared in BPM for purposes of migrating from v10 to v13.

I've also fixed some bugs related to typos, as the actual directory for Postgres 9.4 is `postgres-9.4` and not `postgres-9`. This was preventing Postgres 10 `pre-start` script from was properly removing the Postgres 9.4 old persistent data after successful upgrade.

Also, after we've merged #2334, some data repair code in migration from Postgres v9.4 to v10 (due to improper signal being previously used to stop Postgres) is no more necessary, so I've removed it.

Less importantly, I've reviewed the `pre-start` scripts for the 3 Postgres jobs. I've noticed that the word 'data dir' was used for persistent data, that go to the ' store' dir in Bosh parlance, whereas 'data' dir usually designates the ephemeral data. So, I'm proposing some improved wording in that regards, for cleaner code.

Best,
Benjamin