### PR TITLE
Remove validation preventing both name and os for stemcells.

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/manifest_validator.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/manifest_validator.rb
@@ -28,14 +28,6 @@ module Bosh
                   'resource_pools is no longer supported. You must now define resources in a cloud-config'
           end
 
-          if manifest.key?('stemcells')
-            manifest['stemcells'].each do |stemcell|
-              if stemcell['name'] && stemcell['os']
-                raise StemcellBothNameAndOS, "Properties 'os' and 'name' are both specified for stemcell, choose one. (#{stemcell})"
-              end
-            end
-          end
-
           Config.event_log.warn_deprecated("Global 'properties' are deprecated. Please define 'properties' at the job level.") if manifest.key?('properties')
         end
 

--- a/src/bosh-director/lib/bosh/director/errors.rb
+++ b/src/bosh-director/lib/bosh/director/errors.rb
@@ -92,7 +92,6 @@ module Bosh::Director
   StemcellNotFound = err(50003, NOT_FOUND)
   StemcellInUse = err(50004)
   StemcellAliasAlreadyExists = err(50005)
-  StemcellBothNameAndOS = err(50006)
   StemcellSha1DoesNotMatch = err(50007)
   StemcellNotSupported = err(50008)
 

--- a/src/bosh-director/spec/unit/deployment_plan/manifest_validator_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/manifest_validator_spec.rb
@@ -86,17 +86,6 @@ module Bosh
             'resource_pools is no longer supported. You must now define resources in a cloud-config',
           )
         end
-
-        it 'raises error when both os and name are specified for a stemcell' do
-          manifest_hash['stemcells'][0]['name'] = 'the-name'
-
-          expect do
-            manifest_validator.validate(manifest_hash)
-          end.to raise_error(
-            Bosh::Director::StemcellBothNameAndOS,
-            %[Properties 'os' and 'name' are both specified for stemcell, choose one. ({"alias"=>"default", "os"=>"toronto-os", "version"=>"latest", "name"=>"the-name"})],
-          )
-        end
       end
     end
   end


### PR DESCRIPTION
Follow up to #2484, which broke everything...

Although those changes worked for full deploys, the way that manifests get parsed when doing things such as recreates causes the jobs to trip over the "cannot specify both name and os for stemcell" validation.

It would probably be possible to find some way to work around this, but the validation just isn't very useful anyway.

This commit removes that validation, making it valid now to specify both name and os.

When both are specified, name is given priority and os is ignored (as name has the os included in it anyway). It is now possible to make an invalid manifest, where the name and os don't actually match, but it will deploy anyway as long as the name is valid. This doesn't seem like a compelling reason to keep this validation around.
