### PR TITLE
Fix for the race condition related to NATs users

### DIFF
--- a/jobs/nats/monit
+++ b/jobs/nats/monit
@@ -4,13 +4,8 @@ check process nats
   stop program "/var/vcap/jobs/bpm/bin/bpm stop nats"
   group vcap
 
-check file nats_auth_conf
-  with path /var/vcap/data/nats/auth.json
-  if changed checksum then exec "/var/vcap/packages/nats/bin/nats-server --signal reload=/var/vcap/sys/run/bpm/nats/nats.pid"
-
 check process bosh_nats_sync
   with pidfile /var/vcap/sys/run/bpm/nats/bosh_nats_sync.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start nats -p bosh_nats_sync"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop nats -p bosh_nats_sync"
   group vcap
-  depends on nats_auth_conf

--- a/jobs/nats/templates/bosh_nats_sync_config.yml.erb
+++ b/jobs/nats/templates/bosh_nats_sync_config.yml.erb
@@ -18,6 +18,8 @@ params = {
   },
   'nats' => {
     'config_file_path' => '/var/vcap/data/nats/auth.json',
+    'nats_server_executable' => '/var/vcap/packages/nats/bin/nats-server',
+    'nats_server_pid_file' => '/var/vcap/sys/run/bpm/nats/nats.pid',
   },
   'logfile' => '/var/vcap/sys/log/nats/bosh-nats-sync.log',
 }

--- a/jobs/nats/templates/bpm.yml
+++ b/jobs/nats/templates/bpm.yml
@@ -8,6 +8,16 @@ bosh_nats_sync_config = {
     "BUNDLE_GEMFILE" => "/var/vcap/packages/nats/Gemfile",
     "GEM_HOME" => "/var/vcap/packages/nats/gem_home/ruby/3.1.0",
   },
