### PR TITLE
Populate stemcell os when manifest contains only the name

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/manifest_validator.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/manifest_validator.rb
@@ -28,6 +28,14 @@ module Bosh
                   'resource_pools is no longer supported. You must now define resources in a cloud-config'
           end
 
+          if manifest.key?('stemcells')
+            manifest['stemcells'].each do |stemcell|
+              if stemcell['name'] && stemcell['os']
+                raise StemcellBothNameAndOS, "Properties 'os' and 'name' are both specified for stemcell, choose one. (#{stemcell})"
+              end
+            end
+          end
+
           Config.event_log.warn_deprecated("Global 'properties' are deprecated. Please define 'properties' at the job level.") if manifest.key?('properties')
         end
 

--- a/src/bosh-director/lib/bosh/director/deployment_plan/stemcell.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/stemcell.rb
@@ -20,10 +20,6 @@ module Bosh::Director
           raise ValidationMissingField, "Required property 'os' or 'name' was not specified in object (#{spec})"
         end
 
-        if !name.nil? && !os.nil?
-          raise StemcellBothNameAndOS, "Properties 'os' and 'name' are both specified for stemcell, choose one. (#{spec})"
-        end
-
         new(name_alias, name, os, version)
       end
 
@@ -33,15 +29,9 @@ module Bosh::Director
         @os = os
         @version = version
         @manager = Api::StemcellManager.new
-        if @os.blank?
-          models = @manager.all_by_name_and_version(@name, @version)
-          unless models.empty?
-            @os = models.first.operating_system
-          end
-        end
       end
 
-      def is_using_os?
+      def is_only_using_os?
         !@os.nil? && @name.nil?
       end
 
@@ -55,7 +45,7 @@ module Bosh::Director
       end
 
       def add_stemcell_models
-        if is_using_os?
+        if is_only_using_os?
           @models = @manager.all_by_os_and_version(@os, @version)
           raise StemcellNotFound, "Stemcell version '#{@version}' for OS '#{@os}' doesn't exist" if models.empty?
         else

--- a/src/bosh-director/spec/unit/deployment_plan/deployment_spec_parser_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/deployment_spec_parser_spec.rb
@@ -127,19 +127,6 @@ module Bosh::Director
           end
         end
 
-        context 'when there are stemcells with both name and OS' do
-          before do
-            stemcell_hash1 = { 'alias' => 'stemcell1', 'name' => 'bosh-aws-xen-hvm-ubuntu-trusty-go_agent', 'os' => 'ubuntu-trusty', 'version' => '1234' }
-            manifest_hash['stemcells'] = [stemcell_hash1]
-          end
-
-          it 'errors out' do
-            expect do
-              parsed_deployment.stemcells
-            end.to raise_error Bosh::Director::StemcellBothNameAndOS
-          end
-        end
-
         context 'when there are 2 stemcells' do
           before do
             stemcell_hash0 = { 'alias' => 'stemcell0', 'name' => 'bosh-aws-xen-hvm-ubuntu-trusty-go_agent', 'version' => '1234' }

--- a/src/bosh-director/spec/unit/deployment_plan/manifest_validator_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/manifest_validator_spec.rb
@@ -86,6 +86,17 @@ module Bosh
             'resource_pools is no longer supported. You must now define resources in a cloud-config',
           )
         end
+
+        it 'raises error when both os and name are specified for a stemcell' do
+          manifest_hash['stemcells'][0]['name'] = 'the-name'
+
+          expect do
+            manifest_validator.validate(manifest_hash)
+          end.to raise_error(
+            Bosh::Director::StemcellBothNameAndOS,
+            %[Properties 'os' and 'name' are both specified for stemcell, choose one. ({"alias"=>"default", "os"=>"toronto-os", "version"=>"latest", "name"=>"the-name"})],
+          )
+        end
       end
     end
   end

--- a/src/bosh-director/spec/unit/deployment_plan/planner_factory_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/planner_factory_spec.rb
@@ -85,7 +85,7 @@ module Bosh
             planner
             expected_deployment_manifest_log = <<~LOGMESSAGE
               Deployment manifest:
