### PR TITLE
Enable signed url for bosh azure storage blobstore

### DIFF
--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -258,7 +258,8 @@ elsif p('blobstore.provider') == 'azure-storage'
   blobstore_options = {
     'account_name' => p('blobstore.account_name'),
     'container_name' => p('blobstore.container_name'),
-    'account_key' => p('blobstore.account_key')
+    'account_key' => p('blobstore.account_key'),
+    'enable_signed_urls' => p('blobstore.enable_signed_urls')
   }
 else
   blobstore_options = {


### PR DESCRIPTION
### What is this change about?

This change make it possible to use signed url if azure storage is used for external blobstore.

### What tests have you run against this PR?

`test_unit` and `test_unit_erb`, we have also created a dev_release and tested on our own dev_landscape.

### How should this change be described in bosh release notes?

Enable signed url for bosh azure storage blobstore


### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!
SAP BOSH team
