### PR TITLE
Rebuilds Postgres indexes on glibc version change

### DIFF
--- a/jobs/postgres-10/templates/pre-start.erb
+++ b/jobs/postgres-10/templates/pre-start.erb
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+set -o pipefail
 
 PACKAGE_DIR=/var/vcap/packages/postgres-10
 
@@ -12,6 +13,11 @@ STORE_DIR_OLD=${PERSISTENT_DISK_DIR}/postgres-9.4
 USER='<%= p("postgres.user") %>'
 
 sysctl -w "kernel.shmmax=67108864"
+
+if [[ -d /var/vcap/store/postgres-15 ]]; then
+  echo "Intentionally failing because data from a newer postgres job may already exist in /var/vcap/store/postgres-15"
+  exit 1
+fi
 
 if [[ -d /var/vcap/store/postgres-13 ]]; then
   echo "Intentionally failing because data from a newer postgres job may already exist in /var/vcap/store/postgres-13"
@@ -56,3 +62,54 @@ fi
 if [[ -f ${STORE_DIR}/postmaster.pid ]] ; then
     rm "${STORE_DIR}/postmaster.pid"
 fi
+
+# The below code reindexes Postgres databases if the glibc version has changed since we last performed a reindex,
+# or if we don't know when we reindexed and are running a version of glibc that made major changes to the system collation.
+#  See: <https://wiki.postgresql.org/wiki/Locale_data_changes>
+#       <https://www.crunchydata.com/blog/glibc-collations-and-data-corruption>
+# for more information about why we do this, and why we consider glibc versions older than 2.28 to be unaffected.
+#
+# NOTE: If you edit this code, make sure to update the copies in all of the other Postgres versions. Extracting this into a common
+#       file and sharing that file amongst the Postgres releases was just as bad as having multiple copies, so this is what we did.
+
+rebuild_postgres_indexes()
+{
+  POSTGRES_DATABASE_USER="vcap"
+  for database in $(echo "select datname from pg_database" | su - vcap -c "${PACKAGE_DIR}/bin/postgres --single -D ${STORE_DIR} postgres | egrep -o '\".*\"'")
+  do
+    echo "Going to reindex database '$database' in '${STORE_DIR}'"
+    echo "REINDEX DATABASE $database" | su - vcap -c "${PACKAGE_DIR}/bin/postgres --single -D ${STORE_DIR} $database"
+    # This doesn't work on Postgres versions earlier than 15, because REFRESH COLLATION VERSION isn't a thing until 15.
+    echo "ALTER DATABASE $database REFRESH COLLATION VERSION" | su - vcap -c "${PACKAGE_DIR}/bin/postgres --single -D ${STORE_DIR} $database" || /bin/true
+  done
+}
+
+PREVIOUS_GLIBC_VERSION_DIR=${PERSISTENT_DISK_DIR}/postgres-previous-glibc-tracking/
+PREVIOUS_GLIBC_VERSION_FILE=${PREVIOUS_GLIBC_VERSION_DIR}/previous-glibc-version.txt
+BREAKING_GLIBC_MAJOR=2
+BREAKING_GLIBC_MINOR=28
+
+previous_glibc_version=$(cat $PREVIOUS_GLIBC_VERSION_FILE 2>/dev/null || echo "")
+previous_glibc_major=$(echo $previous_glibc_version | cut -d "." -f 1)
+previous_glibc_minor=$(echo $previous_glibc_version | cut -d "." -f 2)
+
+current_glibc_version="$(dpkg-query --show --showformat '${Version}\n' libc6 | egrep -o '^[0-9.]+')"
+current_glibc_major=$(echo $current_glibc_version | cut -d "." -f 1)
+current_glibc_minor=$(echo $current_glibc_version | cut -d "." -f 2)
+
+if [[ -f $PREVIOUS_GLIBC_VERSION_FILE ]]
+then
+  if [[ $current_glibc_version != $previous_glibc_version ]]
+  then
+    rebuild_postgres_indexes
+  fi
+else
+  # If we're newer or equal to 2.28, we'll rebuild indexes to handle the issue we know about and any future ones.
+  if [[ $current_glibc_major -gt $BREAKING_GLIBC_MAJOR || $current_glibc_minor -ge $BREAKING_GLIBC_MINOR ]]
+  then
+    rebuild_postgres_indexes
+  fi
+fi
+
+mkdir -p $PREVIOUS_GLIBC_VERSION_DIR 2>/dev/null
+echo $current_glibc_version > $PREVIOUS_GLIBC_VERSION_FILE

