### PR TITLE
do not add more than one scan_and_fix task to the director queue

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/plugins/http_request_helper.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/http_request_helper.rb
@@ -4,7 +4,6 @@ module Bosh::Monitor::Plugins
   module HttpRequestHelper
     def send_http_put_request(uri, request)
       logger.debug("sending HTTP PUT to: #{uri}")
-
       env_proxy = URI.parse(uri.to_s).find_proxy
       request[:proxy] = { host: env_proxy.host, port: env_proxy.port } unless env_proxy.nil?
       name = self.class.name
@@ -36,13 +35,16 @@ module Bosh::Monitor::Plugins
       end
     end
 
-    def send_http_get_request(uri)
+    def send_http_get_request(uri, headers = nil)
       # we are interested in response, so send sync request
       logger.debug("Sending GET request to #{uri}")
       cli = sync_client(OpenSSL::SSL::VERIFY_NONE)
       env_proxy = URI.parse(uri.to_s).find_proxy
       cli.proxy = env_proxy unless env_proxy.nil?
-      cli.get(uri)
+
+      return cli.get(uri) if headers.nil?
+
+      cli.get(uri, nil, headers)
     end
 
     def send_http_post_sync_request(uri, request)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
@@ -3,7 +3,6 @@ require_relative '../../../../spec_helper'
 module Bosh::Monitor::Plugins
   describe Resurrector do
     include Support::UaaHelpers
-
     let(:options) do
       {
         'director' => {
@@ -20,7 +19,7 @@ module Bosh::Monitor::Plugins
     let(:uri) { 'http://foo.bar.com:25555' }
     let(:status_uri) { "#{uri}/info" }
     let(:tasks_uri) { "#{uri}/tasks?deployment=d&state=queued,processing&verbose=2" }
-    let(:tasks_body) {
+    let(:tasks_body) do
       '[{
         "id": 60337,
         "state": "processing",
@@ -32,10 +31,16 @@ module Bosh::Monitor::Plugins
         "deployment": "d",
         "context_id": ""
       }]'
-    }
+    end
 
     before do
-      stub_request(:get, tasks_uri).to_return(status: 200, headers: {}, body: tasks_body)
+      stub_request(:get, tasks_uri).to_return(lambda do |request|
+        if request.headers.fetch('Authorization') || request.headers.fetch('authorization')
+          { status: 200, body: tasks_body }
+        else
+          { status: 401, body: '{"error": "unauthorized"}' }
+        end
+      end)
       stub_request(:get, status_uri)
         .to_return(status: 200, body: JSON.dump('user_authentication' => user_authentication))
     end
@@ -69,7 +74,9 @@ module Bosh::Monitor::Plugins
 
       context 'when there are already scan and fix tasks scheduled for a deployment' do
         let(:event_processor) { Bhm::EventProcessor.new }
-        let(:state) { double(Bhm::Plugins::ResurrectorHelper::DeploymentState, managed?: true, meltdown?: false, summary: 'summary') }
+        let(:state) do
+          double(Bhm::Plugins::ResurrectorHelper::DeploymentState, managed?: true, meltdown?: false, summary: 'summary')
+        end
 
         before do
           Bhm.event_processor = event_processor
@@ -77,8 +84,8 @@ module Bosh::Monitor::Plugins
           expect(Bhm::Plugins::ResurrectorHelper::AlertTracker).to receive(:new).and_return(@don)
         end
 
-        context 'with a scan task already queued' do 
-          let(:tasks_body) {
+        context 'with a scan task already queued' do
+          let(:tasks_body) do
             '[{
               "id": 12345,
               "state": "queued",
@@ -90,7 +97,7 @@ module Bosh::Monitor::Plugins
               "deployment": "d",
               "context_id": ""
             }]'
-          }
+          end
           it 'will not add an additional queued task' do
             plugin.run
 
@@ -100,8 +107,8 @@ module Bosh::Monitor::Plugins
           end
         end
 
