### PR TITLE
Add name parameter to cloud_configs_controller

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/cloud_config_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/cloud_config_manager.rb
@@ -2,17 +2,17 @@ module Bosh
   module Director
     module Api
       class CloudConfigManager
-        def update(cloud_config_yaml)
+        def update(cloud_config_yaml, name='default')
           cloud_config = Bosh::Director::Models::Config.new(
             type: 'cloud',
-            name: 'default',
             content: cloud_config_yaml,
+            name: name,
           )
           cloud_config.save
         end
 
-        def list(limit)
-          Bosh::Director::Models::Config.where(deleted: false, type: 'cloud', name: 'default').order(Sequel.desc(:id)).limit(limit).to_a
+        def list(limit, name='default')
+          Bosh::Director::Models::Config.where(deleted: false, type: 'cloud', name: name).order(Sequel.desc(:id)).limit(limit).to_a
         end
 
         def self.interpolated_manifest(cloud_configs, deployment_name)

--- a/src/bosh-director/lib/bosh/director/api/controllers/cloud_configs_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/cloud_configs_controller.rb
@@ -4,30 +4,27 @@ module Bosh::Director
   module Api::Controllers
     class CloudConfigsController < BaseController
       post '/', :consumes => :yaml do
+        config_name = name_from_params(params)
         manifest_text = request.body.read
         begin
           validate_manifest_yml(manifest_text)
 
-          latest_cloud_config = Bosh::Director::Api::CloudConfigManager.new.list(1)
+          latest_cloud_config = Bosh::Director::Api::CloudConfigManager.new.list(1, config_name)
 
           if latest_cloud_config.empty? || latest_cloud_config.first[:content] != manifest_text
-            Bosh::Director::Api::CloudConfigManager.new.update(manifest_text)
-            create_event
+            Bosh::Director::Api::CloudConfigManager.new.update(manifest_text, config_name)
+            create_event(config_name)
           end
 
         rescue => e
-          create_event e
+          create_event(config_name, e)
           raise e
         end
         status(201)
       end
 
       post '/diff', :consumes => :yaml do
-        old_config_hash = cloud_config_or_empty(
-          Bosh::Director::Models::Config.
-            latest_set('cloud').
-            find{|config| config[:name] == 'default'}
-        )
+        old_config_hash = cloud_config_or_empty(cloud_config_by_name(name_from_params(params)))
         new_config_hash = validate_manifest_yml(request.body.read) || {}
 
         result = {}
@@ -57,7 +54,10 @@ module Bosh::Director
           return
         end
 
-        cloud_configs = Bosh::Director::Api::CloudConfigManager.new.list(limit)
+        config_name = name_from_params(params)
+
+        cloud_configs = Bosh::Director::Api::CloudConfigManager.new.list(limit, config_name)
+
         json_encode(
           cloud_configs.map do |cloud_config|
             {
@@ -70,17 +70,28 @@ module Bosh::Director
 
       private
 
+      def name_from_params(params)
+        name = params['name']
+        name.nil? || name.empty? ? 'default' : name
+      end
+
+      def cloud_config_by_name(config_name)
+        Bosh::Director::Models::Config.latest_set('cloud').find do |cloud_config|
+          cloud_config.name == config_name
+        end
+      end
+
       def cloud_config_or_empty(cloud_config_model)
         return {} if cloud_config_model.nil? || cloud_config_model.raw_manifest.nil?
         cloud_config_model.raw_manifest
       end
 
-      def create_event(error = nil)
+      def create_event(config_name, error = nil)
         @event_manager.create_event({
             user:        current_user,
             action:      'update',
             object_type: 'cloud-config',
-            object_name: 'default',
+            object_name: config_name,
             error:       error
         })
       end


### PR DESCRIPTION
### What is this change about?

This change add a `name` parameter to the `cloud_configs_controller.rb`.
This is required to the fix https://github.com/cloudfoundry/bosh-cli/issues/542

In general this solves a inconsistency between the options of command `update-runtime-config` and `update-cloud-config`
This PR is prerequisite for: https://github.com/cloudfoundry/bosh/pull/2390

### Please provide contextual information.

https://github.com/cloudfoundry/bosh-cli/issues/542

### What tests have you run against this PR?

I ran the bosh-director unit tests

### How should this change be described in bosh release notes?

cloud_configs_controller offers a `--name` parameter to upload, diff and retrieve a named cloud config


### Does this PR introduce a breaking change?

no

### Tag your pair, your PM, and/or team!
PO: @friegger