### PR TITLE
Update additional YAML.load calls with required named params

### DIFF
--- a/src/bosh-dev/lib/bosh/dev/postgres_version.rb
+++ b/src/bosh-dev/lib/bosh/dev/postgres_version.rb
@@ -12,7 +12,7 @@ module Bosh::Dev
 
       def release_version
         @release_version ||= begin
-          postgres_release_config = YAML.load_file(File.join(File.dirname(__FILE__), '../../../../../jobs/postgres-10/spec.yml'))
+          postgres_release_config = YAML.load_file(File.join(File.dirname(__FILE__), '../../../../../jobs/postgres-10/spec.yml'), permitted_classes: [Symbol], aliases: true)
 
           # sort alphanumerics correctly, i.e 10 > 9
           postgres_version = postgres_release_config['packages'].max_by { |s| s.scan(/\d+/).first.to_i }

--- a/src/bosh-dev/lib/bosh/dev/sandbox/services/director_service.rb
+++ b/src/bosh-dev/lib/bosh/dev/sandbox/services/director_service.rb
@@ -118,7 +118,7 @@ module Bosh::Dev::Sandbox
     end
 
     def db_config
-      connection_config = YAML.load_file(@director_config)['db']
+      connection_config = YAML.load_file(@director_config, permitted_classes: [Symbol], aliases: true)['db']
 
       custom_connection_options = connection_config.delete('connection_options') do
         {}

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -421,7 +421,7 @@ module Bosh::Director
       end
 
       def load_file(path)
-        Config.new(YAML.load_file(path))
+        Config.new(YAML.load_file(path, permitted_classes: [Symbol], aliases: true))
       end
 
       def load_hash(hash)

--- a/src/spec/support/integration_example_group.rb
+++ b/src/spec/support/integration_example_group.rb
@@ -431,7 +431,7 @@ module IntegrationSandboxHelpers
     FileUtils.cp_r(TEST_RELEASE_TEMPLATE, destination_dir, preserve: true)
 
     final_config_path = File.join(destination_dir, 'config', 'final.yml')
-    final_config = YAML.load_file(final_config_path)
+    final_config = YAML.load_file(final_config_path, permitted_classes: [Symbol], aliases: true)
     final_config['blobstore']['options']['blobstore_path'] = ClientSandbox.blobstore_dir
     File.open(final_config_path, 'w') { |file| file.write(YAML.dump(final_config)) }
 


### PR DESCRIPTION
the default for load calls on psych changed from
unsafe to safe. We need to allow Symbol classes and
aliases for symbol hash access and anchors to work.

currently integration tests are still broken with psych load errors.


refer to 27536bf2f86f97f6eca26fd3c2f88e1869d17481 for additional context