### PR TITLE
Remove BOSH DNS entry for errand VMs after completion

### DIFF
--- a/src/bosh-director/lib/bosh/director/errand/instance_group_manager.rb
+++ b/src/bosh-director/lib/bosh/director/errand/instance_group_manager.rb
@@ -58,6 +58,7 @@ module Bosh::Director
         end
 
         @vm_deleter.delete_for_instance(instance_model)
+        LocalDnsManager.create(Config.root_domain, @logger).delete_dns_for_instance(instance_model)
         instance_model.remove_all_templates
       end
     end


### PR DESCRIPTION
This resolves unpleasant messages from services (e.g. metrics scraper) which occur when DNS entries exist for VMs which are not present.

Example from `/var/vcap/sys/log/loggr-system-metric-scraper/loggr-system-metric-scraper.stderr.log`:
```
2023-04-08 06:37:09	[id: clock_global, instance_id: , metric_url: https://10.2.0.37:53035/metrics]: Get "https://10.2.0.37:53035/metrics": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2023-04-08 06:38:10	[id: clock_global, instance_id: , metric_url: https://10.2.0.37:53035/metrics]: Get "https://10.2.0.37:53035/metrics": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
2023-04-08 06:39:10	[id: clock_global, instance_id: , metric_url: https://10.2.0.37:53035/metrics]: Get "https://10.2.0.37:53035/metrics": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Signed-off-by: aram price <pricear@vmware.com>

[#184931646]

### What tests have you run against this PR?

We ran `rake spec:unit:parallel`, and hot-patched a running director to validate the behavior.


### Does this PR introduce a breaking change?

> No