### PR TITLE
Remove json minor-version-dependency lock

### DIFF
--- a/packages/director/packaging
+++ b/packages/director/packaging
@@ -29,7 +29,7 @@ popd > /dev/null
 
 cat > Gemfile <<EOF
 # Explicitly require vendored version to avoid requiring builtin json gem
-gem 'json', '2.6.3'
+gem 'json', '~>2'
 
 gem 'bosh-director'
 gem 'mysql2'

--- a/packages/health_monitor/packaging
+++ b/packages/health_monitor/packaging
@@ -6,7 +6,7 @@ source /var/vcap/packages/director-ruby-3.2/bosh/compile.env
 
 cat > Gemfile <<EOF
 # Explicitly require vendored version to avoid requiring builtin json gem
-gem 'json', '2.6.3'
+gem 'json', '~>2'
 gem 'bosh-monitor'
 EOF
 

--- a/src/Gemfile
+++ b/src/Gemfile
@@ -20,7 +20,7 @@ gem 'openssl', '>=3.2.0'
 
 # json version is hardcoded in release director and health_monitor
 # when modified needs to be updated there as well
-gem 'json', '2.6.3'
+gem 'json', '~>2'
 
 gem 'talentbox-delayed_job_sequel', '~>4.3'
 

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json (2.6.3)
+    json (2.7.1)
     language_server-protocol (3.17.0.3)
     little-plugger (1.1.4)
     logging (2.2.2)
@@ -360,7 +360,7 @@ DEPENDENCIES
   factory_bot (~> 6.2)
   fakefs
   httpclient
-  json (= 2.6.3)
+  json (~> 2)
   machinist (~> 1.0)
   minitar
   mysql2

--- a/src/vendor/cache/json-2.6.3.gem
+++ b/src/vendor/cache/json-2.6.3.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86aaea16adf346a2b22743d88f8dcceeb1038843989ab93cda44b5176c845459
-size 67072

--- a/src/vendor/cache/json-2.7.1.gem
+++ b/src/vendor/cache/json-2.7.1.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:187ea312fb58420ff0c40f40af1862651d4295c8675267c6a1c353f1a0ac3265
+size 68608

--- a/src/vendor/cache/sqlite3-1.7.1-arm64-darwin.gem
+++ b/src/vendor/cache/sqlite3-1.7.1-arm64-darwin.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96dfb220aedb0056b22848b6663bd1b5e69fb84e373ac9f1c57b76b902703b43
+size 3502080


### PR DESCRIPTION
### What is this change about?

The currently used version of json library (json 2.6.3) has not been updated for more than 1 year.

This change updates the gems to the latest version with no known vulnerabilities. `bundle update json `was used to ensure indirect dependencies are updated as well.

### What tests have you run against this PR?

unit tests

### How should this change be described in bosh release notes?

bump json gem

### Does this PR introduce a breaking change?

No
