### PR TITLE
Properly handle package fingerprint collisions

### DIFF
--- a/src/bosh-director/lib/bosh/director/jobs/update_release/package_persister.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_release/package_persister.rb
@@ -302,7 +302,7 @@ module Bosh::Director
 
           def fix_similar_packages(logger, package, fix, stemcell, dependency_key, compiled_package_sha1, compiled_pkg_tgz)
             other_compiled_packages = []
-            packages = Models::Package.where(fingerprint: package.fingerprint).order_by(:id).all
+            packages = Models::Package.where(name: package.name, fingerprint: package.fingerprint).order_by(:id).all
             packages.each do |pkg|
               other_packages = find_compiled_packages(pkg.id, stemcell[:os], stemcell[:version], dependency_key).all
               other_packages.each do |other_compiled_package|

--- a/src/bosh-director/spec/unit/jobs/update_release_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_release_spec.rb
@@ -1106,7 +1106,7 @@ module Bosh::Director
           let!(:existing_package_with_same_fingerprint) do
             package = Models::Package.make(
               release: another_release,
-              name: 'fake-name-2',
+              name: 'fake-name-1',
               version: 'fake-version-2',
               fingerprint: 'fake-fingerprint-1',
             ).save


### PR DESCRIPTION
When a release is uploaded, the BOSH Director attempts to match those packages in the release to "similar" packages that have been previously uploaded. It does this currently by solely looking at the package fingerprint.

Recently, the golang-release was updated to template its various packages (e.g. golang-1-linux, golang-1.20-linux) and also support prefixes when vendoring its packages into another release. The packaging scripts then replace a string literal with the actual version/prefix in the final compiled package. Because of this templating, the fingerprint for each package is identical, but the compiled bits are different.

Since the Director matches only on fingerprint, this has led to situations where two releases vendor different packages from the golang-release, those packages have matching fingerprints, and thus when deploying VMs, one will receive its expected package bits while the other will receive the other release's version of the package.

For example, if the golang-1.20-linux package is compiled first, then a release that uses the golang-1-linux package will receive the compiled bits for the golang-1.20-linux package instead. This can be identified by `/var/vcap/packages/golang-1-linux/bosh/compile.env` referencing golang-1.20-linux instead of golang-1-linux:
```
  export GOROOT=$(readlink -nf /var/vcap/packages/golang-1.20-linux)
```

Theoretically, this could also happen to any unrelated packages that happened to have the same fingerprint. It would also occur if two releases were vendoring the same package but with different prefixes.

To solve this, "similar" packages are now discovered using the combination of the package name and the package fingerprint.

[#185044288] BOSH Director should only re-use compiled packages if both fingerprint and package name match
