### PR TITLE
Fix for "Extracting compiled package archive failed" bug when uploading release with compiled packages

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/packages_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/packages_controller.rb
@@ -67,7 +67,12 @@ module Bosh::Director
             filtered_packages << package
           end
         end
-        filtered_packages
+
+        # Remove packages that were not matched, but have identical fingerprints to ones that were matched
+        # This step is needed to prevent the cli from filtering compiled packages that have a matching fingerprint already
+        # but not the exact compiled package with an identical name too
+        unmatched_package_fingerprints = compiled_release_manifest.fingerprints_not_matching_packages(matching_packages)
+        filtered_packages.reject { |package| unmatched_package_fingerprints.include?(package.fingerprint) }
       end
 
       def existing_release_version_dirty?(manifest)

--- a/src/bosh-director/lib/bosh/director/compiled_release/manifest.rb
+++ b/src/bosh-director/lib/bosh/director/compiled_release/manifest.rb
@@ -15,6 +15,15 @@ module Bosh::Director
         KeyGenerator.new.dependency_key_from_manifest(package_name, @manifest['compiled_packages'])
       end
 
+      def fingerprints_not_matching_packages(packages)
+        missing_compiled_packages = @manifest['compiled_packages'].reject do |manifest_package|
+          packages.any? do |package|
+            package[:name] == manifest_package['name'] && package[:fingerprint] == manifest_package['fingerprint']
+          end
+        end
+        missing_compiled_packages.map { |package| package['fingerprint'] }
+      end
+
       private
 
       def meta_data(package_name)

--- a/src/bosh-director/spec/unit/api/controllers/packages_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/packages_controller_spec.rb
@@ -330,6 +330,19 @@ module Bosh::Director
             expect(JSON.parse(last_response.body)).to eq(%w[fake-pkg4-fingerprint])
           end
 
+          it 'does not return a fingerprint when two packages with identical fingerprints are passed, but only one has a matching name' do
+            params_compiled = {'compiled_packages' => [
+              { 'name' => 'fake-pkg1', 'version' => 'fake-pkg1-version', 'fingerprint' => 'fake-pkg1-fingerprint', 'stemcell' => 'ubuntu-trusty/3000','dependencies' => ['fake-pkg2', 'fake-pkg3'] },
+              { 'name' => 'fake-pkg2', 'version' => 'fake-pkg2-version', 'fingerprint' => 'fake-pkg2-fingerprint', 'stemcell' => 'ubuntu-trusty/3000','dependencies' => [] },
+              { 'name' => 'fake-pkg3', 'version' => 'fake-pkg3-version', 'fingerprint' => 'fake-pkg3-fingerprint', 'stemcell' => 'ubuntu-trusty/3000','dependencies' => [] },
+              { 'name' => 'renamed-fake-pkg1', 'version' => 'fake-pkg1-version', 'fingerprint' => 'fake-pkg1-fingerprint', 'stemcell' => 'ubuntu-trusty/3000','dependencies' => ['fake-pkg2', 'fake-pkg3'] },
+              { 'name' => 'fake-pkg4', 'version' => 'fake-pkg4-version', 'fingerprint' => 'fake-pkg4-fingerprint', 'stemcell' => 'ubuntu-trusty/3000','dependencies' => ['fake-pkg1'] },
+            ]}
+            perform_matches_compiled(params_compiled)
+            expect(last_response.status).to eq(200)
+            expect(JSON.parse(last_response.body)).to eq(%w[fake-pkg4-fingerprint])
+          end
+
           context 'when release-version is dirty due to failed relea`se upload' do
             before do
               release_version.update_completed = false

--- a/src/bosh-director/spec/unit/compiled_package/manifest_spec.rb
+++ b/src/bosh-director/spec/unit/compiled_package/manifest_spec.rb
@@ -3,36 +3,43 @@ require 'spec_helper'
 module Bosh::Director
   module CompiledRelease
     describe Manifest do
