### PR TITLE
Introduce on-stemcell-change variable strategy

### DIFF
--- a/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/deployments_controller.rb
@@ -416,6 +416,7 @@ module Bosh::Director
         options['canaries'] = params[:canaries] if params['canaries']
         options['max_in_flight'] = params[:max_in_flight] if params['max_in_flight']
         options['scopes'] = token_scopes
+        options['force_latest_variables'] = true if params['force_latest_variables'] == 'true'
 
         # since authorizer does not look at manifest payload for deployment name
         @deployment = Models::Deployment[name: deployment_name]

--- a/src/bosh-director/lib/bosh/director/config_server/variables_interpolator.rb
+++ b/src/bosh-director/lib/bosh/director/config_server/variables_interpolator.rb
@@ -49,8 +49,8 @@ module Bosh::Director::ConfigServer
       @config_server_client.interpolate_with_versioning(raw_hash, variable_set, options)
     end
 
-    def generate_values(variables, deployment_name, converge_variables = false, use_link_dns_names = false)
-      @config_server_client.generate_values(variables, deployment_name, converge_variables, use_link_dns_names)
+    def generate_values(variables, deployment_name, converge_variables = false, use_link_dns_names = false, stemcell_change = false)
+      @config_server_client.generate_values(variables, deployment_name, converge_variables, use_link_dns_names, stemcell_change)
     end
 
     def interpolated_versioned_variables_changed?(previous_raw_hash, next_raw_hash, previous_variable_set, target_variable_set)

--- a/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/assembler.rb
@@ -25,6 +25,7 @@ module Bosh::Director
       should_bind_links = is_deploy_action && options.fetch(:should_bind_links, true)
       should_bind_properties = options.fetch(:should_bind_properties, true)
       should_bind_new_variable_set = options.fetch(:should_bind_new_variable_set, false)
+      stemcell_change = options.fetch(:stemcell_change, false)
       deployment_options = @deployment_plan.deployment_wide_options
       fix = deployment_options.fetch(:fix, false)
       tags = deployment_options.fetch(:tags, {})
@@ -100,7 +101,7 @@ module Bosh::Director
       bind_instance_networks
       bind_dns
       bind_links if should_bind_links
-      generate_variables if is_deploy_action
+      generate_variables(stemcell_change) if is_deploy_action
     end
 
     private
@@ -169,12 +170,13 @@ module Bosh::Director
       end
     end
 
-    def generate_variables
+    def generate_variables(stemcell_change)
       @variables_interpolator.generate_values(
         @deployment_plan.variables,
         @deployment_plan.name,
         @deployment_plan.features.converge_variables,
         @deployment_plan.features.use_link_dns_names,
+        stemcell_change,
       )
     end
 

--- a/src/bosh-director/lib/bosh/director/deployment_plan/planner.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/planner.rb
@@ -26,7 +26,6 @@ module Bosh::Director
       #   Default job update configuration
       attr_accessor :update
 
-      # @return [Array<Bosh::Director::DeploymentPlan::Job>]
       #   All instance_groups in the deployment
       attr_reader :instance_groups
 

--- a/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_deployment.rb
@@ -91,9 +91,15 @@ module Bosh::Director
           # the DNS encoder having an updated index before bind_models is called
           dns_encoder # TODO(ja): unit test that new_encoder_with_updated_index is called before bind_models
 
+          existing_stemcells = current_deployment.stemcells.map { |s| { os: s.operating_system, version: s.version } }.uniq
+          plan_stemcells = deployment_plan.stemcells.values.map { |s| { os: s.os || s.name, version: s.version } }.uniq
+
+          all_stemcell_versions_changed = (existing_stemcells.intersection(plan_stemcells)).empty?
+
           DeploymentPlan::Assembler.create(deployment_plan, @variables_interpolator).bind_models(
             is_deploy_action: deploy_action?,
             should_bind_new_variable_set: deploy_action?,
+            stemcell_change: @options['force_latest_variables'] || all_stemcell_versions_changed
           )
         end
       end

