### PR TITLE
Enable coverage report generation when running unit tests on ci

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/src/vendor/cache/** filter=lfs diff=lfs merge=lfs -text

--- a/ci/tasks/test-unit.yml
+++ b/ci/tasks/test-unit.yml
@@ -16,3 +16,4 @@ params:
   RUBY_VERSION: 3.2.0
   DB:           replace-me
   DB_VERSION:   replace-me
+  COVERAGE:     true

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -48,6 +48,8 @@ group :development, :test do
   gem 'sinatra-contrib', '>= 2.2.0'
   gem 'webmock'
 
+  gem 'simplecov', require: false
+
   gem 'pry-byebug'
   gem 'pry-remote'
 

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
     delayed_job (4.1.11)
       activesupport (>= 3.0, < 8.0)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     dogapi (1.21.0)
       multi_json
     domain_name (0.5.20190701)
@@ -270,6 +271,12 @@ GEM
       fugit (~> 1.1, >= 1.1.6)
     semi_semantic (1.2.0)
     sequel (5.29.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     sinatra (2.2.3)
       mustermann (~> 2.0)
       rack (~> 2.2)
@@ -351,6 +358,7 @@ DEPENDENCIES
   rubocop
   rubocop-git
   ruby-prof (= 0.17.0)
+  simplecov
   sinatra (>= 2.2.0)
   sinatra-contrib (>= 2.2.0)
   sqlite3

--- a/src/spec/shared/spec_helper.rb
+++ b/src/spec/shared/spec_helper.rb
@@ -5,15 +5,14 @@ if ENV['COVERAGE'] == 'true'
 
   SimpleCov.configure do
     add_filter '/spec/'
+    add_filter '/vendor/'
   end
 
   SimpleCov.start do
-    root          File.expand_path('../../..', __FILE__)
+    root          File.expand_path('../..', __dir__)
     merge_timeout 3600
     # command name is injected by the spec.rake runner
-    if ENV['BOSH_BUILD_NAME']
-      command_name ENV['BOSH_BUILD_NAME']
-    end
+    command_name ENV['BOSH_BUILD_NAME'] if ENV['BOSH_BUILD_NAME']
   end
 end
 
@@ -23,10 +22,10 @@ require 'rspec/its'
 # Useful to see that tests are using expected version of Ruby in CI
 puts "Using #{RUBY_DESCRIPTION}"
 
-Dir.glob(File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require(f) }
+Dir.glob(File.expand_path('support/**/*.rb', __dir__)).each { |f| require(f) }
 
 RSpec.configure do |config|
-  #config.deprecation_stream = StringIO.new
+  # config.deprecation_stream = StringIO.new
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true

--- a/src/vendor/cache/docile-1.4.0.gem
+++ b/src/vendor/cache/docile-1.4.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f1734bde23721245c20c3d723e76c104208e1aa01277a69901ce770f0ebb8d3
+size 16384

--- a/src/vendor/cache/simplecov-0.22.0.gem
+++ b/src/vendor/cache/simplecov-0.22.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+size 47616

--- a/src/vendor/cache/simplecov-html-0.12.3.gem
+++ b/src/vendor/cache/simplecov-html-0.12.3.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b1aad33259ffba8b29c6876c12db70e5750cb9df829486e4c6e5da4fa0aa07b
+size 336896

--- a/src/vendor/cache/simplecov_json_formatter-0.1.4.gem
+++ b/src/vendor/cache/simplecov_json_formatter-0.1.4.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+size 6656


### PR DESCRIPTION
### What is this change about?

This PR restores simplecov code coverage reporting when running unit tests in ci.
In the past, this must have worked because the required configuration is [already in place](https://github.com/cloudfoundry/bosh/blob/main/src/spec/shared/spec_helper.rb#L3-L18), however, the simpelcov gem itself was no longer included in the Gemfile.

### Please provide contextual information.

At VMware we have an internal ask to report test coverage for components we ship, also from an OSS point of view knowing our test coverage is a best practise. 

### What tests have you run against this PR?

Have tested locally using:
```
docker run \
       --mount type=bind,source="$(pwd)",target=/workspace/bosh-src \
       --workdir /workspace \
       --env DB=sqlite \
       --env RUBY_VERSION=3.2.0 \
       --env COVERAGE=true \
       bosh/integration bosh-src/ci/tasks/test-unit.sh
```
Which matches the [test-unit.yml ](https://github.com/cloudfoundry/bosh/blob/main/ci/tasks/test-unit.yml)task invocation
