### PR TITLE
Attempt to fix "Extracting compiled package archive failed" error

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/packages_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/packages_controller.rb
@@ -3,50 +3,67 @@ require 'bosh/director/api/controllers/base_controller'
 module Bosh::Director
   module Api::Controllers
     class PackagesController < BaseController
-      post '/matches', :consumes => :yaml do
-        manifest = YAML.load(request.body.read, aliases: true)
+      post '/matches', consumes: :yaml do
+        manifest_hash = YAML.load(request.body.read, aliases: true)
 
-        unless manifest.is_a?(Hash) && manifest['packages'].is_a?(Array)
+        unless manifest_hash.is_a?(Hash) && manifest_hash['packages'].is_a?(Array)
           raise BadManifest, "Manifest doesn't have a usable packages section"
         end
 
-        fingerprint_list = []
+        fingerprints =
+          if existing_release_version_dirty?(manifest_hash)
+            []
+          else
+            fingerprint_list = manifest_hash['packages'].map { |package| package['fingerprint'] }.compact
+            Models::Package.where(fingerprint: fingerprint_list)
+              .where(Sequel.~(sha1: nil))
+              .where(Sequel.~(blobstore_id: nil)).all
+              .map(&:fingerprint).compact.uniq
+          end
 
-        manifest['packages'].each do |package|
-          fingerprint_list << package['fingerprint'] if package['fingerprint']
-        end
-
-        matching_packages = []
-
-        unless existing_release_version_dirty?(manifest)
-          matching_packages = Models::Package.where(fingerprint: fingerprint_list)
-                                             .where(Sequel.~(sha1: nil))
-                                             .where(Sequel.~(blobstore_id: nil)).all
-        end
-
-        json_encode(matching_packages.map(&:fingerprint).compact.uniq)
+        json_encode(fingerprints)
       end
 
-      post '/matches_compiled', :consumes => :yaml do
-        manifest = YAML.load(request.body.read, aliases: true)
+      post '/matches_compiled', consumes: :yaml do
+        manifest_hash = YAML.load(request.body.read, aliases: true)
 
-        unless manifest.is_a?(Hash) && manifest['compiled_packages'].is_a?(Array)
+        unless manifest_hash.is_a?(Hash) && manifest_hash['compiled_packages'].is_a?(Array)
           raise BadManifest, "Manifest doesn't have a usable packages section"
         end
 
-        fingerprints = []
-
-        unless existing_release_version_dirty?(manifest)
-          fingerprints = fingerprints_that_do_not_need_to_be_uploaded(manifest)
-        end
+        fingerprints =
+          if existing_release_version_dirty?(manifest_hash)
+            []
+          else
+            compiled_package_fingerprints_not_to_be_uploaded(manifest_hash)
+          end
 
         json_encode(fingerprints)
       end
 
       private
 
-      def fingerprints_that_do_not_need_to_be_uploaded(manifest_yaml)
-        manifest_fingerprints = manifest_yaml['compiled_packages'].map { |package| package['fingerprint'] }.compact
+      def compiled_package_fingerprints_not_to_be_uploaded(manifest_hash)
+        compiled_release_manifest = CompiledRelease::Manifest.new(manifest_hash)
+
+        existing_package_hashes = get_existing_package_hashes(compiled_release_manifest)
+        compiled_package_hashes = get_compiled_package_hashes(compiled_release_manifest)
+
+        # Remove packages that were not matched, but have identical fingerprints to ones that were matched
+        # This step is needed to prevent the cli from filtering compiled packages that have a matching fingerprint already
+        # but not the exact compiled package with an identical name too
+        package_hashes_that_need_upload = compiled_package_hashes - existing_package_hashes
+
+        package_hashes_that_are_already_uploaded = existing_package_hashes & compiled_package_hashes
+
+        fingerprints_that_need_upload = package_hashes_that_need_upload.map { |h| h[:fingerprint] }.compact.uniq
+        fingerprints_that_are_already_uploaded = package_hashes_that_are_already_uploaded.map { |h| h[:fingerprint] }.compact.uniq
+
+        fingerprints_that_are_already_uploaded - fingerprints_that_need_upload
+      end
+
+      def get_existing_package_hashes(compiled_release_manifest)
+        manifest_fingerprints = compiled_release_manifest.compiled_packages.map { |package| package['fingerprint'] }.compact
 
         existing_packages =
           Models::Package.join('compiled_packages', package_id: :id)
@@ -57,42 +74,30 @@ module Bosh::Director
                     :stemcell_version)
             .where(fingerprint: manifest_fingerprints).all
 
