### PR TITLE
docker in docker service fails to start

### DIFF
--- a/ci/dockerfiles/docker-cpi/install.sh
+++ b/ci/dockerfiles/docker-cpi/install.sh
@@ -34,4 +34,18 @@ apt-get update
 
 apt-get install -y --no-install-recommends docker-ce
 
+# https://github.com/docker/cli/issues/4807
+# As of 02/01/2024 a change in the "/etc/init.d/docker" script shipped with docker v25 
+# is preventing the cpi image to work. 
+# when start-bosh runs `service docker start` it errors with:
+# "/etc/init.d/docker: 62: ulimit: error setting limit (Invalid argument)"
+# disable resetting ulimit. Pre v25 the script contained `ulimit -n 1048576`
+# the default in our base image is: 
+# ulimit | grep file
+# `open files                          (-n) 1048576`
+# so it was a noOp..
+# running `ulimit -Hn 1048576` will succeed.. The issue happens when we want to raise the ulimit.
+
+sed -i 's/\(ulimit -Hn [0-9]*\)/#\1/' /etc/init.d/docker
+
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
https://github.com/docker/cli/issues/4807

As of 02/01/2024 a change in the "/etc/init.d/docker" script shipped with docker v25 is preventing the cpi image to work.
when start-bosh runs `service docker start` it errors with: "/etc/init.d/docker: 62: ulimit: error setting limit (Invalid argument)"

Workaround recommended in github issue suggests to disable resetting ulimit.

Pre v25 the script contained `ulimit -n 1048576`, with v25 it changed to: `ulimit -Hn 524288`.

the default in our base image is:

ulimit -a | grep file
`open files                          (-n) 1048576`

so it was a noOp before the change shipped with v25 of docker

to confirm I tried running `ulimit -Hn 1048576` and it will succeed..

The issue happens when we want to actually change the ulimit. In our case it would attempt to lower it and it's probably fine not doing that in CI?

### What is this change about?

_Describe the change and why it's needed._

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What tests have you run against this PR?

_Include a comprehensive list of all tests run successfully._

### How should this change be described in bosh release notes?

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/bosh/releases) for examples._


### Does this PR introduce a breaking change?

_Does this introduce changes that would require operators to take care in order to upgrade without a failure?_

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