-              {"name"=>"simple", "releases"=>[{"name"=>"bosh-release", "version"=>"0.1-dev"}], "stemcells"=>[{"name"=>"ubuntu-stemcell", "version"=>"1", "alias"=>"default"}], "update"=>{"canaries"=>2, "canary_watch_time"=>4000, "max_in_flight"=>1, "update_watch_time"=>20}, "instance_groups"=>[{"name"=>"foobar", "stemcell"=>"default", "vm_type"=>"a", "instances"=>3, "networks"=>[{"name"=>"a"}], "jobs"=>[{"name"=>"foobar", "release"=>"bosh-release", "properties"=>{}}]}]}
+              {"name"=>"simple", "releases"=>[{"name"=>"bosh-release", "version"=>"0.1-dev"}], "stemcells"=>[{"name"=>"ubuntu-stemcell", "version"=>"1", "alias"=>"default", "os"=>"stemcell-os"}], "update"=>{"canaries"=>2, "canary_watch_time"=>4000, "max_in_flight"=>1, "update_watch_time"=>20}, "instance_groups"=>[{"name"=>"foobar", "stemcell"=>"default", "vm_type"=>"a", "instances"=>3, "networks"=>[{"name"=>"a"}], "jobs"=>[{"name"=>"foobar", "release"=>"bosh-release", "properties"=>{}}]}]}
             LOGMESSAGE
             expected_cloud_manifest_log = <<~LOGMESSAGE
               Cloud config manifest:
@@ -459,7 +459,7 @@ module Bosh
 
         def upload_stemcell
           stemcell_entry = manifest_hash['stemcells'].first
-          Models::Stemcell.make(name: stemcell_entry['name'], version: stemcell_entry['version'])
+          Models::Stemcell.make(name: stemcell_entry['name'], version: stemcell_entry['version'], operating_system: 'stemcell-os')
         end
       end
     end

--- a/src/bosh-director/spec/unit/deployment_plan/stemcell_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/stemcell_spec.rb
@@ -48,13 +48,6 @@ describe Bosh::Director::DeploymentPlan::Stemcell do
           valid_spec['name'] = 'stemcell-name'
           expect { make(valid_spec) }.to_not raise_error
         end
-        it 'populates os' do
-          make_stemcell('stemcell-name','0.5.2','plan-9')
-          valid_spec.delete('os')
-          valid_spec['name'] = 'stemcell-name'
-          stemcell = make(valid_spec)
-          expect(stemcell.os).to eq('plan-9')
-        end
       end
 
       context 'when neither os or name are specified' do
@@ -64,17 +57,6 @@ describe Bosh::Director::DeploymentPlan::Stemcell do
           expect { make(valid_spec) }.to raise_error(
             BD::ValidationMissingField,
             "Required property 'os' or 'name' was not specified in object ({\"version\"=>\"0.5.2\"})",
-          )
-        end
-      end
-      context 'when both os and name are specified' do
-        it 'raises' do
-          valid_spec['name'] = 'stemcell-name'
-          valid_spec['os'] = 'os1'
-          expect { make(valid_spec) }.to raise_error(
-            BD::StemcellBothNameAndOS,
-            "Properties 'os' and 'name' are both specified for stemcell, choose one. "\
-            '({"name"=>"stemcell-name", "version"=>"0.5.2", "os"=>"os1"})',
           )
         end
       end


### PR DESCRIPTION
Follow up to: https://github.com/cloudfoundry/bosh/pull/2475

The previous PR didn't handle diffs correctly so it showed that runtime configs were getting added/removed even though they weren't.

This commit moves the OS population up into the manifest parsing so it can apply to both the deployment manifest and the diff manifest.

This caused the DeploymentPlan Stemcell to start failing because it had a validation that both Name and OS shouldn't be specified. We moved that validation up to the ManifestValidator which seems like a more appropriate place for it anyway.

We modified the manifest parsing to prefer Name over OS when resolving the stemcell version aliases. This is more consistent with how the DeploymentPlan Stemcell resolves Name and OS. It shouldn't be a behavioral change though since you can't specify both Name and OS.