-      describe 'has_matching_package' do
-        subject(:compiled_release_manifest) { Manifest.new(manifest_hash) }
-        let(:manifest_hash) do
-          {
-              'compiled_packages' => [
-                  {
-                      'name' => 'fake-pkg1',
-                      'version' => 'fake-pkg1-version',
-                      'fingerprint' => 'fake-pkg1-fingerprint',
-                      'stemcell' => 'ubuntu-trusty/3000',
-                      'dependencies' => ['fake-pkg2', 'fake-pkg3']
-                  },
-                  {
-                      'name' => 'fake-pkg2',
-                      'version' => 'fake-pkg2-version',
-                      'fingerprint' => 'fake-pkg2-fingerprint',
-                      'stemcell' => 'ubuntu-trusty/3000',
-                      'dependencies' => []
-                  },
-                  {
-                      'name' => 'fake-pkg3',
-                      'version' => 'fake-pkg3-version',
-                      'fingerprint' => 'fake-pkg3-fingerprint',
-                      'stemcell' => 'ubuntu-trusty/3000',
-                      'dependencies' => []
-                  },
-              ]
-          }
-        end
+      subject(:compiled_release_manifest) { Manifest.new(manifest_hash) }
+      let(:manifest_hash) do
+        {
+          'compiled_packages' => [
+            {
+              'name' => 'fake-pkg1',
+              'version' => 'fake-pkg1-version',
+              'fingerprint' => 'fake-pkg1-fingerprint',
+              'stemcell' => 'ubuntu-trusty/3000',
+              'dependencies' => ['fake-pkg2', 'fake-pkg3']
+            },
+            {
+              'name' => 'fake-pkg2',
+              'version' => 'fake-pkg2-version',
+              'fingerprint' => 'fake-pkg2-fingerprint',
+              'stemcell' => 'ubuntu-trusty/3000',
+              'dependencies' => []
+            },
+            {
+              'name' => 'fake-pkg3',
+              'version' => 'fake-pkg3-version',
+              'fingerprint' => 'fake-pkg3-fingerprint',
+              'stemcell' => 'ubuntu-trusty/3000',
+              'dependencies' => []
+            },
+            {
+              'name' => 'renamed-fake-pkg1',
+              'version' => 'fake-pkg1-version',
+              'fingerprint' => 'fake-pkg1-fingerprint',
+              'stemcell' => 'ubuntu-trusty/3000',
+              'dependencies' => ['fake-pkg2', 'fake-pkg3']
+            },
+          ]
+        }
+      end
 
+      describe 'has_matching_package' do
         it 'returns true when it has a matching package' do
           expect(compiled_release_manifest.has_matching_package('fake-pkg1', 'ubuntu-trusty', '3000', '[["fake-pkg2","fake-pkg2-version"],["fake-pkg3","fake-pkg3-version"]]')).to be(true)
           expect(compiled_release_manifest.has_matching_package('fake-pkg2', 'ubuntu-trusty', '3000', '[]')).to be(true)
@@ -61,6 +68,29 @@ module Bosh::Director
           it 'returns false' do
             expect(compiled_release_manifest.has_matching_package('fake-pkg2', 'ubuntu-trusty', '2999', '[]')).to be(false)
           end
+        end
+      end
+
+      describe 'fingerprints_not_matching_packages' do
+        let(:packages) do
+          [
+            {
+              name: 'fake-pkg1',
+              fingerprint: 'fake-pkg1-fingerprint'
+            },
+            {
+              name: 'fake-pkg2',
+              fingerprint: 'fake-pkg2-fingerprint'
+            },
+            {
+              name: 'fake-pkg3',
+              fingerprint: 'fake-pkg3-fingerprint'
+            },
+          ]
+        end
+
+        it 'returns fingerprints from the manifest that do not match the name and fingerprint of provided packages' do
+          expect(compiled_release_manifest.fingerprints_not_matching_packages(packages)).to eq(['fake-pkg1-fingerprint'])
         end
       end
     end


### PR DESCRIPTION
This situation exists if the bosh director already has a compiled package with a fingerprint and the cli is trying to upload a release that has two different copies of that same package with the same fingerprint using two different names. The current package matching logic only uses fingerprints to match, so the cli ends up removing both packages from the release before uploading it, but the director doesn't actually have compiled versions of both packages.

So instead, we now do not send the fingerprint in the matching response if there is a package in the release manifest that includes that fingerprint but was not successfully matched.

Reproduction steps:
Two compiled releases that share a common package name and fingerprint.
The second release contains a second copy of the package with a different name
Upload the first release
Upload the second release (with two packages) 