### PR TITLE
ERB template rendering code review: rename old bosh v1 names to v2

### DIFF
--- a/src/bosh-director-core/lib/bosh/director/core/templates/job_template_loader.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/job_template_loader.rb
@@ -15,6 +15,24 @@ module Bosh::Director
         @dns_encoder = dns_encoder
       end
 
+      # Perform these operations in order:
+      #
+      #  1. Download (or fetch from cache) a single job blob tarball.
+      #
+      #  2. Extract the job blob tarball in a temporary directory.
+      #
+      #  3. Access the extracted 'job.MF' manifest from the job blob.
+      #
+      #  4. Load all ERB templates (including the 'monit' file and all other
+      #     declared files within the 'templates' subdir) and create one
+      #     'SourceErb' object for each of these.
+      #
+      #  5. Create and return a 'JobTemplateRenderer' object, populated with
+      #     all created 'SourceErb' objects.
+      #
+      # @param [DeploymentPlan::Job] instance_job The job whose templates
+      #                                           should be rendered
+      # @return [JobTemplateRenderer] Object that can render the templates
       def process(job_template)
         template_dir = extract_template(job_template)
         manifest = Psych.load_file(File.join(template_dir, 'job.MF'), aliases: true)

--- a/src/bosh-director-core/lib/bosh/director/core/templates/job_template_loader.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/job_template_loader.rb
@@ -35,21 +35,13 @@ module Bosh::Director
       # @return [JobTemplateRenderer] Object that can render the templates
       def process(instance_job)
         template_dir = extract_template(instance_job)
-        manifest = Psych.load_file(File.join(template_dir, 'job.MF'), aliases: true)
 
         monit_erb_file = File.read(File.join(template_dir, 'monit'))
         monit_source_erb = SourceErb.new('monit', 'monit', monit_erb_file, instance_job.name)
 
         source_erbs = []
 
-        job_name_from_manifest = manifest.fetch('name', {})
-        if job_name_from_manifest != instance_job.name
-          raise Bosh::Director::JobTemplateUnpackFailed,
-            "Inconsistent name in extracted job.MF manifest " +
-              "(exptected: '#{instance_job.name}', got: '#{job_name_from_manifest}')"
-        end
-
-        manifest.fetch('templates', {}).each_pair do |src_name, dest_name|
+        instance_job.model.spec.fetch('templates', {}).each_pair do |src_name, dest_name|
           erb_file = File.read(File.join(template_dir, 'templates', src_name))
           source_erbs << SourceErb.new(src_name, dest_name, erb_file, instance_job.name)
         end

--- a/src/bosh-director-core/lib/bosh/director/core/templates/job_template_loader.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/job_template_loader.rb
@@ -41,9 +41,9 @@ module Bosh::Director
 
         source_erbs = []
 
