### PR TITLE
Deployment problems now returned with `instance_group`

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -368,6 +368,7 @@ module Bosh::Director
             'data' => problem.data,
             'description' => problem.description,
             'resolutions' => problem.resolutions,
+            'instance_group' => problem.instance_group,
           }
         end
 

--- a/src/bosh-director/lib/bosh/director/models/deployment_problem.rb
+++ b/src/bosh-director/lib/bosh/director/models/deployment_problem.rb
@@ -46,5 +46,9 @@ module Bosh::Director::Models
     def instance_problem?
       handler.instance_problem?
     end
+
+    def instance_group
+      handler.instance_group
+    end
   end
 end

--- a/src/bosh-director/lib/bosh/director/problem_handlers/base.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/base.rb
@@ -56,6 +56,8 @@ module Bosh::Director
 
       def instance_problem?; end
 
+      def instance_group; end
+
       def resolutions
         self.class.resolutions.map do |name|
           { :name => name.to_s, :plan => resolution_plan(name) }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/inactive_disk.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/inactive_disk.rb
@@ -37,6 +37,10 @@ module Bosh::Director
         false
       end
 
+      def instance_group
+        @instance.job || 'unknown job'
+      end
+
       resolution :ignore do
         plan { 'Skip for now' }
         action { }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/invalid_problem.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/invalid_problem.rb
@@ -20,6 +20,10 @@ module Bosh::Director
         false
       end
 
+      def instance_group
+        'unknown job'
+      end
+
       resolution :close do
         plan { "Close problem" }
         action { }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/missing_disk.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/missing_disk.rb
@@ -32,6 +32,10 @@ module Bosh::Director
         false
       end
 
+      def instance_group
+        @instance.job || 'unknown job'
+      end
+
       resolution :ignore do
         plan { 'Skip for now' }
         action { }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/missing_vm.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/missing_vm.rb
@@ -42,6 +42,10 @@ module Bosh::Director
       def instance_problem?
         true
       end
+
+      def instance_group
+        @instance.job || 'unknown job'
+      end
     end
   end
 end

--- a/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/mount_info_mismatch.rb
@@ -45,6 +45,10 @@ module Bosh::Director
         false
       end
 
+      def instance_group
+        @instance.job || 'unknown job'
+      end
+
       resolution :ignore do
         plan { "Ignore" }
         action { }

--- a/src/bosh-director/lib/bosh/director/problem_handlers/unresponsive_agent.rb
+++ b/src/bosh-director/lib/bosh/director/problem_handlers/unresponsive_agent.rb
@@ -31,6 +31,10 @@ module Bosh::Director
         true
       end
 
+      def instance_group
+        @instance.job || 'unknown job'
+      end
+
       resolution :ignore do
         plan { 'Skip for now' }
         action { }

--- a/src/bosh-director/spec/unit/problem_handlers/inactive_disk_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/inactive_disk_spec.rb
@@ -44,6 +44,12 @@ describe Bosh::Director::ProblemHandlers::InactiveDisk do
     expect(@handler.instance_problem?).to be_falsey
   end
 
+  describe 'instance group' do
+    it 'returns the job of the instance of the disk' do
+      expect(@handler.instance_group).to eq('mysql_node')
+    end
+  end
+
   describe 'invalid states' do
     it 'is invalid if disk is gone' do
       @disk.destroy

--- a/src/bosh-director/spec/unit/problem_handlers/invalid_problem_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/invalid_problem_spec.rb
@@ -16,4 +16,11 @@ describe Bosh::Director::ProblemHandlers::InvalidProblem do
     expect(handler.instance_problem?).to be_falsey
     expect(handler.description).to eq('Problem (err 42) is no longer valid: foobar')
   end
+
+  describe 'instance group' do
+    it 'returns "unknown job"' do
+      handler = Bosh::Director::ProblemHandlers::Base.create_by_type(:err, 42, {})
+      expect(handler.instance_group).to eq('unknown job')
+    end
+  end
 end

--- a/src/bosh-director/spec/unit/problem_handlers/missing_disk_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/missing_disk_spec.rb
@@ -40,6 +40,12 @@ describe Bosh::Director::ProblemHandlers::MissingDisk do
     expect(handler.description).to eq("Disk 'disk-cid' (mysql_node/uuid-42, 300M) is missing")
   end
 
+  describe 'instance group' do
+    it 'returns the job of the instance of the disk' do
+      expect(handler.instance_group).to eq('mysql_node')
+    end
+  end
+
   describe 'resolutions' do
     describe 'delete_disk_reference' do
       let(:event_manager) {Bosh::Director::Api::EventManager.new(true)}

--- a/src/bosh-director/spec/unit/problem_handlers/missing_vm_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/missing_vm_spec.rb
@@ -81,6 +81,12 @@ module Bosh::Director
       handler.auto_resolve
     end
 
+    describe 'instance group' do
+      it 'returns the job of the instance of the disk' do
+        expect(handler.instance_group).to eq('foobar')
+      end
+    end
+
     describe '#description' do
       context 'when vm cid is given' do
         it 'includes instance job name, uuid, index and vm cid' do

--- a/src/bosh-director/spec/unit/problem_handlers/mount_info_mismatch_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/mount_info_mismatch_spec.rb
@@ -54,6 +54,12 @@ describe Bosh::Director::ProblemHandlers::MountInfoMismatch do
     expect(@handler.description).to match(/Not mounted in any VM/)
   end
 
+  describe 'instance group' do
+    it 'returns the job of the instance of the disk' do
+      expect(@handler.instance_group).to eq('mysql_node')
+    end
+  end
+
   describe 'invalid states' do
     it 'is invalid if disk is gone' do
       @disk.destroy

--- a/src/bosh-director/spec/unit/problem_handlers/unresponsive_agent_spec.rb
+++ b/src/bosh-director/spec/unit/problem_handlers/unresponsive_agent_spec.rb
@@ -101,6 +101,12 @@ module Bosh::Director
       expect(handler.description).to eq("VM for 'mysql_node/uuid-1 (0)' with cloud ID 'vm-cid' is not responding.")
     end
 
+    describe 'instance group' do
+      it 'returns the job of the instance of the disk' do
+        expect(handler.instance_group).to eq('mysql_node')
+      end
+    end
+
     describe 'reboot_vm resolution' do
       it 'skips reboot if CID is not present' do
         instance.active_vm = nil


### PR DESCRIPTION
### What is this change about?

This will allow for display/sorting of problems via this value in the CLI.

### Please provide contextual information.

In support of the bosh recover work ([story](https://www.pivotaltracker.com/story/show/185483613)), which asks users for desired problem resolutions on a per-instance-group basis.  Prior to this change, there was no way for the CLI to have the value of the instance group of a problem.

[bosh create-recovery-plan PR](https://github.com/cloudfoundry/bosh-cli/pull/622)

### How should this change be described in bosh release notes?

List problems endpoint now returns the instance group of each problem.

### Does this PR introduce a breaking change?

No