### PR TITLE
Add postgres package autobumping

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1095,7 +1095,10 @@ jobs:
     plan:
     - in_parallel:
       - get: bosh-src
-      - get: postgres-src
+      - get: postgres-10-src
+        trigger: true
+      - get: postgres-13-src
+        trigger: true
       - get: nginx-release
         trigger: true
       - get: ruby-release
@@ -1113,14 +1116,29 @@ jobs:
             options:
               credentials_source: static
               json_key: '((bosh_release_blobs_gcp_credentials_json))'
-    - task: bump-postgres-package
+    - task: bump-postgres-10-package
       file: bosh-src/ci/tasks/bump-postgres-packages.yml
       input_mapping:
         bosh-src: bosh-src-out
+        postgres-src: postgres-10-src
       output_mapping:
         bosh-src: bosh-src-out
       params:
-        MAJOR_VERSIONS: "10,13"
+        MAJOR_VERSION: 10
+        PRIVATE_YML: |
+          blobstore:
+            options:
+              credentials_source: static
+              json_key: '((bosh_release_blobs_gcp_credentials_json))'
+    - task: bump-postgres-13-package
+      file: bosh-src/ci/tasks/bump-postgres-packages.yml
+      input_mapping:
+        bosh-src: bosh-src-out
+        postgres-src: postgres-13-src
+      output_mapping:
+        bosh-src: bosh-src-out
+      params:
+        MAJOR_VERSION: 13
         PRIVATE_YML: |
           blobstore:
             options:
@@ -1166,14 +1184,25 @@ resource_types:
     username: ((docker.username))
     password: ((docker.password))
 
+- name: http-resource
+  type: docker-image
+  source:
+    repository: aequitas/http-resource
+
 resources:
-  - name: postgres-src
-    type: git
+  - name: postgres-10-src
+    type: http-resource
     source:
-      uri: https://github.com/postgres/postgres.git
-      #match minor 10,13 and all patch versions
-      fetch_tags: true
-      tag_regex: "REL_1[0,3]_[0-9]*"
+      index: "https://ftp.postgresql.org/pub/source/"
+      regex: 'href="v(?P<version>10\.[0-9.]+)/"'
+      uri: "https://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.gz"
+
+  - name: postgres-13-src
+    type: http-resource
+    source:
+      index: "https://ftp.postgresql.org/pub/source/"
+      regex: 'href="v(?P<version>13\.[0-9.]+)/"'
+      uri: "https://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.gz"
 
   - name: weekly
     type: time

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1095,6 +1095,7 @@ jobs:
     plan:
     - in_parallel:
       - get: bosh-src
+      - get: postgres-src
       - get: nginx-release
         trigger: true
       - get: ruby-release
@@ -1107,6 +1108,19 @@ jobs:
         output_repo: bosh-src-out
       params:
         PACKAGES: [nginx]
+        PRIVATE_YML: |
+          blobstore:
+            options:
+              credentials_source: static
+              json_key: '((bosh_release_blobs_gcp_credentials_json))'
+    - task: bump-postgres-package
+      file: bosh-src/ci/tasks/bump-postgres-packages.yml
+      input_mapping:
+        bosh-src: bosh-src-out
+      output_mapping:
+        bosh-src: bosh-src-out
+      params:
+        MAJOR_VERSIONS: "10,13"
         PRIVATE_YML: |
           blobstore:
             options:
@@ -1153,6 +1167,14 @@ resource_types:
     password: ((docker.password))
 
 resources:
+  - name: postgres-src
+    type: git
+    source:
+      uri: https://github.com/postgres/postgres.git
+      #match minor 10,13 and all patch versions
+      fetch_tags: true
+      tag_regex: "REL_1[0,3]_[0-9]*"
+
   - name: weekly
     type: time
     source:

--- a/ci/tasks/bump-postgres-packages.sh
+++ b/ci/tasks/bump-postgres-packages.sh
@@ -1,0 +1,43 @@
+#/usr/bin/env bash
+NEED_COMMIT=false
+
+echo "${PRIVATE_YML}" > bosh-src/config/private.yml
+
+set -e
+
+pushd postgres-src
+  IFS=,; for VERSION in $MAJOR_VERSIONS; do 
+    MINOR=$(git tag --list  "REL_${VERSION}_[0-9]*" | cut -f3 -d_ | sort -n | tail -1 )
+    echo "creating package for: Major $VERSION.$MINOR";
+    git checkout "REL_${VERSION}_${MINOR}"
+    tar -czf ../postgresql-${VERSION}.${MINOR}.tar.gz --exclude=.git* .
+  done
+popd
+
+pushd bosh-src
+  CURRENT_BLOBS=$(bosh blobs)
+  IFS=,; for VERSION in ${MAJOR_VERSIONS}; do 
+    BLOB_PATH=$(ls ../postgresql-${VERSION}*)
+    FILENAME=$( echo ${BLOB_PATH} | cut -f2 -d'/' )
+    OLD_BLOB_PATH=$(cat config/blobs.yml  | grep "postgresql-${VERSION}" | cut -f1 -d:)
+    if ! echo "${CURRENT_BLOBS}" | grep "${FILENAME}" ; then
+      NEED_COMMIT=true
+      echo "adding ${FILENAME}"
+      bosh add-blob --sha2 "${BLOB_PATH}" "postgres/${FILENAME}"
+      bosh remove-blob ${OLD_BLOB_PATH}
+      bosh upload-blobs
+    fi
+  done
+
+  if ${NEED_COMMIT}; then
+    echo "-----> $(date): Creating git commit"
+    git config user.name "$GIT_USER_NAME"
+    git config user.email "$GIT_USER_EMAIL"
+    git add .
+
+    git --no-pager diff --cached
+    if [[ "$( git status --porcelain )" != "" ]]; then
+      git commit -am "Bump packages"
+    fi
+  fi
+popd

