### PR TITLE
add pg-13 job

### DIFF
--- a/jobs/postgres-13/monit
+++ b/jobs/postgres-13/monit
@@ -1,0 +1,5 @@
+check process postgres
+  with pidfile /var/vcap/sys/run/bpm/postgres-13/postgres-13.pid
+  start program "/var/vcap/jobs/bpm/bin/bpm start postgres-13" with timeout 300 seconds
+  stop program "/var/vcap/jobs/bpm/bin/bpm stop postgres-13"
+  group vcap

--- a/jobs/postgres-13/spec
+++ b/jobs/postgres-13/spec
@@ -1,0 +1,35 @@
+---
+name: postgres-13
+
+templates:
+  bpm.yml: config/bpm.yml
+  pre-start.erb: bin/pre-start
+  create-database.erb: bin/create-database
+  postgres.erb: bin/postgres
+  postgresql.conf.erb: config/postgresql.conf
+
+packages:
+  - postgres-13
+  - postgres-10
+
+properties:
+  postgres.user:
+    description: Username clients must use to access Postgres
+    default: bosh
+  postgres.password:
+    description: Password clients must use to access Postgres
+  postgres.listen_address:
+    description: IP address Postgres listens on; use 0.0.0.0 to listen on all IP addresses
+    default: 127.0.0.1
+  postgres.port:
+    description: TCP port Postgres listens on
+    default: 5432
+  postgres.database:
+    description: Default Postgres database (it will be created during the startup process)
+    default: bosh
+  postgres.additional_databases:
+    description: Additional Postgres databases to be created (during the startup process)
+    default: []
+  postgres.max_connections:
+    description: Set max concurrent connections for database
+    default: 200

--- a/jobs/postgres-13/spec.yml
+++ b/jobs/postgres-13/spec.yml
@@ -1,0 +1,35 @@
+---
+name: postgres-13
+
+templates:
+  bpm.yml: config/bpm.yml
+  pre-start.erb: bin/pre-start
+  create-database.erb: bin/create-database
+  postgres.erb: bin/postgres
+  postgresql.conf.erb: config/postgresql.conf
+
+packages:
+  - postgres-13
+  - postgres-10
+
+properties:
+  postgres.user:
+    description: Username clients must use to access Postgres
+    default: bosh
+  postgres.password:
+    description: Password clients must use to access Postgres
+  postgres.listen_address:
+    description: IP address Postgres listens on; use 0.0.0.0 to listen on all IP addresses
+    default: 127.0.0.1
+  postgres.port:
+    description: TCP port Postgres listens on
+    default: 5432
+  postgres.database:
+    description: Default Postgres database (it will be created during the startup process)
+    default: bosh
+  postgres.additional_databases:
+    description: Additional Postgres databases to be created (during the startup process)
+    default: []
+  postgres.max_connections:
+    description: Set max concurrent connections for database
+    default: 200

--- a/jobs/postgres-13/templates/bpm.yml
+++ b/jobs/postgres-13/templates/bpm.yml
@@ -1,0 +1,19 @@
+<%=
+
+postgres_config = {
+  "name" => "postgres-13",
+  "executable" => "/var/vcap/jobs/postgres-13/bin/postgres",
+  "shutdown_signal" => "INT",
+  "persistent_disk" => true,
+  "limits" => {
+    "open_files" => 65536,
+  },
+}
+
+config = {
+  "processes" => [postgres_config],
+}
+
+YAML.dump(config)
+
+%>

--- a/jobs/postgres-13/templates/create-database.erb
+++ b/jobs/postgres-13/templates/create-database.erb
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+PACKAGE_DIR=/var/vcap/packages/postgres-13
+
+HOST=<%= p("postgres.listen_address") %>
+PORT=<%= p("postgres.port") %>
+USER='<%= p("postgres.user") %>'
+PASSWORD='<%= p("postgres.password") %>'
+DBNAMES=(<%= p("postgres.additional_databases").join(" ") %>)
+DBNAMES+=('<%= p("postgres.database") %>')
+
+export LD_LIBRARY_PATH="$PACKAGE_DIR/lib:$LD_LIBRARY_PATH"
+
+# wait for database to be running
+for i in $( seq 0 30 ); do
+  if /var/vcap/packages/postgres-13/bin/oid2name -H ${HOST} -U ${USER} -d postgres -q ; then
+    break
+  fi
+
+  sleep 1
+done
+
+set +e
+
+for DBNAME in "${DBNAMES[@]}"; do
+  echo "Trying to create database $DBNAME..."
+  $PACKAGE_DIR/bin/createdb $DBNAME -h $HOST -p $PORT -U vcap
+  if [ $? != 0 ]; then
+    echo "Warning: failed to create $DBNAME; ignoring"
+  fi
+
+  echo "Trying to create user..."
+  $PACKAGE_DIR/bin/psql -d $DBNAME -h $HOST -p $PORT -U vcap -c "create role \"$USER\" NOSUPERUSER LOGIN INHERIT CREATEDB"
+
+  echo "Trying to alter user (to change password)..."
+  $PACKAGE_DIR/bin/psql -d $DBNAME -h $HOST  -p $PORT -U vcap -c "alter role \"$USER\" with password '$PASSWORD'"
+done