-        filtered_packages = filter_matching_packages(existing_packages, manifest_yaml)
-        filtered_packages.map(&:fingerprint).compact.uniq
-      end
-
-      # dependencies & stemcell should also match
-      def filter_matching_packages(existing_packages, manifest_yaml)
-        compiled_release_manifest = CompiledRelease::Manifest.new(manifest_yaml)
-
-        # Remove packages that were not matched, but have identical fingerprints to ones that were matched
-        # This step is needed to prevent the cli from filtering compiled packages that have a matching fingerprint already
-        # but not the exact compiled package with an identical name too
-        unmatched_package_fingerprints = fingerprints_not_matching_packages(existing_packages, compiled_release_manifest)
-
-        filtered_packages =
-          existing_packages.select do |package|
-            compiled_release_manifest.has_matching_package(package.name, package[:stemcell_os], package[:stemcell_version],
-                                                           package[:dependency_key]) &&
-              !unmatched_package_fingerprints.include?(package.fingerprint)
-          end
-
-        filtered_packages
-      end
-
-      def fingerprints_not_matching_packages(existing_packages, compiled_release_manifest)
-        missing_compiled_packages = compiled_release_manifest.compiled_packages.reject do |manifest_package|
-          existing_packages.any? do |package|
-            package[:name] == manifest_package['name'] &&
-              package[:fingerprint] == manifest_package['fingerprint']
-          end
+        existing_packages.map do |package|
+          {
+            name: package.name,
+            fingerprint: package[:fingerprint],
+            stemcell: "#{package[:stemcell_os]}/#{package[:stemcell_version]}",
+            dependency_key: package[:dependency_key],
+          }
         end
-        missing_compiled_packages.map { |package| package['fingerprint'] }
       end
 
-      def existing_release_version_dirty?(manifest)
-        release = Models::Release.first(name: manifest['name'])
-        release_version = Models::ReleaseVersion.first(release_id: release&.id, version: manifest['version'])
+      def get_compiled_package_hashes(compiled_release_manifest)
+        compiled_release_manifest.compiled_packages.map do |package|
+          {
+            name: package['name'],
+            fingerprint: package['fingerprint'],
+            stemcell: package['stemcell'],
+            dependency_key: compiled_release_manifest.dependency_key(package['name']),
+          }
+        end
+      end
+
+      def existing_release_version_dirty?(manifest_hash)
+        release = Models::Release.first(name: manifest_hash['name'])
+        release_version = Models::ReleaseVersion.first(release_id: release&.id, version: manifest_hash['version'])
 
         release_version && !release_version.update_completed
       end

--- a/src/bosh-director/lib/bosh/director/compiled_release/manifest.rb
+++ b/src/bosh-director/lib/bosh/director/compiled_release/manifest.rb
@@ -5,29 +5,23 @@ module Bosh::Director
         @manifest = manifest_hash
       end
 
-      def has_matching_package(package_name, stemcell_os, stemcell_version, dependency_key)
+      def compiled_packages
+        @manifest.fetch('compiled_packages', [])
+      end
 
+      def has_matching_package(package_name, stemcell_os, stemcell_version, dependency_key)
         "#{stemcell_os}/#{stemcell_version}" == stemcell_os_and_version(package_name) &&
-            dependency_key == dependency_key(package_name)
+          dependency_key == dependency_key(package_name)
       end
 
       def dependency_key(package_name)
         KeyGenerator.new.dependency_key_from_manifest(package_name, @manifest['compiled_packages'])
       end
 
-      def fingerprints_not_matching_packages(packages)
-        missing_compiled_packages = @manifest['compiled_packages'].reject do |manifest_package|
-          packages.any? do |package|
-            package[:name] == manifest_package['name'] && package[:fingerprint] == manifest_package['fingerprint']
-          end
-        end
-        missing_compiled_packages.map { |package| package['fingerprint'] }
-      end
-
       private
 
       def meta_data(package_name)
-        @manifest['compiled_packages'].find { |p| p['name'] == package_name }
+        compiled_packages.find { |p| p['name'] == package_name }
       end
 
       def stemcell_os_and_version(package_name)


### PR DESCRIPTION
Previously, there were cases where a package existed the name and fingerprint, but did not match stemcell, was mistakenly excluded from upload. This results in errors like the following:

```
Task 1939132 | 20:03:34 | Creating new compiled packages: routing-golang-1-linux/8c04109541f4d504f5be559da433998bd459b0f45cd3654557cc3642cc4d2f60 for ubuntu-jammy/1.147 (00:00:00)
                        L Error: Extracting compiled package archive failed. Check task debug log for details.
```

Now, when deciding which packages do not need to be uploaded, we consider name, fingerprint, dependency key, and stemcell os/version.

We ended up refactoring quite a bit in an effort to make the code more understandable (and understand it ourselves...). The most relevant logic change is in the `compiled_package_fingerprints_not_to_be_uploaded` method.