### PR TITLE
bump golang in ci bosh/integration docker image to 1.20

### DIFF
--- a/ci/dockerfiles/integration/Dockerfile
+++ b/ci/dockerfiles/integration/Dockerfile
@@ -85,7 +85,7 @@ RUN gem update --system \
     && bundle config --global path "${GEM_HOME}" \
     && bundle config --global bin "${GEM_HOME}/bin"
 
-COPY --from=golang:1.19 /usr/local/go /usr/local/go
+COPY --from=golang:1.20 /usr/local/go /usr/local/go
 ENV GOROOT=/usr/local/go PATH=/usr/local/go/bin:$PATH
 
 # Java to start UAA


### PR DESCRIPTION
### What is this change about?

Bump the golang version in the ci `bosh/integration image` to 1.20

