### PR TITLE
IPv6 ambiguity issues

### DIFF
--- a/src/bosh-director/spec/unit/deployment_plan/ip_provider/database_ip_repo_ipv6_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/ip_provider/database_ip_repo_ipv6_spec.rb
@@ -378,18 +378,27 @@ module Bosh::Director::DeploymentPlan
 
     describe :delete do
       before do
-        network_spec['subnets'].first['static'] = ['fdab:d85c:118d:8a46::5']
+        network_spec['subnets'].first['static'] = ['0000:0000:0000:0000:0000:0000:c0a8:0105']
 
-        reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, 'fdab:d85c:118d:8a46::5')
+        reservation = BD::DesiredNetworkReservation.new_static(instance_model, network, '0000:0000:0000:0000:0000:0000:c0a8:0105')
         ip_repo.add(reservation)
       end
 
       it 'deletes IP address' do
         expect {
-          ip_repo.delete('fdab:d85c:118d:8a46::5')
+          ip_repo.delete('0000:0000:0000:0000:0000:0000:c0a8:0105')
         }.to change {
             Bosh::Director::Models::IpAddress.all.size
           }.by(-1)
+      end
+
+      it 'does not accidentally delete a IPv6 address when a IPv4 address is being deleted' do
+        expect(logger).to receive(:debug).with("[network-configuration] Skipping releasing ip '192.168.1.5': not reserved")
+        expect {
+          ip_repo.delete('192.168.1.5')
+        }.to change {
+            Bosh::Director::Models::IpAddress.all.size
+          }.by(0)
       end
     end
   end

--- a/src/bosh-director/spec/unit/deployment_plan/ip_provider/ip_repo_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/ip_provider/ip_repo_spec.rb
@@ -511,6 +511,15 @@ module Bosh::Director::DeploymentPlan
             Bosh::Director::Models::IpAddress.all.size
           }.by(-1)
       end
+
+      it 'does not accidentally delete a IPv4 address when a IPv6 address is being deleted' do
+        expect(logger).to receive(:debug).with("[network-configuration] Skipping releasing ip '0000:0000:0000:0000:0000:0000:c0a8:0105': not reserved")
+        expect {
+          ip_repo.delete('0000:0000:0000:0000:0000:0000:c0a8:0105')
+        }.to change {
+            Bosh::Director::Models::IpAddress.all.size
+          }.by(0)
+      end
     end
   end
 end

--- a/src/bosh-director/spec/unit/ip_util_spec.rb
+++ b/src/bosh-director/spec/unit/ip_util_spec.rb
@@ -65,7 +65,7 @@ describe Bosh::Director::IpUtil do
   end
 
   describe 'format_ip' do
-    it 'converts integer to CIDR IP' do
+    it 'converts integer to IPv4 string representation' do
       expect(@obj.format_ip(168427582)).to eq('10.10.0.62')
     end
   end


### PR DESCRIPTION
### tldr
I believe currently only IPv6 addresses larger than `::ffff:ffff` are supported - all others will result in issues when using them together with IPv4 addresses. I added some tests to illustrate those issues and to serve as a starting point for a discussion how to fix it.

### What is this issue about?

IPv4 and IPv6 addresses have overlapping integer ranges. Since bosh stores all IP addresses in their integer representation in the database without storing any information about their IP version, this leads to ambiguity when retrieving the IP addresses and converting them back to their human-readable string representation.

More specifically, the current implementation considers all integers less than `2**32` as IPv4 addresses by default. Consequently, IPv6 addresses from `::` to `::ffff:ffff` are treated as or converted to IPv4 addresses for instance when [storing](https://github.com/cloudfoundry/bosh/blob/acf041f931f808057c043e7f02162a1fd021e996/src/bosh-director/lib/bosh/director/deployment_plan/ip_provider/ip_repo.rb#L164) and [retrieving](https://github.com/cloudfoundry/bosh/blob/acf041f931f808057c043e7f02162a1fd021e996/src/bosh-director/lib/bosh/director/deployment_plan/ip_provider/ip_repo.rb#L14) them from the database, making [network reservations](https://github.com/cloudfoundry/bosh/blob/acf041f931f808057c043e7f02162a1fd021e996/src/bosh-director/lib/bosh/director/network_reservation.rb#L33) or [looping over them with IpUtil's each_ip function](https://github.com/cloudfoundry/bosh/blob/acf041f931f808057c043e7f02162a1fd021e996/src/bosh-director/lib/bosh/director/ip_util.rb#L54-L57).

Illustration with vendored netaddr gem:
```
3.1.0 > NetAddr::CIDR.create('192.168.1.5').to_i
 => 3232235781
3.1.0 > NetAddr::CIDR.create('::c0a8:105').to_i
 => 3232235781
3.1.0 > NetAddr::CIDR.create(3232235781).ip
 => "192.168.1.5"
```
Resulting problems include:
* accidental deletion or blocking of IPv4/IPv6 addresses with same integer representation respectively
* all IPv6 addresses smaller than `::ffff:ffff` are essentially converted to IPv4 addresses

Please refer to the added unit tests for more detailed examples of what specific problems are caused by this ambiguity.

### What is this change about?

This PR introduces unit tests to ensure that this ambiguity is being handled in a selection of important cases, for instance IPv4 addresses are not accidentally deleted when IPv6 addresses should be deleted. However, the test suite is not complete in covering all possible cases of ambiguity. More importantly, the PR should serve as a starting point for further discussions.

### Example of allocating and releasing IP addresses based on their integer representation
https://github.com/cloudfoundry/bosh/blob/acf041f931f808057c043e7f02162a1fd021e996/src/bosh-director/lib/bosh/director/deployment_plan/ip_provider/ip_repo.rb#L162-L164
https://github.com/cloudfoundry/bosh/blob/acf041f931f808057c043e7f02162a1fd021e996/src/bosh-director/lib/bosh/director/deployment_plan/ip_provider/ip_repo.rb#L11-L14

### Ideas how to fix / mitigate it

* storing IP version in database as additional auxiliary attribute
* storing string representation of IP addresses in database
* updating docs and announcing that only IPv6 addresses larger than `::ffff:ffff` are supported (when using them together with IPv4 addresses)

To a large extent, we leave it to the vendored netaddr gem to distinguish between IPv6 and IPv4 addresses and manage them under the hood. Using the `:Version` parameter of `NetAddr::CIDR` would allow us to explicitly distinguish the version.
```
3.1.0 > NetAddr::CIDR.create(3232235781, Version: 6).ip
 => "0000:0000:0000:0000:0000:0000:c0a8:0105"
3.1.0 > NetAddr::CIDR.create(3232235781).ip
 => "192.168.1.5"
```

### What tests have you run against this PR?
* Newly introduced bosh-director unit tests fail as expected.

### Does this PR introduce a breaking change?
* No, only unit tests have been changed.

### Tag your pair, your PM, and/or team!
@friegger @cloudfoundry/cf-bosh-europe 