-        instance_job.model.spec.fetch('templates', {}).each_pair do |src_name, dest_name|
-          erb_file = File.read(File.join(template_dir, 'templates', src_name))
-          source_erbs << SourceErb.new(src_name, dest_name, erb_file, instance_job.name)
+        instance_job.model.spec.fetch('templates', {}).each_pair do |src_filepath, dest_filepath|
+          erb_contents = File.read(File.join(template_dir, 'templates', src_filepath))
+          source_erbs << SourceErb.new(src_filepath, dest_filepath, erb_contents, instance_job.name)
         end
 
         JobTemplateRenderer.new(instance_job: instance_job,

--- a/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb
@@ -57,7 +57,7 @@ module Bosh::Director::Core::Templates
           errors.push e
         end
 
-        RenderedFileTemplate.new(source_erb.src_name, source_erb.dest_name, file_contents)
+        RenderedFileTemplate.new(source_erb.src_filepath, source_erb.dest_filepath, file_contents)
       end
 
       if errors.length > 0

--- a/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/job_template_renderer.rb
@@ -11,17 +11,15 @@ module Bosh::Director::Core::Templates
 
     attr_reader :monit_erb, :source_erbs
 
-    def initialize(job_template:,
-                   template_name:,
+    def initialize(instance_job:,
                    monit_erb:,
                    source_erbs:,
                    logger:,
                    link_provider_intents:,
                    dns_encoder: nil)
-      @links_provided = job_template.model.provides
-      @name = job_template.name
-      @release = job_template.release
-      @template_name = template_name
+      @links_provided = instance_job.model.provides
+      @job_name = instance_job.name
+      @release = instance_job.release
       @monit_erb = monit_erb
       @source_erbs = source_erbs
       @logger = logger
@@ -33,7 +31,7 @@ module Bosh::Director::Core::Templates
       spec = Bosh::Common::DeepCopy.copy(spec)
 
       if spec['properties_need_filtering']
-        spec = remove_unused_properties(spec)
+        spec = pick_job_properties(spec)
       end
 
       spec = namespace_links_to_current_job(spec)
@@ -64,7 +62,7 @@ module Bosh::Director::Core::Templates
 
       if errors.length > 0
         combined_errors = errors.map{|error| "- #{error.message.strip}"}.join("\n")
-        header = "- Unable to render templates for job '#{@name}'. Errors are:"
+        header = "- Unable to render templates for job '#{@job_name}'. Errors are:"
         message = Bosh::Director::FormatterHelper.new.prepend_header_and_indent_body(header, combined_errors.strip, {:indent_by => 2})
 
         raise message
@@ -72,7 +70,7 @@ module Bosh::Director::Core::Templates
 
       rendered_files << RenderedFileTemplate.new('.bosh/links.json', '.bosh/links.json', links_data(spec))
 
-      RenderedJobTemplate.new(@name, monit, rendered_files)
+      RenderedJobTemplate.new(@job_name, monit, rendered_files)
     end
 
     private
@@ -83,8 +81,8 @@ module Bosh::Director::Core::Templates
       modified_spec = spec
 
       if modified_spec.has_key?('links')
-        if modified_spec['links'][@template_name]
-          links_spec = modified_spec['links'][@template_name]
+        if modified_spec['links'][@job_name]
+          links_spec = modified_spec['links'][@job_name]
           modified_spec['links'] = links_spec
         else
           modified_spec['links'] = {}
@@ -93,15 +91,15 @@ module Bosh::Director::Core::Templates
       modified_spec
     end
 
-    def remove_unused_properties(spec)
+    def pick_job_properties(spec)
       return nil if spec.nil?
 
       modified_spec = spec
 
       if modified_spec.has_key?('properties')
-        if modified_spec['properties'][@template_name]
-          properties_template = modified_spec['properties'][@template_name]
-          modified_spec['properties'] = properties_template
+        if modified_spec['properties'][@job_name]
+          job_properties = modified_spec['properties'][@job_name]
+          modified_spec['properties'] = job_properties
         end
       end
 
@@ -111,7 +109,7 @@ module Bosh::Director::Core::Templates
     def links_data(spec)
       provider_intents = @link_provider_intents.select do |provider_intent|
         provider_intent.link_provider.instance_group == spec['name'] &&
-          provider_intent.link_provider.name == @name
+          provider_intent.link_provider.name == @job_name
       end
 
       data = provider_intents.map do |provider_intent|

--- a/src/bosh-director-core/lib/bosh/director/core/templates/rendered_file_template.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/rendered_file_template.rb
@@ -1,5 +1,5 @@
 require 'bosh/director/core/templates'
 
 module Bosh::Director::Core::Templates
-  RenderedFileTemplate = Struct.new(:src_name, :dest_name, :contents)
+  RenderedFileTemplate = Struct.new(:src_filepath, :dest_filepath, :contents)
 end

--- a/src/bosh-director-core/lib/bosh/director/core/templates/rendered_job_instance.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/rendered_job_instance.rb
@@ -20,9 +20,9 @@ module Bosh::Director::Core::Templates
         bound_templates << rendered_job_template.monit
         bound_templates << rendered_job_template.name
 
-        rendered_job_template.templates.sort { |x, y| x.src_name <=> y.src_name }.each do |template_file|
+        rendered_job_template.templates.sort { |x, y| x.src_filepath <=> y.src_filepath }.each do |template_file|
           bound_templates << template_file.contents
-          bound_templates << template_file.dest_name
+          bound_templates << template_file.dest_filepath
         end
 
         instance_digest << bound_templates

--- a/src/bosh-director-core/lib/bosh/director/core/templates/rendered_job_template.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/rendered_job_template.rb
@@ -14,7 +14,7 @@ module Bosh::Director::Core::Templates
     def template_hash
       template_digest = Digest::SHA1.new
       template_digest << monit
-      templates.sort { |x, y| x.src_name <=> y.src_name }.each do |template_file|
+      templates.sort { |x, y| x.src_filepath <=> y.src_filepath }.each do |template_file|
         template_digest << template_file.contents
       end
 

--- a/src/bosh-director-core/lib/bosh/director/core/templates/rendered_templates_in_memory_tar_gzipper.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/rendered_templates_in_memory_tar_gzipper.rb
@@ -22,7 +22,7 @@ module Bosh::Director::Core::Templates
           end
 
           rendered_job_template.templates.each do |rendered_file_template|
-            template_path = File.join(job_name, rendered_file_template.dest_name)
+            template_path = File.join(job_name, rendered_file_template.dest_filepath)
 
             tar.add_file template_path, CREATED_FILES_PERMISSIONS do |tf|
               tf.write(rendered_file_template.contents)

--- a/src/bosh-director-core/lib/bosh/director/core/templates/rendered_templates_writer.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/rendered_templates_writer.rb
@@ -13,7 +13,7 @@ module Bosh::Director::Core::Templates
         end
 
         job_template.templates.each do |file_template|
-          file_template_dest = File.join(job_template_dir, file_template.dest_name)
+          file_template_dest = File.join(job_template_dir, file_template.dest_filepath)
           FileUtils.mkdir_p(File.dirname(file_template_dest))
           File.open(file_template_dest, 'w') do |f|
             f.write(file_template.contents)

--- a/src/bosh-director-core/lib/bosh/director/core/templates/source_erb.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/source_erb.rb
@@ -5,13 +5,13 @@ module Bosh::Director::Core::Templates
   class SourceErb
     @@mutex = Mutex.new
 
-    attr_reader :src_name, :dest_name, :erb
+    attr_reader :src_filepath, :dest_filepath, :erb
 
-    def initialize(src_name, dest_name, erb_contents, job_name)
-      @src_name = src_name
-      @dest_name = dest_name
+    def initialize(src_filepath, dest_filepath, erb_contents, job_name)
+      @src_filepath = src_filepath
+      @dest_filepath = dest_filepath
       erb = ERB.new(erb_contents, trim_mode: "-")
-      erb.filename = File.join(job_name, src_name)
+      erb.filename = File.join(job_name, src_filepath)
       @erb = erb
     end
 
@@ -28,7 +28,7 @@ module Bosh::Director::Core::Templates
       line = line_index ? e.backtrace[line_index] : '(unknown):(unknown)'
       template_name, line = line.split(':')
 
-      message = "Error filling in template '#{File.basename(template_name)}' (line #{line}: #{e})"
+      message = "Error filling in template '#{@src_filepath}' (line #{line}: #{e})"
 
       logger.debug("#{message}\n#{e.backtrace.join("\n")}")
       raise message

--- a/src/bosh-director-core/lib/bosh/director/core/templates/source_erb.rb
+++ b/src/bosh-director-core/lib/bosh/director/core/templates/source_erb.rb
@@ -7,11 +7,11 @@ module Bosh::Director::Core::Templates
 
     attr_reader :src_name, :dest_name, :erb
 
-    def initialize(src_name, dest_name, erb_contents, template_name)
+    def initialize(src_name, dest_name, erb_contents, job_name)
       @src_name = src_name
       @dest_name = dest_name
       erb = ERB.new(erb_contents, trim_mode: "-")
-      erb.filename = File.join(template_name, src_name)
+      erb.filename = File.join(job_name, src_name)
       @erb = erb
     end
 

--- a/src/bosh-director-core/spec/bosh/director/core/templates/job_instance_renderer_spec.rb
+++ b/src/bosh-director-core/spec/bosh/director/core/templates/job_instance_renderer_spec.rb
@@ -10,7 +10,8 @@ module Bosh::Director::Core::Templates
 
       let(:spec) do
         {
-          'job' => {
+          'name' => 'fake-instance-group-name',
+          'job' => { # <- here 'job' is the Bosh v1 term for 'instance group'
             'name' => 'fake-instance-group-name'
           }
         }

--- a/src/bosh-director-core/spec/bosh/director/core/templates/job_template_loader_spec.rb
+++ b/src/bosh-director-core/spec/bosh/director/core/templates/job_template_loader_spec.rb
@@ -95,6 +95,10 @@ module Bosh::Director::Core::Templates
           release: release
         )
 
+        job_model = double('Bosh::Director::Models::Template')
+        expect(job).to receive(:model).and_return(job_model)
+        expect(job_model).to receive(:spec).and_return({ "templates" => { "test" => "test_dst" } })
+
         monit_erb = instance_double(SourceErb)
         job_template_erb = instance_double(SourceErb)
         fake_renderer = instance_double(JobTemplateRenderer)
@@ -136,6 +140,10 @@ module Bosh::Director::Core::Templates
           blobstore_id: 'blob-id',
           release: release,
         )
+
+        job_model = double('Bosh::Director::Models::Template')
+        expect(job).to receive(:model).and_return(job_model)
+        expect(job_model).to receive(:spec).and_return({ "templates" => {} })
 
         monit_erb = instance_double(SourceErb)
         fake_renderer = instance_double(JobTemplateRenderer)
@@ -181,6 +189,10 @@ module Bosh::Director::Core::Templates
             release: release,
             model: double('Bosh::Director::Models::Template', provides: [])
           )
+
+          job_model = double('Bosh::Director::Models::Template')
+          expect(job).to receive(:model).and_return(job_model)
+          expect(job_model).to receive(:spec).and_return({ "templates" => {} })
 
           job_template_renderer = job_template_loader.process(job)
           expect(job_template_renderer.source_erbs).to eq([])