-        context 'with a scan task being processed' do 
-          let(:tasks_body) {
+        context 'with a scan task being processed' do
+          let(:tasks_body) do
             '[{
               "id": 12345,
               "state": "processing",
@@ -113,7 +120,7 @@ module Bosh::Monitor::Plugins
               "deployment": "d",
               "context_id": ""
             }]'
-          }
+          end
           it 'will not add an additional queued task' do
             plugin.run
 
@@ -126,7 +133,9 @@ module Bosh::Monitor::Plugins
 
       context 'alert of CATEGORY_DEPLOYMENT_HEALTH' do
         let(:event_processor) { Bhm::EventProcessor.new }
-        let(:state) { double(Bhm::Plugins::ResurrectorHelper::DeploymentState, managed?: true, meltdown?: false, summary: 'summary') }
+        let(:state) do
+          double(Bhm::Plugins::ResurrectorHelper::DeploymentState, managed?: true, meltdown?: false, summary: 'summary')
+        end
 
         before do
           Bhm.event_processor = event_processor
@@ -192,7 +201,9 @@ module Bosh::Monitor::Plugins
         end
 
         context 'while melting down' do
-          let(:state) { double(Bhm::Plugins::ResurrectorHelper::DeploymentState, managed?: false, meltdown?: true, summary: 'summary') }
+          let(:state) do
+            double(Bhm::Plugins::ResurrectorHelper::DeploymentState, managed?: false, meltdown?: true, summary: 'summary')
+          end
 
           it 'does not send requests to scan and fix' do
             plugin.run
@@ -312,7 +323,9 @@ module Bosh::Monitor::Plugins
       end
 
       context 'alert of CATEGORY_VM_HEALTH' do
-        let(:alert) { Bhm::Events::Base.create!(:alert, alert_payload(category: Bosh::Monitor::Events::Alert::CATEGORY_VM_HEALTH)) }
+        let(:alert) do
+          Bhm::Events::Base.create!(:alert, alert_payload(category: Bosh::Monitor::Events::Alert::CATEGORY_VM_HEALTH))
+        end
 
         it 'does not send request to scan and fix' do
           plugin.run
@@ -325,7 +338,7 @@ module Bosh::Monitor::Plugins
 
       context 'when director status is not 200' do
         before do
-          stub_request(:get, status_uri).to_return(status: 500, headers: {}, body: 'Failed')
+          stub_request(:get, status_uri).to_return({ status: 500, headers: {}, body: 'Failed' })
         end
 
         it 'returns false' do
@@ -340,7 +353,6 @@ module Bosh::Monitor::Plugins
           before do
             state = double(Bhm::Plugins::ResurrectorHelper::DeploymentState, managed?: true, meltdown?: false, summary: 'summary')
             expect(Bhm::Plugins::ResurrectorHelper::DeploymentState).to receive(:new).and_return(state)
-            stub_request(:get, status_uri).to_return({ status: 500 }, { status: 200, body: '{}' })
           end
 
           it 'starts sending alerts' do
@@ -348,7 +360,11 @@ module Bosh::Monitor::Plugins
 
             expect(plugin).to receive(:send_http_put_request).once
 
+            stub_request(:get, status_uri).to_return({ status: 500 })
             plugin.process(alert) # fails to send request
+
+            stub_request(:get,
+                         status_uri).to_return({ status: 200, body: JSON.dump('user_authentication' => user_authentication) })
             plugin.process(alert)
           end
         end


### PR DESCRIPTION
When a director manages a large number of single instance deployments in one AZ

And that AZ goes down

Then queuing additional scan_and_fix tasks for a deployment can create a very large queue for the director containing duplicate scan_and_fix tasks for the same deployments.

If we already have a scan and fix task queued or being processed for a particular deployment, there is no additional benefit in queuing more tasks.

This PR adds a check and some tests around that scenario to avoid overloading a director that is currently dealing with a large number of deployments in a bad state.

[ #183759912 ]