### PR TITLE
Use Clang if available for Ruby 3.1+

### DIFF
--- a/ci/templates/packages/ruby/packaging.erb
+++ b/ci/templates/packages/ruby/packaging.erb
@@ -14,6 +14,11 @@ if [ $(uname -s) == "Darwin" ]; then
   fi
 fi
 
+# Use Clang if available; the resulting Ruby is faster
+if [ -x /usr/bin/clang ]; then
+  export CXX=/usr/bin/clang++ CC=/usr/bin/clang
+fi
+
 openssl_version=$(openssl version)
 openssl_major_version=$(echo "${openssl_version}" | cut -f2 -d\ | cut -f1 -d.)
 if [ "${openssl_major_version}" == 0 ]; then

--- a/ci/templates/src/compile.env.erb
+++ b/ci/templates/src/compile.env.erb
@@ -3,6 +3,11 @@
 # shellcheck disable=1090
 source "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/<%= ruby_packagename %>/bosh/runtime.env"
 
+# Use Clang if available; the resulting Ruby is faster
+if [ -x /usr/bin/clang ]; then
+  export CXX=/usr/bin/clang++ CC=/usr/bin/clang
+fi
+
 bosh_bundle() {
   bundle config set --local no_prune 'true'
   bundle config set --local without 'development test'

--- a/packages/director-ruby-3.1/packaging
+++ b/packages/director-ruby-3.1/packaging
@@ -14,6 +14,11 @@ if [ $(uname -s) == "Darwin" ]; then
   fi
 fi
 
+# Use Clang if available; the resulting Ruby is faster
+if [ -x /usr/bin/clang ]; then
+  export CXX=/usr/bin/clang++ CC=/usr/bin/clang
+fi
+
 openssl_version=$(openssl version)
 openssl_major_version=$(echo "${openssl_version}" | cut -f2 -d\ | cut -f1 -d.)
 if [ "${openssl_major_version}" == 0 ]; then

--- a/src/compile-3.1.env
+++ b/src/compile-3.1.env
@@ -3,6 +3,11 @@
 # shellcheck disable=1090
 source "${BOSH_PACKAGES_DIR:-/var/vcap/packages}/director-ruby-3.1/bosh/runtime.env"
 
+# Use Clang if available; the resulting Ruby is faster
+if [ -x /usr/bin/clang ]; then
+  export CXX=/usr/bin/clang++ CC=/usr/bin/clang
+fi
+
 bosh_bundle() {
   bundle config set --local no_prune 'true'
   bundle config set --local without 'development test'


### PR DESCRIPTION
The Clang compiler generates a smaller, faster Ruby than GCC on Jammy stemcells.

Specifically, the thread memory footprint is much smaller, from our notes:

- Jammy w/ GCC: 21688 initial, 32156 after thread, 32156 after finish, around 1MB per Thread.new call
- Jammy w/ Clang: 13932 initial, 14012 after thread, 14208 after finish, between 8KB and 28KB per Thread.new call

### What is this change about?

Ruby programs using Ruby compiled with GCC (GNU Compiler Collection) on Jammy stemcells have a much larger RSS (Resident Set Size) memory footprint, which can cause memory pressure. This affects Ruby-based programs such as the BOSH Director and the BOSH Azure, AWS, and vSphere CPIs. This can cause BOSH operations such as “bosh deploy” to take much longer and even time out.

This change compiles the Ruby interpreter on Jammy with Clang (an Apple-sponsored GCC-compatible compiler). Ruby interpreters compiled with Clang don’t appear to have the same memory bloat when running the BOSH Director or the Ruby-based CPIs.

### Please provide contextual information.

- [BOSH Director Performance on Jammy Stemcells FAQ](https://docs.google.com/document/d/1umE4SwaE0wxXNsQs3D4VdFufoBn06KjnHrzNltKIba8/edit#)
- [Modify BOSH Director and Ruby package to use Clang if available](https://www.pivotaltracker.com/story/show/183676698)

### What tests have you run against this PR?

We ran unit tests and deployed a BOSH Director with the changes (i.e. Ruby was compiled with Clang instead of GCC)

### How should this change be described in BOSH release notes?

When Clang C compiler is available on Jammy stemcells, the Ruby on the BOSH Director will be compiled with Clang instead of GCC. This results in a smaller memory footprint and faster deploys. It also fixes certain timeout failures.

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!

@lnguyen 