### PR TITLE
Remove EventMachine from nats package

### DIFF
--- a/packages/nats/packaging
+++ b/packages/nats/packaging
@@ -22,11 +22,6 @@ pushd bosh-nats-sync/ > /dev/null
   mv *.gem ../vendor/cache
 popd > /dev/null
 
-pushd vendor/cache/eventmachine-* > /dev/null
-  gem build eventmachine.gemspec
-  mv *.gem ../
-popd > /dev/null
-
 if [ "`uname -m`" == "ppc64le" ]; then
     bundle config build.nokogiri '--use-system-libraries'
 fi

--- a/packages/nats/spec
+++ b/packages/nats/spec
@@ -8,5 +8,4 @@ files:
 - nats/nats-server-v*-linux-amd64.tar.gz
 - bosh-nats-sync/**/*
 - vendor/cache/*.gem
-- vendor/cache/eventmachine-*/**
 - vendor/cache/extensions/**

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -90,14 +90,10 @@ PATH
   specs:
     bosh-nats-sync (0.0.0)
       cf-uaa-lib (~> 3.2.1)
-      em-http-request
-      eventmachine (~> 1.3.0.dev.1)
       logging (~> 2.2.2)
-      nats-pure
       openssl (>= 3.2.0)
       rest-client
-      sinatra (~> 2.2.0)
-      thin
+      rufus-scheduler
 
 PATH
   remote: bosh-template

--- a/src/bosh-nats-sync/bosh-nats-sync.gemspec
+++ b/src/bosh-nats-sync/bosh-nats-sync.gemspec
@@ -19,12 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables << 'bosh-nats-sync'
 
   spec.add_dependency 'cf-uaa-lib',  '~>3.2.1'
-  spec.add_dependency 'eventmachine',    '~>1.3.0.dev.1'
   spec.add_dependency 'logging',         '~>2.2.2'
-  spec.add_dependency 'em-http-request'
-  spec.add_dependency 'nats-pure'
   spec.add_dependency 'openssl', '>=3.2.0'
-  spec.add_dependency 'thin'
-  spec.add_dependency 'sinatra',   '~>2.2.0'
+  spec.add_dependency 'rufus-scheduler'
   spec.add_dependency 'rest-client'
 end

--- a/src/bosh-nats-sync/lib/nats_sync.rb
+++ b/src/bosh-nats-sync/lib/nats_sync.rb
@@ -9,6 +9,5 @@ require 'nats_sync/users_sync'
 require 'nats_sync/nats_auth_config'
 require 'nats_sync/auth_provider'
 
-require 'eventmachine'
 require 'json'
 require 'yaml'


### PR DESCRIPTION
This switches from using the EventMachine scheduler functionality to
using Rufus Scheduler, which is already used by the metrics collector in
the Director.

See also #2497, #2500 for more removals of EventMachine.