### PR TITLE
Support instance group tags

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/compilation_instance_pool.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/compilation_instance_pool.rb
@@ -277,7 +277,7 @@ module Bosh::Director
 
     class CompilationInstanceGroup
       attr_reader :vm_type, :vm_resources, :vm_extensions, :stemcell, :env, :name
-      attr_reader :instance_plans
+      attr_reader :instance_plans, :tags
 
       def initialize(vm_type, vm_resources, vm_extensions, stemcell, env, compilation_network_name, logger)
         @vm_type = vm_type
@@ -289,6 +289,7 @@ module Bosh::Director
         @name = "compilation-#{SecureRandom.uuid}"
         @instance_plans = []
         @logger = logger
+        @tags = {}
       end
 
       def default_network

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_group.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_group.rb
@@ -82,6 +82,8 @@ module Bosh::Director
 
       attr_accessor :did_change
 
+      attr_accessor :tags
+
       def self.parse(plan, instance_group_spec, event_log, logger, parse_options = {})
         parser = InstanceGroupSpecParser.new(plan, instance_group_spec, event_log, logger)
         parser.parse(parse_options)
@@ -106,7 +108,8 @@ module Bosh::Director
         migrated_from: [],
         state: nil,
         instance_states: {},
-        deployment_name: nil
+        deployment_name: nil,
+        tags: {}
       )
         @name = name
         @canonical_name = canonical_name
@@ -134,6 +137,8 @@ module Bosh::Director
         @packages = {}
         @instance_plans = []
         @did_change = false
+
+        @tags = tags
       end
 
       def self.legacy_spec?(instance_group_spec)

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_group_spec_parser.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_group_spec_parser.rb
@@ -54,6 +54,8 @@ module Bosh::Director
 
         num_desired_instances = parse_desired_instances(name, networks)
 
+        tags = safe_property(@instance_group_spec, 'tags', class: Hash, default: {})
+
         instance_group = InstanceGroup.new(
           name: name,
           canonical_name: Canonicalizer.canonicalize(name),
@@ -74,6 +76,7 @@ module Bosh::Director
           instance_states: instance_states,
           deployment_name: @deployment.name,
           logger: @logger,
+          tags: tags
         )
 
         instance_group.create_desired_instances(num_desired_instances, @deployment)

--- a/src/bosh-director/spec/unit/deployment_plan/instance_group_spec_parser_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_group_spec_parser_spec.rb
@@ -116,6 +116,7 @@ module Bosh::Director
             'env' => { 'key' => 'value' },
             'instances' => 1,
             'networks' => [{ 'name' => 'fake-network-name' }],
+            'tags' => { 'mytag' => 'foobar' },
           }
         end
 
@@ -129,6 +130,19 @@ module Bosh::Director
             instance_group = parsed_instance_group
             expect(instance_group.name).to eq('instance-group-name')
             expect(instance_group.canonical_name).to eq('instance-group-name')
+          end
+        end
+
+        describe 'tags key' do
+          it 'parses tags' do
+            instance_group = parsed_instance_group
+            expect(instance_group.tags).to eq({ 'mytag' => 'foobar' })
+          end
+
+          it 'tags default empty Hash if not found' do
+            instance_group_spec.delete('tags')
+            instance_group = parsed_instance_group
+            expect(instance_group.tags).to eq({})
           end
         end
 


### PR DESCRIPTION
### What is this change about?

The change allows to configure instance group specific tags, by allowing the user to include tags under <instance_group> -> tags in the manifest.

These tags can be configured as follows:

```
instance_groups:
- name: <instance_group>
  tags:
    tag1: value1
    tag2: value2
```

These tags are merged with the instance plan tags during VM creation and have higher priority when there are keys which already exist. These tags can be useful under many circumstances, for example, in a large organisation, it makes identifying teams responsible for different instances easier. Also, This feature removes the necessity of including tags for the entire deployment when such tags aren't needed for all the involved instance groups.

### Please provide contextual information.

This PR builds on the feedback given in: https://github.com/cloudfoundry/bosh/pull/2444 

### What tests have you run against this PR?

bosh-director unit tests, dev-release testing on development environments

### How should this change be described in bosh release notes?

Support instance group specific tags.

### Does this PR introduce a breaking change?

No breaking change, since this PR just supports additional functionality of supporting instance tags.

### Tag your pair, your PM, and/or team!
@anshrupani @mvach 