### PR TITLE
Change expected openssl error

### DIFF
--- a/src/bosh-director/spec/unit/nats_client_cert_generator_spec.rb
+++ b/src/bosh-director/spec/unit/nats_client_cert_generator_spec.rb
@@ -92,23 +92,25 @@ module Bosh
 
           expect { subject }.to raise_error(DeploymentNATSClientCertificateGenerationError) do |error|
             expect(error.message).to include('Error occurred while loading CA Certificate to generate NATS Client certificates')
-            expect(error.message).to include('OpenSSL::X509::CertificateError: PEM_read_bio_X509: short header')
+            expect(error.message).to include('OpenSSL::X509::CertificateError: PEM_read_bio_X509: bad end line')
           end
         end
 
         it 'throws an invalid Private Key error if an error occurs while loading the certificate private key' do
-          allow(Config).to receive(:nats_client_ca_private_key_path).and_return(asset('nats/invalid_nats_ca_certificate_private_key.pem'))
+          allow(Config).to receive(:nats_client_ca_private_key_path)
+            .and_return(asset('nats/invalid_nats_ca_certificate_private_key.pem'))
 
           expect { subject }.to raise_error(DeploymentNATSClientCertificateGenerationError) do |error|
             expect(error.message).to include('Error occurred while loading private key to generate NATS Client certificates')
-            expect(error.message).to include('OpenSSL::PKey::RSAError: Neither PUB key nor PRIV key: short header')
+            expect(error.message).to include('OpenSSL::PKey::RSAError: Neither PUB key nor PRIV key: bad end line')
           end
         end
 
         context 'when the key does not correspond to the certificate passed' do
           before do
             allow(Config).to receive(:nats_client_ca_certificate_path).and_return(asset('nats/nats_ca_certificate.pem'))
-            allow(Config).to receive(:nats_client_ca_private_key_path).and_return(asset('nats/one_off_intermediate_certificate_private_key.pem'))
+            allow(Config).to receive(:nats_client_ca_private_key_path)
+              .and_return(asset('nats/one_off_intermediate_certificate_private_key.pem'))
           end
 
           it 'throws an error' do
@@ -140,8 +142,10 @@ module Bosh
         end
 
         before do
-          allow(Config).to receive(:nats_client_ca_certificate_path).and_return(asset('nats/one_off_intermediate_certificate.pem'))
-          allow(Config).to receive(:nats_client_ca_private_key_path).and_return(asset('nats/one_off_intermediate_certificate_private_key.pem'))
+          allow(Config).to receive(:nats_client_ca_certificate_path)
+            .and_return(asset('nats/one_off_intermediate_certificate.pem'))
+          allow(Config).to receive(:nats_client_ca_private_key_path)
+            .and_return(asset('nats/one_off_intermediate_certificate_private_key.pem'))
         end
 
         it_behaves_like 'agents nats certificates generation'


### PR DESCRIPTION
### What is this change about?
OpenSSL change the expected error for invalid certs from `short header` to `bad end line`.
See pull request https://github.com/openssl/openssl/pull/11793.

Also fixed some offenses regarding line length

### Please provide contextual information.

On my local machine I'm using openssl version `1.1.1o` and the two tests are failing without this fix. 

### What tests have you run against this PR?

All unit tests
