### PR TITLE
Switch metrics server from thin to puma 

### DIFF
--- a/jobs/health_monitor/spec
+++ b/jobs/health_monitor/spec
@@ -52,7 +52,7 @@ properties:
     default: info
 
   hm.em_threadpool_size:
-    description: EM thread pool size
+    description: EventMachine thread pool size
     default: 20
 
   #

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -65,7 +65,6 @@ PATH
       sinatra (~> 2.2.0)
       sys-filesystem (~> 1.4.1)
       talentbox-delayed_job_sequel (~> 4.3)
-      thin
       tzinfo-data
       unix-crypt (~> 1.3.0)
 

--- a/src/bosh-director/bin/bosh-director-metrics-server
+++ b/src/bosh-director/bin/bosh-director-metrics-server
@@ -5,7 +5,8 @@ require 'bosh/director/metrics_collector'
 require 'optparse'
 require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
-require 'thin'
+require 'puma'
+require 'puma/configuration'
 
 config_file = ::File.expand_path('../../config/bosh-director.yml', __FILE__)
 
@@ -25,7 +26,7 @@ metrics_collector = Bosh::Director::MetricsCollector.new(config)
 metrics_collector.prep
 metrics_collector.start
 
-thin_server = Thin::Server.new('127.0.0.1', config.metrics_server_port, signals: false) do
+rack_app = Puma::Rack::Builder.app do
   use Rack::CommonLogger
   use Prometheus::Middleware::Collector
   use Prometheus::Middleware::Exporter
