### PR TITLE
Fix: `golangci-lint` warnings in `bosh-release-acceptance-tests`

### DIFF
--- a/src/go/src/github.com/cloudfoundry/bosh-release-acceptance-tests/brats-utils/utils.go
+++ b/src/go/src/github.com/cloudfoundry/bosh-release-acceptance-tests/brats-utils/utils.go
@@ -344,7 +344,7 @@ func StartInnerBoshWithExpectation(expectedFailure bool, expectedErrorToMatch st
 	effectiveArgs = append(effectiveArgs, args...)
 
 	cmd := exec.Command(
-		fmt.Sprintf("../../../../../../../ci/dockerfiles/docker-cpi/start-inner-bosh-parallel.sh"),
+		"../../../../../../../ci/dockerfiles/docker-cpi/start-inner-bosh-parallel.sh",
 		effectiveArgs...,
 	)
 	cmd.Env = os.Environ()
@@ -362,7 +362,7 @@ func StartInnerBoshWithExpectation(expectedFailure bool, expectedErrorToMatch st
 
 func CreateAndUploadBOSHRelease() {
 	cmd := exec.Command(
-		fmt.Sprintf("../../../../../../../ci/dockerfiles/docker-cpi/create-and-upload-release.sh"),
+		"../../../../../../../ci/dockerfiles/docker-cpi/create-and-upload-release.sh",
 		strconv.Itoa(config.GinkgoConfig.ParallelNode),
 	)
 	cmd.Env = os.Environ()

--- a/src/go/src/github.com/cloudfoundry/bosh-release-acceptance-tests/brats/blobstore_test.go
+++ b/src/go/src/github.com/cloudfoundry/bosh-release-acceptance-tests/brats/blobstore_test.go
@@ -75,7 +75,8 @@ var _ = Describe("Blobstore", func() {
 			Expect(err).ToNot(HaveOccurred())
 			jqSession, err := gexec.Start(jq, ioutil.Discard, ioutil.Discard)
 			Expect(err).ToNot(HaveOccurred())
-			io.Copy(si, bytes.NewReader(boshCmdOutput))
+			_, err = io.Copy(si, bytes.NewReader(boshCmdOutput))
+			Expect(err).ToNot(HaveOccurred())
 			si.Close()
 			Eventually(jqSession, 5*time.Second).Should(gexec.Exit(0))
 			return jqSession.Out.Contents()
@@ -94,7 +95,8 @@ var _ = Describe("Blobstore", func() {
 			)
 			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
 			c := config{}
-			json.Unmarshal(getStdout(session.Out.Contents()), &c)
+			err := json.Unmarshal(getStdout(session.Out.Contents()), &c)
+			Expect(err).ToNot(HaveOccurred())
 			return c.BlobstoreConfig.Options.User,
 				c.BlobstoreConfig.Options.Password,
 				c.Env.AgentEnv.BlobstoresConfig[0].Options.Password,
@@ -216,7 +218,8 @@ var _ = Describe("Blobstore", func() {
 			session = bratsutils.BoshQuiet("-d", "syslog-deployment", "ssh", "syslog_forwarder/0", "-r", "--json", "-c", "sudo cat /var/vcap/bosh/settings.json")
 			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
 			c := config{}
-			json.Unmarshal(getStdout(session.Out.Contents()), &c)
+			err := json.Unmarshal(getStdout(session.Out.Contents()), &c)
+			Expect(err).ToNot(HaveOccurred())
 			fmt.Printf("%+v\n", c)
 			Expect(c.Env.AgentEnv.BlobstoresConfig[0].Options.Password).To(Equal(""))
 			Expect(c.Env.AgentEnv.BlobstoresConfig[0].Options.User).To(Equal(""))
@@ -228,7 +231,8 @@ var _ = Describe("Blobstore", func() {
 			session = bratsutils.BoshQuiet("-d", "syslog-deployment", "ssh", "syslog_forwarder/0", "-r", "--json", "-c", "sudo cat /var/vcap/bosh/warden-cpi-agent-env.json")
 			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
 			c = config{}
-			json.Unmarshal(getStdout(session.Out.Contents()), &c)
+			err = json.Unmarshal(getStdout(session.Out.Contents()), &c)
+			Expect(err).ToNot(HaveOccurred())
 			fmt.Printf("%+v\n", c)
 			Expect(c.Env.AgentEnv.BlobstoresConfig[0].Options.Password).To(Equal(""))
 			Expect(c.Env.AgentEnv.BlobstoresConfig[0].Options.User).To(Equal(""))


### PR DESCRIPTION
### What is this change about?

* Remove unneccessary uses of `fmt.Sprintf`
* Check errors that were being discarded

### Please provide contextual information.

In `main` branch:

```bash
$ cd bosh/src/go/src/github.com/cloudfoundry/bosh-release-acceptance-tests
$ golangci-lint run ./...
brats-utils/utils.go:347:3: S1039: unnecessary use of fmt.Sprintf (gosimple)
		fmt.Sprintf("../../../../../../../ci/dockerfiles/docker-cpi/start-inner-bosh-parallel.sh"),
		^
brats-utils/utils.go:365:3: S1039: unnecessary use of fmt.Sprintf (gosimple)
		fmt.Sprintf("../../../../../../../ci/dockerfiles/docker-cpi/create-and-upload-release.sh"),
		^
brats/blobstore_test.go:78:11: Error return value of `io.Copy` is not checked (errcheck)
			io.Copy(si, bytes.NewReader(boshCmdOutput))
			       ^
brats/blobstore_test.go:97:18: Error return value of `json.Unmarshal` is not checked (errcheck)
			json.Unmarshal(getStdout(session.Out.Contents()), &c)
			              ^
brats/blobstore_test.go:219:18: Error return value of `json.Unmarshal` is not checked (errcheck)
			json.Unmarshal(getStdout(session.Out.Contents()), &c)
			              ^
brats/blobstore_test.go:231:18: Error return value of `json.Unmarshal` is not checked (errcheck)
			json.Unmarshal(getStdout(session.Out.Contents()), &c)
```

### What tests have you run against this PR?

None

### How should this change be described in bosh release notes?

N/A

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!

N/A