### PR TITLE
enable metrics for deploy config

### DIFF
--- a/jobs/director/templates/indicator.yml.erb
+++ b/jobs/director/templates/indicator.yml.erb
@@ -25,6 +25,8 @@ spec:
         type: "Type of the task (e.g. update_deployment, snapshot_deployment...)"
   - name: bosh_resurrection_enabled
     promql: bosh_resurrection_enabled
+  - name: bosh_deploy_config_enabled
+    promql: bosh_deploy_config_enabled
   - name: bosh_networks_dynamic_ips_total
     promql: bosh_networks_dynamic_ips_total
     documentation:

--- a/src/bosh-director/lib/bosh/director/api/config_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/config_manager.rb
@@ -16,10 +16,7 @@ module Bosh
           def deploy_config_enabled?
             deploy_config = find(type: 'deploy', limit: 999)
 
-            deploy_config.each do |config|
-              return true
-            end
-            false
+            return !deploy_config.empty?
           end
 
           def find(type: nil, name: nil, limit: 1)

--- a/src/bosh-director/lib/bosh/director/api/config_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/config_manager.rb
@@ -13,6 +13,15 @@ module Bosh
             config.save
           end
 
+          def deploy_config_enabled?
+            deploy_config = find(type: 'deploy', limit: 999)
+
+            deploy_config.each do |config|
+              return true
+            end
+            false
+          end
+
           def find(type: nil, name: nil, limit: 1)
             dataset = Bosh::Director::Models::Config.where(deleted: false)
             dataset = dataset.where(type: type) if type

--- a/src/bosh-director/lib/bosh/director/api/config_manager.rb
+++ b/src/bosh-director/lib/bosh/director/api/config_manager.rb
@@ -14,7 +14,7 @@ module Bosh
           end
 
           def deploy_config_enabled?
-            deploy_config = find(type: 'deploy', limit: 999)
+            deploy_config = find(type: 'deploy')
 
             return !deploy_config.empty?
           end

--- a/src/bosh-director/lib/bosh/director/metrics_collector.rb
+++ b/src/bosh-director/lib/bosh/director/metrics_collector.rb
@@ -10,6 +10,11 @@ module Bosh
         @config = config
         @logger = config.metrics_server_logger
 
+        @deploy_config_enabled = Prometheus::Client.registry.gauge(
+          :bosh_deploy_config_enabled,
+          docstring: 'Is a config of type deploy uploaded? 0 for no, 1 for yes',
+        )
+
         @resurrection_enabled = Prometheus::Client.registry.gauge(
           :bosh_resurrection_enabled,
           docstring: 'Is resurrection enabled? 0 for disabled, 1 for enabled',
@@ -82,6 +87,7 @@ module Bosh
       def populate_metrics
         @logger.info('populating metrics')
 
+        @deploy_config_enabled.set(Api::ConfigManager.deploy_config_enabled? ? 1 : 0)
         @resurrection_enabled.set(Api::ResurrectorManager.new.pause_for_all? ? 0 : 1)
 
         metrics = { 'processing' => {}, 'queued' => {} }

--- a/src/bosh-director/spec/unit/api/config_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/config_manager_spec.rb
@@ -289,7 +289,7 @@ describe Bosh::Director::Api::ConfigManager do
       end
     end
 
-    context 'when config of type deploy does not exist' do
+    context 'when config of type deploy exists' do
       let!(:config_id) { Bosh::Director::Models::Config.make(type: 'deploy', name: 'my-name') }
 
       it "returns 'true'" do

--- a/src/bosh-director/spec/unit/api/config_manager_spec.rb
+++ b/src/bosh-director/spec/unit/api/config_manager_spec.rb
@@ -282,5 +282,19 @@ describe Bosh::Director::Api::ConfigManager do
     end
   end
 
+  describe '#deploy_config_enabled?' do
+    context 'when config of type deploy does not exist' do
+      it "returns 'false'" do
+        expect(manager.deploy_config_enabled?).to eq(false)
+      end
+    end
 
+    context 'when config of type deploy does not exist' do
+      let!(:config_id) { Bosh::Director::Models::Config.make(type: 'deploy', name: 'my-name') }
+
+      it "returns 'true'" do
+        expect(manager.deploy_config_enabled?).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What is this change about?

We introduced deploy configs with Bosh CLI v7.5.0+. As this could potentially lead to unwanted deploy flags if the config is forgotten/enabled too long, we introduce a metrics that returns 1 in case a deploy config is uploaded.

### Please provide contextual information.

https://github.com/cloudfoundry/docs-bosh/blob/master/content/deploy-config.md

### What tests have you run against this PR?

Create Dev Release and checked the response of the metrics server 

### How should this change be described in bosh release notes?

The default metrics now return if a deploy config was uploaded or not to avoid it being forgotten

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@AttilaAlmasi 