@@ -33,11 +34,21 @@ thin_server = Thin::Server.new('127.0.0.1', config.metrics_server_port, signals:
   run ->(_) { [200, { 'Content-Type' => 'text/html' }, ['OK']] }
 end
 
+puma_configuration = Puma::Configuration.new do |user_config|
+  user_config.tag 'metrics_server'
+  user_config.bind "tcp://127.0.0.1:#{config.metrics_server_port}"
+  user_config.app rack_app
+  user_config.preload_app!
+  # this makes sure that all puma workers get their own db connections
+  user_config.before_fork { Bosh::Director::Config.db.disconnect }
+end
+puma_launcher = Puma::Launcher.new(puma_configuration)
+
 %w[TERM INT QUIT].each do |signal|
   trap(signal) do
-    thin_server.stop!
+    puma_launcher.stop
     metrics_collector.stop
   end
 end
 
-thin_server.start!
+puma_launcher.run

--- a/src/bosh-director/bosh-director.gemspec
+++ b/src/bosh-director/bosh-director.gemspec
@@ -60,7 +60,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sinatra',          '~>2.2.0'
   spec.add_dependency 'sys-filesystem',   '~>1.4.1'
   spec.add_dependency 'talentbox-delayed_job_sequel', '~>4.3'
-  spec.add_dependency 'thin'
   spec.add_dependency 'tzinfo-data'
   spec.add_dependency 'unix-crypt',       '~>1.3.0'
 end

--- a/src/bosh-director/lib/bosh/director/api/controllers/base_controller.rb
+++ b/src/bosh-director/lib/bosh/director/api/controllers/base_controller.rb
@@ -79,7 +79,7 @@ module Bosh::Director
           true
         end
 
-        after { headers('Date' => Time.now.rfc822) } # As thin doesn't inject date
+        after { headers('Date' => Time.now.rfc822) } # As puma doesn't inject date
 
         configure do
           set(:show_exceptions, false)

--- a/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
@@ -6,8 +6,8 @@ module Bosh::Monitor
       @heartbeat = Time.now
       @instance_manager = Bosh::Monitor.instance_manager
 
-      EM.add_periodic_timer(1) do
-        EM.defer { @heartbeat = Time.now }
+      EventMachine.add_periodic_timer(1) do
+        EventMachine.defer { @heartbeat = Time.now }
       end
 
       super

--- a/src/bosh-monitor/lib/bosh/monitor/director.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/director.rb
@@ -68,7 +68,7 @@ module Bosh::Monitor
       headers = {}
       headers['authorization'] = auth_provider.auth_header unless options.fetch(:no_login, false)
 
-      http = EM::HttpRequest.new(target_uri, tls: { verify_peer: false }).send(method.to_sym, head: headers)
+      http = EventMachine::HttpRequest.new(target_uri, tls: { verify_peer: false }).send(method.to_sym, head: headers)
 
       http.callback { f.resume(http) }
       http.errback  { f.resume(http) }

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/datadog.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/datadog.rb
@@ -31,9 +31,9 @@ module Bosh::Monitor
       def process(event)
         case event
         when Bosh::Monitor::Events::Heartbeat
-          EM.defer { process_heartbeat(event) } if event.instance_id
+          EventMachine.defer { process_heartbeat(event) } if event.instance_id
         when Bosh::Monitor::Events::Alert
-          EM.defer { process_alert(event) }
+          EventMachine.defer { process_alert(event) }
         end
       end
 

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/email.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/email.rb
@@ -24,7 +24,7 @@ module Bosh::Monitor
       end
 
       def run
-        unless EM.reactor_running?
+        unless EventMachine.reactor_running?
           logger.error('Email plugin can only be started when event loop is running')
           return false
         end
@@ -33,7 +33,7 @@ module Bosh::Monitor
 
         logger.info('Email plugin is running...')
 
-        EM.add_periodic_timer(@delivery_interval) do
+        EventMachine.add_periodic_timer(@delivery_interval) do
           process_queues
         rescue StandardError => e
           logger.error("Problem processing email queues: #{e}")
@@ -106,14 +106,14 @@ module Bosh::Monitor
 
         if smtp_options['auth']
           smtp_client_options[:auth] = {
-            # FIXME: EM SMTP client will only work with plain auth
+            # FIXME: EventMachine SMTP client will only work with plain auth
             type: smtp_options['auth'].to_sym,
             username: smtp_options['user'],
             password: smtp_options['password'],
           }
         end
 
-        email = EM::Protocols::SmtpClient.send(smtp_client_options)
+        email = EventMachine::Protocols::SmtpClient.send(smtp_client_options)
 
         email.callback do
           logger.debug("Email sent (took #{Time.now - started} seconds)")

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/event_logger.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/event_logger.rb
@@ -17,7 +17,7 @@ module Bosh::Monitor
       end
 
       def run
-        unless EM.reactor_running?
+        unless EventMachine.reactor_running?
           logger.error('Event logger plugin can only be started when event loop is running')
           return false
         end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/graphite.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/graphite.rb
@@ -10,7 +10,7 @@ module Bosh::Monitor
       end
 
       def run
-        unless EM.reactor_running?
+        unless EventMachine.reactor_running?
           logger.error('Graphite delivery agent can only be started when event loop is running')
           return false
         end
@@ -18,7 +18,7 @@ module Bosh::Monitor
         host = options['host']
         port = options['port']
         retries = options['max_retries'] || Bhm::TcpConnection::DEFAULT_RETRIES
-        @connection = EM.connect(host, port, Bhm::GraphiteConnection, host, port, retries)
+        @connection = EventMachine.connect(host, port, Bhm::GraphiteConnection, host, port, retries)
       end
 
       def process(event)

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/http_request_helper.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/http_request_helper.rb
@@ -8,7 +8,7 @@ module Bosh::Monitor::Plugins
       request[:proxy] = { host: env_proxy.host, port: env_proxy.port } unless env_proxy.nil?
       name = self.class.name
       started = Time.now
-      http = EM::HttpRequest.new(uri, tls: { verify_peer: false }).send(:put, request)
+      http = EventMachine::HttpRequest.new(uri, tls: { verify_peer: false }).send(:put, request)
       http.callback do
         logger.debug("#{name} event sent (took #{Time.now - started} seconds): #{http.response_header.status}")
       end
@@ -25,7 +25,7 @@ module Bosh::Monitor::Plugins
       started = Time.now
       env_proxy = URI.parse(uri.to_s).find_proxy
       request[:proxy] = { host: env_proxy.host, port: env_proxy.port } unless env_proxy.nil?
-      http = EM::HttpRequest.new(uri, tls: { verify_peer: false }).send(:post, request)
+      http = EventMachine::HttpRequest.new(uri, tls: { verify_peer: false }).send(:post, request)
       http.callback do
         logger.debug("#{name} event sent (took #{Time.now - started} seconds): #{http.response_header.status}")
       end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
@@ -26,7 +26,7 @@ module Bosh::Monitor::Plugins
     end
 
     def start
-      unless EM.reactor_running?
+      unless EventMachine.reactor_running?
         @logger.error('JSON Plugin can only be started when event loop is running')
         return false
       end
@@ -75,7 +75,7 @@ module Bosh::Monitor::Plugins
     end
   end
 
-  # EM's DeferrableChildProcess does not give an opportunity
+  # EventMachine's DeferrableChildProcess does not give an opportunity
   # to get the exit status. So we are implementing our own unbind logic to handle the exit status.
   # This way we can execute our process restart on the err callback (errback).
   # https://stackoverflow.com/a/12092647

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/pagerduty.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/pagerduty.rb
@@ -6,7 +6,7 @@ module Bosh::Monitor
       API_URI = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'.freeze
 
       def run
-        unless EM.reactor_running?
+        unless EventMachine.reactor_running?
           logger.error('Pagerduty plugin can only be started when event loop is running')
           return false
         end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
@@ -20,7 +20,7 @@ module Bosh::Monitor
       end
 
       def run
-        unless EM.reactor_running?
+        unless EventMachine.reactor_running?
           logger.error('Resurrector plugin can only be started when event loop is running')
           return false
         end
@@ -121,7 +121,7 @@ module Bosh::Monitor
         # Getting the current tasks may fail. In a situation where the director is already dealing with lots of scan and fix tasks,
         # we may want to postpone adding another one to the queue to give the director time to deal with the currently scheduled tasks.
         # In the case of the tasks endpoint misbehaving ( status != 200 ) we can safely skip scheduling the the scan and fix in the current iteration.
-        # The alerts about missing healthchecks will trigger again some time later (when the director is under less pressure). 
+        # The alerts about missing healthchecks will trigger again some time later (when the director is under less pressure).
         return true if tasks_response.status != 200
 
         queued_scan_and_fix = JSON.parse(tasks_response.body).select do |task|

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/riemann.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/riemann.rb
@@ -4,7 +4,7 @@ module Bosh::Monitor
   module Plugins
     class Riemann < Base
       def run
-        unless EM.reactor_running?
+        unless EventMachine.reactor_running?
           logger.error('Riemann plugin can only be started when event loop is running')
           return false
         end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/tsdb.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/tsdb.rb
@@ -10,7 +10,7 @@ module Bosh::Monitor
       end
 
       def run
-        unless EM.reactor_running?
+        unless EventMachine.reactor_running?
           logger.error('TSDB delivery agent can only be started when event loop is running')
           return false
         end
@@ -18,7 +18,7 @@ module Bosh::Monitor
         host = options['host']
         port = options['port']
         retries = options['max_retries'] || Bhm::TcpConnection::DEFAULT_RETRIES
-        @tsdb = EM.connect(host, port, Bhm::TsdbConnection, host, port, retries)
+        @tsdb = EventMachine.connect(host, port, Bhm::TsdbConnection, host, port, retries)
       end
 
       def process(event)

--- a/src/bosh-monitor/lib/bosh/monitor/protocols/tcp_connection.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/protocols/tcp_connection.rb
@@ -40,7 +40,7 @@ module Bosh::Monitor
 
       @logger.info("#{logger_name}-failed-to-reconnect, will try again in #{retry_in} seconds...") if retries > 1
 
-      EM.add_timer(retry_in) { retry_reconnect }
+      EventMachine.add_timer(retry_in) { retry_reconnect }
     end
 
     def retry_reconnect

--- a/src/bosh-monitor/lib/bosh/monitor/runner.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/runner.rb
@@ -15,17 +15,17 @@ module Bosh::Monitor
       @mbus          = Bhm.mbus
       @instance_manager = Bhm.instance_manager
       @resurrection_manager = Bhm.resurrection_manager
-      EM.threadpool_size = Bhm.em_threadpool_size
+      EventMachine.threadpool_size = Bhm.em_threadpool_size
     end
 
     def run
       @logger.info('HealthMonitor starting...')
-      EM.kqueue if EM.kqueue?
-      EM.epoll if EM.epoll?
+      EventMachine.kqueue if EventMachine.kqueue?
+      EventMachine.epoll if EventMachine.epoll?
 
-      EM.error_handler { |e| handle_em_error(e) }
+      EventMachine.error_handler { |e| handle_em_error(e) }
 
-      EM.run do
+      EventMachine.run do
         connect_to_mbus
         @director_monitor = DirectorMonitor.new(Bhm)
         @director_monitor.subscribe
@@ -40,18 +40,18 @@ module Bosh::Monitor
     def stop
       @logger.info('HealthMonitor shutting down...')
       @http_server&.stop!
-      EM.stop_event_loop
+      EventMachine.stop_event_loop
     end
 
     def setup_timers
-      EM.schedule do
+      EventMachine.schedule do
         poll_director
-        EM.add_periodic_timer(@intervals.poll_director) { poll_director }
-        EM.add_periodic_timer(@intervals.log_stats) { log_stats }
-        EM.add_periodic_timer(@intervals.resurrection_config) { update_resurrection_config }
-        EM.add_timer(@intervals.poll_grace_period) do
-          EM.add_periodic_timer(@intervals.analyze_agents) { analyze_agents }
-          EM.add_periodic_timer(@intervals.analyze_instances) { analyze_instances }
+        EventMachine.add_periodic_timer(@intervals.poll_director) { poll_director }
+        EventMachine.add_periodic_timer(@intervals.log_stats) { log_stats }
+        EventMachine.add_periodic_timer(@intervals.resurrection_config) { update_resurrection_config }
+        EventMachine.add_timer(@intervals.poll_grace_period) do
+          EventMachine.add_periodic_timer(@intervals.analyze_agents) { analyze_agents }
+          EventMachine.add_periodic_timer(@intervals.analyze_instances) { analyze_instances }
         end
       end
     end

--- a/src/bosh-monitor/spec/functional/notifying_plugins_spec.rb
+++ b/src/bosh-monitor/spec/functional/notifying_plugins_spec.rb
@@ -46,17 +46,17 @@ describe 'notifying plugins' do
 
       called = false
       alert = nil
-      EM.run do
+      EventMachine.run do
         nats = FakeNATS.new
         allow(Bhm).to receive(:nats).and_return(nats)
         runner.run
         wait_for_plugins
         nats.alert(JSON.dump(payload))
-        EM.add_timer(2) { EM.stop }
-        EM.add_periodic_timer(0.1) do
+        EventMachine.add_timer(2) { EventMachine.stop }
+        EventMachine.add_periodic_timer(0.1) do
           alert = get_alert
           called = true
-          EM.stop if alert&.attributes&.match(payload)
+          EventMachine.stop if alert&.attributes&.match(payload)
         end
       end
 
@@ -87,16 +87,16 @@ describe 'notifying plugins' do
 
       called = false
       alert = nil
-      EM.run do
+      EventMachine.run do
         nats = FakeNATS.new
         allow(Bhm).to receive(:nats).and_return(nats)
         runner.run
         wait_for_plugins
-        EM.add_timer(5) { EM.stop }
-        EM.add_periodic_timer(0.1) do
+        EventMachine.add_timer(5) { EventMachine.stop }
+        EventMachine.add_periodic_timer(0.1) do
           alert = get_alert
           called = true
-          EM.stop if alert&.attributes&.match(alert_json)
+          EventMachine.stop if alert&.attributes&.match(alert_json)
         end
       end
 

--- a/src/bosh-monitor/spec/spec_helper.rb
+++ b/src/bosh-monitor/spec/spec_helper.rb
@@ -90,24 +90,24 @@ end
 RSpec.configure do |c|
   c.color = true
 
-  # Could not use after hook because the tests can start EM in an around block
-  # which causes EM.reactor_running? to always return true.
+  # Could not use after hook because the tests can start EventMachine in an around block
+  # which causes EventMachine.reactor_running? to always return true.
   c.around do |example|
     Bhm.config = default_config
 
     example.call
-    if EM.reactor_running?
-      EM.stop
+    if EventMachine.reactor_running?
+      EventMachine.stop
 
       max_tries = 50
       while max_tries > 0
-        break unless EM.reactor_running?
+        break unless EventMachine.reactor_running?
 
         max_tries -= 1
         sleep(0.1)
       end
 
-      raise 'EM still running, but expected to not.' if EM.reactor_running?
+      raise 'EventMachine still running, but expected to not.' if EventMachine.reactor_running?
     end
   end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/api_controller_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/api_controller_spec.rb
@@ -8,15 +8,15 @@ describe Bosh::Monitor::ApiController do
     Bosh::Monitor::ApiController.new
   end
 
-  before { allow(EM).to receive(:add_periodic_timer) {} }
+  before { allow(EventMachine).to receive(:add_periodic_timer) {} }
 
   describe '/healthz' do
     let(:periodic_timers) { [] }
     let(:defers) { [] }
     now = 0
     before do
-      allow(EM).to receive(:add_periodic_timer) { |&block| periodic_timers << block }
-      allow(EM).to receive(:defer) { |&block| defers << block }
+      allow(EventMachine).to receive(:add_periodic_timer) { |&block| periodic_timers << block }
+      allow(EventMachine).to receive(:defer) { |&block| defers << block }
       allow(Time).to receive(:now) { now }
 
       current_session # get the App started
@@ -32,7 +32,7 @@ describe Bosh::Monitor::ApiController do
       expect(last_response.status).to eq(200)
     end
 
-    context 'when a thread has become available in the EM thread pool within a time limit' do
+    context 'when a thread has become available in the EventMachine thread pool within a time limit' do
       it 'returns 200 OK' do
         now + Bosh::Monitor::ApiController::PULSE_TIMEOUT + 1
         run_em_timers
@@ -42,7 +42,7 @@ describe Bosh::Monitor::ApiController do
       end
     end
 
-    context 'when the EM thread pool has been occupied for a while' do
+    context 'when the EventMachine thread pool has been occupied for a while' do
       let(:last_pulse) { Bosh::Monitor::ApiController::PULSE_TIMEOUT + 1 }
 
       before { now += last_pulse }

--- a/src/bosh-monitor/spec/unit/bosh/monitor/director_monitor_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/director_monitor_spec.rb
@@ -19,7 +19,7 @@ describe Bosh::Monitor::DirectorMonitor do
   end
 
   before do
-    allow(EM).to receive(:schedule).and_yield
+    allow(EventMachine).to receive(:schedule).and_yield
   end
 
   describe 'subscribe' do

--- a/src/bosh-monitor/spec/unit/bosh/monitor/director_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/director_spec.rb
@@ -151,10 +151,10 @@ describe 'Bhm::Director' do
   end
 
   def with_fiber
-    EM.run do
+    EventMachine.run do
       Fiber.new do
         yield
-        EM.stop
+        EventMachine.stop
       end.resume
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
@@ -534,7 +534,7 @@ module Bhm
         Bhm.config = YAML.load_file(sample_config,  permitted_classes: [Symbol], permitted_symbols:[], aliases: true)
         allow(mock_nats).to receive(:subscribe)
         allow(Bhm).to receive(:nats).and_return(mock_nats)
-        allow(EM).to receive(:schedule).and_yield
+        allow(EventMachine).to receive(:schedule).and_yield
       end
 
       it 'has the tsdb plugin' do

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/consul_event_forwarder_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/consul_event_forwarder_spec.rb
@@ -169,43 +169,43 @@ describe Bhm::Plugins::ConsulEventForwarder do
     end
 
     it 'should send a put request to the ttl endpoint the second time an event is encountered' do
-      EM.run do
+      EventMachine.run do
         subject.run
         subject.process(heartbeat)
         expect(subject).to receive(:send_http_put_request).with(ttl_pass_uri, heartbeat_request)
         subject.process(heartbeat)
-        EM.stop
+        EventMachine.stop
       end
     end
 
     it 'should send a fail ttl message when heartbeat is failing' do
       heartbeat.attributes['job_state'] = 'failing'
-      EM.run do
+      EventMachine.run do
         subject.run
         subject.process(heartbeat)
         expect(subject).to receive(:send_http_put_request).with(ttl_fail_uri, heartbeat_request)
         subject.process(heartbeat)
-        EM.stop
+        EventMachine.stop
       end
     end
 
     it 'should send a fail ttl message when heartbeat is unknown' do
       heartbeat.attributes['job_state'] = 'failing'
 
-      EM.run do
+      EventMachine.run do
         subject.run
         subject.process(heartbeat)
         expect(subject).to receive(:send_http_put_request).with(ttl_fail_uri, heartbeat_request)
         subject.process(heartbeat)
-        EM.stop
+        EventMachine.stop
       end
     end
 
     it 'should not send a registration request if an event is already registered' do
       subject.run
-      EM.run do
+      EventMachine.run do
         subject.process(heartbeat)
-        EM.stop
+        EventMachine.stop
       end
 
       expect(subject).to_not receive(:send_http_put_request).with(register_uri, register_request)
@@ -219,9 +219,9 @@ describe Bhm::Plugins::ConsulEventForwarder do
       it 'should not forward events' do
         subject.run
 
-        EM.run do
+        EventMachine.run do
           subject.process(heartbeat)
-          EM.stop
+          EventMachine.stop
         end
         expect(subject).to_not receive(:send_http_put_request).with(alert_uri, event_request)
         subject.process(alert)
@@ -244,9 +244,9 @@ describe Bhm::Plugins::ConsulEventForwarder do
       it 'should not send ttl and event requests for same event' do
         subject.run
 
-        EM.run do
+        EventMachine.run do
           subject.process(heartbeat)
-          EM.stop
+          EventMachine.stop
         end
         expect(subject).to_not receive(:send_http_put_request).with(alert_uri, event_request)
         expect(subject).to receive(:send_http_put_request).with(ttl_pass_uri, heartbeat_request)
@@ -258,9 +258,9 @@ describe Bhm::Plugins::ConsulEventForwarder do
           options.merge!('heartbeats_as_alerts' => true)
           subject.run
 
-          EM.run do
+          EventMachine.run do
             subject.process(heartbeat)
-            EM.stop
+            EventMachine.stop
           end
           expect(subject).to receive(:send_http_put_request).with(heartbeat_alert_uri, heartbeat_request)
           expect(subject).to receive(:send_http_put_request).with(ttl_pass_uri, heartbeat_request)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/datadog_spec.rb
@@ -75,7 +75,7 @@ describe Bhm::Plugins::DataDog do
 
   context 'processing metrics' do
     it "didn't freak out once timeout sending datadog metric" do
-      expect(EM).to receive(:defer).and_yield
+      expect(EventMachine).to receive(:defer).and_yield
       heartbeat = make_heartbeat
       allow(dog_client).to receive(:batch_metrics).and_yield
       allow(dog_client).to receive(:emit_points).and_raise(Timeout::Error)
@@ -83,7 +83,7 @@ describe Bhm::Plugins::DataDog do
     end
 
     it "didn't freak out with exceptions while sending datadog event" do
-      expect(EM).to receive(:defer).and_yield
+      expect(EventMachine).to receive(:defer).and_yield
       heartbeat = make_heartbeat
       allow(dog_client).to receive(:batch_metrics).and_yield
       allow(dog_client).to receive(:emit_points).and_raise
@@ -108,7 +108,7 @@ describe Bhm::Plugins::DataDog do
       )
       expect(dog_client).to receive(:batch_metrics).and_yield
 
