### PR TITLE
Support running errands on stopped instances

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -179,6 +179,9 @@ properties:
   director.parallel_problem_resolution:
     description: When true, problems (e.g. resurrection, disk reattaching) are resolved in parallel
     default: true
+  director.allow_errands_on_stopped_instances:
+    description: When true, bosh will not error out when running errands on stopped instances
+    default: false
 
   director.cpi.preferred_api_version:
     description: The preferred api version to use when communicating with the CPI. If specified greater than the max supported version it will only communicate via the highest available api version.

--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -42,6 +42,7 @@ params = {
   },
   'audit_log_path' => '/var/vcap/sys/log/director',
   'parallel_problem_resolution' => p('director.parallel_problem_resolution', true),
+  'allow_errands_on_stopped_instances' => p('director.allow_errands_on_stopped_instances'),
   'metrics_server' => {
     'enabled' => p('director.metrics_server.enabled'),
     'port' => p('director.metrics_server.port'),

--- a/spec/director.yml.erb_spec.rb
+++ b/spec/director.yml.erb_spec.rb
@@ -50,6 +50,7 @@ describe 'director.yml.erb' do
         'enable_post_deploy' => true,
         'enable_nats_delivered_templates' => false,
         'enable_cpi_resize_disk' => false,
+        'allow_errands_on_stopped_instances' => false,
         'generate_vm_passwords' => false,
         'remove_dev_tools' => false,
         'log_level' => 'debug',
@@ -337,6 +338,22 @@ describe 'director.yml.erb' do
 
           it 'parses correctly' do
             expect(parsed_yaml['config_server']).to eq({"enabled"=>false})
+          end
+        end
+      end
+
+      describe 'allow_errands_on_stopped_instances' do
+        it 'defaults to false' do
+          expect(parsed_yaml['allow_errands_on_stopped_instances']).to be_falsey
+        end
+
+        context 'when set to true' do
+          before do
+            merged_manifest_properties['director']['allow_errands_on_stopped_instances'] = true
+          end
+
+          it 'parses correctly' do
+            expect(parsed_yaml['allow_errands_on_stopped_instances']).to be_truthy
           end
         end
       end

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -61,6 +61,7 @@ module Bosh::Director
         :db_config,
         :director_ips,
         :enable_nats_delivered_templates,
+        :allow_errands_on_stopped_instances,
         :ignore_missing_gateway,
         :director_certificate_expiry_json_path,
         :nats_client_ca_certificate_path,
@@ -209,6 +210,7 @@ module Bosh::Director
         @keep_unreachable_vms = config.fetch('keep_unreachable_vms', false)
         @enable_post_deploy = config.fetch('enable_post_deploy', true)
         @enable_nats_delivered_templates = config.fetch('enable_nats_delivered_templates', false)
+        @allow_errands_on_stopped_instances = config.fetch('allow_errands_on_stopped_instances', false)
         @generate_vm_passwords = config.fetch('generate_vm_passwords', false)
         @remove_dev_tools = config['remove_dev_tools']
         @record_events = config.fetch('record_events', false)

--- a/src/bosh-director/spec/unit/config_spec.rb
+++ b/src/bosh-director/spec/unit/config_spec.rb
@@ -351,6 +351,24 @@ describe Bosh::Director::Config do
       end
     end
 
+    describe 'allow_errands_on_stopped_instances' do
+      it 'defaults to false' do
+        described_class.configure(test_config)
+        expect(described_class.allow_errands_on_stopped_instances).to be_falsey
+      end
+
+      context 'when explicitly set to true' do
+        before do
+          test_config['allow_errands_on_stopped_instances'] = true
+        end
+
+        it 'resolves to true' do
+          described_class.configure(test_config)
+          expect(described_class.allow_errands_on_stopped_instances).to be_truthy
+        end
+      end
+    end
+
     describe 'director version' do
       it 'sets the expected version/revision' do
         described_class.configure(test_config)


### PR DESCRIPTION
### PR following up discussion in #2349

Introduce a new director property to support running errands on stopped instances. The property defaults to false. If set to true, the property brings back old director behavior prior to #2339 which is still needed by some customers.

Please note that we didn't touch the bosh-dev sandbox because we believe integration tests are not needed for this property. It acts as a feature flag, so if not set it defaults to the current behavior.

Please let us know, if changes to the sandbox are still required.

Pair: @ShilpaChandrashekara
PM: @friegger 
Team: @cloudfoundry/cf-bosh-europe 