--- a/src/bosh-director-core/spec/bosh/director/core/templates/job_template_loader_spec.rb
+++ b/src/bosh-director-core/spec/bosh/director/core/templates/job_template_loader_spec.rb
@@ -79,7 +79,7 @@ module Bosh::Director::Core::Templates
 
       it 'returns the jobs template erb objects' do
         tarball_path = create_job_tarball(
-          'release-job-name',
+          'fake-job-name-1',
           'monit file erb contents',
           tmp_file,
           { 'test' => {
@@ -90,7 +90,7 @@ module Bosh::Director::Core::Templates
 
         job = double('Bosh::Director::DeploymentPlan::Job',
           download_blob: tarball_path,
-          name: 'plan-job-name',
+          name: 'fake-job-name-1',
           blobstore_id: 'blob-id',
           release: release
         )
@@ -103,19 +103,18 @@ module Bosh::Director::Core::Templates
           'monit',
           'monit',
           'monit file erb contents',
-          'plan-job-name',
+          'fake-job-name-1',
         ).and_return(monit_erb)
 
         expect(SourceErb).to receive(:new).with(
           'test',
           'test_dst',
           'test contents',
-          'plan-job-name'
+          'fake-job-name-1'
         ).and_return(job_template_erb)
 
         expect(JobTemplateRenderer).to receive(:new).with(
-          job_template: job,
-          template_name: 'release-job-name',
+          instance_job: job,
           monit_erb: monit_erb,
           source_erbs: [job_template_erb],
           logger: logger,
@@ -128,12 +127,12 @@ module Bosh::Director::Core::Templates
       end
 
       it 'includes only monit erb object when no other templates exist' do
-        tarball_path = create_job_tarball('release-job-no-templates', 'monit file erb contents', tmp_file, {})
+        tarball_path = create_job_tarball('fake-job-name-2', 'monit file erb contents', tmp_file, {})
 
         job = double(
           'Bosh::Director::DeploymentPlan::Job',
           download_blob: tarball_path,
-          name: 'plan-job-name',
+          name: 'fake-job-name-2',
           blobstore_id: 'blob-id',
           release: release,
         )
@@ -145,12 +144,11 @@ module Bosh::Director::Core::Templates
           'monit',
           'monit',
           'monit file erb contents',
-          'plan-job-name',
+          'fake-job-name-2',
         ).and_return(monit_erb)
 
         expect(JobTemplateRenderer).to receive(:new).with(
-          job_template: job,
-          template_name: 'release-job-no-templates',
+          instance_job: job,
           monit_erb: monit_erb,
           source_erbs: [],
           logger: logger,
@@ -167,7 +165,7 @@ module Bosh::Director::Core::Templates
           manifest = <<~EOF
             ---
             bogus_key: &empty_hash {}
-            name: test
+            name: test-job-name
             templates: *empty_hash
             packages: []
           EOF
@@ -178,7 +176,7 @@ module Bosh::Director::Core::Templates
 
           job = double('Bosh::Director::DeploymentPlan::Job',
             download_blob: tmp_file.path,
-            name: 'plan-job-name',
+            name: 'test-job-name',
             blobstore_id: 'blob-id',
             release: release,
             model: double('Bosh::Director::Models::Template', provides: [])

--- a/src/bosh-director-core/spec/bosh/director/core/templates/job_template_renderer_spec.rb
+++ b/src/bosh-director-core/spec/bosh/director/core/templates/job_template_renderer_spec.rb
@@ -16,8 +16,8 @@ module Bosh::Director::Core::Templates
       let(:source_erb) do
         instance_double(
           'Bosh::Director::Core::Templates::SourceErb',
-          src_name: 'fake-template-src-name',
-          dest_name: 'fake-template-dest-name',
+          src_filepath: 'fake-template-src-name',
+          dest_filepath: 'fake-template-dest-name',
           render: 'test template',
         )
       end
@@ -67,8 +67,8 @@ module Bosh::Director::Core::Templates
 
           expect(rendered_templates.monit).to eq('monit file')
           rendered_file_template = rendered_templates.templates.first
-          expect(rendered_file_template.src_name).to eq('fake-template-src-name')
-          expect(rendered_file_template.dest_name).to eq('fake-template-dest-name')
+          expect(rendered_file_template.src_filepath).to eq('fake-template-src-name')
+          expect(rendered_file_template.dest_filepath).to eq('fake-template-dest-name')
           expect(rendered_file_template.contents).to eq('test template')
 
           expect(monit_erb).to have_received(:render).with(context_copy, logger)
@@ -268,8 +268,8 @@ module Bosh::Director::Core::Templates
           expect(dns_encoder).to have_received(:id_for_group_tuple).once
 
           rendered_links_file = rendered_files.pop
-          expect(rendered_links_file.src_name).to(eq('.bosh/links.json'))
-          expect(rendered_links_file.dest_name).to(eq('.bosh/links.json'))
+          expect(rendered_links_file.src_filepath).to(eq('.bosh/links.json'))
+          expect(rendered_links_file.dest_filepath).to(eq('.bosh/links.json'))
 
           expect(JSON.parse(rendered_links_file.contents)).to eq(
             [

--- a/src/bosh-director-core/spec/bosh/director/core/templates/job_template_renderer_spec.rb
+++ b/src/bosh-director-core/spec/bosh/director/core/templates/job_template_renderer_spec.rb
@@ -26,7 +26,7 @@ module Bosh::Director::Core::Templates
         {
           'index' => 1,
           'job' => {
-            'name' => 'fake-job-name',
+            'name' => 'fake-instance-group-name',
           },
         }
       end
@@ -34,7 +34,7 @@ module Bosh::Director::Core::Templates
       let(:links_provided) { [] }
       let(:release) { double('Bosh::Director::DeploymentPlan::ReleaseVersion', name: 'fake-release-name', version: '0.1') }
       let(:job_template_model) { double('Bosh::Director::Models::Template', provides: links_provided) }
-      let(:job_template) do
+      let(:instance_job) do
         double('Bosh::Director::DeploymentPlan::Job', name: 'fake-job-name', release: release, model: job_template_model)
       end
       let(:logger) { instance_double('Logger', debug: nil) }
@@ -43,8 +43,7 @@ module Bosh::Director::Core::Templates
 
       subject(:job_template_renderer) do
         JobTemplateRenderer.new(
-          job_template: job_template,
-          template_name: 'template-name',
+          instance_job: instance_job,
           monit_erb: monit_erb,
           source_erbs: [source_erb],
           logger: logger,
@@ -81,16 +80,17 @@ module Bosh::Director::Core::Templates
         let(:spec) do
           {
             'index' => 1,
-            'job' => {
-              'name' => 'reg-job-name',
-              'templates' =>
-                      [{ 'name' => 'template-name',
+            'name' => 'instance-group-name',
+            'job' => { # <- here 'job' is the Bosh v1 term for 'instance group'
+              'name' => 'reg-instance-group-name',
+              'templates' => # <- here 'template' is the Bosh v1 term for 'job'
+                      [{ 'name' => 'fake-job-name',
                          'version' => '1bbe5ab00082797999e2101d730de64aeb601b6a',
                          'sha1' => '728399f9ef342532c6224bce4eb5331b5c38d595',
                          'blobstore_id' => '6c1eec85-3c08-4464-8b11-dc43acaa79f9' }],
             },
             'properties' => {
-              'template-name' => {
+              'fake-job-name' => {
                 'inside' => 'insideValue',
                 'smurfs' => { 'name' => 'snoopy' },
               },
@@ -109,15 +109,16 @@ module Bosh::Director::Core::Templates
           expect(Bosh::Template::EvaluationContext).to have_received(:new).with(
             {
               'index' => 1,
-              'job' => {
-                'name' => 'reg-job-name',
-                'templates' =>
-                        [{ 'name' => 'template-name',
+              'name' => 'instance-group-name',
+              'job' => { # <- here 'job' is the Bosh v1 term for 'instance group'
+                'name' => 'reg-instance-group-name',
+                'templates' => # <- here 'template' is the Bosh v1 term for 'job'
+                        [{ 'name' => 'fake-job-name',
                            'version' => '1bbe5ab00082797999e2101d730de64aeb601b6a',
                            'sha1' => '728399f9ef342532c6224bce4eb5331b5c38d595',
                            'blobstore_id' => '6c1eec85-3c08-4464-8b11-dc43acaa79f9' }],
               },
-              'properties' => { # note: loses 'template-name' from :spec
+              'properties' => { # note: loses 'fake-job-name' from :spec
                 'inside' => 'insideValue',
                 'smurfs' => { 'name' => 'snoopy' },
               },
@@ -130,8 +131,7 @@ module Bosh::Director::Core::Templates
         context 'rendering templates returns errors' do
           let(:job_template_renderer) do
             JobTemplateRenderer.new(
-              job_template: job_template,
-              template_name: 'template-name',
+              instance_job: instance_job,
               monit_erb: monit_erb,
               source_erbs: [source_erb, source_erb],
               logger: logger,
@@ -161,18 +161,22 @@ module Bosh::Director::Core::Templates
       context 'when spec has links' do
         let(:raw_spec) do
           {
-            'name' => 'joao-da-silva',
+            'name' => 'fake-instance-group-name',
             'index' => 1,
-            'job' => {
-              'name' => 'template-name',
+            'job' => { # <- here 'job' is the Bosh v1 term for 'instance group'
+              'name' => 'fake-instance-group-name',
             },
             'properties_need_filtering' => true,
             'links' => {
-              'template-name' => {
-                'db_link' =>
-                    { 'properties' => { 'foo' => 'bar' }, 'instances' => [{ 'name' => 'mysql1' }, { 'name' => 'mysql' }] },
-                'backup_db' =>
-                    { 'properties' => { 'moop' => 'yar' }, 'instances' => [{ 'name' => 'postgres1' }, { 'name' => 'postgres' }] },
+              'fake-job-name' => {
+                'db_link' => {
+                  'properties' => { 'foo' => 'bar' },
+                  'instances' => [{ 'name' => 'mysql1' }, { 'name' => 'mysql' }]
+                },
+                'backup_db' => {
+                  'properties' => { 'moop' => 'yar' },
+                  'instances' => [{ 'name' => 'postgres1' }, { 'name' => 'postgres' }]
+                },
               },
             },
             'release' => { 'name' => 'fake-release-name', 'version' => '0.1' },
@@ -181,38 +185,36 @@ module Bosh::Director::Core::Templates
 
         let(:modified_spec) do
           {
-            'name' => 'joao-da-silva',
+            'name' => 'fake-instance-group-name',
             'index' => 1,
-            'job' => {
-              'name' => 'template-name',
+            'job' => { # <- here 'job' is the Bosh v1 term for 'instance group'
+              'name' => 'fake-instance-group-name',
             },
             'properties_need_filtering' => true,
             'links' => {
-              'db_link' =>
-              {
+              'db_link' => {
                 'properties' => { 'foo' => 'bar' },
                 'instances' => [{ 'name' => 'mysql1' }, { 'name' => 'mysql' }],
               },
-              'backup_db' =>
-                  {
-                    'properties' => { 'moop' => 'yar' },
-                    'instances' => [{ 'name' => 'postgres1' }, { 'name' => 'postgres' }],
-                  },
+              'backup_db' => {
+                'properties' => { 'moop' => 'yar' },
+                'instances' => [{ 'name' => 'postgres1' }, { 'name' => 'postgres' }],
+              },
             },
             'release' => { 'name' => 'fake-release-name', 'version' => '0.1' },
           }
         end
 
         let(:provider1) do
-          double('provider1', instance_group: 'joao-da-silva', name: 'fake-job-name')
+          double('provider1', instance_group: 'fake-instance-group-name', name: 'fake-job-name')
         end
 
         let(:provider2) do
-          double('provider2', instance_group: 'bob-de-smith')
+          double('provider2', instance_group: 'another-instance-group-name')
         end
 
         let(:provider3) do
-          double('provider3', instance_group: 'joao-da-silva', name: 'another-job-name')
+          double('provider3', instance_group: 'fake-instance-group-name', name: 'another-job-name')
         end
 
         let(:provider_intent) do

--- a/src/bosh-director-core/spec/bosh/director/core/templates/rendered_job_instance_spec.rb
+++ b/src/bosh-director-core/spec/bosh/director/core/templates/rendered_job_instance_spec.rb
@@ -18,8 +18,8 @@ module Bosh::Director::Core::Templates
             [
               instance_double(
                 'Bosh::Director::Core::Templates::RenderedFileTemplate',
-                src_name: 'template-file1',
-                dest_name: 'template-file1',
+                src_filepath: 'template-file1',
+                dest_filepath: 'template-file1',
                 contents: 'template file contents 1',
               ),
             ],
@@ -30,14 +30,14 @@ module Bosh::Director::Core::Templates
             [
               instance_double(
                 'Bosh::Director::Core::Templates::RenderedFileTemplate',
-                src_name: 'template-file3',
-                dest_name: 'template-file3',
+                src_filepath: 'template-file3',
+                dest_filepath: 'template-file3',
                 contents: 'template file contents 3',
               ),
               instance_double(
                 'Bosh::Director::Core::Templates::RenderedFileTemplate',
-                src_name: 'template-file2',
-                dest_name: 'template-file2',
+                src_filepath: 'template-file2',
+                dest_filepath: 'template-file2',
                 contents: 'template file contents 2',
               ),
             ],
@@ -57,8 +57,8 @@ module Bosh::Director::Core::Templates
               'monit file contents 1',
               [
                 instance_double('Bosh::Director::Core::Templates::RenderedFileTemplate',
-                                src_name: 'template-file1',
-                                dest_name: 'template-file1',
+                                src_filepath: 'template-file1',
+                                dest_filepath: 'template-file1',
                                 contents: 'template file contents 1'),
               ],
             ),
@@ -72,8 +72,8 @@ module Bosh::Director::Core::Templates
               'monit file contents 1',
               [
                 instance_double('Bosh::Director::Core::Templates::RenderedFileTemplate',
-                                src_name: 'template-file1',
-                                dest_name: 'template-file1',
+                                src_filepath: 'template-file1',
+                                dest_filepath: 'template-file1',
                                 contents: 'template file contents 1'),
               ],
             ),
@@ -82,8 +82,8 @@ module Bosh::Director::Core::Templates
               '',
               [
                 instance_double('Bosh::Director::Core::Templates::RenderedFileTemplate',
-                                src_name: 'template-file1',
-                                dest_name: 'template-file1',
+                                src_filepath: 'template-file1',
+                                dest_filepath: 'template-file1',
                                 contents: ''),
               ],
             ),
@@ -103,8 +103,8 @@ module Bosh::Director::Core::Templates
               'monit file contents 1',
               [
                 instance_double('Bosh::Director::Core::Templates::RenderedFileTemplate',
-                                src_name: 'template-file1',
-                                dest_name: 'template-file1',
+                                src_filepath: 'template-file1',
+                                dest_filepath: 'template-file1',
                                 contents: 'template file contents 1'),
               ],
             ),
@@ -118,8 +118,8 @@ module Bosh::Director::Core::Templates
               'monit file contents 1',
               [
                 instance_double('Bosh::Director::Core::Templates::RenderedFileTemplate',
-                                src_name: 'template-file1',
-                                dest_name: 'template-file1',
+                                src_filepath: 'template-file1',
+                                dest_filepath: 'template-file1',
                                 contents: 'template file contents 1'),
               ],
             ),

--- a/src/bosh-director-core/spec/bosh/director/core/templates/rendered_job_template_spec.rb
+++ b/src/bosh-director-core/spec/bosh/director/core/templates/rendered_job_template_spec.rb
@@ -9,12 +9,12 @@ module Bosh::Director::Core::Templates
         [
           instance_double(
             'Bosh::Director::Core::Templates::RenderedFileTemplate',
-            src_name: 'foo.erb',
+            src_filepath: 'foo.erb',
             contents: 'rendered foo erb',
           ),
           instance_double(
             'Bosh::Director::Core::Templates::RenderedFileTemplate',
-            src_name: 'bar.erb',
+            src_filepath: 'bar.erb',
             contents: 'rendered bar erb',
           ),
         ]

--- a/src/bosh-director-core/spec/bosh/director/core/templates/rendered_templates_writer_spec.rb
+++ b/src/bosh-director-core/spec/bosh/director/core/templates/rendered_templates_writer_spec.rb
@@ -10,14 +10,14 @@ module Bosh::Director::Core::Templates
 
     let(:rendered_file_template) do
       instance_double('Bosh::Director::Core::Templates::RenderedFileTemplate',
-                      dest_name: 'bin/script-filename',
+                      dest_filepath: 'bin/script-filename',
                       contents: 'script file contents'
       )
     end
 
     let(:rendered_file_template_with_deep_path) do
       instance_double('Bosh::Director::Core::Templates::RenderedFileTemplate',
-                      dest_name: 'config/with/deeper/path/filename.cfg',
+                      dest_filepath: 'config/with/deeper/path/filename.cfg',
                       contents: 'config file contents'
       )
     end

--- a/src/bosh-director/lib/bosh/director/config_server/variables_interpolator.rb
+++ b/src/bosh-director/lib/bosh/director/config_server/variables_interpolator.rb
@@ -7,10 +7,19 @@ module Bosh::Director::ConfigServer
       @cache_by_job_name = {}
     end
 
-    # @param [Hash] template_spec_properties Hash to be interpolated
-    # @param [Hash] deployment_name The deployment context in-which the interpolation will occur
-    # @param [VariableSet] variable_set The variable set which the interpolation will use.
-    # @return [Hash] A Deep copy of the interpolated template_spec_properties
+    # From a `job_name => job_properties` hash of instance group properties,
+    # resolve the `((var_name))`` placeholders, fetching their values from the
+    # config server. Most often, these placeholders refers to secrets stored
+    # in CredHub.
+    #
+    # @param [Hash] instance_group_properties a hash of per-job properties, to
+    #                                         be interpolated
+    # @param [String] deployment_name The name of the deployment, as context
+    #                                 in-which the interpolation will occur
+    # @param [String] instance_group_name The name of the instance group
+    # @param [VariableSet] variable_set The variable set which the
+    #                                   interpolation will use.
+    # @return [Hash] A Deep copy of the interpolated instance_group_properties
     def interpolate_template_spec_properties(template_spec_properties, deployment_name, instance_name, variable_set)
       if template_spec_properties.nil?
         return template_spec_properties

--- a/src/bosh-director/lib/bosh/director/config_server/variables_interpolator.rb
+++ b/src/bosh-director/lib/bosh/director/config_server/variables_interpolator.rb
@@ -20,9 +20,9 @@ module Bosh::Director::ConfigServer
     # @param [VariableSet] variable_set The variable set which the
     #                                   interpolation will use.
     # @return [Hash] A Deep copy of the interpolated instance_group_properties
-    def interpolate_template_spec_properties(template_spec_properties, deployment_name, instance_name, variable_set)
-      if template_spec_properties.nil?
-        return template_spec_properties
+    def interpolate_template_spec_properties(instance_group_properties, deployment_name, instance_group_name, variable_set)
+      if instance_group_properties.nil?
+        return instance_group_properties
       end
 
       if deployment_name.nil?
@@ -32,9 +32,9 @@ module Bosh::Director::ConfigServer
       result = {}
       errors = []
 
-      template_spec_properties.each do |job_name, job_properties|
+      instance_group_properties.each do |job_name, job_properties|
         begin
-          key = job_name + "-" + instance_name
+          key = job_name + "-" + instance_group_name
           if @cache_by_job_name.has_key?(key)
             interpolated_hash = @cache_by_job_name[key]
           else

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_group.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_group.rb
@@ -409,10 +409,19 @@ module Bosh::Director
 
       private
 
+      # Returns the aggregated list of package names, considering all jobs
+      # desired on this instance group, with no duplicate.
+      #
+      # @return [Array<String>] The list of package names
       def run_time_dependencies
         run_time_packages.map(&:name)
       end
 
+      # The aggregated list of models for all packages to install on instances
+      # of the group, considering all jobs desired on this instance group,
+      # with no duplicate.
+      #
+      # @return [Array<Models::Package>] The list of packages
       def run_time_packages
         jobs.flat_map(&:package_models).uniq
       end

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_group.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_group.rb
@@ -239,8 +239,8 @@ module Bosh::Director
       # name. To be used by all instances to populate agent state.
       # @return [Hash<String, Hash>] All package specs indexed by package name
       def package_spec
-        @packages.each_with_object({}) do |(name, package), acc|
-          acc[name] = package.spec
+        @packages.each_with_object({}) do |(name, package), accu|
+          accu[name] = package.spec
         end.select { |name, _| run_time_dependencies.include? name }
       end
 
@@ -272,9 +272,9 @@ module Bosh::Director
       # before 'bind_properties' is being called (as we persist instance group template
       # property definitions in DB).
       def bind_properties
-        @properties = @jobs.each_with_object({}) do |job, acc|
+        @properties = @jobs.each_with_object({}) do |job, accu|
           job.bind_properties(@name)
-          acc[job.name] = job.properties[@name]
+          accu[job.name] = job.properties[@name]
         end
       end
 

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
@@ -379,6 +379,11 @@ module Bosh
           InstanceSpec.create_from_instance_plan(self)
         end
 
+        # Returns the desired jobs for the instance
+        #
+        # Here “template” is the old Bosh v1 name for “job”.
+        #
+        # @return [Array<DeploymentPlan::Job>] List of desired jobs
         def templates
           @desired_instance.instance_group.jobs
         end

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_spec.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_spec.rb
@@ -17,7 +17,7 @@ module Bosh::Director
 
         spec = {
           'deployment' => deployment_name,
-          'job' => instance_group.spec,
+          'job' => instance_group.spec, # <- here 'job' is old Bosh v1 naming, meaning 'instance group'
           'index' => instance.index,
           'bootstrap' => instance.bootstrap?,
           'lifecycle' => instance_group.lifecycle,

--- a/src/bosh-director/lib/bosh/director/deployment_plan/job.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/job.rb
@@ -55,11 +55,12 @@ module Bosh::Director
         @model = model
       end
 
-      # Downloads template blob to a given path
+      # Downloads job blob to a given path
+      #
       # @return [String] Path to downloaded blob
       def download_blob
         uuid = SecureRandom.uuid
-        path = File.join(Dir.tmpdir, "template-#{uuid}")
+        path = File.join(Dir.tmpdir, "job-#{uuid}")
 
         @logger.debug("Downloading job '#{@name}' (#{blobstore_id})...")
         t1 = Time.now

--- a/src/bosh-director/lib/bosh/director/deployment_plan/job.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/job.rb
@@ -34,7 +34,10 @@ module Bosh::Director
         @properties = {}
       end
 
-      # Looks up template model and its package models in DB
+      # Looks up job model and its package models in DB.
+      #
+      # Here “template” is the old Bosh v1 name for “job”.
+      #
       # @return [void]
       def bind_models
         @model = @release.get_template_model_by_name(@name)

--- a/src/bosh-director/lib/bosh/director/deployment_plan/release_version.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/release_version.rb
@@ -91,8 +91,11 @@ module Bosh::Director
         }
       end
 
-      # Looks up up template model by template name
-      # @param [String] name Template name
+      # Looks up up job model by job name.
+      #
+      # Here “template” is the old Bosh v1 name for “job”.
+      #
+      # @param [String] name Job name
       # @return [Models::Template]
       def get_template_model_by_name(name)
         @all_jobs ||= @model.templates.each_with_object({}) do |job, all_jobs|
@@ -109,25 +112,38 @@ module Bosh::Director
         @model.package_by_name(name)
       end
 
-      # Adds template to a list of templates used by this release for the
-      # current deployment
+      # Adds a job to a list of jobs used by this release for the current
+      # deployment.
+      #
+      # Here “template” is the old Bosh v1 name for “job”.
+      #
       # @param [String] options Template name
       def get_or_create_template(name)
         @jobs[name] ||= Job.new(self, name)
       end
 
+      # Return a given job, identified by name.
+      #
+      # Here “template” is the old Bosh v1 name for “job”.
+      #
       # @param [String] name Job name
       # @return [DeploymentPlan::Job] Job with given name used by this
-      #   release (if any)
+      #                               release (if any)
       def template(name)
         @jobs[name]
       end
 
-      # Returns a list of job templates that need to be included into this
-      # release. Note that this is not just a list of all templates existing
-      # in the release but rather a list of templates for jobs that are included
-      # into current deployment plan.
-      # @return [Array<DeploymentPlan::Job>] List of job templates
+      # Returns a list of jobs from the release that are used by the
+      # deployment.
+      #
+      # Note that this is not the full list of all jobs existing in the
+      # release, but a subset list of the jobs defined in that release that
+      # are used by the current deployment, and thus included in its plan.
+      #
+      # Here “template” is the old Bosh v1 name for “job”.
+      #
+      # @return [Array<DeploymentPlan::Job>] List of the release jobs used by
+      #                                      the deployment
       def templates
         @jobs.values
       end

--- a/src/bosh-director/lib/bosh/director/errors.rb
+++ b/src/bosh-director/lib/bosh/director/errors.rb
@@ -134,6 +134,7 @@ module Bosh::Director
   JobInvalidLinkSpec = err(80013)
   JobDuplicateLinkName = err(80014)
   JobWithExportedFromMismatch = err(80015)
+  JobInvalidName = err(80016)
 
   ResourceError = err(100001)
   ResourceNotFound = err(100002, NOT_FOUND)

--- a/src/bosh-director/lib/bosh/director/job_renderer.rb
+++ b/src/bosh-director/lib/bosh/director/job_renderer.rb
@@ -4,6 +4,20 @@ require 'bosh/director/core/templates/template_blob_cache'
 
 module Bosh::Director
   class JobRenderer
+
+    # Render the related job templates for each instance plan passed as
+    # argument in the 'instance_plans' array.
+    #
+    # @param [Logging::Logger] logger A logger where to log activity
+    # @param [Array<InstancePlan>] instance_plans A list of instance plans
+    # @param [TemplateBlobCache] cache A cache through which job blobs are to
+    #                                  be fetched
+    # @param [DnsEncoder] dns_encoder A DNS encoder for generating Bosh DNS
+    #                                 queries out of context and criteria
+    # @param [Array<LinkProviderIntent>] link_provider_intents Relevant
+    #                                                          context-dependant
+    #                                                          link provider
+    #                                                          intents
     def self.render_job_instances_with_cache(logger, instance_plans, cache, dns_encoder, link_provider_intents)
       job_template_loader = Core::Templates::JobTemplateLoader.new(
         logger,
@@ -17,6 +31,15 @@ module Bosh::Director
       end
     end
 
+    # For one instance plan, create a 'JobInstanceRenderer' object that will
+    # lazily load the ERB templates for all desired jobs on the instance, then
+    # render these templates with the bindings populated by the
+    # 'spec' properties of the instance plan.
+    #
+    # @param [DeploymentPlan::InstancePlan] instance_plan An instance plan
+    # @param [JobTemplateLoader] loader The object that will load the ERB
+    #                                   templates
+    # @param [Logging::Logger] logger A logger where to log activity
     def self.render_job_instance(instance_plan, loader, logger)
       instance = instance_plan.instance
 

--- a/src/bosh-director/lib/bosh/director/job_renderer.rb
+++ b/src/bosh-director/lib/bosh/director/job_renderer.rb
@@ -43,14 +43,15 @@ module Bosh::Director
     def self.render_job_instance(instance_plan, loader, logger)
       instance = instance_plan.instance
 
-      if instance_plan.templates.empty?
-        logger.debug("Skipping rendering templates for '#{instance}', no templates")
+      instance_jobs = instance_plan.templates
+      if instance_jobs.empty?
+        logger.debug("Skipping rendering templates for '#{instance}': no job")
         return
       end
 
       logger.debug("Rendering templates for instance #{instance}")
 
-      instance_renderer = Core::Templates::JobInstanceRenderer.new(instance_plan.templates, loader)
+      instance_renderer = Core::Templates::JobInstanceRenderer.new(instance_jobs, loader)
       rendered_job_instance = instance_renderer.render(get_templates_spec(instance_plan))
 
       instance_plan.rendered_templates = rendered_job_instance

--- a/src/bosh-director/lib/bosh/director/jobs/release/release_job.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/release/release_job.rb
@@ -15,6 +15,7 @@ module Bosh::Director
 
       job_manifest = load_manifest
 
+      validate_name(job_manifest)
       validate_templates(job_manifest)
       validate_monit
       validate_logs(job_manifest)
@@ -73,6 +74,13 @@ module Bosh::Director
       end
 
       YAML.load_file(manifest_file, aliases: true)
+    end
+
+    def validate_name(job_manifest)
+      unless name == job_manifest['name']
+        raise JobInvalidName, "Inconsistent name for job '#{name}'" +
+          "(exptected: '#{name}', got: '#{job_manifest['name']}')"
+      end
     end
 
     def validate_templates(job_manifest)

--- a/src/bosh-director/lib/bosh/director/jobs/release/release_job.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/release/release_job.rb
@@ -22,25 +22,25 @@ module Bosh::Director
       validate_properties(job_manifest)
       validate_links(job_manifest)
 
-      template = Models::Template.find_or_init_from_release_meta(
+      job_model = Models::Template.find_or_init_from_release_meta(
         release: @release_model,
         job_meta: @job_meta,
         job_manifest: job_manifest,
       )
 
-      if template.blobstore_id
+      if job_model.blobstore_id
         begin
-          @logger.info("Deleting blob for template '#{name}/#{@version}' with blobstore_id '#{template.blobstore_id}'")
-          BlobUtil.delete_blob(template.blobstore_id)
-          template.blobstore_id = nil
+          @logger.info("Deleting blob for job '#{name}/#{@version}' with blobstore_id '#{job_model.blobstore_id}'")
+          BlobUtil.delete_blob(job_model.blobstore_id)
+          job_model.blobstore_id = nil
         rescue Bosh::Blobstore::BlobstoreError => e
-          @logger.info("Error deleting blob for template '#{name}/#{@version}' with blobstore_id '#{template.blobstore_id}': #{e.inspect}")
+          @logger.info("Error deleting blob for job '#{name}/#{@version}' with blobstore_id '#{job_model.blobstore_id}': #{e.inspect}")
         end
       end
 
-      template.blobstore_id = BlobUtil.create_blob(job_tgz)
+      job_model.blobstore_id = BlobUtil.create_blob(job_tgz)
 
-      template.save
+      job_model.save
     end
 
     private

--- a/src/bosh-director/lib/bosh/director/jobs/update_release.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_release.rb
@@ -230,10 +230,11 @@ module Bosh::Director
         )
       end
 
-      # Finds job template definitions in release manifest and sorts them into
-      # two buckets: new and existing job templates, then creates new job
-      # template records in the database and points release version to existing ones.
-      # @param [String] release_dir local path to the unpacked release
+      # Finds job definitions in release manifest and sorts them into two
+      # buckets: new and existing jobs, then creates new job template records
+      # in the database and points release version to existing ones.
+      #
+      # @param [String] release_dir Local path to the unpacked release
       # @return [void]
       def process_jobs(release_dir)
         logger.info('Checking for new jobs in release')
@@ -242,29 +243,29 @@ module Bosh::Director
         existing_jobs = []
         manifest_jobs = @manifest['jobs'] || []
 
-        manifest_jobs.each do |job_meta|
+        manifest_jobs.each do |manifest_job|
           # Checking whether we might have the same bits somewhere
-          @release_version_model.templates.select { |t| t.name == job_meta['name'] }.each do |tmpl|
-            next unless tmpl.fingerprint != job_meta['fingerprint']
+          @release_version_model.templates.select { |t| t.name == manifest_job['name'] }.each do |release_job|
+            next unless release_job.fingerprint != manifest_job['fingerprint']
 
             raise(
               ReleaseExistingJobFingerprintMismatch,
-              "job '#{job_meta['name']}' had different fingerprint in previously uploaded release '#{@name}/#{@version}'",
+              "job '#{manifest_job['name']}' had different fingerprint in previously uploaded release '#{@name}/#{@version}'",
             )
           end
 
-          jobs = Models::Template.where(fingerprint: job_meta['fingerprint']).all
+          job_models = Models::Template.where(fingerprint: manifest_job['fingerprint']).all
 
-          template = jobs.find do |job|
+          job_model = job_models.find do |job|
             job.release_id == @release_model.id &&
-              job.name == job_meta['name'] &&
-              job.version == job_meta['version']
+              job.name == manifest_job['name'] &&
+              job.version == manifest_job['version']
           end
 
-          if template.nil?
-            new_jobs << job_meta
+          if job_model.nil?
+            new_jobs << manifest_job
           else
-            existing_jobs << [template, job_meta]
+            existing_jobs << [job_model, manifest_job]
           end
         end
 
@@ -279,21 +280,21 @@ module Bosh::Director
         return false if jobs.empty?
 
         event_log_stage = Config.event_log.begin_stage('Creating new jobs', jobs.size)
-        jobs.each do |job_meta|
-          job_desc = "#{job_meta['name']}/#{job_meta['version']}"
+        jobs.each do |manifest_job|
+          job_desc = "#{manifest_job['name']}/#{manifest_job['version']}"
           event_log_stage.advance_and_track(job_desc) do
-            logger.info("Creating new template '#{job_desc}'")
-            template = create_job(job_meta, release_dir)
-            register_template(template)
+            logger.info("Creating new job '#{job_desc}'")
+            job = create_job(manifest_job, release_dir)
+            register_template(job)
           end
         end
 
         true
       end
 
-      def create_job(job_meta, release_dir)
-        release_job = ReleaseJob.new(job_meta, @release_model, release_dir, logger)
-        logger.info("Creating job template '#{job_meta['name']}/#{job_meta['version']}' " \
+      def create_job(manifest_job, release_dir)
+        release_job = ReleaseJob.new(manifest_job, @release_model, release_dir, logger)
+        logger.info("Creating job '#{manifest_job['name']}/#{manifest_job['version']}' " \
             'from provided bits')
         release_job.update
       end
@@ -304,18 +305,18 @@ module Bosh::Director
         return false if jobs.empty?
 
         single_step_stage("Processing #{jobs.size} existing job#{'s' if jobs.size > 1}") do
-          jobs.each do |template, job_meta|
-            job_desc = "#{template.name}/#{template.version}"
+          jobs.each do |job_model, manifest_job|
+            job_desc = "#{job_model.name}/#{job_model.version}"
 
             if @fix
               logger.info("Fixing existing job '#{job_desc}'")
-              release_job = ReleaseJob.new(job_meta, @release_model, release_dir, logger)
+              release_job = ReleaseJob.new(manifest_job, @release_model, release_dir, logger)
               release_job.update
             else
               logger.info("Using existing job '#{job_desc}'")
             end
 
-            register_template(template) unless template.release_versions.include? @release_version_model
+            register_template(job_model) unless job_model.release_versions.include? @release_version_model
           end
         end
 
@@ -325,10 +326,13 @@ module Bosh::Director
       private
 
       # Marks job template model as being used by release version
-      # @param [Models::Template] template Job template model
+      #
+      # Here “template” is the old Bosh v1 name for “job”.
+      #
+      # @param [Models::Template] job The job model
       # @return [void]
-      def register_template(template)
-        @release_version_model.add_template(template)
+      def register_template(job)
+        @release_version_model.add_template(job)
       end
 
       def manifest_packages

--- a/src/bosh-director/lib/bosh/director/models/template.rb
+++ b/src/bosh-director/lib/bosh/director/models/template.rb
@@ -1,4 +1,8 @@
 module Bosh::Director::Models
+
+  # This class models a job, as defined within a Bosh Release.
+  #
+  # Here “template” is the old Bosh v1 name for “job”.
   class Template < Sequel::Model(Bosh::Director::Config.db)
     many_to_one :release
     many_to_many :release_versions

--- a/src/bosh-director/spec/unit/instance_deleter_spec.rb
+++ b/src/bosh-director/spec/unit/instance_deleter_spec.rb
@@ -68,9 +68,6 @@ module Bosh::Director
 
       describe 'deleting instances' do
         let(:deployment_model) { Models::Deployment.make(name: 'deployment-name') }
-        let(:deployment_plan) { instance_double(DeploymentPlan::Planner, model: deployment_model) }
-        let(:job) { DeploymentPlan::InstanceGroup.new(logger) }
-        let(:network) { instance_double(DeploymentPlan::ManualNetwork, name: 'manual-network') }
         let(:vm_deleter) { VmDeleter.new(logger, false, false) }
 
         let(:job_templates_cleaner) do

--- a/src/bosh-director/spec/unit/job_renderer_spec.rb
+++ b/src/bosh-director/spec/unit/job_renderer_spec.rb
@@ -41,13 +41,21 @@ module Bosh::Director
 
       before do
         release_version = DeploymentPlan::ReleaseVersion.parse(deployment_model, 'name' => 'fake-release', 'version' => '123')
+
         job1 = DeploymentPlan::Job.new(release_version, 'dummy')
-        job1.bind_existing_model(
-          Models::Template.make(blobstore_id: 'my-blobstore-id', sha1: '16baf0c24e2dac2a21ccdcd4655be403a602f573'),
-        )
+        job1.bind_existing_model(Models::Template.make(
+          name: 'dummy',
+          spec_json: '{ "templates": { "ctl.erb": "bin/dummy_ctl" } }',
+          blobstore_id: 'my-blobstore-id',
+          sha1: '16baf0c24e2dac2a21ccdcd4655be403a602f573'
+        ))
 
         job2 = DeploymentPlan::Job.new(release_version, 'dummy')
-        job2.bind_existing_model(Models::Template.make(blobstore_id: 'my-blobstore-id'))
+        job2.bind_existing_model(Models::Template.make(
+          name: 'dummy',
+          spec_json: '{ "templates": { "ctl.erb": "bin/dummy_ctl" } }',
+          blobstore_id: 'my-blobstore-id')
+        )
 
         allow(instance_plan).to receive_message_chain(:spec, :as_template_spec).and_return('template' => 'spec')
         allow(instance_plan).to receive(:templates).and_return([job1, job2])

--- a/src/bosh-director/spec/unit/job_renderer_spec.rb
+++ b/src/bosh-director/spec/unit/job_renderer_spec.rb
@@ -59,7 +59,7 @@ module Bosh::Director
         end
 
         it 'does not render' do
-          expect(logger).to receive(:debug).with("Skipping rendering templates for 'test-instance-group/5', no templates")
+          expect(logger).to receive(:debug).with("Skipping rendering templates for 'test-instance-group/5': no job")
           expect { perform }.not_to change { instance_plan.rendered_templates }
         end
       end

--- a/src/bosh-template/lib/bosh/template/evaluation_context.rb
+++ b/src/bosh-template/lib/bosh/template/evaluation_context.rb
@@ -40,11 +40,7 @@ module Bosh
                     "Hash expected, #{spec.class} given"
         end
 
-        if spec['job'].is_a?(Hash)
-          @name = spec['job']['name']
-        else
-          @name = nil
-        end
+        @name = spec['name']
 
         @index = spec['index']
         @spec = openstruct(spec, BackCompatOpenStruct)

--- a/src/bosh-template/lib/bosh/template/property_helper.rb
+++ b/src/bosh-template/lib/bosh/template/property_helper.rb
@@ -71,7 +71,7 @@ module Bosh
 
         dst_ref[keys[-1]] = value
       end
-      
+
       def validate_properties_format(properties, name)
         keys = name.split('.')
         properties_ref = properties

--- a/src/bosh-template/spec/unit/bosh/template/evaluation_context_spec.rb
+++ b/src/bosh-template/spec/unit/bosh/template/evaluation_context_spec.rb
@@ -24,6 +24,7 @@ module Bosh
 
       let(:spec) do
         {
+          'name' => 'foobar',
           'job' => {
             'name' => 'foobar',
           },


### PR DESCRIPTION
### What is this change about?

Here, I’ve reviewed the ERB template rendering code in order to document it in the cloudfoundry/docs-bosh#813 PR.

In that part of the Director’s code, I’ve noticed _many_ misleading use of the term “template”, used instead of “job”. And this makes the code very confusing because “template” could also refer to “ERB template”.

So, I’ve started chasing these names that had not been migrated back in 2017 (when Bosh v1→v2 refactoring effort had been conducted), and I’ve looked for more suitable names. Don’t hesitate to challenge these, by the way.

Then I’ve updated the unit tests. Here also I’ve tried to clarify some ambiguous namings.

In that process, I’ve noticed that when rendering ERB templates, the job name was read from `job.MF`, freshly extracted from the job blob, whereas the name already persisted in database. I’ve removed the unnecessary unmarshalling of `job.MF` and added a name verification at release-upload time.

The modifications in this PR are quite large overall, but I’ve paid great attention in separating this into smaller chunks of work in to the individual commits.

### Please provide contextual information.

This work was done in order to gather information for authoring cloudfoundry/docs-bosh#813.

### What tests have you run against this PR?

Successful run of these test suites:

```shell
bundle exec rake spec:unit:parallel

DB=sqlite     bundle exec rake spec:unit:director
DB=postgresql bundle exec rake spec:unit:director
DB=mysql      bundle exec rake spec:unit:director
```

### How should this change be described in bosh release notes?

This change brings no new feature, and only more clarity in the ERB rendering code.

### Does this PR introduce a breaking change?

Definitely not.

### Tag your pair, your PM, and/or team!

I’m a [poor lonesome cowboy](https://www.pipelinecomics.com/wp-content/uploads/2020/10/lucky_luke_75_the_end.jpg?ezimgfmt=ngcb1/notWebP) 😄