### PR TITLE
Allow overriding of `max_in_flight` values when resolving deployment problems

### DIFF
--- a/src/bosh-director/lib/bosh/director.rb
+++ b/src/bosh-director/lib/bosh/director.rb
@@ -65,6 +65,7 @@ require 'bosh/director/download_helper'
 require 'bosh/director/formatter_helper'
 require 'bosh/director/tagged_logger'
 require 'bosh/director/duplicate_detector'
+require 'bosh/director/numerical_value_calculator'
 
 require 'bosh/director/version'
 require 'bosh/director/config'

--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -377,7 +377,15 @@ module Bosh::Director
 
       put '/:deployment/problems', consumes: [:json] do
         payload = json_decode(request.body.read)
-        start_task { @problem_manager.apply_resolutions(current_user, deployment, payload['resolutions']) }
+
+        start_task do
+          @problem_manager.apply_resolutions(
+            current_user,
+            deployment,
+            payload['resolutions'],
+            payload['max_in_flight_overrides'] || {},
+          )
+        end
       end
 
       put '/:deployment/scan_and_fix', consumes: :json do

--- a/src/bosh-director/lib/bosh/director/api/problem_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/problem_manager.rb
@@ -14,8 +14,8 @@ module Bosh::Director
         Models::DeploymentProblem.filter(filters).order(:created_at).all
       end
 
-      def apply_resolutions(username, deployment, resolutions)
-        JobQueue.new.enqueue(username, Jobs::CloudCheck::ApplyResolutions, 'apply resolutions', [deployment.name, resolutions], deployment)
+      def apply_resolutions(username, deployment, resolutions, max_in_flight_overrides)
+        JobQueue.new.enqueue(username, Jobs::CloudCheck::ApplyResolutions, 'apply resolutions', [deployment.name, resolutions, max_in_flight_overrides], deployment)
       end
 
       def scan_and_fix(username, deployment, jobs)

--- a/src/bosh-director/lib/bosh/director/deployment_plan/update_config.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/update_config.rb
@@ -114,11 +114,11 @@ module Bosh::Director
       end
 
       def canaries(size)
-        get_numerical_value(@canaries_before_calculation, size)
+        NumericalValueCalculator.get_numerical_value(@canaries_before_calculation, size)
       end
 
       def max_in_flight(size)
-        value = get_numerical_value(@max_in_flight_before_calculation, size)
+        value = NumericalValueCalculator.get_numerical_value(@max_in_flight_before_calculation, size)
         value < 1 ? 1 : value
       end
 
@@ -148,19 +148,6 @@ module Bosh::Director
 
       def update_azs_in_parallel_on_initial_deploy?
         @initial_deploy_az_update_strategy == PARALLEL_AZ_UPDATE_STRATEGY
-      end
-
-      private
-
-      def get_numerical_value(value, size)
-        case value
-        when /^\d+%$/
-          [((/\d+/.match(value)[0].to_i * size) / 100).round, size].min
-        when /\A[-+]?[0-9]+\z/
-          value.to_i
-        else
-          raise 'cannot be calculated'
-        end
       end
     end
   end

--- a/src/bosh-director/lib/bosh/director/jobs/cloud_check/apply_resolutions.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/cloud_check/apply_resolutions.rb
@@ -12,7 +12,8 @@ module Bosh::Director
 
         # @param [String] deployment_name Deployment name
         # @param [Hash] resolutions Problem resolutions
-        def initialize(deployment_name, resolutions)
+        # @param [Hash] max_in_flight_overrides Instance Group max_in_flight overrides
+        def initialize(deployment_name, resolutions, max_in_flight_overrides)
           @deployment_manager = Api::DeploymentManager.new
           @deployment = @deployment_manager.find_by_name(deployment_name)
 
@@ -28,12 +29,19 @@ module Bosh::Director
               hash
             }
 
+          # Normalizing max_in_flight
+          @max_in_flight_overrides =
+            max_in_flight_overrides.inject({}) { |hash, (instance_group, override)|
+              hash[instance_group] = override.to_s
+              hash
+            }
+
           @problem_resolver = ProblemResolver.new(@deployment)
         end
 
         def perform
           with_deployment_lock(@deployment) do
-            count, error_message = @problem_resolver.apply_resolutions(@resolutions)
+            count, error_message = @problem_resolver.apply_resolutions(@resolutions, @max_in_flight_overrides)
 
             if error_message
               raise Bosh::Director::ProblemHandlerError, error_message

