### PR TITLE
🐞 Director correctly places runtime config jobs...

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/stemcell.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/stemcell.rb
@@ -33,6 +33,12 @@ module Bosh::Director
         @os = os
         @version = version
         @manager = Api::StemcellManager.new
+        if @os.blank?
+          models = @manager.all_by_name_and_version(@name, @version)
+          unless models.empty?
+            @os = models.first.operating_system
+          end
+        end
       end
 
       def is_using_os?

--- a/src/bosh-director/spec/unit/deployment_plan/stemcell_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/stemcell_spec.rb
@@ -48,6 +48,13 @@ describe Bosh::Director::DeploymentPlan::Stemcell do
           valid_spec['name'] = 'stemcell-name'
           expect { make(valid_spec) }.to_not raise_error
         end
+        it 'populates os' do
+          make_stemcell('stemcell-name','0.5.2','plan-9')
+          valid_spec.delete('os')
+          valid_spec['name'] = 'stemcell-name'
+          stemcell = make(valid_spec)
+          expect(stemcell.os).to eq('plan-9')
+        end
       end
 
       context 'when neither os or name are specified' do


### PR DESCRIPTION
...when the deployment manifest does not list the stemcell OS.

Manifests can select stemcells by name or OS (but not both). <https://bosh.io/docs/manifest-v2/#stemcells>

Runtime config jobs can be placed by stemcell OS. <https://bosh.io/docs/runtime-config/#placement-rules>

If your manifest uses stemcell name, even if that stemcell has an OS that matches the runtime config, it will not be used. Stemcells in manifest:
```
stemcells:
- alias: default
  name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
  version: latest
```
Placement rules in runtime config:
```
include:
  stemcell:
  - os: ubuntu-jammy
```

This commit fixes that shortcoming; now if the manifest specifies stemcells by name, the Director will appropriately place the runtime config jobs on the VMs.