--- a/jobs/postgres-13/templates/pre-start.erb
+++ b/jobs/postgres-13/templates/pre-start.erb
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+set -o pipefail
 
 PACKAGE_DIR=/var/vcap/packages/postgres-13
 PACKAGE_DIR_OLD=/var/vcap/packages/postgres-10
@@ -14,6 +15,11 @@ STORE_DIR_OBSOLETE=${PERSISTENT_DISK_DIR}/postgres-9.4
 USER='<%= p("postgres.user") %>'
 
 sysctl -w "kernel.shmmax=67108864"
+
+if [[ -d /var/vcap/store/postgres-15 ]]; then
+  echo "Intentionally failing because data from a newer postgres job may already exist in /var/vcap/store/postgres-15"
+  exit 1
+fi
 
 if [ -d $STORE_DIR_OBSOLETE ]; then
   # uh-oh, we have years-old BOSH Director
@@ -73,3 +79,54 @@ fi
 if [[ -f ${STORE_DIR}/postmaster.pid ]] ; then
     rm "${STORE_DIR}/postmaster.pid"
 fi
+
+# The below code reindexes Postgres databases if the glibc version has changed since we last performed a reindex,
+# or if we don't know when we reindexed and are running a version of glibc that made major changes to the system collation.
+#  See: <https://wiki.postgresql.org/wiki/Locale_data_changes>
+#       <https://www.crunchydata.com/blog/glibc-collations-and-data-corruption>
+# for more information about why we do this, and why we consider glibc versions older than 2.28 to be unaffected.
+#
+# NOTE: If you edit this code, make sure to update the copies in all of the other Postgres versions. Extracting this into a common
+#       file and sharing that file amongst the Postgres releases was just as bad as having multiple copies, so this is what we did.
+
+rebuild_postgres_indexes()
+{
+  POSTGRES_DATABASE_USER="vcap"
+  for database in $(echo "select datname from pg_database" | su - vcap -c "${PACKAGE_DIR}/bin/postgres --single -D ${STORE_DIR} postgres | egrep -o '\".*\"'")
+  do
+    echo "Going to reindex database '$database' in '${STORE_DIR}'"
+    echo "REINDEX DATABASE $database" | su - vcap -c "${PACKAGE_DIR}/bin/postgres --single -D ${STORE_DIR} $database"
+    # This doesn't work on Postgres versions earlier than 15, because REFRESH COLLATION VERSION isn't a thing until 15.
+    echo "ALTER DATABASE $database REFRESH COLLATION VERSION" | su - vcap -c "${PACKAGE_DIR}/bin/postgres --single -D ${STORE_DIR} $database" || /bin/true
+  done
+}
+
+PREVIOUS_GLIBC_VERSION_DIR=${PERSISTENT_DISK_DIR}/postgres-previous-glibc-tracking/
+PREVIOUS_GLIBC_VERSION_FILE=${PREVIOUS_GLIBC_VERSION_DIR}/previous-glibc-version.txt
+BREAKING_GLIBC_MAJOR=2
+BREAKING_GLIBC_MINOR=28
+
+previous_glibc_version=$(cat $PREVIOUS_GLIBC_VERSION_FILE 2>/dev/null || echo "")
+previous_glibc_major=$(echo $previous_glibc_version | cut -d "." -f 1)
+previous_glibc_minor=$(echo $previous_glibc_version | cut -d "." -f 2)
+
+current_glibc_version="$(dpkg-query --show --showformat '${Version}\n' libc6 | egrep -o '^[0-9.]+')"
+current_glibc_major=$(echo $current_glibc_version | cut -d "." -f 1)
+current_glibc_minor=$(echo $current_glibc_version | cut -d "." -f 2)
+
+if [[ -f $PREVIOUS_GLIBC_VERSION_FILE ]]
+then
+  if [[ $current_glibc_version != $previous_glibc_version ]]
+  then
+    rebuild_postgres_indexes
+  fi
+else
+  # If we're newer or equal to 2.28, we'll rebuild indexes to handle the issue we know about and any future ones.
+  if [[ $current_glibc_major -gt $BREAKING_GLIBC_MAJOR || $current_glibc_minor -ge $BREAKING_GLIBC_MINOR ]]
+  then
+    rebuild_postgres_indexes
+  fi
+fi
+
+mkdir -p $PREVIOUS_GLIBC_VERSION_DIR 2>/dev/null
+echo $current_glibc_version > $PREVIOUS_GLIBC_VERSION_FILE

--- a/jobs/postgres/templates/pre-start.erb
+++ b/jobs/postgres/templates/pre-start.erb
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+set -o pipefail
 
 PACKAGE_DIR=/var/vcap/packages/postgres-15
 PACKAGE_DIR_OLD=/var/vcap/packages/postgres-13
