### PR TITLE
Cache /info on nats sync

### DIFF
--- a/src/bosh-nats-sync/lib/nats_sync/users_sync.rb
+++ b/src/bosh-nats-sync/lib/nats_sync/users_sync.rb
@@ -117,9 +117,10 @@ module NATSSync
     end
 
     def info
+      return @director_info if @director_info
       body = call_bosh_api_no_auth('/info')
 
-      JSON.parse(body)
+      @director_info = JSON.parse(body)
     end
 
     def create_authentication_header


### PR DESCRIPTION
 The nats sync calls info endpoint on every call it does to /vms This is not ideal.
This is not ideal. This caches the info call as it doesn't change that often
