### PR TITLE
Bump openssl gem to 3.2.0 for FIPS compatibility

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -12,6 +12,12 @@ gem 'bosh_common', path: 'bosh_common'
 
 gem 'rake', '~>13.0.3'
 
+# Bumping to openssl 3.2.0 while we are still on Ruby 3.2. This version
+# implements features necessary to support running on a FIPS stemcell.
+# If this is modified, it will need to be modified in the gemspecs for each
+# gem.
+gem 'openssl', '>=3.2.0'
+
 # json version is hardcoded in release director and health_monitor
 # when modified needs to be updated there as well
 gem 'json', '2.6.3'
@@ -65,7 +71,6 @@ group :development, :test do
 
   # for root level specs
   gem 'nats-pure', '~>2.3'
-  gem 'openssl'
   gem 'rest-client'
 
   gem 'blue-shell'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
   remote: bosh-core
   specs:
     bosh-core (0.0.0)
+      openssl (>= 3.2.0)
 
 PATH
   remote: bosh-dev
@@ -26,6 +27,7 @@ PATH
       bosh_common
       bundler
       logging
+      openssl (>= 3.2.0)
 
 PATH
   remote: bosh-director-core
@@ -33,6 +35,7 @@ PATH
     bosh-director-core (0.0.0)
       bosh-template (~> 0.0.0)
       bosh_common (~> 0.0.0)
+      openssl (>= 3.2.0)
 
 PATH
   remote: bosh-director
@@ -51,6 +54,7 @@ PATH
       membrane (~> 1.1.0)
       nats-pure
       netaddr (~> 1.5.3.dev.1)
+      openssl (>= 3.2.0)
       prometheus-client (~> 2.1.0)
       puma
       rack-test
@@ -76,6 +80,7 @@ PATH
       httpclient (~> 2.8.3)
       logging (~> 2.2.2)
       nats-pure
+      openssl (>= 3.2.0)
       riemann-client (~> 0.2.6)
       sinatra (~> 2.2.0)
       thin
@@ -89,6 +94,7 @@ PATH
       eventmachine (~> 1.3.0.dev.1)
       logging (~> 2.2.2)
       nats-pure
+      openssl (>= 3.2.0)
       rest-client
       sinatra (~> 2.2.0)
       thin
@@ -98,6 +104,7 @@ PATH
   specs:
     bosh-template (0.0.0)
       activesupport
+      openssl (>= 3.2.0)
       semi_semantic (~> 1.2.0)
 
 PATH
@@ -105,6 +112,7 @@ PATH
   specs:
     bosh_common (0.0.0)
       logging (~> 2.2.2)
+      openssl (>= 3.2.0)
       semi_semantic (~> 1.2.0)
 
 GEM
@@ -359,7 +367,7 @@ DEPENDENCIES
   nats-pure (~> 2.3)
   net-ssh
   netaddr (~> 1.5.3.dev.1)!
-  openssl
+  openssl (>= 3.2.0)
   parallel_tests (~> 2.0)
   pg
   pry-byebug

--- a/src/bosh-core/bosh-core.gemspec
+++ b/src/bosh-core/bosh-core.gemspec
@@ -17,4 +17,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = %w[lib]
+
+  spec.add_dependency 'openssl', '>=3.2.0'
 end

--- a/src/bosh-dev/bosh-dev.gemspec
+++ b/src/bosh-dev/bosh-dev.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bosh-director'
   spec.add_dependency 'bundler'
   spec.add_dependency 'logging'
+  spec.add_dependency 'openssl', '>=3.2.0'
 end

--- a/src/bosh-director-core/bosh-director-core.gemspec
+++ b/src/bosh-director-core/bosh-director-core.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bosh_common', "~>#{version}"
   spec.add_dependency 'bosh-template', "~>#{version}"
+  spec.add_dependency 'openssl', '>=3.2.0'
 end

--- a/src/bosh-director/bosh-director.gemspec
+++ b/src/bosh-director/bosh-director.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'membrane',         '~>1.1.0'
   spec.add_dependency 'nats-pure'
   spec.add_dependency 'netaddr',          '~>1.5.3.dev.1'
+  spec.add_dependency 'openssl', '>=3.2.0'
   spec.add_dependency 'prometheus-client','~>2.1.0'
   spec.add_dependency 'puma'
   spec.add_dependency 'rack-test'

--- a/src/bosh-monitor/bosh-monitor.gemspec
+++ b/src/bosh-monitor/bosh-monitor.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'logging',         '~>2.2.2'
   spec.add_dependency 'em-http-request'
   spec.add_dependency 'nats-pure'
+  spec.add_dependency 'openssl', '>=3.2.0'
   spec.add_dependency 'thin'
   spec.add_dependency 'sinatra',   '~>2.2.0'
   spec.add_dependency 'dogapi',    '~> 1.21.0'

--- a/src/bosh-nats-sync/bosh-nats-sync.gemspec
+++ b/src/bosh-nats-sync/bosh-nats-sync.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'logging',         '~>2.2.2'
   spec.add_dependency 'em-http-request'
   spec.add_dependency 'nats-pure'
+  spec.add_dependency 'openssl', '>=3.2.0'
   spec.add_dependency 'thin'
   spec.add_dependency 'sinatra',   '~>2.2.0'
   spec.add_dependency 'rest-client'

--- a/src/bosh-template/bosh-template.gemspec
+++ b/src/bosh-template/bosh-template.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'semi_semantic', '~>1.2.0'
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'openssl', '>=3.2.0'
 end

--- a/src/bosh_common/bosh_common.gemspec
+++ b/src/bosh_common/bosh_common.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'semi_semantic', '~>1.2.0'
   spec.add_dependency 'logging',       '~>2.2.2'
+  spec.add_dependency 'openssl', '>=3.2.0'
 end


### PR DESCRIPTION
openssl 3.2.0 gem implements features necessary for running OpenSSL-related code in Ruby in a FIPS environment. We've added this as a minimum requirement for each gem that makes up the overall BOSH Director code.

It should be possible to remove this requirement once we upgrade to Ruby 3.3, which ships with openssl 3.2.0 gem as a standard gem.