### PR TITLE
Do not fail if you have old postgres data dir if you've already upgraded

### DIFF
--- a/jobs/postgres-10/templates/pre-start.erb
+++ b/jobs/postgres-10/templates/pre-start.erb
@@ -18,7 +18,7 @@ if [[ -d /var/vcap/store/postgres-13 ]]; then
   exit 1
 fi
 
-if [[ -d ${STORE_DIR_OLD} ]]; then
+if [[ -d ${STORE_DIR_OLD} ]]  && [[ ! -d ${STORE_DIR} ]]; then
   echo "Please use a previous bosh release version (271.x or lower) to migrate data from postgres-9.4 to postgres-10."
   exit 1
 fi


### PR DESCRIPTION
If you have both postgres 9 and 10 data directories it currently fails. In the new
postgres 13 job we've handled this appropriately so you won't get failures.

We could `rm -rf` the postgres 9 folder also, but the postgres 13 job will do that
when users eventually move to that.

