### PR TITLE
Exported Releases only contain first level job dependent packages

### DIFF
--- a/src/bosh-director/lib/bosh/director/compiled_package_group.rb
+++ b/src/bosh-director/lib/bosh/director/compiled_package_group.rb
@@ -15,8 +15,6 @@ module Bosh::Director
             @package_names.include? package.name
           end
 
-          packages_to_compile = resolve_dependencies(packages_to_compile)
-
           packages_to_compile.map do |package|
             package_dependency_key = KeyGenerator.new.dependency_key_from_models(package, @release_version)
 
@@ -32,21 +30,6 @@ module Bosh::Director
 
     def stemcell_sha1
       @stemcell.sha1
-    end
-
-    private
-
-    def resolve_dependencies(packages)
-      initial_count = packages.count
-      new_list = (packages + packages.map do |package|
-        @release_version.packages.select { |p| package.dependency_set.include?(p.name) }
-      end).flatten.uniq
-
-      if initial_count < new_list.count
-        resolve_dependencies(new_list)
-      else
-        new_list
-      end
     end
   end
 end

--- a/src/bosh-director/spec/unit/compiled_package_group_spec.rb
+++ b/src/bosh-director/spec/unit/compiled_package_group_spec.rb
@@ -9,11 +9,11 @@ module Bosh::Director
     let(:release) { Models::Release.make }
     let(:stemcell) { make_stemcell(sha1: 'fakestemcellsha1', operating_system: 'chrome-os') }
 
-    let(:package1) { Models::Package.make(release: release, dependency_set_json: ['pkg-2', 'pkg-4'].to_json) }
+    let(:package1) { Models::Package.make(name: 'pkg-1', release: release, dependency_set_json: ['pkg-2', 'pkg-4'].to_json) }
     let(:package2) { Models::Package.make(name: 'pkg-2', version: '2', release: release) }
     let(:package3) { Models::Package.make(name: 'pkg-3', version: '3', release: release) }
     let(:package4) { Models::Package.make(name: 'pkg-4', version: '4', release: release) }
-    let(:templates) { [Models::Template.make(package_names_json: JSON.generate([package1.name]))] }
+    let(:templates) { [Models::Template.make(package_names_json: JSON.generate([package1.name, package3.name]))] }
 
     subject(:package_group) { CompiledPackageGroup.new(release_version, stemcell, templates) }
 
@@ -50,15 +50,15 @@ module Bosh::Director
         release_version.add_package(package4)
       end
 
-      it 'returns list of packages for the given release version and stemcell' do
-        expect(package_group.compiled_packages).to eq([compiled_package1, compiled_package4])
+      it 'returns list of first level dependent packages for the given release version and stemcell' do
+        expect(package_group.compiled_packages).to eq([compiled_package1, compiled_package3])
       end
 
       it 'only queries database once' do
         allow(Models::CompiledPackage).to receive(:[]).and_call_original
         package_group.compiled_packages
         package_group.compiled_packages
-        expect(Models::CompiledPackage).to have_received(:[]).exactly(3).times
+        expect(Models::CompiledPackage).to have_received(:[]).exactly(2).times
       end
     end
 

--- a/src/bosh-director/spec/unit/jobs/export_release_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/export_release_spec.rb
@@ -239,11 +239,20 @@ module Bosh::Director
         let(:release_version) {release.add_version(:version => '0.1-dev')}
 
         before do
-          release_version.add_package(
+          package_foo = release_version.add_package(
             Bosh::Director::Models::Package.make(
               name: 'foo',
+              version: 'foo_version',
               dependency_set_json: JSON.generate(['postgres']),
             ),
+          )
+          package_foo.add_compiled_package(
+            sha1: 'foocompiledpackagesha1',
+            blobstore_id: 'foo_package_blobstore_id',
+            dependency_key: '[["postgres","postgres_version",[["ruby","ruby_version"]]]]',
+            build: 23,
+            stemcell_os: 'ubuntu',
+            stemcell_version: '1'
           )
           release_version.add_package(Bosh::Director::Models::Package.make(name: 'bar'))
 
@@ -338,7 +347,7 @@ module Bosh::Director
               expect(files).to include('compiled_packages', 'release.MF', 'jobs')
 
               files = Dir.entries(File.join(download_dir, 'compiled_packages'))
-              expect(files).to include('postgres.tgz')
+              expect(files).to include('foo.tgz')
 
               files = Dir.entries(File.join(download_dir, 'jobs'))
               expect(files).to include('foobar.tgz')
@@ -347,8 +356,7 @@ module Bosh::Director
             }
 
             expect(blobstore_client).to receive(:create).and_return('blobstore_id')