-      expect(EM).to receive(:defer).and_yield
+      expect(EventMachine).to receive(:defer).and_yield
       %w[
         cpu.user
         cpu.sys
@@ -133,7 +133,7 @@ describe Bhm::Plugins::DataDog do
     end
 
     it 'should do nothing if instance_id is missing' do
-      expect(EM).to_not receive(:defer)
+      expect(EventMachine).to_not receive(:defer)
       heartbeat = make_heartbeat(timestamp: Time.now.to_i, instance_id: nil)
       subject.process(heartbeat)
     end
@@ -160,7 +160,7 @@ describe Bhm::Plugins::DataDog do
 
         expect(dog_client).to receive(:batch_metrics).and_yield
         allow(dog_client).to receive(:emit_points)
-        expect(EM).to receive(:defer).and_yield
+        expect(EventMachine).to receive(:defer).and_yield
         expect(dog_client).to receive(:emit_points).with(
           anything,
           anything,
@@ -175,7 +175,7 @@ describe Bhm::Plugins::DataDog do
 
   context 'processing alerts' do
     it "didn't freak out once timeout sending datadog event" do
-      expect(EM).to receive(:defer).and_yield
+      expect(EventMachine).to receive(:defer).and_yield
       make_heartbeat
       allow(dog_client).to receive(:emit_event).and_raise(Timeout::Error)
       alert = make_alert
@@ -183,7 +183,7 @@ describe Bhm::Plugins::DataDog do
     end
 
     it "didn't freak out with exceptions while sending datadog event" do
-      expect(EM).to receive(:defer).and_yield
+      expect(EventMachine).to receive(:defer).and_yield
       make_heartbeat
       allow(dog_client).to receive(:emit_event).and_raise
       alert = make_alert
@@ -191,7 +191,7 @@ describe Bhm::Plugins::DataDog do
     end
 
     it 'sends datadog alerts' do
-      expect(EM).to receive(:defer).and_yield
+      expect(EventMachine).to receive(:defer).and_yield
 
       time = Time.now.to_i - 10
       fake_event = double('Datadog Event')
@@ -210,7 +210,7 @@ describe Bhm::Plugins::DataDog do
     end
 
     it 'sends datadog a low priority event for warning alerts' do
-      expect(EM).to receive(:defer).and_yield
+      expect(EventMachine).to receive(:defer).and_yield
 
       expect(Dogapi::Event).to receive(:new) do |_, options|
         expect(options[:priority]).to eq('low')
@@ -240,7 +240,7 @@ describe Bhm::Plugins::DataDog do
           customkey2:customvalue2
         ]
 
-        expect(EM).to receive(:defer).and_yield
+        expect(EventMachine).to receive(:defer).and_yield
 
         expect(Dogapi::Event).to receive(:new) do |_, options|
           expect(options[:tags]).to include(*custom_tags)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/email_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/email_spec.rb
@@ -100,16 +100,16 @@ describe Bhm::Plugins::Email do
     expect(@plugin.queue_size(:alert)).to eq(20)
     expect(@plugin.queue_size(:heartbeat)).to eq(20)
 
-    EM.run do
+    EventMachine.run do
       @plugin.run
-      EM.add_timer(30) do
+      EventMachine.add_timer(30) do
         # By this time the test is failing
         puts('Timeout canceling the event machine')
-        EM.stop
+        EventMachine.stop
       end
 
-      EM.add_periodic_timer(0.5) do
-        EM.stop if @plugin.queue_size(:alert).zero? && @plugin.queue_size(:heartbeat).zero?
+      EventMachine.add_periodic_timer(0.5) do
+        EventMachine.stop if @plugin.queue_size(:alert).zero? && @plugin.queue_size(:heartbeat).zero?
       end
     end
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/event_logger_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/event_logger_spec.rb
@@ -42,9 +42,9 @@ describe 'Bhm::Plugins::Resurrector' do
 
   context 'when the event machine reactor is running' do
     around do |example|
-      EM.run do
+      EventMachine.run do
         example.call
-        EM.stop
+        EventMachine.stop
       end
     end
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/graphite_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/graphite_spec.rb
@@ -45,7 +45,7 @@ describe Bhm::Plugins::Graphite do
   describe 'process metrics' do
     let(:connection) { instance_double('Bosh::Monitor::GraphiteConnection') }
     before do
-      allow(EM).to receive(:connect)
+      allow(EventMachine).to receive(:connect)
         .with('fake-graphite-host', 2003, Bhm::GraphiteConnection, 'fake-graphite-host', 2003, 42)
         .and_return(connection)
     end
@@ -60,13 +60,13 @@ describe Bhm::Plugins::Graphite do
       let(:event) { make_alert(timestamp: Time.now.to_i) }
 
       it 'does not send metrics' do
-        EM.run do
+        EventMachine.run do
           plugin.run
           expect(connection).to_not receive(:send_metric)
 
           plugin.process(event)
 
-          EM.stop
+          EventMachine.stop
         end
       end
     end
@@ -74,7 +74,7 @@ describe Bhm::Plugins::Graphite do
     context 'when event is of type Heartbeat' do
       it 'sends metrics to Graphite' do
         event = make_heartbeat(timestamp: Time.now.to_i)
-        EM.run do
+        EventMachine.run do
           plugin.run
 
           event.metrics.each do |metric|
@@ -84,20 +84,20 @@ describe Bhm::Plugins::Graphite do
 
           plugin.process(event)
 
-          EM.stop
+          EventMachine.stop
         end
       end
 
       it 'skips sending metrics if instance_id is missing' do
         event = make_heartbeat(timestamp: Time.now.to_i, instance_id: nil)
-        EM.run do
+        EventMachine.run do
           plugin.run
 
           expect(connection).not_to receive(:send_metric)
 
           plugin.process(event)
 
-          EM.stop
+          EventMachine.stop
         end
       end
     end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
@@ -8,11 +8,11 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
   end
 
   describe '#send_http_put_request' do
-    let(:http_request) { instance_double(EM::HttpRequest) }
-    let(:http_response) { instance_double(EM::Completion) }
+    let(:http_request) { instance_double(EventMachine::HttpRequest) }
+    let(:http_response) { instance_double(EventMachine::Completion) }
 
     it 'sends a put request' do
-      expect(EM::HttpRequest).to receive(:new).with('http://some-uri', tls: { verify_peer: false }).and_return(http_request)
+      expect(EventMachine::HttpRequest).to receive(:new).with('http://some-uri', tls: { verify_peer: false }).and_return(http_request)
 
       expect(http_request).to receive(:send).with(:put, 'some-request').and_return(http_response)
       expect(http_response).to receive(:callback)
@@ -24,11 +24,11 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
   end
 
   describe '#send_http_post_request' do
-    let(:http_request) { instance_double(EM::HttpRequest) }
-    let(:http_response) { instance_double(EM::Completion) }
+    let(:http_request) { instance_double(EventMachine::HttpRequest) }
+    let(:http_response) { instance_double(EventMachine::Completion) }
 
     it 'sends a post request' do
-      expect(EM::HttpRequest).to receive(:new).with('http://some-uri', tls: { verify_peer: false }).and_return(http_request)
+      expect(EventMachine::HttpRequest).to receive(:new).with('http://some-uri', tls: { verify_peer: false }).and_return(http_request)
 
       expect(http_request).to receive(:send).with(:post, 'some-request').and_return(http_response)
       expect(http_response).to receive(:callback)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/json_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/json_spec.rb
@@ -37,10 +37,10 @@ describe Bhm::Plugins::ProcessManager do
     expect(Bosh::Monitor::Plugins::DeferrableChildProcess).to receive(:open).once.with('/plugin').and_return(process)
     allow(EventMachine).to receive(:defer).and_yield
 
-    EM.run do
+    EventMachine.run do
       process_manager.start
 
-      EM.stop
+      EventMachine.stop
     end
   end
 
@@ -48,9 +48,9 @@ describe Bhm::Plugins::ProcessManager do
     allow(Dir).to receive(:[]).with('/*/json-plugin/*').and_return(['/non-existent-plugin'])
     expect(Bosh::Monitor::Plugins::DeferrableChildProcess).to receive(:open).at_least(2).times.with('/non-existent-plugin').and_call_original
 
-    EM.run do
+    EventMachine.run do
       allow(EventMachine).to receive(:add_timer).with(0.1).at_least(2).times.and_yield
-      expect(EventMachine).to receive(:add_timer) { EM.stop }
+      expect(EventMachine).to receive(:add_timer) { EventMachine.stop }
       process_manager.start
     end
   end
@@ -63,17 +63,17 @@ describe Bhm::Plugins::ProcessManager do
 
     succeeded = true
     begin
-      EM.run do
+      EventMachine.run do
         process_manager.start
 
-        EM.add_timer(5) do
+        EventMachine.add_timer(5) do
           # By this time the test is failing
           succeeded = false
-          EM.stop
+          EventMachine.stop
         end
 
-        EM.add_periodic_timer(0.5) do
-          EM.stop if process_manager.instance_variable_get(:@processes).size == 1
+        EventMachine.add_periodic_timer(0.5) do
+          EventMachine.stop if process_manager.instance_variable_get(:@processes).size == 1
         end
       end
     ensure
@@ -92,7 +92,7 @@ describe Bhm::Plugins::ProcessManager do
     process_b = double('process-b').as_null_object
     allow(Bosh::Monitor::Plugins::DeferrableChildProcess).to receive(:open).with('/process-b').and_return(process_b)
 
-    EM.run do
+    EventMachine.run do
       process_manager.start
 
       process_manager.send_event(alert)
@@ -100,7 +100,7 @@ describe Bhm::Plugins::ProcessManager do
       expect(process_a).to have_received(:send_data).with("#{alert.to_json}\n")
       expect(process_b).to have_received(:send_data).with("#{alert.to_json}\n")
 
-      EM.stop
+      EventMachine.stop
     end
   end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/pagerduty_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/pagerduty_spec.rb
@@ -56,7 +56,7 @@ describe Bhm::Plugins::Pagerduty do
       ),
     }
 
