### PR TITLE
expose agent_wait_timeout property

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -441,6 +441,9 @@ properties:
   agent.env.bosh:
     description: Base env for agent
     default: {}
+  agent.agent_wait_timeout:
+    description: optional agent wait timeout setting, default 600s
+    default: 600
   registry.address:
     description: Address of the Registry to connect to
   registry.port:

--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -369,7 +369,8 @@ params['cloud'] = {
 params['agent'] = {
   'env' => {
     'bosh' => p('agent.env.bosh')
-  }
+  },
+  'agent_wait_timeout' => p('agent.agent_wait_timeout')
 }
 
 JSON.dump(params)


### PR DESCRIPTION
expose agent_wait_timeout property, it maybe useful in slow environment.

Fixes-Bug: #2405

### What is this change about?

The bosh agent timeout is 600 by default, and there is no way to customize right now for ops manager managed bosh cause the manifest is not exposed.

We are running in nested environment, sometimes due to resource contention, the environment can get slow, expose the timeout setting, we can adjust the timeout setting to redure failure rate.

To avoid error like this:
```
Task 32

Task 32 | 03:19:13 | Preparing deployment: Preparing deployment (00:00:09)
Task 32 | 03:19:22 | Preparing deployment: Rendering templates (00:00:10)
Task 32 | 03:19:32 | Preparing package compilation: Finding packages to compile (00:00:00)
Task 32 | 03:19:32 | Compiling packages: jq-1.6/a0adb6701bf46e97d40023cd6cc02c5c2c59b9bc
Task 32 | 03:19:32 | Compiling packages: golang-1.17-linux/355e0f4a536222d97a513bf5ca619f4abd4b755f4d3b9a5f788c84995414da7c
Task 32 | 03:19:32 | Compiling packages: ruby-3.1.1-r0.86.0/6cbb082298da54481330e30a57a4c587ae20db0c51b1bdee448ca817263bda3a
Task 32 | 03:19:32 | Compiling packages: jemalloc-5.2.1/a2271abcfb45d7943bf671cbdf4322176de7ef8c
Task 32 | 03:22:20 | Compiling packages: jq-1.6/a0adb6701bf46e97d40023cd6cc02c5c2c59b9bc (00:02:48)
Task 32 | 03:22:20 | Compiling packages: ruby-3.1.1-r0.86.0/6cbb082298da54481330e30a57a4c587ae20db0c51b1bdee448ca817263bda3a
Task 32 | 03:24:08 | Compiling packages: jemalloc-5.2.1/a2271abcfb45d7943bf671cbdf4322176de7ef8c (00:04:36)
Task 32 | 03:24:08 | Compiling packages: pks-nsx-t-curl/5bd047f96fe7d228f2d188a23941b6bbb74dabdf2c5f9a2da5dd8cc14945e1e9 (00:01:15)
Task 32 | 03:25:23 | Compiling packages: pks-nsx-t-jq/04efd099e0390fdc6fe33166fbd76991d36b182a93705cd817f0660ae1892540 (00:00:18)
Task 32 | 03:25:41 | Compiling packages: pks-nsx-t-govc/3a5954e78a7d8bbf71b8d0479429f5264e501f2045524fd4187fbeccfed5184d (00:00:19)
Task 32 | 03:26:00 | Compiling packages: pks-nsx-t-scripts/ea2810557652749d719aea9624957aa39fb15856c5247668535b7497fcfcd239 (00:00:17)
Task 32 | 03:26:17 | Compiling packages: database-backup-restorer-boost/05f72399bdd8d91643f42ac411ba65befb78ac0334484dbc3ca95c5286ab7680
Task 32 | 03:26:43 | Compiling packages: ruby-3.1.1-r0.86.0/6cbb082298da54481330e30a57a4c587ae20db0c51b1bdee448ca817263bda3a (00:07:11)
Task 32 | 03:26:43 | Compiling packages: libopenssl1/fc7399fff08220e310276752269465ea796a68700f506af401b14693a266458f
Task 32 | 03:26:51 | Compiling packages: ruby-3.1.1-r0.86.0/6cbb082298da54481330e30a57a4c587ae20db0c51b1bdee448ca817263bda3a (00:07:19)
Task 32 | 03:26:51 | Compiling packages: libpcre2/179e9ac923922eafa49c6ca5ba58c1a0ef996a066ff1673d57549c2a6e140f52
Task 32 | 03:26:56 | Compiling packages: database-backup-restorer-boost/05f72399bdd8d91643f42ac411ba65befb78ac0334484dbc3ca95c5286ab7680 (00:00:39)
Task 32 | 03:26:56 | Compiling packages: database-backup-restorer-postgres-13/cde50a4f0c08d11adfa6ae4a55a6d7a7a116f7cf8206de6262080d20128f976c
Task 32 | 03:27:20 | Compiling packages: libpcre2/179e9ac923922eafa49c6ca5ba58c1a0ef996a066ff1673d57549c2a6e140f52 (00:00:29)
Task 32 | 03:27:20 | Compiling packages: database-backup-restorer-postgres-11/9988edefe0e8272e2621ba76177ec39cd359c5f80a106f7ba0d5579e7c33a32a
Task 32 | 03:30:43 | Compiling packages: libopenssl1/fc7399fff08220e310276752269465ea796a68700f506af401b14693a266458f (00:04:00)
Task 32 | 03:30:43 | Compiling packages: database-backup-restorer-postgres-10/67733ad1b5143425b5ee7a46a491e1389910f5b96c15d8c29bd73b8bae70e6f7
Task 32 | 03:30:45 | Compiling packages: golang-1.17-linux/355e0f4a536222d97a513bf5ca619f4abd4b755f4d3b9a5f788c84995414da7c (00:11:13)
L Error: Timed out pinging VM 'vm-ddcc1564-3897-41a6-958c-8194f0a16015' with agent '5eb45e7a-f007-4b18-a969-db19db307d37' after 600 seconds
Task 32 | 03:32:58 | Compiling packages: database-backup-restorer-postgres-11/9988edefe0e8272e2621ba76177ec39cd359c5f80a106f7ba0d5579e7c33a32a (00:05:38)
Task 32 | 03:32:58 | Compiling packages: database-backup-restorer-postgres-13/cde50a4f0c08d11adfa6ae4a55a6d7a7a116f7cf8206de6262080d20128f976c (00:06:02)could not execute "apply-changes": installation was unsuccessful

Task 32 | 03:36:25 | Compiling packages: database-backup-restorer-postgres-10/67733ad1b5143425b5ee7a46a491e1389910f5b96c15d8c29bd73b8bae70e6f7 (00:05:42)
Task 32 | 03:36:51 | Error: Timed out pinging VM 'vm-ddcc1564-3897-41a6-958c-8194f0a16015' with agent '5eb45e7a-f007-4b18-a969-db19db307d37' after 600 seconds

Task 32 Started  Tue Oct 25 03:19:13 UTC 2022
Task 32 Finished Tue Oct 25 03:36:51 UTC 2022
Task 32 Duration 00:17:38
Task 32 error
Updating deployment:
Expected task '32' to succeed but state is 'error'

Exit code 1
```

### Please provide contextual information.

https://vmware.slack.com/archives/C047TFNTP98/p1666616286016119

### What tests have you run against this PR?

_Include a comprehensive list of all tests run successfully._

### How should this change be described in bosh release notes?

-  allow use to customize agent_wait_timeout, for slow environments

### Does this PR introduce a breaking change?

Should not break anything, the default value 600 is the same as previously hardcoded value.

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
