### PR TITLE
Use director proxy_timeout also for metrics server

### DIFF
--- a/jobs/director/templates/nginx.conf.erb
+++ b/jobs/director/templates/nginx.conf.erb
@@ -132,6 +132,8 @@ http {
     ssl_client_certificate /var/vcap/jobs/director/config/metrics_server/ca.pem;
     ssl_verify_client on;
 
+    proxy_read_timeout       <%= p('director.proxy_timeout') %>;
+
     location / {
       proxy_pass http://metrics_server;
     }


### PR DESCRIPTION
### What is this change about?

Use proxy_timeout also for metrics server nginx configuration.

### Please provide contextual information.

Depending on the size of the environment, the amount of metrics produced also increases and metrics gathering may take more than the default 60s proxy_read_timeout after which nginx responds with "504 Gateway Time-out".

### What tests have you run against this PR?

After applying the change to a director the described symptom (504 Gateway Time-out)...
1. curl the /metrics endpoint
2. curl the /api_metrics endpoint

### How should this change be described in bosh release notes?

Use director proxy_timeout also for metrics server

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!
@benjaminguttmann-avtq
