### PR TITLE
deleted bosh config leaves dangling hm rule

### DIFF
--- a/src/bosh-monitor/spec/unit/bosh/monitor/resurrection_manager_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/resurrection_manager_spec.rb
@@ -119,6 +119,31 @@ module Bhm
           expect(resurrection_rules[1].enabled?).to be_falsey
         end
       end
+
+      context 'when resurrection config is an empty array' do
+        it 'deletes existing resurrection rules' do
+          manager.update_rules(resurrection_config)
+          expect(logger).to receive(:info).with('Resurrection config update starting...')
+          expect(logger).to receive(:info).with('Resurrection config update finished')
+          manager.update_rules([])
+          resurrection_rules = manager.instance_variable_get(:@parsed_rules)
+          expect(resurrection_rules.count).to eq(0)
+        end
+      end
+
+      context 'when resurrection config is nil' do
+        it 'uses existing resurrection rules' do
+          expect(logger).to receive(:info).with('Resurrection config update starting...')
+          expect(logger).to receive(:info).with('Resurrection config update finished')
+          manager.update_rules(resurrection_config)
+
+          manager.update_rules(nil)
+          resurrection_rules = manager.instance_variable_get(:@parsed_rules)
+          expect(resurrection_rules.count).to eq(2)
+          expect(resurrection_rules[0].enabled?).to be_truthy
+          expect(resurrection_rules[1].enabled?).to be_falsey
+        end
+      end
     end
 
     describe '#resurrection_enabled?' do


### PR DESCRIPTION
start with no existing bosh configs of type resurrection

create a config of type resurrection via `bosh updatei-config`healthmanager
will create a rule for that config that it tracks internally in the `@parsed_rules`
array.

```
number of bosh configs of type resurrection == 1
parsed rules array length == 1
```

run `bosh delete-config`

```
number of bosh configs of type resurrection == 0
parsed rules array length == 1
```

The problem is in the return early. While it makes sense to return
early if the argument for the method call is nil, it didn't make
sense to return early if the argument was set to an empty array.
Because we actually want the array to be empty if we try to delete
the last resurrection config.

Effectively this issue will cache the contents of the last rule. In a
scenario where the global config is ON and the contents of the last
rule were used to override that value for deployment XYZ, even after
deleting the rule, deployment XYZ would have the resurrection switched
off because the rule in health manager was never deleted even if the
bosh config didn't exists anymore.