### PR TITLE
Do not attempt to "fix" packages in other releases

### DIFF
--- a/src/bosh-director/lib/bosh/director/jobs/update_release.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_release.rb
@@ -214,6 +214,7 @@ module Bosh::Director
           @version,
           manifest_packages,
           logger,
+          @fix,
         )
 
         PackagePersister.persist(

--- a/src/bosh-director/lib/bosh/director/jobs/update_release/package_processor.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_release/package_processor.rb
@@ -3,7 +3,7 @@ module Bosh::Director
     class UpdateRelease
       class PackageProcessor
         class << self
-          def process(release_version_model, release_model, name, version, manifest_packages, logger)
+          def process(release_version_model, release_model, name, version, manifest_packages, logger, fix)
             new_packages = []
             existing_packages = []
             registered_packages = []
@@ -23,7 +23,9 @@ module Bosh::Director
                   package.version == package_meta['version']
               end
 
-              reuse_package_matching_fingerprint(packages, package_meta) unless existing_package&.blobstore_id
+              if !existing_package&.blobstore_id && !fix
+                reuse_package_matching_fingerprint(packages, package_meta)
+              end
 
               unless existing_package
                 new_packages << package_meta

--- a/src/bosh-director/spec/unit/jobs/update_release/package_processor_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_release/package_processor_spec.rb
@@ -14,6 +14,7 @@ module Bosh::Director
             version,
             manifest_packages,
             logger,
+            fix,
           )
         end
 
@@ -23,6 +24,7 @@ module Bosh::Director
         let(:release_model) { nil }
         let(:name) { nil }
         let(:version) { nil }
+        let(:fix) { false }
 
         context 'if a package fingerprint changes' do
           let(:manifest_packages) do
@@ -256,6 +258,26 @@ module Bosh::Director
                                                  'blobstore_id' => blobstore_id,
                                                  'sha1' => model_sha,
                                                ),
+                                             ])
+                  expect(existing_packages).to eq([])
+                  expect(registered_packages).to eq([])
+                end
+              end
+
+              context 'and the release is being uploaded via --fix' do
+                let(:release_model) { double(id: release.id + 1) }
+                let(:fix) { true }
+
+                it 'does not reuse the blob' do
+                  new_packages, existing_packages, registered_packages = process_packages
+
+                  new_package_sha1 = new_package_metadata['sha1']
+
+                  expect(new_packages).to eq([
+                                               new_package_metadata.merge(
+                                                 'compiled_package_sha1' => new_package_sha1,
+                                                 'sha1' => new_package_sha1,
+                                               ).except('blobstore_id'),
                                              ])
                   expect(existing_packages).to eq([])
                   expect(registered_packages).to eq([])


### PR DESCRIPTION
When to different releases contain a package with the same fingerprint but different shasums, running `bosh upload-release --fix` on one of those releases will update the blobs for the original release. However, it does not update the shasum for that package to reflect the new contents of the blob. This will result in compilation failures like:

> Checking downloaded blob ''0a282ed0-9c46-4a13-bbbe-6ed1578480d5'': Expected stream to have digest ''sha256:ff5a3c4c82953ddc10ee19fa776ff4603216b58d673b3fd90fa0ee80cf750340'' but was ''sha256:279bfb24ccede8477400bb76d636a41da973d9b33fa811898b3d43bb4d3bb4a5''

The intention of `--fix` is to re-upload a release that has become corrupted in some way. As such, we have changed the behavior to not attempt to re-use packages from unrelated releases when `--fix` is present.

[#184562287] `bosh upload-release --fix` should not tamper with existing packages in other releases

Signed-off-by: Joseph Palermo <jpalermo@vmware.com>