--- a/src/bosh-director/lib/bosh/director/models/deployment.rb
+++ b/src/bosh-director/lib/bosh/director/models/deployment.rb
@@ -104,6 +104,10 @@ module Bosh::Director::Models
       variable_sets_dataset.order(Sequel.desc(:created_at)).limit(1).first
     end
 
+    def previous_variable_set
+      variable_sets_dataset.order(Sequel.desc(:created_at)).limit(2, 1).first
+    end
+
     def last_successful_variable_set
       variable_sets_dataset.where(deployed_successfully: true).order(Sequel.desc(:created_at)).limit(1).first
     end

--- a/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -421,6 +421,17 @@ module Bosh::Director
               post '/', spec_asset('test_manifest.yml'), { 'CONTENT_TYPE' => 'text/yaml' }
             end
           end
+
+          context 'with the "force_latest_variables" param which is needed because their BOSH DNS certs expire tomorrow and there is no new stemcell to trigger a cert rotation' do
+            it 'passes the parameter' do
+              expect_any_instance_of(DeploymentManager)
+                .to receive(:create_deployment)
+                      .with(anything(), anything(), anything(), anything(), anything(), hash_including('force_latest_variables' => true), anything())
+                      .and_return(OpenStruct.new(:id => 1))
+              post '/?force_latest_variables=true', spec_asset('test_conf.yaml'), {'CONTENT_TYPE' => 'text/yaml'}
+              expect(last_response).to be_redirect
+            end
+          end
         end
 
         describe 'deleting deployment' do

--- a/src/bosh-director/spec/unit/config_server/variables_interpolator_spec.rb
+++ b/src/bosh-director/spec/unit/config_server/variables_interpolator_spec.rb
@@ -663,4 +663,26 @@ describe Bosh::Director::ConfigServer::VariablesInterpolator do
       end
     end
   end
+
+  describe '#generate_values' do
+    let(:variables) { double(:variables) }
+
+    it 'passes through arguments to the config server client' do
+      allow(config_server_client).to receive(:generate_values).with(
+        variables,
+        "deployment-name",
+        true,
+        true,
+        true,
+        )
+
+      subject.generate_values(
+        variables,
+        "deployment-name",
+        true,
+        true,
+        true,
+        )
+    end
+  end
 end

--- a/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/assembler_spec.rb
@@ -342,7 +342,7 @@ module Bosh::Director
             end
 
             it 'generates the values through config server' do
-              expect(variables_interpolator).to receive(:generate_values).with(variables, 'simple', false, false)
+              expect(variables_interpolator).to receive(:generate_values).with(variables, 'simple', false, false, false)
               assembler.bind_models(is_deploy_action: true)
             end
 
@@ -350,7 +350,7 @@ module Bosh::Director
               let(:converge_variables) { true }
 
               it 'should generate the values through config server' do
-                expect(variables_interpolator).to receive(:generate_values).with(variables, 'simple', true, false)
+                expect(variables_interpolator).to receive(:generate_values).with(variables, 'simple', true, false, false)
                 assembler.bind_models(is_deploy_action: true)
               end
             end
@@ -359,7 +359,19 @@ module Bosh::Director
               let(:use_link_dns_names) { true }
 
               it 'should generate the values through config server' do
-                expect(variables_interpolator).to receive(:generate_values).with(variables, 'simple', false, true)
+                expect(variables_interpolator).to receive(:generate_values).with(variables, 'simple', false, true, false)
+                assembler.bind_models(is_deploy_action: true)
+              end
+            end
+
+            context 'stemcell change' do
+              it 'passes through the :stemcell_change value' do
+                expect(variables_interpolator).to receive(:generate_values).with(variables, 'simple', false, false, true)
+                assembler.bind_models(is_deploy_action: true, stemcell_change: true)
+              end
+
+              it 'defaults :stemcell_change to false' do
+                expect(variables_interpolator).to receive(:generate_values).with(variables, 'simple', false, false, false)
                 assembler.bind_models(is_deploy_action: true)
               end
             end