+  "unsafe" => {
+    "privileged" => true,
+    "host_pid_namespace" => true,
+  },
+  "additional_volumes" => [
+    {
+      "path" => "/var/vcap/sys/run/bpm/nats",
+      "mount_only" => true,
+    }
+  ]
 }
 
 nats_config = {

--- a/spec/nats_templates_spec.rb
+++ b/spec/nats_templates_spec.rb
@@ -48,6 +48,8 @@ describe 'bosh_nats_sync_config.yml.erb' do
           poll_user_sync: sync-me
         nats:
           config_file_path: "/var/vcap/data/nats/auth.json"
+          nats_server_executable: "/var/vcap/packages/nats/bin/nats-server"
+          nats_server_pid_file: "/var/vcap/sys/run/bpm/nats/nats.pid"
         logfile: "/var/vcap/sys/log/nats/bosh-nats-sync.log"
 
 

--- a/src/bosh-nats-sync/lib/nats_sync/runner.rb
+++ b/src/bosh-nats-sync/lib/nats_sync/runner.rb
@@ -8,12 +8,15 @@ module NATSSync
       @bosh_config = config['director']
       @poll_user_sync = config['intervals']['poll_user_sync']
       @nats_config_file_path = config['nats']['config_file_path']
+      @nats_server_executable = config['nats']['nats_server_executable']
+      @nats_server_pid_file = config['nats']['nats_server_pid_file']
     end
 
     def run
       NATSSync.logger.info('Nats Sync starting...')
       EM.error_handler { |e| handle_em_error(e) }
       EM.run do
+        UsersSync.restart_nats_server(@nats_server_executable, @nats_server_pid_file)
         setup_timers
       end
     end
@@ -31,7 +34,7 @@ module NATSSync
     end
 
     def sync_nats_users
-      UsersSync.new(@nats_config_file_path, @bosh_config).execute_users_sync
+      UsersSync.new(@nats_config_file_path, @bosh_config, @nats_server_executable, @nats_server_pid_file).execute_users_sync
     end
 
     def handle_em_error(err)

--- a/src/bosh-nats-sync/lib/nats_sync/runner.rb
+++ b/src/bosh-nats-sync/lib/nats_sync/runner.rb
@@ -16,7 +16,7 @@ module NATSSync
       NATSSync.logger.info('Nats Sync starting...')
       EM.error_handler { |e| handle_em_error(e) }
       EM.run do
-        UsersSync.restart_nats_server(@nats_server_executable, @nats_server_pid_file)
+        UsersSync.reload_nats_server_config(@nats_server_executable, @nats_server_pid_file)
         setup_timers
       end
     end

--- a/src/bosh-nats-sync/lib/nats_sync/users_sync.rb
+++ b/src/bosh-nats-sync/lib/nats_sync/users_sync.rb
@@ -1,21 +1,34 @@
 require 'rest-client'
 require 'base64'
 require 'nats_sync/nats_auth_config'
+require 'open3'
 
 module NATSSync
   class UsersSync
-    def initialize(nats_config_file_path, bosh_config)
+    def initialize(nats_config_file_path, bosh_config, nats_server_executable, nats_server_pid_file)
       @nats_config_file_path = nats_config_file_path
       @bosh_config = bosh_config
+      @nats_server_executable = nats_server_executable
+      @nats_server_pid_file = nats_server_pid_file
     end
 
     def execute_users_sync
       NATSSync.logger.info 'Executing NATS Users Synchronization'
       vms_uuids = query_all_running_vms
+      current_file_hash = nats_file_hash
       write_nats_config_file(vms_uuids, read_subject_file(@bosh_config['director_subject_file']),
                              read_subject_file(@bosh_config['hm_subject_file']))
+      new_file_hash = nats_file_hash
+      UsersSync.restart_nats_server(@nats_server_executable, @nats_server_pid_file) unless current_file_hash == new_file_hash
       NATSSync.logger.info 'Finishing NATS Users Synchronization'
       vms_uuids
+    end
+
+    def self.restart_nats_server(nats_server_executable, nats_server_pid_file)
+      output, status = Open3.capture2e("#{nats_server_executable} --signal reload=#{nats_server_pid_file}")
+      unless status.success?
+        raise("Cannot execute: #{nats_server_executable} --signal reload=#{nats_server_pid_file}, Status Code: #{status} \nError: #{output}")
+      end
     end
 
     private

--- a/src/bosh-nats-sync/lib/nats_sync/users_sync.rb
+++ b/src/bosh-nats-sync/lib/nats_sync/users_sync.rb
@@ -19,12 +19,12 @@ module NATSSync
       write_nats_config_file(vms_uuids, read_subject_file(@bosh_config['director_subject_file']),
                              read_subject_file(@bosh_config['hm_subject_file']))
       new_file_hash = nats_file_hash
-      UsersSync.restart_nats_server(@nats_server_executable, @nats_server_pid_file) unless current_file_hash == new_file_hash
+      UsersSync.reload_nats_server_config(@nats_server_executable, @nats_server_pid_file) unless current_file_hash == new_file_hash
       NATSSync.logger.info 'Finishing NATS Users Synchronization'
       vms_uuids
     end
 
-    def self.restart_nats_server(nats_server_executable, nats_server_pid_file)
+    def self.reload_nats_server_config(nats_server_executable, nats_server_pid_file)
       output, status = Open3.capture2e("#{nats_server_executable} --signal reload=#{nats_server_pid_file}")
       unless status.success?
         raise("Cannot execute: #{nats_server_executable} --signal reload=#{nats_server_pid_file}, Status Code: #{status} \nError: #{output}")

--- a/src/bosh-nats-sync/spec/assets/sample_config.yml
+++ b/src/bosh-nats-sync/spec/assets/sample_config.yml
@@ -15,6 +15,8 @@ intervals:
 
 nats:
   config_file_path: /var/vcap/data/nats/auth.json
+  nats_server_executable: /var/vcap/packages/nats/bin/nats-server
+  nats_server_pid_file: /var/vcap/sys/run/bpm/nats/nats.pid
 
 logfile: /tmp/bosh-nats-sync.log
 

--- a/src/bosh-nats-sync/spec/nats_sync/runner_spec.rb
+++ b/src/bosh-nats-sync/spec/nats_sync/runner_spec.rb
@@ -25,7 +25,7 @@ describe NATSSync::Runner do
     let(:file_path) { '/var/vcap/data/nats/auth.json' }
     before do
       allow(user_sync_instance).to receive(:execute_users_sync)
-      allow(user_sync_class).to receive(:restart_nats_server)
+      allow(user_sync_class).to receive(:reload_nats_server_config)
       allow(user_sync_class).to receive(:new).and_return(user_sync_instance)
       Thread.new do
         subject.run
@@ -54,7 +54,7 @@ describe NATSSync::Runner do
       allow(EM).to receive(:stop_event_loop)
 
       allow(user_sync_instance).to receive(:execute_users_sync).and_raise(error)
-      allow(user_sync_class).to receive(:restart_nats_server)
+      allow(user_sync_class).to receive(:reload_nats_server_config)
       allow(user_sync_class).to receive(:new).and_return(user_sync_instance)
       Thread.new do
         subject.run


### PR DESCRIPTION
Every time that a new VM is added by BOSH the authentication file for NATs receives a new user so the BOSH Agent of that VM is able to authenticate to NATs. Changes in this file require a NATs reload. This reload was being made by monit, but it was proving to be unreliable specifically at director startup. This change is to remove the responsibility of restarting NATs from monit and move it to the bosh-nats-sync program, which is more flexible since we control its behavior.

NATs reload will happen in the following scenarios:
- NATs is up and running and bosh-nats-sync is starting.
- NATs is up and running and bosh-nats-sync finds a change in the bosh instances that are running.

If for some reason bosh-nats-sync is unable to reload NATs, it will raise an error and monit will restart it.

For the bosh-nats-sync to be able to reload NATs, privileges were given to its container, so it's able to send signals to the NATs server process.

Signed-off-by: Daniel Felipe Ochoa <danielfelipo@vmware.com>
Signed-off-by: Brian Upton <bupton@vmware.com>