--- a/ci/tasks/bump-postgres-packages.sh
+++ b/ci/tasks/bump-postgres-packages.sh
@@ -5,29 +5,18 @@ echo "${PRIVATE_YML}" > bosh-src/config/private.yml
 
 set -e
 
-pushd postgres-src
-  IFS=,; for VERSION in $MAJOR_VERSIONS; do 
-    MINOR=$(git tag --list  "REL_${VERSION}_[0-9]*" | cut -f3 -d_ | sort -n | tail -1 )
-    echo "creating package for: Major $VERSION.$MINOR";
-    git checkout "REL_${VERSION}_${MINOR}"
-    tar -czf ../postgresql-${VERSION}.${MINOR}.tar.gz --exclude=.git* .
-  done
-popd
-
 pushd bosh-src
   CURRENT_BLOBS=$(bosh blobs)
-  IFS=,; for VERSION in ${MAJOR_VERSIONS}; do 
-    BLOB_PATH=$(ls ../postgresql-${VERSION}*)
-    FILENAME=$( echo ${BLOB_PATH} | cut -f2 -d'/' )
-    OLD_BLOB_PATH=$(cat config/blobs.yml  | grep "postgresql-${VERSION}" | cut -f1 -d:)
-    if ! echo "${CURRENT_BLOBS}" | grep "${FILENAME}" ; then
-      NEED_COMMIT=true
-      echo "adding ${FILENAME}"
-      bosh add-blob --sha2 "${BLOB_PATH}" "postgres/${FILENAME}"
-      bosh remove-blob ${OLD_BLOB_PATH}
-      bosh upload-blobs
-    fi
-  done
+  BLOB_PATH=$(ls ../postgres-src/postgresql-*.tar.gz)
+  FILENAME=$( basename ${BLOB_PATH} )
+  OLD_BLOB_PATH=$(cat config/blobs.yml  | grep "postgresql-${MAJOR_VERSION}" | cut -f1 -d:)
+  if ! echo "${CURRENT_BLOBS}" | grep "${FILENAME}" ; then
+    NEED_COMMIT=true
+    echo "adding ${FILENAME}"
+    bosh add-blob --sha2 "${BLOB_PATH}" "postgres/${FILENAME}"
+    bosh remove-blob ${OLD_BLOB_PATH}
+    bosh upload-blobs
+  fi
 
   if ${NEED_COMMIT}; then
     echo "-----> $(date): Creating git commit"

--- a/ci/tasks/bump-postgres-packages.yml
+++ b/ci/tasks/bump-postgres-packages.yml
@@ -1,0 +1,24 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: bosh/main-bosh-docker
+
+inputs:
+- name: bosh-src
+- name: postgres-src
+
+outputs:
+- name: bosh-src
+
+run:
+  path: bosh-src/ci/tasks/bump-postgres-packages.sh
+
+params:
+  PRIVATE_YML:
+  MAJOR_VERSIONS: "10,13"
+  GIT_USER_NAME: CI Bot
+  GIT_USER_EMAIL: cf-bosh-eng@pivotal.io
+

--- a/ci/tasks/bump-postgres-packages.yml
+++ b/ci/tasks/bump-postgres-packages.yml
@@ -18,7 +18,7 @@ run:
 
 params:
   PRIVATE_YML:
-  MAJOR_VERSIONS: "10,13"
+  MAJOR_VERSION:
   GIT_USER_NAME: CI Bot
   GIT_USER_EMAIL: cf-bosh-eng@pivotal.io
 


### PR DESCRIPTION
we want to keep postgres packages up to date for the supported major
version lines. This task does exactly that. It checks the postgres git
repo for REL_* tags matching our used postgres versions and creates bosh
blobs from the src. It then replaces and uploads the packages used in
the release.

Implenents: [#182288132]
Fixes: CVE-2022-1552