### PR TITLE
Enable support for verify-ca SSL mode for cases when hostname verification is not possible/required

### DIFF
--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -65,6 +65,7 @@ director_db = {
   'connection_options' => p('director.db.connection_options'),
   'tls' => {
     'enabled' => p('director.db.tls.enabled', false),
+    'skip_host_verify' => p('director.db.tls.skip_host_verify', false),
     'cert' => {
       'ca' => '/var/vcap/jobs/director/config/db/ca.pem',
       'certificate' => '/var/vcap/jobs/director/config/db/client_certificate.pem',

--- a/spec/director.yml.erb_spec.rb
+++ b/spec/director.yml.erb_spec.rb
@@ -419,6 +419,36 @@ describe 'director.yml.erb' do
           end
         end
 
+        context 'when director.db.tls.skip_host_verify is true' do
+          before do
+            merged_manifest_properties['director']['db']['tls']['skip_host_verify'] = true
+          end
+
+          it 'configures enabled TLS for database property' do
+            expect(parsed_yaml['db']['tls']['skip_host_verify']).to be_truthy
+          end
+        end
+
+        context 'when director.db.tls.skip_host_verify is false' do
+          before do
+            merged_manifest_properties['director']['db']['tls']['skip_host_verify'] = false
+          end
+
+          it 'configures disables TLS for database property' do
+            expect(parsed_yaml['db']['tls']['skip_host_verify']).to be_falsey
+          end
+        end
+
+        context 'when director.db.tls.skip_host_verify is not defined' do
+          before do
+            merged_manifest_properties['director']['db']['tls'].delete('skip_host_verify')
+          end
+
+          it 'configures disables TLS for database property' do
+            expect(parsed_yaml['db']['tls']['skip_host_verify']).to be_falsey
+          end
+        end
+
         context 'when director.db.tls.cert.ca is provided' do
           it 'set bosh_internal ca_provided to true' do
             expect(parsed_yaml['db']['tls']['bosh_internal']['ca_provided']).to be_truthy

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -326,14 +326,14 @@ module Bosh::Director
           case connection_config['adapter']
             when 'mysql2'
               # http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-mysql+
-              connection_config['ssl_mode'] = 'verify_identity'
+              connection_config['ssl_mode'] = tls_options.fetch('skip_host_verify', false) ? 'verify_ca' : 'verify_identity'
               connection_config['sslverify'] = true
               connection_config['sslca'] = db_ca_path if db_ca_provided
               connection_config['sslcert'] = db_client_cert_path if mutual_tls_enabled
               connection_config['sslkey'] = db_client_private_key_path if mutual_tls_enabled
             when 'postgres'
               # http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-postgres
-              connection_config['sslmode'] = 'verify-full'
+              connection_config['sslmode'] = tls_options.fetch('skip_host_verify', false) ? 'verify-ca' : 'verify-full'
               connection_config['sslrootcert'] = db_ca_path if db_ca_provided
 
               postgres_driver_options = {

--- a/src/bosh-director/spec/unit/config_spec.rb
+++ b/src/bosh-director/spec/unit/config_spec.rb
@@ -967,6 +967,45 @@ describe Bosh::Director::Config do
             end
           end
         end
+
+        context 'when skip_host_verify is enabled' do
+          it_behaves_like 'db connects with custom parameters' do
+            let(:config) do
+              {
+                'adapter' => 'postgres',
+                'host' => '127.0.0.1',
+                'port' => 5432,
+                'tls' => {
+                  'enabled' => true,
+                  'cert' => {
+                    'ca' => '/path/to/root/ca',
+                    'certificate' => '/path/to/client/certificate',
+                    'private_key' => '/path/to/client/private_key',
+                  },
+                  'skip_host_verify' => true,
+                  'bosh_internal' => {
+                    'ca_provided' => true,
+                    'mutual_tls_enabled' => true,
+                  },
+                },
+              }
+            end
+
+            let(:connection_parameters) do
+              {
+                'adapter' => 'postgres',
+                'host' => '127.0.0.1',
+                'port' => 5432,
+                'sslmode' => 'verify-ca',
+                'sslrootcert' => '/path/to/root/ca',
+                'driver_options' => {
+                  'sslcert' =>  '/path/to/client/certificate',
+                  'sslkey' => '/path/to/client/private_key',
+                },
+              }
+            end
+          end
+        end
       end
 
       context 'mysql2' do
@@ -1105,6 +1144,44 @@ describe Bosh::Director::Config do
                 'host' => '127.0.0.1',
                 'port' => 3306,
                 'ssl_mode' => 'verify_identity',
+                'sslca' => '/path/to/root/ca',
+                'sslverify' => true,
+                'sslcert' =>  '/path/to/client/certificate',
+                'sslkey' => '/path/to/client/private_key',
+              }
+            end
+          end
+        end
+
+        context 'when skip_host_verify is enabled' do
+          it_behaves_like 'db connects with custom parameters' do
+            let(:config) do
+              {
+                'adapter' => 'mysql2',
+                'host' => '127.0.0.1',
+                'port' => 3306,
+                'tls' => {
+                  'enabled' => true,
+                  'skip_host_verify' => true,
+                  'cert' => {
+                    'ca' => '/path/to/root/ca',
+                    'certificate' => '/path/to/client/certificate',
+                    'private_key' => '/path/to/client/private_key',
+                  },
+                  'bosh_internal' => {
+                    'ca_provided' => true,
+                    'mutual_tls_enabled' => true,
+                  },
+                },
+              }
+            end
+
+            let(:connection_parameters) do
+              {
+                'adapter' => 'mysql2',
+                'host' => '127.0.0.1',
+                'port' => 3306,
+                'ssl_mode' => 'verify_ca',
                 'sslca' => '/path/to/root/ca',
                 'sslverify' => true,
                 'sslcert' =>  '/path/to/client/certificate',


### PR DESCRIPTION
### What is this change about?

[Bosh docs](https://bosh.io/jobs/director?source=github.com/cloudfoundry/bosh#p%3ddirector.db.tls.skip_host_verify) claim that bosh provides support for the director DB TLS config property `skip_host_verify`, but unfortunately there was not implementation in the code or support in the director specs template. This PR provides support for this property, enabling another SSL verification mode (**verify-ca** for postgres, **verify_ca** for mysql2). This will especially be useful for enabling TLS communication with GCP databases, where hostname verification is currently not possible.

### What tests have you run against this PR?

Ran the director unit tests and verified the usage of a dev-release with this feature on a development environment.

### How should this change be described in bosh release notes?

Provide support for **verify-ca** SSL mode by enabling `skip_host_verify` director DB TLS config.

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@Malsourie 