@@ -88,3 +89,54 @@ fi
 if [[ -f ${STORE_DIR}/postmaster.pid ]] ; then
     rm "${STORE_DIR}/postmaster.pid"
 fi
+
+# The below code reindexes Postgres databases if the glibc version has changed since we last performed a reindex,
+# or if we don't know when we reindexed and are running a version of glibc that made major changes to the system collation.
+#  See: <https://wiki.postgresql.org/wiki/Locale_data_changes>
+#       <https://www.crunchydata.com/blog/glibc-collations-and-data-corruption>
+# for more information about why we do this, and why we consider glibc versions older than 2.28 to be unaffected.
+#
+# NOTE: If you edit this code, make sure to update the copies in all of the other Postgres versions. Extracting this into a common
+#       file and sharing that file amongst the Postgres releases was just as bad as having multiple copies, so this is what we did.
+
+rebuild_postgres_indexes()
+{
+  POSTGRES_DATABASE_USER="vcap"
+  for database in $(echo "select datname from pg_database" | su - vcap -c "${PACKAGE_DIR}/bin/postgres --single -D ${STORE_DIR} postgres | egrep -o '\".*\"'")
+  do
+    echo "Going to reindex database '$database' in '${STORE_DIR}'"
+    echo "REINDEX DATABASE $database" | su - vcap -c "${PACKAGE_DIR}/bin/postgres --single -D ${STORE_DIR} $database"
+    # This doesn't work on Postgres versions earlier than 15, because REFRESH COLLATION VERSION isn't a thing until 15.
+    echo "ALTER DATABASE $database REFRESH COLLATION VERSION" | su - vcap -c "${PACKAGE_DIR}/bin/postgres --single -D ${STORE_DIR} $database" || /bin/true
+  done
+}
+
+PREVIOUS_GLIBC_VERSION_DIR=${PERSISTENT_DISK_DIR}/postgres-previous-glibc-tracking/
+PREVIOUS_GLIBC_VERSION_FILE=${PREVIOUS_GLIBC_VERSION_DIR}/previous-glibc-version.txt
+BREAKING_GLIBC_MAJOR=2
+BREAKING_GLIBC_MINOR=28
+
+previous_glibc_version=$(cat $PREVIOUS_GLIBC_VERSION_FILE 2>/dev/null || echo "")
+previous_glibc_major=$(echo $previous_glibc_version | cut -d "." -f 1)
+previous_glibc_minor=$(echo $previous_glibc_version | cut -d "." -f 2)
+
+current_glibc_version="$(dpkg-query --show --showformat '${Version}\n' libc6 | egrep -o '^[0-9.]+')"
+current_glibc_major=$(echo $current_glibc_version | cut -d "." -f 1)
+current_glibc_minor=$(echo $current_glibc_version | cut -d "." -f 2)
+
+if [[ -f $PREVIOUS_GLIBC_VERSION_FILE ]]
+then
+  if [[ $current_glibc_version != $previous_glibc_version ]]
+  then
+    rebuild_postgres_indexes
+  fi
+else
+  # If we're newer or equal to 2.28, we'll rebuild indexes to handle the issue we know about and any future ones.
+  if [[ $current_glibc_major -gt $BREAKING_GLIBC_MAJOR || $current_glibc_minor -ge $BREAKING_GLIBC_MINOR ]]
+  then
+    rebuild_postgres_indexes
+  fi
+fi
+
+mkdir -p $PREVIOUS_GLIBC_VERSION_DIR 2>/dev/null
+echo $current_glibc_version > $PREVIOUS_GLIBC_VERSION_FILE


### PR DESCRIPTION
### What is this change about?

This commit:
* Adds early fails to the Postgres 10 and Postgres 13 jobs if the Postgres 15 data directory is present. This omission seemed to be a clear oversight.
* Adds code to detect glibc version changes and rebuild indexes on all Postgres databases if the running glibc is newer than 2.27, and has changed since the last time we rebuild the indexes.

glibc version 2.28 introduced a major change to how it performs collation. Whenever any changes to collations are introduced, indexes on Postgres tables must be rebuilt in order to avoid problems which include successful insertion of rows that violate uniqueness constraints on some keys but not others.

Postgres 15 and later includes code that detects and warns about this situation, but leaves correcting the issue up to the operator... so the updates in this commit are still required.


### Please provide contextual information.

 See: <https://wiki.postgresql.org/wiki/Locale_data_changes>
      <https://www.crunchydata.com/blog/glibc-collations-and-data-corruption>

### What tests have you run against this PR?

Manual testing for script correctness.

### Does this PR introduce a breaking change?

No.