### PR TITLE
Re-allow job spec manifests to use yaml anchors

### DIFF
--- a/src/bosh-director-core/lib/bosh/director/core/templates/job_template_loader.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/job_template_loader.rb
@@ -17,7 +17,7 @@ module Bosh::Director
 
       def process(job_template)
         template_dir = extract_template(job_template)
-        manifest = Psych.load_file(File.join(template_dir, 'job.MF'))
+        manifest = Psych.load_file(File.join(template_dir, 'job.MF'), aliases: true)
 
         monit_erb_file = File.read(File.join(template_dir, 'monit'))
         monit_source_erb = SourceErb.new('monit', 'monit', monit_erb_file, job_template.name)


### PR DESCRIPTION
This was previously allowed, but the functionality was removed as part of a previous upgrade of Ruby.

Report of the problem in [CFF Slack](https://cloudfoundry.slack.com/archives/C02FL4A2K/p1698317333685859)