### PR TITLE
Unifying azure storage cli config across director and agent to prevent conflicts

### DIFF
--- a/src/bosh-director/lib/bosh/blobstore_client/azurestoragecli_blobstore_client.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/azurestoragecli_blobstore_client.rb
@@ -27,9 +27,9 @@ module Bosh::Blobstore
       end
 
       @azure_storage_cli_options = {
-        "account-name": @options[:account_name],
-        "container-name": @options[:container_name],
-        "account-key": @options[:account_key]
+        "account_name": @options[:account_name],
+        "container_name": @options[:container_name],
+        "account_key": @options[:account_key]
       }
 
       @azure_storage_cli_options.reject! { |_k, v| v.nil? }

--- a/src/bosh-director/spec/unit/blobstore_client/azurestoragecli_blobstore_client_spec.rb
+++ b/src/bosh-director/spec/unit/blobstore_client/azurestoragecli_blobstore_client_spec.rb
@@ -35,9 +35,9 @@ module Bosh::Blobstore
     describe 'options' do
       let(:expected_options) do
         {
-          'container-name' => 'test',
-          'account-name' => 'NAME',
-          'account-key' => 'SECRET'
+          'container_name' => 'test',
+          'account_name' => 'NAME',
+          'account_key' => 'SECRET'
         }
       end
       let(:stored_config_file) { File.new(expected_config_file).readlines }


### PR DESCRIPTION
### What is this change about?

This change unifies the config property names for the director and the agent to prevent unnecessary [inconsistencies](https://github.com/cloudfoundry/bosh/blob/e29074609901f68662ea3d77facd11312bee4dd1/src/bosh-director/lib/bosh/blobstore_client/base.rb#L136). A [PR](https://github.com/cloudfoundry/bosh-azure-storage-cli/pull/9) is also proposed for the required relevant changes in the [bosh-azure-storage-cli](https://github.com/cloudfoundry/bosh-azure-storage-cli).

### What tests have you run against this PR?

Unite tests.

### How should this change be described in bosh release notes?

bosh-azure-storage config properties refactored

### Does this PR introduce a breaking change?

Yes, if upgrading to the new bosh release does not happen together with the new bosh-azure-storage-cli release (released after this [PR](https://github.com/cloudfoundry/bosh-azure-storage-cli/pull/9) is merged).

### Tag your pair, your PM, and/or team!
@Malsourie 
