### PR TITLE
make task state db calls more resilient against flaky pg. Add cleanup for orphaned tasks without a delayed job entry.

### DIFF
--- a/src/bosh-director/lib/bosh/director/job_queue.rb
+++ b/src/bosh-director/lib/bosh/director/job_queue.rb
@@ -8,6 +8,7 @@ module Bosh::Director
       task = create_task(username, job_class.job_type, description, deployment, context_id)
 
       Delayed::Worker.backend = :sequel
+
       db_job = Bosh::Director::Jobs::DBJob.new(job_class, task.id, params)
       Delayed::Job.enqueue db_job
       task

--- a/src/bosh-director/lib/bosh/director/job_queue.rb
+++ b/src/bosh-director/lib/bosh/director/job_queue.rb
@@ -42,13 +42,7 @@ module Bosh::Director
       end
 
       task.output = log_dir
-      Config.db.transaction(
-        wait: 1.seconds,
-        attempts: 5,
-        retry_on: [Sequel::DatabaseConnectionError, Sequel::DatabaseDisconnectError],
-      ) do
-        task.save
-      end
+      task.save
 
       task
     end

--- a/src/bosh-director/lib/bosh/director/job_queue.rb
+++ b/src/bosh-director/lib/bosh/director/job_queue.rb
@@ -4,7 +4,7 @@ module Bosh::Director
   # Abstracts the delayed jobs system.
 
   class JobQueue
-    def enqueue(username, job_class, description, params, deployment = nil, context_id = '')
+    def enqueue(username, job_class, description, params, deployment = nil, context_id = '') # rubocop:disable Metrics/ParameterLists
       task = create_task(username, job_class.job_type, description, deployment, context_id)
 
       Delayed::Worker.backend = :sequel
@@ -16,17 +16,20 @@ module Bosh::Director
     private
 
     def create_task(username, type, description, deployment, context_id)
-      task = Models::Task.create_with_teams(username:,
-                                            type:,
-                                            description:,
-                                            state: :queued,
-                                            deployment_name: deployment ? deployment.name : nil,
-                                            timestamp: Time.now,
-                                            teams: deployment ? deployment.teams : nil,
-                                            checkpoint_time: Time.now,
-                                            context_id:,
-                                            result_output: '',
-                                            event_output: '')
+      task = Models::Task.create_with_teams(
+        username:,
+        type:,
+        description:,
+        state: :queued,
+        deployment_name: deployment ? deployment.name : nil,
+        timestamp: Time.now,
+        teams: deployment ? deployment.teams : nil,
+        checkpoint_time: Time.now,
+        context_id:,
+        result_output: '',
+        event_output: '',
+      )
+
       log_dir = File.join(Config.base_dir, 'tasks', task.id.to_s)
       FileUtils.rm_rf(log_dir)
       task_status_file = File.join(log_dir, 'debug')
@@ -38,7 +41,14 @@ module Bosh::Director
       end
 
       task.output = log_dir
-      task.save
+      Config.db.transaction(
+        wait: 1.seconds,
+        attempts: 5,
+        retry_on: [Sequel::DatabaseConnectionError, Sequel::DatabaseDisconnectError],
+      ) do
+        task.save
+      end
+
       task
     end
 

--- a/src/bosh-director/lib/bosh/director/job_queue.rb
+++ b/src/bosh-director/lib/bosh/director/job_queue.rb
@@ -1,7 +1,6 @@
 require 'bosh/director/api/task_remover'
 
 module Bosh::Director
-
   # Abstracts the delayed jobs system.
 
   class JobQueue
@@ -17,17 +16,17 @@ module Bosh::Director
     private
 
     def create_task(username, type, description, deployment, context_id)
-      task = Models::Task.create_with_teams(:username => username,
-        :type => type,
-        :description => description,
-        :state => :queued,
-        :deployment_name => deployment ? deployment.name : nil,
-        :timestamp => Time.now,
-        :teams => deployment ? deployment.teams : nil,
-        :checkpoint_time => Time.now,
-        :context_id => context_id,
-        :result_output => "",
-        :event_output => "")
+      task = Models::Task.create_with_teams(username:,
+                                            type:,
+                                            description:,
+                                            state: :queued,
+                                            deployment_name: deployment ? deployment.name : nil,
+                                            timestamp: Time.now,
+                                            teams: deployment ? deployment.teams : nil,
+                                            checkpoint_time: Time.now,
+                                            context_id:,
+                                            result_output: '',
+                                            event_output: '')
       log_dir = File.join(Config.base_dir, 'tasks', task.id.to_s)
       FileUtils.rm_rf(log_dir)
       task_status_file = File.join(log_dir, 'debug')

--- a/src/bosh-director/lib/bosh/director/jobs/db_job.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/db_job.rb
@@ -53,13 +53,15 @@ module Bosh::Director
       private
 
       def update_task_state
+        task = Models::Task.where(id: @task_id).first
+        current_state = task.state
+
         Config.db.transaction(wait: 1.seconds, attempts: 5,
                               retry_on: [Sequel::DatabaseDisconnectError, Sequel::DatabaseConnectionError]) do
-          task = Models::Task.where(id: @task_id).first
           raise DirectorError, "Task #{@task_id} not found in queue" unless task
 
           task.checkpoint_time = Time.now
-          case task.state
+          case current_state
           when 'cancelling'
             task.state = 'cancelled'
             Config.logger.debug("Task #{@task_id} cancelled")


### PR DESCRIPTION
in some environments postgres may be overloaded or not working properly. This can lead to connections being unexpectedly closed or failing. In a scenario where a `delayed job` execuction finished (and the job was updated by the `delayed job` gem in the `delayed job table` the update for the task itself in the `tasks` table may fail. The worker will not pick up the task again (as the data in `delayed jobs` table indicates it finished, but the tasks table (which bosh uses to display `bosh tasks`) leaves the task in the `queued` or another state.

Fixes:
`Bosh::Director::Jobs::DBJob (id=897735) (queue=urgent) FAILED (0 prior attempts) with Sequel::DatabaseDisconnectError: PG::UnableToSend: server closed the connection unexpectedly`

Currently some of the task update logic was already wrapped in a repeatable transaction but the errors we've seen in the user-report indicated that updating the task fail with the above error.

While we cannot ensure that the task state will be updated in 100% of the cases, this PR  minimizes the chance that the task state will not be updated when the connection to postgres is flaky.

Additionally this adds discovery of such oprhaned tasks in the tasks cleanup jobs. Only tasks that still have a backing delayed job can possibly get their state updated. If we find no delayed job containing a handler yaml (which contains the task id for the delayed job) with a corresponding task_id, that indicates the task is orphaned and won't be updated anymore. It should be safe to mark these tasks as `error`ed. 

This behaviour can be reproduced by executing the below sql statement against the PG instance backing the director

```
SELECT
 pg_terminate_backend(pid)
FROM
 pg_stat_activity
WHERE
 -- don't kill my own connection!
 pid <> pg_backend_pid()
 -- don't kill the connections to other databases
 AND datname = 'bosh';
pg_terminate_backend
```

while running arbitrary bosh tasks.