### PR TITLE
remove unused ruby 3.1 package

### DIFF
--- a/packages/director-ruby-3.1/spec.lock
+++ b/packages/director-ruby-3.1/spec.lock
@@ -1,2 +1,0 @@
-name: director-ruby-3.1
-fingerprint: 82651486268c5a872706d5e1a2458b76af7e69fe36dbfed64903c64a3af39eae


### PR DESCRIPTION
as we migrated to ruby 3.2 a while ago i think its time to remove the unused ruby 3.1 package