### PR TITLE
Fix regression: Deployment manifests can contain yaml anchors

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/packages_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/packages_controller.rb
@@ -4,7 +4,7 @@ module Bosh::Director
   module Api::Controllers
     class PackagesController < BaseController
       post '/matches', :consumes => :yaml do
-        manifest = YAML.load(request.body.read)
+        manifest = YAML.load(request.body.read, aliases: true)
 
         unless manifest.is_a?(Hash) && manifest['packages'].is_a?(Array)
           raise BadManifest, "Manifest doesn't have a usable packages section"
@@ -28,7 +28,7 @@ module Bosh::Director
       end
 
       post '/matches_compiled', :consumes => :yaml do
-        manifest = YAML.load(request.body.read)
+        manifest = YAML.load(request.body.read, aliases: true)
 
         unless manifest.is_a?(Hash) && manifest['compiled_packages'].is_a?(Array)
           raise BadManifest, "Manifest doesn't have a usable packages section"

--- a/src/bosh-director/lib/bosh/director/api/runtime_config_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/runtime_config_manager.rb
@@ -20,7 +20,7 @@ module Bosh
         private
 
         def validate_yml(runtime_config)
-          YAML.load(runtime_config)
+          YAML.load(runtime_config, aliases: true)
         rescue Exception => e
           raise InvalidYamlError, e.message
         end

--- a/src/bosh-director/lib/bosh/director/jobs/export_release.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/export_release.rb
@@ -80,7 +80,7 @@ module Bosh::Director
       end
 
       def deployment_manifest_has_release?(manifest)
-        deployment_manifest = YAML.load(manifest)
+        deployment_manifest = YAML.load(manifest, aliases: true)
         deployment_manifest['releases'].each do |release|
           if (release['name'] == @release_name) && (release['version'].to_s == @release_version.to_s)
             return true

--- a/src/bosh-director/lib/bosh/director/jobs/release/release_job.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/release/release_job.rb
@@ -72,7 +72,7 @@ module Bosh::Director
           "Missing job manifest for '#{name}'"
       end
 
-      YAML.load_file(manifest_file)
+      YAML.load_file(manifest_file, aliases: true)
     end
 
     def validate_templates(job_manifest)

--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -327,7 +327,7 @@ module Bosh::Director
         raise(BadManifest, 'No successful BOSH deployment manifest available') if raw_manifest_text.nil?
 
         logger.info('Reading deployment manifest')
-        @manifest_hash = YAML.load(raw_manifest_text)
+        @manifest_hash = YAML.load(raw_manifest_text, aliases: true)
         logger.debug("Manifest:\n#{raw_manifest_text}")
         @manifest_hash
       end

--- a/src/bosh-director/lib/bosh/director/jobs/update_release.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_release.rb
@@ -86,7 +86,7 @@ module Bosh::Director
         manifest_file = File.join(release_dir, 'release.MF')
         raise ReleaseManifestNotFound, 'Release manifest not found' unless File.file?(manifest_file)
 
-        @manifest = YAML.load_file(manifest_file)
+        @manifest = YAML.load_file(manifest_file, aliases: true)
 
         # handle compiled_release case
         @compiled_release = !!@manifest['compiled_packages']

--- a/src/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
@@ -56,7 +56,7 @@ module Bosh::Director
 
         track_and_log('Verifying stemcell manifest') do
           stemcell_manifest_file = File.join(stemcell_dir, 'stemcell.MF')
-          stemcell_manifest = YAML.load_file(stemcell_manifest_file)
+          stemcell_manifest = YAML.load_file(stemcell_manifest_file, aliases: true)
 
           @name = safe_property(stemcell_manifest, 'name', class: String)
           @operating_system = safe_property(stemcell_manifest, 'operating_system', class: String, optional: true, default: @name)

--- a/src/bosh-director/lib/bosh/director/models/cpi_config.rb
+++ b/src/bosh-director/lib/bosh/director/models/cpi_config.rb
@@ -11,7 +11,7 @@ module Bosh
         end
 
         def manifest
-          YAML.load properties
+          YAML.load(properties, aliases: true)
         end
       end
     end

--- a/src/bosh-director/lib/bosh/director/models/deployment.rb
+++ b/src/bosh-director/lib/bosh/director/models/deployment.rb
@@ -86,7 +86,7 @@ module Bosh::Director::Models
     def tags
       return {} unless manifest
 
-      manifest_tags = YAML.load(manifest)['tags']
+      manifest_tags = YAML.load(manifest, aliases: true)['tags']
 
       consolidated_runtime_config = Bosh::Director::RuntimeConfig::RuntimeConfigsConsolidator.new(runtime_configs)
 

--- a/src/bosh-director/lib/cloud/dummy.rb
+++ b/src/bosh-director/lib/cloud/dummy.rb
@@ -49,7 +49,7 @@ module Bosh
         validate_and_record_inputs(CREATE_STEMCELL_SCHEMA, __method__, image_path, cloud_properties)
 
         content = File.read(image_path)
-        data = YAML.load(content)
+        data = YAML.load(content, aliases: true)
         data.merge!('image' => image_path)
         stemcell_id = SecureRandom.uuid
 
@@ -377,7 +377,7 @@ module Bosh
           [].tap do |results|
             files.each do |file|
               # data --> [{ 'name' => 'ubuntu-stemcell', 'version': '1', 'image' => <image path> }]
-              data = YAML.load(File.read(file))
+              data = YAML.load(File.read(file), aliases: true)
               results << { 'id' => file.sub(/^stemcell_/, '') }.merge(data)
             end
           end.sort { |a, b| a[:version].to_i <=> b[:version].to_i }

--- a/src/bosh-template/lib/bosh/template/test/job.rb
+++ b/src/bosh-template/lib/bosh/template/test/job.rb
@@ -8,7 +8,7 @@ module Bosh::Template::Test
       @job_path = File.join(@release_path, 'jobs', @name)
       # raise "No such job at path: #{@job_path}" if !File.exist?(@job_path)
       spec_path = File.join(@job_path, 'spec')
-      @spec = YAML.load(File.read(spec_path))
+      @spec = YAML.load(File.read(spec_path), aliases: true)
       @templates = @spec['templates']
     end
 


### PR DESCRIPTION
### What is this change about?
Manifest do support yaml anchors again. That support got lost as regression of bosh version v272.1.0.

With Ruby 3.1 Psych was updated to version 4 which comes with an incompatible change. The incompatible change is that YAML.load is not an alias to unsave_load anymore but to save_load instead.

### Please provide contextual information.

The Issue for that PR is: https://github.com/cloudfoundry/bosh/issues/2385

### What tests have you run against this PR?

I have executed the director unittests and deployed it onto one of our landscapes. Then I deployed with that fixed BOSH version a manifest that uses aliases.

### How should this change be described in bosh release notes?

Deployment manifests do support yaml anchors again.


### Does this PR introduce a breaking change?

Actually it fixes a breaking change

### Tag your pair, your PM, and/or team!
@fmoehler