--- a/jobs/postgres-13/templates/postgres.erb
+++ b/jobs/postgres-13/templates/postgres.erb
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+PACKAGE_DIR=/var/vcap/packages/postgres-13
+
+STORE_DIR=/var/vcap/store
+
+# then we switched to including version so it is easier to detect version changes
+DATA_DIR=$STORE_DIR/postgres-13
+
+JOB_DIR=/var/vcap/jobs/postgres-13
+RUN_DIR=/var/vcap/sys/run/bpm/postgres-13
+
+HOST=<%= p("postgres.listen_address") %>
+PORT=<%= p("postgres.port") %>
+USER='<%= p("postgres.user") %>'
+
+export LD_LIBRARY_PATH="$PACKAGE_DIR/lib:$LD_LIBRARY_PATH"
+
+
+cp $JOB_DIR/config/postgresql.conf $DATA_DIR
+
+/var/vcap/jobs/postgres-13/bin/create-database &
+
+echo "Starting PostgreSQL:"
+exec $PACKAGE_DIR/bin/postgres -h $HOST -p $PORT -D $DATA_DIR

--- a/jobs/postgres-13/templates/postgresql.conf.erb
+++ b/jobs/postgres-13/templates/postgresql.conf.erb
@@ -1,0 +1,20 @@
+data_directory = '/var/vcap/store/postgres-13'
+
+listen_addresses = '<%= p('postgres.listen_address') %>'
+port = <%= p('postgres.port') %>
+max_connections = <%= p('postgres.max_connections') %>
+
+ssl = false
+
+shared_buffers = 32MB
+
+log_line_prefix = '%t '
+
+datestyle = 'iso, mdy'
+
+lc_messages = 'en_US.UTF-8'
+lc_monetary = 'en_US.UTF-8'
+lc_numeric = 'en_US.UTF-8'
+lc_time = 'en_US.UTF-8'
+
+default_text_search_config = 'pg_catalog.english'

--- a/jobs/postgres-13/templates/pre-start.erb
+++ b/jobs/postgres-13/templates/pre-start.erb
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -eu
+
+PACKAGE_DIR=/var/vcap/packages/postgres-13
+PACKAGE_DIR_OLD=/var/vcap/packages/postgres-10
+
+PERSISTENT_DISK_DIR=/var/vcap/store
+
+STORE_DIR=${PERSISTENT_DISK_DIR}/postgres-13
+STORE_DIR_OLD=${PERSISTENT_DISK_DIR}/postgres-10
+STORE_DIR_OBSOLETE=${PERSISTENT_DISK_DIR}/postgres-9.4
+
+USER='<%= p("postgres.user") %>'
+
+sysctl -w "kernel.shmmax=67108864"
+
+if [ -d $STORE_DIR_OBSOLETE ]; then
+  # uh-oh, we have years-old BOSH Director
+  if [ ! -d $STORE_DIR_OLD ] && [ ! -d $STORE_DIR ]; then
+    # we never upgraded this BOSH Director from PostgreSQL 9.4 to 10
+    echo "Please use a previous bosh release version (271.x or lower) to migrate data from postgres-9.4 to postgres-10."
+    exit 1
+  fi
+  # delete the obsolete 9.4 directory to free up space
+  echo "Deleting obsolete $STORE_DIR_OBSOLETE directory."
+  rm -rf "${STORE_DIR_OBSOLETE}"
+fi
+
+# We cannot kill the following conditional
+# because initdb is very picky about looking at an empty dir
+if [[ ! -d ${STORE_DIR} || ! -f ${STORE_DIR}/postgresql.conf ]]; then
+  mkdir -p "${STORE_DIR}"
+  chown vcap:vcap "${STORE_DIR}"
+
+  # initdb creates data directories
+  su - vcap -c "${PACKAGE_DIR}/bin/initdb -E utf8 -D ${STORE_DIR}"
+
+  touch "${STORE_DIR}/fresh"
+
+  if [ $? != 0 ]; then
+    echo "ERROR: Unable to Initialize Postgres DB"
+    exit 1
+  fi
+
+  echo "host all ${USER} 0.0.0.0/0 md5" >> "${STORE_DIR}/pg_hba.conf"
+
+  mkdir -p "${STORE_DIR}/pg_log"
+  chown vcap:vcap "${STORE_DIR}/pg_log"
+fi
+
+if [[ -f ${STORE_DIR}/fresh ]] ; then
+  if [[ -d ${STORE_DIR_OLD} ]] ; then
+    echo "copying contents of postgres-10 to postgres-13 for postgres upgrade..."
+    su - vcap -c "${PACKAGE_DIR}/bin/pg_upgrade \
+      --old-bindir=${PACKAGE_DIR_OLD}/bin \
+      --new-bindir=${PACKAGE_DIR}/bin \
+      --old-datadir=${STORE_DIR_OLD} \
+      --new-datadir=${STORE_DIR}"
+
+    echo "successfully upgraded from postgres-10"
+    rm -rf "${STORE_DIR_OLD}"
+  fi
+
+  rm "${STORE_DIR}/fresh"
+fi
+
+# "bpm enforces its own locking around process operations to avoid race conditions"
+# from docs: https://bosh.io/docs/bpm/runtime/
+# so postmaster.pid is stale if it still exists
+# remove it to prevent running into:
+# FATAL:  lock file "postmaster.pid" already exists
+if [[ -f ${STORE_DIR}/postmaster.pid ]] ; then
+    rm "${STORE_DIR}/postmaster.pid"
+fi


### PR DESCRIPTION
some scenarios may require users to keep using pg-13 for various reasons (compliance, testing, etc). These users are currently locked out from receiving release updates since they have to update to pg15 to consume newer release versions. This adds a pg13 job based on what we've had used previously.

[ #184442896 ]