-            expect(blobstore_client).to receive(:get).with('ruby_compiled_package_blobstore_id', anything, sha1: 'rubycompiledpackagesha1')
-            expect(blobstore_client).to receive(:get).with('postgres_package_blobstore_id', anything, sha1: 'postgrescompiledpackagesha1')
+            expect(blobstore_client).to receive(:get).with('foo_package_blobstore_id', anything, sha1: 'foocompiledpackagesha1')
             expect(blobstore_client).to receive(:get).with('foobar_blobstore_id', anything, sha1: 'foo_sha1')
             expect(blobstore_client).to receive(:get).with('foobaz_blobstore_id', anything, sha1: 'foo_sha1')
             expect(blobstore_client).to receive(:get).with('foofoo_blobstore_id', anything, sha1: 'foo_sha1')
@@ -360,19 +368,13 @@ module Bosh::Director
               manifest_hash = YAML.load_file(File.join(download_dir, 'release.MF'))
               expected_manifest_hash = YAML.load(%q(---
 compiled_packages:
-- name: postgres
-  version: postgres_version
-  fingerprint: postgres_fingerprint
-  sha1: postgrescompiledpackagesha1
+- name: foo
+  version: foo_version
+  fingerprint:
+  sha1: foocompiledpackagesha1
   stemcell: ubuntu/1
   dependencies:
-  - ruby
-- name: ruby
-  version: ruby_version
-  fingerprint: ruby_fingerprint
-  sha1: rubycompiledpackagesha1
-  stemcell: ubuntu/1
-  dependencies: []
+  - postgres
 jobs:
 - name: foobar
   version: foo_version
@@ -426,7 +428,7 @@ version: 0.1-dev
               expect(files).to include('compiled_packages', 'release.MF', 'jobs')
 
               files = Dir.entries(File.join(download_dir, 'compiled_packages'))
-              expect(files).to include('postgres.tgz')
+              expect(files).to include('foo.tgz')
 
               files = Dir.entries(File.join(download_dir, 'jobs'))
               expect(files).to contain_exactly('.', '..', 'foobaz.tgz', 'foobar.tgz', 'foofoo.tgz')
@@ -435,8 +437,7 @@ version: 0.1-dev
             }
 
             expect(blobstore_client).to receive(:create).and_return('blobstore_id')
-            expect(blobstore_client).to receive(:get).with('ruby_compiled_package_blobstore_id', anything, sha1: 'rubycompiledpackagesha1')
-            expect(blobstore_client).to receive(:get).with('postgres_package_blobstore_id', anything, sha1: 'postgrescompiledpackagesha1')
+            expect(blobstore_client).to receive(:get).with('foo_package_blobstore_id', anything, sha1: 'foocompiledpackagesha1')
             allow(blobstore_client).to receive(:get)
             job.perform
           end
@@ -457,7 +458,7 @@ version: 0.1-dev
               expect(files).to include('compiled_packages', 'release.MF', 'jobs')
 
               files = Dir.entries(File.join(download_dir, 'compiled_packages'))
-              expect(files).to include('postgres.tgz')
+              expect(files).to include('foo.tgz')
 
               files = Dir.entries(File.join(download_dir, 'jobs'))
               expect(files).to include('foobaz.tgz')
@@ -467,8 +468,7 @@ version: 0.1-dev
             }
 
             expect(blobstore_client).to receive(:create).and_return('blobstore_id')
-            expect(blobstore_client).to receive(:get).with('ruby_compiled_package_blobstore_id', anything, sha1: 'rubycompiledpackagesha1')
-            expect(blobstore_client).to receive(:get).with('postgres_package_blobstore_id', anything, sha1: 'postgrescompiledpackagesha1')
+            expect(blobstore_client).to receive(:get).with('foo_package_blobstore_id', anything, sha1: 'foocompiledpackagesha1')
             allow(blobstore_client).to receive(:get)
             job.perform
           end
@@ -478,19 +478,13 @@ version: 0.1-dev
               manifest_hash = YAML.load_file(File.join(download_dir, 'release.MF'))
               expected_manifest_hash = YAML.load(%q(---
 compiled_packages:
-- name: postgres
-  version: postgres_version
-  fingerprint: postgres_fingerprint
-  sha1: postgrescompiledpackagesha1
+- name: foo
+  version: foo_version
+  fingerprint:
+  sha1: foocompiledpackagesha1
   stemcell: ubuntu/1
   dependencies:
-  - ruby
-- name: ruby
-  version: ruby_version
-  fingerprint: ruby_fingerprint
-  sha1: rubycompiledpackagesha1
-  stemcell: ubuntu/1
-  dependencies: []
+  - postgres
 jobs:
 - name: foobaz
   version: foo_version


### PR DESCRIPTION
Current if a package depends on another package, that is also exported.

Jobs never use these packages, and they don't even end up getting deployed to VMs so they are just making compiled release tarballs larger.