--- a/src/bosh-director/spec/unit/deployment_plan/planner_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/planner_spec.rb
@@ -32,6 +32,7 @@ module Bosh::Director
       let(:minimal_manifest) { Bosh::Spec::Deployments.minimal_manifest }
 
       its(:model) { deployment_model }
+
       describe 'with valid options' do
         let(:stemcell_model) { Bosh::Director::Models::Stemcell.create(name: 'default', version: '1', cid: 'abc') }
         let(:vm_type) { VmType.new('name' => 'vm_type') }

--- a/src/bosh-director/spec/unit/models/deployment_spec.rb
+++ b/src/bosh-director/spec/unit/models/deployment_spec.rb
@@ -213,11 +213,32 @@ module Bosh::Director::Models
         VariableSet.make(id: 3, deployment: deployment_1, created_at: time + 3, deployed_successfully: true)
         VariableSet.make(id: 4, deployment: deployment_1, created_at: time + 4, deployed_successfully: true)
         VariableSet.make(id: 5, deployment: deployment_1, created_at: time + 5, deployed_successfully: false)
+        VariableSet.make(id: 6, deployment: deployment_1, created_at: time + 6, deployed_successfully: false)
       end
 
-      it 'returns the deployment current variable set' do
+      it 'returns the deployment last successful variable set' do
         expect(deployment_1.last_successful_variable_set.id).to eq(4)
         expect(deployment_2.last_successful_variable_set).to be_nil
+      end
+    end
+
+    describe '#previous_variable_set' do
+      let(:deployment_1) { Deployment.make(manifest: 'test') }
+      let(:deployment_2) { Deployment.make(manifest: 'vroom') }
+
+      before do
+        time = Time.now
+        VariableSet.make(id: 1, deployment: deployment_1, created_at: time + 1, deployed_successfully: true)
+        VariableSet.make(id: 2, deployment: deployment_1, created_at: time + 2, deployed_successfully: true)
+        VariableSet.make(id: 3, deployment: deployment_1, created_at: time + 3, deployed_successfully: true)
+        VariableSet.make(id: 4, deployment: deployment_1, created_at: time + 4, deployed_successfully: true)
+        VariableSet.make(id: 5, deployment: deployment_1, created_at: time + 5, deployed_successfully: false)
+        VariableSet.make(id: 6, deployment: deployment_1, created_at: time + 6, deployed_successfully: false)
+      end
+
+      it 'returns the deployment previous variable set, regardless of whether it was deployed_successfully' do
+        expect(deployment_1.previous_variable_set.id).to eq(5)
+        expect(deployment_2.previous_variable_set).to be_nil
       end
     end
 


### PR DESCRIPTION
This commit introduces a new `update` block under variable declarations, as well as a `strategy` key underneath it to control when BOSH retrieves the latest version of that variable. This feature allows better control over when new variable versions are rolled out to VMs during a deploy.

Currently, when a manifest is deployed, the BOSH Director will query CredHub for the latest version of each variable in the manifest. This ensures that deployments always use the current configuration stored in CredHub.

This is a problem for being able to automatically rotate certificates - if a new version of a certificate is in CredHub, the deploy will use it. Normally this would be desirable, but since the rotation is done without users taking a direct action, they may not be aware that there are updated certs and thus will be surprised by a longer-than-normal deploy if they have no other changes. Predicting when there's going to be a longer-than-normal deploy is important for strict change / maintenance windows.

The new key on variables has two potential values:
* on-deploy: BOSH will use the current behavior of looking up the latest variable value on each deploy (default)
* on-stemcell-change: BOSH will only look up the latest variable value when a deploy is occuring that updates all stemcells for the deployment. If one or more stemcells is not being updated, then BOSH will continue to use the previously deployed value for the variable.

The on-stemcell-change behavior can be overridden by passing the `force_latest_variables` parameter to the deploy API endpoint. This will ensure that the latest variable value is used, regardless of the variable's declared strategy.

Corresponding docs PR: https://github.com/cloudfoundry/docs-bosh/pull/799