-    EM.run do
+    EventMachine.run do
       @plugin.run
 
       allow(EventMachine).to receive(:defer) { |&arg| arg.call }
@@ -66,7 +66,7 @@ describe Bhm::Plugins::Pagerduty do
 
       @plugin.process(alert)
       @plugin.process(heartbeat)
-      EM.stop
+      EventMachine.stop
     end
   end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/resurrector_spec.rb
@@ -67,9 +67,9 @@ module Bosh::Monitor::Plugins
 
     context 'when the event machine reactor is running' do
       around do |example|
-        EM.run do
+        EventMachine.run do
           example.call
-          EM.stop
+          EventMachine.stop
         end
       end
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/riemann_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/riemann_spec.rb
@@ -38,7 +38,7 @@ describe Bhm::Plugins::Riemann do
     )
     heartbeat_request.delete :vitals
 
-    EM.run do
+    EventMachine.run do
       expect(@plugin.run).to be(true)
 
       allow(@client).to receive(:<<)
@@ -47,7 +47,7 @@ describe Bhm::Plugins::Riemann do
 
       @plugin.process(alert)
       @plugin.process(heartbeat)
-      EM.stop
+      EventMachine.stop
     end
   end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/tsdb_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/tsdb_spec.rb
@@ -12,7 +12,7 @@ describe Bhm::Plugins::Tsdb do
   end
 
   let(:connection) { instance_double('Bosh::Monitor::TsdbConnection') }