--- a/src/bosh-director/lib/bosh/director/numerical_value_calculator.rb
+++ b/src/bosh-director/lib/bosh/director/numerical_value_calculator.rb
@@ -1,0 +1,14 @@
+module Bosh::Director
+  class NumericalValueCalculator
+    def self.get_numerical_value(value, size)
+      case value
+      when /^\d+%$/
+        [((/\d+/.match(value)[0].to_i * size) / 100).round, size].min
+      when /\A[-+]?[0-9]+\z/
+        value.to_i
+      else
+        raise 'cannot be calculated'
+      end
+    end
+  end
+end

--- a/src/bosh-director/spec/unit/api/problem_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/problem_manager_spec.rb
@@ -23,12 +23,13 @@ module Bosh::Director
 
     describe '#apply_resolutions' do
       let(:resolutions) { double('Resolutions') }
+      let(:max_in_flight_overrides) { double('Max_in_flight_overrides') }
 
       it 'enqueues a task' do
         expect(job_queue).to receive(:enqueue).with(
             username, Jobs::CloudCheck::ApplyResolutions, 'apply resolutions',
-            [deployment.name, resolutions], deployment).and_return(task)
-        expect(subject.apply_resolutions(username, deployment, resolutions)).to eq(task)
+            [deployment.name, resolutions, max_in_flight_overrides], deployment).and_return(task)
+        expect(subject.apply_resolutions(username, deployment, resolutions, max_in_flight_overrides)).to eq(task)
       end
     end
 

--- a/src/bosh-director/spec/unit/jobs/cloud_check/apply_resolutions_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/cloud_check/apply_resolutions_spec.rb
@@ -16,19 +16,25 @@ module Bosh::Director
     let(:resolutions) do
       { 1 => 'delete_disk', 2 => 'ignore' }
     end
+    let(:max_in_flight_overrides) do
+      { 'diego_cell' => '100%', 'router' => 5 }
+    end
+    let(:normalized_max_in_flight_overrides) do
+      { 'diego_cell' => '100%', 'router' => '5' }
+    end
     let(:normalized_resolutions) do
       { '1' => 'delete_disk', '2' => 'ignore' }
     end
-    let(:job) { described_class.new('deployment', resolutions) }
+    let(:job) { described_class.new('deployment', resolutions, max_in_flight_overrides) }
     let(:resolver) { instance_double('Bosh::Director::ProblemResolver') }
     let(:deployment) { Models::Deployment.first }
 
     describe '#perform' do
       context 'when resolution succeeds' do
-        it 'should normalize the problem ids' do
+        it 'should normalize the problem ids and overrides' do
           allow(job).to receive(:with_deployment_lock).and_yield
 
-          expect(resolver).to receive(:apply_resolutions).with(normalized_resolutions)
+          expect(resolver).to receive(:apply_resolutions).with(normalized_resolutions, normalized_max_in_flight_overrides)
 
           job.perform
         end

--- a/src/bosh-director/spec/unit/numerical_value_calculator_spec.rb
+++ b/src/bosh-director/spec/unit/numerical_value_calculator_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module Bosh::Director
+  describe NumericalValueCalculator do
+    describe '#get_numerical_value' do
+      context 'when value is a string representation of an integer' do
+        it 'returns the integer value' do
+          expect(NumericalValueCalculator.get_numerical_value('10', 10)).to eq(10)
+        end
+      end
+
+      context 'when value is a percentage' do
+        it 'returns that percentage of size' do
+          expect(NumericalValueCalculator.get_numerical_value('33%', 10)).to eq(3)
+        end
+      end
+
+      context 'when value is not the right format' do
+        it 'raises' do
+          expect { NumericalValueCalculator.get_numerical_value('foobar', 10) }.to raise_error(/cannot be calculated/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What is this change about?

This will allow the CLI (or other clients) to override the `max_in_flight` values per instance group when resolving deployment problems.  Previously, the `max_in_flight` values in the manifest were used, and the only way to change them was to re-deploy.  However, in disaster recovery scenarios, often a re-deploy is quite difficult, but you want to resolve problems as fast as possible.

### Please provide contextual information.

In support of the bosh recover work ([story](https://www.pivotaltracker.com/story/show/185483613)), which asks users for desired problem resolutions on a per-instance-group basis, and asks if they'd like to override the `max_in_flight` values.

[bosh create-recovery-plan PR](https://github.com/cloudfoundry/bosh-cli/pull/622)

### What tests have you run against this PR?

Units

### How should this change be described in bosh release notes?

Resolve problem endpoint now allows `max_in_flight_overrides`.


### Does this PR introduce a breaking change?

No