### PR TITLE
Speed up template rendering by not using marshal load/dump

### DIFF
--- a/src/bosh_common/lib/common/deep_copy.rb
+++ b/src/bosh_common/lib/common/deep_copy.rb
@@ -1,7 +1,22 @@
 module Bosh::Common
   module DeepCopy
     def self.copy(object)
-      Marshal.load(Marshal.dump(object))
+      deep_copy(object)
+    end
+
+    def self.deep_copy(object)
+      if object.is_a?(Hash)
+        result = object.clone
+        object.each{|k, v| result[k] = self.deep_copy(v)}
+        result
+      elsif object.is_a?(Array)
+        result = object.clone
+        result.clear
+        object.each{|v| result << self.deep_copy(v)}
+        result
+      else
+        object.clone
+      end
     end
   end
 end


### PR DESCRIPTION
Speed up template rendering by using clone and not marshal load/dump. 

In big environments with large numbers of vms with links. Marshal load/dump is quite slow.

In testing this is result with cf-deployment  with number of vms being diego vms on BOSH-lite

```
| VMS     | Baseline | Updated |
|---------|----------|---------|
| 250 vms | 5 mins   | 3 mins  |
| 500 vms | 14 mins  | 8 mins  |
| 750 vms | 30 mins  | 16 mins |
| 1000 vms | 52 mins | 27 mins |
```