### PR TITLE
bumped dependencies for nats-pure and ruby-prof to the most recent versions

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -18,7 +18,7 @@ gem 'json', '2.6.3'
 
 gem 'talentbox-delayed_job_sequel', '~>4.3'
 
-gem 'ruby-prof', '0.17.0'
+gem 'ruby-prof', '1.6.3'
 
 group :production do
   gem 'mysql2'
@@ -64,7 +64,7 @@ group :development, :test do
   gem 'factory_bot', '~> 6.2'
 
   # for root level specs
-  gem 'nats-pure', '~>0.6.2'
+  gem 'nats-pure', '~>2.3'
   gem 'openssl'
   gem 'rest-client'
 

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -49,7 +49,7 @@ PATH
       httpclient (~> 2.8.3)
       logging (~> 2.2.2)
       membrane (~> 1.1.0)
-      nats-pure (~> 0.6.2)
+      nats-pure (~> 2.3)
       netaddr (~> 1.5.3.dev.1)
       prometheus-client (~> 2.1.0)
       puma
@@ -75,7 +75,7 @@ PATH
       eventmachine (~> 1.3.0.dev.1)
       httpclient (~> 2.8.3)
       logging (~> 2.2.2)
-      nats-pure (~> 0.6.2)
+      nats-pure (~> 2.3)
       riemann-client (~> 0.2.6)
       sinatra (~> 2.2.0)
       thin
@@ -88,7 +88,7 @@ PATH
       em-http-request
       eventmachine (~> 1.3.0.dev.1)
       logging (~> 2.2.2)
-      nats-pure (~> 0.6.2)
+      nats-pure (~> 2.3)
       rest-client
       sinatra (~> 2.2.0)
       thin
@@ -203,7 +203,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.2.0)
     mysql2 (0.5.5)
-    nats-pure (0.6.2)
+    nats-pure (2.3.0)
     net-ssh (7.2.0)
     netrc (0.11.0)
     nio4r (2.5.9)
@@ -281,7 +281,7 @@ GEM
       parser (>= 3.2.1.0)
     rubocop-git (0.1.3)
       rubocop (>= 0.24.1)
-    ruby-prof (0.17.0)
+    ruby-prof (1.6.3)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rufus-scheduler (3.9.1)
@@ -359,7 +359,7 @@ DEPENDENCIES
   machinist (~> 1.0)
   minitar
   mysql2
-  nats-pure (~> 0.6.2)
+  nats-pure (~> 2.3)
   net-ssh
   netaddr (~> 1.5.3.dev.1)!
   openssl
@@ -375,7 +375,7 @@ DEPENDENCIES
   rspec-its
   rubocop
   rubocop-git
-  ruby-prof (= 0.17.0)
+  ruby-prof (= 1.6.3)
   simplecov
   sinatra (>= 2.2.0)
   sinatra-contrib (>= 2.2.0)

--- a/src/bosh-director/bosh-director.gemspec
+++ b/src/bosh-director/bosh-director.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'httpclient',       '~>2.8.3'
   spec.add_dependency 'logging',          '~>2.2.2'
   spec.add_dependency 'membrane',         '~>1.1.0'
-  spec.add_dependency 'nats-pure',        '~>0.6.2'
+  spec.add_dependency 'nats-pure'
   spec.add_dependency 'netaddr',          '~>1.5.3.dev.1'
   spec.add_dependency 'prometheus-client','~>2.1.0'
   spec.add_dependency 'puma'

--- a/src/bosh-monitor/bosh-monitor.gemspec
+++ b/src/bosh-monitor/bosh-monitor.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'eventmachine',    '~>1.3.0.dev.1'
   spec.add_dependency 'logging',         '~>2.2.2'
   spec.add_dependency 'em-http-request'
-  spec.add_dependency 'nats-pure',       '~>0.6.2'
+  spec.add_dependency 'nats-pure'
   spec.add_dependency 'thin'
   spec.add_dependency 'sinatra',   '~>2.2.0'
   spec.add_dependency 'dogapi',    '~> 1.21.0'

--- a/src/bosh-nats-sync/bosh-nats-sync.gemspec
+++ b/src/bosh-nats-sync/bosh-nats-sync.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'eventmachine',    '~>1.3.0.dev.1'
   spec.add_dependency 'logging',         '~>2.2.2'
   spec.add_dependency 'em-http-request'
-  spec.add_dependency 'nats-pure',       '~>0.6.2'
+  spec.add_dependency 'nats-pure'
   spec.add_dependency 'thin'
   spec.add_dependency 'sinatra',   '~>2.2.0'
   spec.add_dependency 'rest-client'

--- a/src/vendor/cache/nats-pure-0.6.2.gem
+++ b/src/vendor/cache/nats-pure-0.6.2.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c8b24466ae4a364ac5e5f066d5045b6825632993a3d39ddd91718c2bc86c1f5
-size 18432

--- a/src/vendor/cache/nats-pure-2.3.0.gem
+++ b/src/vendor/cache/nats-pure-2.3.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1b6c1784b2c97bddea1ad6e706f3bda4997e5988b44d4ac37c91d8ff8a7dd6c
+size 50176

--- a/src/vendor/cache/ruby-prof-0.17.0.gem
+++ b/src/vendor/cache/ruby-prof-0.17.0.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c3838e460d6af672861983c80dc0be6d6c41c24d9d0a04239a8851d03a4e40b
-size 492032

--- a/src/vendor/cache/ruby-prof-1.6.3.gem
+++ b/src/vendor/cache/ruby-prof-1.6.3.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a140bf76405fe63cc999e124c4b6c44df9045e49ab7f177a6437f53f0877da8d
+size 101376


### PR DESCRIPTION
### What is this change about?

Update outdated dependencies for ruby-prof and nats-pure. 

Internal Blackduck scans found some very outdated libs in the upstream bosh director.

### Please provide contextual information.

https://cloudfoundry.slack.com/archives/C02HPPYQ2/p1698155192619889

### What tests have you run against this PR?
-
### How should this change be described in bosh release notes?
bumped dependencies for nats-pure and ruby-prof to the most recent versions

### Does this PR introduce a breaking change?

### Tag your pair, your PM, and/or team!
@fmoehler 