-  before { allow(EM).to receive(:connect).with('fake-host', 4242, Bhm::TsdbConnection, 'fake-host', 4242, 42).and_return(connection) }
+  before { allow(EventMachine).to receive(:connect).with('fake-host', 4242, Bhm::TsdbConnection, 'fake-host', 4242, 42).and_return(connection) }
 
   it 'validates options' do
     valid_options = {
@@ -56,21 +56,21 @@ describe Bhm::Plugins::Tsdb do
   it 'does not send metrics for alerts' do
     alert = make_alert(timestamp: Time.now.to_i)
 
-    EM.run do
+    EventMachine.run do
       plugin.run
 
       expect(connection).not_to receive(:send_metric)
 
       plugin.process(alert)
 
-      EM.stop
+      EventMachine.stop
     end
   end
 
   it 'does not send empty tags to TSDB' do
     heartbeat = make_heartbeat(timestamp: Time.now.to_i, instance_id: '')
 
-    EM.run do
+    EventMachine.run do
       plugin.run
 
       heartbeat.metrics.each do |metric|
@@ -80,14 +80,14 @@ describe Bhm::Plugins::Tsdb do
 
       plugin.process(heartbeat)
 
-      EM.stop
+      EventMachine.stop
     end
   end
 
   it 'sends heartbeat metrics to TSDB' do
     heartbeat = make_heartbeat(timestamp: Time.now.to_i)
 
-    EM.run do
+    EventMachine.run do
       plugin.run
 
       heartbeat.metrics.each do |metric|
@@ -98,7 +98,7 @@ describe Bhm::Plugins::Tsdb do
 
       plugin.process(heartbeat)
 
-      EM.stop
+      EventMachine.stop
     end
   end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/protocols/tcp_connection_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/protocols/tcp_connection_spec.rb
@@ -8,34 +8,34 @@ describe Bosh::Monitor::TcpConnection do
       before { Bhm.logger = logger }
 
       it 'tries to reconnect when unbinding' do
-        expect(EM).to receive(:add_timer).with(0)
+        expect(EventMachine).to receive(:add_timer).with(0)
         tcp_connection.unbind
       end
 
       it "doesn't log on the first unbind" do
-        allow(EM).to receive(:add_timer)
+        allow(EventMachine).to receive(:add_timer)
         expect(logger).to_not receive(:info)
         tcp_connection.unbind
       end
 
       it 'logs on subsequent unbinds' do
-        allow(EM).to receive(:add_timer)
+        allow(EventMachine).to receive(:add_timer)
         tcp_connection.unbind
         expect(logger).to receive(:info).with('connection.tcp-failed-to-reconnect, will try again in 1 seconds...')
         tcp_connection.unbind
       end
 
       it 'takes exponentially longer' do
-        expect(EM).to receive(:add_timer).with(0)
+        expect(EventMachine).to receive(:add_timer).with(0)
         tcp_connection.unbind
-        expect(EM).to receive(:add_timer).with(1)
+        expect(EventMachine).to receive(:add_timer).with(1)
         tcp_connection.unbind
-        expect(EM).to receive(:add_timer).with(3)
+        expect(EventMachine).to receive(:add_timer).with(3)
         tcp_connection.unbind
       end
 
       it 'should exit after MAX_RETRIES retries' do
-        allow(EM).to receive(:add_timer)
+        allow(EventMachine).to receive(:add_timer)
 
         expect do
           (Bhm::TcpConnection::DEFAULT_RETRIES + 1).times do
@@ -48,7 +48,7 @@ describe Bosh::Monitor::TcpConnection do
         let(:tcp_connection) { Bosh::Monitor::TcpConnection.new('signature', 'connection.tcp', '127.0.0.1', 80, -1) }
 
         it 'should try "indefinitely"' do
-          expect(EM).to receive(:add_timer).at_least(Bhm::TcpConnection::DEFAULT_RETRIES + 5).times
+          expect(EventMachine).to receive(:add_timer).at_least(Bhm::TcpConnection::DEFAULT_RETRIES + 5).times
 
           expect do
             (Bhm::TcpConnection::DEFAULT_RETRIES + 5).times do

--- a/src/bosh-monitor/spec/unit/bosh/monitor/runner_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/runner_spec.rb
@@ -29,7 +29,7 @@ describe Bosh::Monitor::Runner do
   end
 
   describe '#handle_em_error' do
-    context 'when EM loop error occurs' do
+    context 'when EventMachine loop error occurs' do
       let(:http_server) { instance_double(Thin::Server) }
 
       before do
@@ -39,18 +39,18 @@ describe Bosh::Monitor::Runner do
         runner.start_http_server
       end
 
-      it 'stops the HM server, stops the EM loop and logs the error' do
-        allow(EM).to receive(:stop_event_loop)
+      it 'stops the HM server, stops the EventMachine loop and logs the error' do
+        allow(EventMachine).to receive(:stop_event_loop)
         allow(http_server).to receive(:stop!)
         allow(logger).to receive(:fatal)
-        error = StandardError.new('EM event loop exception')
+        error = StandardError.new('EventMachine event loop exception')
         error.set_backtrace(['backtrace'])
 
         runner.handle_em_error(error)
 
-        expect(EM).to have_received(:stop_event_loop)
+        expect(EventMachine).to have_received(:stop_event_loop)
         expect(http_server).to have_received(:stop!)
-        expect(logger).to have_received(:fatal).with('EM event loop exception')
+        expect(logger).to have_received(:fatal).with('EventMachine event loop exception')
         expect(logger).to have_received(:fatal).with('backtrace')
       end
     end


### PR DESCRIPTION
In an effort to get rid of EventMachine, which has been unmaintained for some time, we are switching from using Thin web server (which is based on EventMachine) to Puma instead.

Since there don't seem to be unit specs for this bin script, we applied our patch to a running director to ensure that the metrics server comes up as expected.

See also #2499, #2500 for more removals of EventMachine.