### PR TITLE
Add option to enable pre ruby 3.2 =~ beahvior

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -144,6 +144,9 @@ properties:
   director.enable_nats_delivered_templates:
     description: When true, rendered templates will be sent over NATs
     default: false
+  director.enable_pre_ruby_3_2_equal_tilde_behavior:
+    description: When true, Kernel will be patched to enable Pre-Ruby 3.2 =~ behavior. This is needed for release templates incorrectly using =~.
+    default: false
   director.enable_short_lived_nats_bootstrap_credentials:
     description: When true, NATS bootstrap credentials will be short lived on new VMs
     default: true

--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -27,6 +27,7 @@ params = {
   },
   'max_vm_create_tries' => p('director.max_vm_create_tries'),
   'enable_nats_delivered_templates' => p('director.enable_nats_delivered_templates'),
+  'enable_pre_ruby_3_2_equal_tilde_behavior' => p('director.enable_pre_ruby_3_2_equal_tilde_behavior'),
   'enable_short_lived_nats_bootstrap_credentials' => p('director.enable_short_lived_nats_bootstrap_credentials', true),
   'enable_cpi_resize_disk' => p('director.enable_cpi_resize_disk'),
   'generate_vm_passwords' => p('director.generate_vm_passwords'),

--- a/src/bosh-director/bin/bosh-director-worker
+++ b/src/bosh-director/bin/bosh-director-worker
@@ -27,6 +27,11 @@ begin
   Bosh::Director::Config.audit_filename = "audit_worker_#{index}.log"
 
   config = Bosh::Director::Config.load_file(config_file)
+
+  if config.enable_pre_ruby_3_2_equal_tilde_behavior
+    require 'ruby_shims/kernel_equals_tilde'
+  end
+
   config.db
 
   worker = Bosh::Director::Worker.new(config, index)

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -452,6 +452,10 @@ module Bosh::Director
       hash['name']
     end
 
+    def enable_pre_ruby_3_2_equal_tilde_behavior
+      hash['enable_pre_ruby_3_2_equal_tilde_behavior']
+    end
+
     def port
       hash['port']
     end

--- a/src/bosh-director/lib/ruby_shims/kernel_equals_tilde.rb
+++ b/src/bosh-director/lib/ruby_shims/kernel_equals_tilde.rb
@@ -1,0 +1,7 @@
+# Prior to ruby 3.2, =~ returned nil by default. You should be calling =~ on a string or a regular expression and this code should not be reached
+# https://bugs.ruby-lang.org/issues/15231
+module Kernel
+  def =~(_)
+    nil
+  end
+end

--- a/src/bosh-director/spec/unit/ruby_shims/kernel_equals_tilde_spec.rb
+++ b/src/bosh-director/spec/unit/ruby_shims/kernel_equals_tilde_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'ruby_shims/kernel_equals_tilde'
+
+describe 'Kernel =~' do
+    it 'preserves pre ruby 3.2 behavior of falling back to nil' do
+      expect(Object.new =~ /anything/).to be_nil
+    end
+end


### PR DESCRIPTION
Addresses #2424

This is disabled by default but is needed if a release template is incorrectly using `=~`
`=~` was removed from Kernel in ruby 3.2 and those templates will now break without this.

Ruby change context: https://bugs.ruby-lang.org/issues/15231
