### PR TITLE
bump mariadb connector

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -14,6 +14,10 @@ mysql/mariadb-connector-c-3.1.11-src.tar.gz:
   size: 752342
   object_id: 0939120b-af11-4faf-7cab-8609bc40d447
   sha: sha256:3e6f6c399493fe90efdc21a3fe70c30434b7480e8195642a959f1dd7a0fa5b0f
+mysql/mariadb-connector-c-3.1.13-src.tar.gz:
+  size: 968401
+  object_id: b3c4867c-ca9f-4819-4e11-e62595e7bd77
+  sha: sha256:0271a5edfd64b13bca5937267474e4747d832ec62e169fc2589d2ead63746875
 postgres/postgresql-9.4.23.tar.gz:
   size: 21943235
   object_id: 94e77351-2ede-4657-46ae-8208e2aee252

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,10 +10,6 @@ gnatsd/gnatsd-1.3.0-bosh.10-linux-amd64:
   size: 11642415
   object_id: 3ee87236-4c36-4477-7bb1-840056c62dde
   sha: sha256:e5362a7c88ed92d4f4263b1b725e901fe29da220c3548e37570793776b5f6d51
-mysql/mariadb-connector-c-3.1.11-src.tar.gz:
-  size: 752342
-  object_id: 0939120b-af11-4faf-7cab-8609bc40d447
-  sha: sha256:3e6f6c399493fe90efdc21a3fe70c30434b7480e8195642a959f1dd7a0fa5b0f
 mysql/mariadb-connector-c-3.1.13-src.tar.gz:
   size: 968401
   object_id: b3c4867c-ca9f-4819-4e11-e62595e7bd77

--- a/packages/mysql/README.md
+++ b/packages/mysql/README.md
@@ -2,4 +2,4 @@ mysql package
 ============
 Mariadb connector
 
-The blob contains mariadb-connector library. It comes from https://downloads.mariadb.org/connector-c/3.0.10/
+The blob contains mariadb-connector library. It comes from https://downloads.mariadb.org/connector-c/3.1.13/

--- a/packages/mysql/packaging
+++ b/packages/mysql/packaging
@@ -1,7 +1,7 @@
 # abort script on any command that exit with a non zero value
 set -e
 
-MARIADB_VERSION='3.1.11'
+MARIADB_VERSION='3.1.13'
 (
   set -e
   tar xzf mysql/mariadb-connector-c-${MARIADB_VERSION}-src.tar.gz

--- a/packages/mysql/spec
+++ b/packages/mysql/spec
@@ -1,5 +1,5 @@
 ---
 name: mysql
 files:
-- mysql/mariadb-connector-c-3.1.11-src.tar.gz
+- mysql/mariadb-connector-c-3.1.13-src.tar.gz
 - mysql-customization/mariadb_config-wrapper.sh


### PR DESCRIPTION
Jammy has a new version of cmake 
and 3.1.11 had a bug which resulted in this error
```
Building C object CMakeFiles/cmTC_ec300.dir/CheckFunctionExists.c.o
/usr/bin/cc   -Wunused -Wlogical-op -Wno-uninitialized -Wall -Wextra -Wformat-security -Wno-init-self -Wwrite-strings -Wshift-count-overflow -Wdeclaration-after-statement -Wno-undef -Wno-unknown-pragmas -DCHECK_FUNCTION_EXISTS=floor -o CMakeFiles/cmTC_ec300.dir/CheckFunctionExists.c.o -c /usr/share/cmake-3.22/Modules/CheckFunctionExists.c
<command-line>: warning: conflicting types for built-in function ‘floor’; expected ‘double(double)’ [-Wbuiltin-declaration-mismatch]
/usr/share/cmake-3.22/Modules/CheckFunctionExists.c:7:3: note: in expansion of macro ‘CHECK_FUNCTION_EXISTS’
    7 |   CHECK_FUNCTION_EXISTS(void);
      |   ^~~~~~~~~~~~~~~~~~~~~
/usr/share/cmake-3.22/Modules/CheckFunctionExists.c:1:1: note: ‘floor’ is declared in header ‘<math.h>’
  +++ |+#include <math.h>
    1 | #ifdef CHECK_FUNCTION_EXISTS
Linking C executable cmTC_ec300
/usr/bin/cmake -E cmake_link_script CMakeFiles/cmTC_ec300.dir/link.txt --verbose=1
/usr/bin/cc  -Wunused -Wlogical-op -Wno-uninitialized -Wall -Wextra -Wformat-security -Wno-init-self -Wwrite-strings -Wshift-count-overflow -Wdeclaration-after-statement -Wno-undef -Wno-unknown-pragmas -DCHECK_FUNCTION_EXISTS=floor -rdynamic CMakeFiles/cmTC_ec300.dir/CheckFunctionExists.c.o -o cmTC_ec300 
/usr/bin/ld: CMakeFiles/cmTC_ec300.dir/CheckFunctionExists.c.o: in function `main':
CheckFunctionExists.c:(.text+0x14): undefined reference to `floor'
collect2: error: ld returned 1 exit status
gmake[1]: *** [CMakeFiles/cmTC_ec300.dir/build.make:99: cmTC_ec300] Error 1
gmake[1]: Leaving directory '/var/vcap/bosh_ssh/bosh_03a2782828dd45d/mariadb-connector-c-3.1.11-src/bld/CMakeFiles/CMakeTmp'
gmake: *** [Makefile:127: cmTC_ec300/fast] Error 2
```
see release notes 
- https://mariadb.com/kb/en/mariadb-connector-c-3112-release-notes/
- https://mariadb.com/kb/en/mariadb-connector-c-3113-release-notes/

a version bumped fixed this issue locally

