### PR TITLE
Remove EventMachine from DNS sync scripts

### DIFF
--- a/src/bosh-director/bin/bosh-director-sync-dns
+++ b/src/bosh-director/bin/bosh-director-sync-dns
@@ -8,7 +8,6 @@ require 'bosh/director/dns/dns_version_converger'
 def stop(reason, dns_sync_broadcaster)
   Bosh::Director::Config.logger.error("Shutting down bosh-director-sync-dns: #{reason}")
   dns_sync_broadcaster.stop!
-  EM.stop
 end
 
 config_file = nil
@@ -34,14 +33,8 @@ dns_sync_broadcaster.prep
 end
 
 
-EventMachine.run do
-  EM.defer do
-    Thread.new do
-      begin
-        dns_sync_broadcaster.start!
-      ensure
-        stop('Thread terminated', dns_sync_broadcaster)
-      end
-    end
-  end
+begin
+  dns_sync_broadcaster.start!
+ensure
+  stop('Thread terminated', dns_sync_broadcaster)
 end

--- a/src/bosh-director/bin/bosh-director-trigger-one-time-sync-dns
+++ b/src/bosh-director/bin/bosh-director-trigger-one-time-sync-dns
@@ -17,10 +17,5 @@ publisher = Bosh::Director::BlobstoreDnsPublisher.new(
   logger
 )
 
-EventMachine.run do
-  Thread.new {
-    Bosh::Director::Models::LocalDnsRecord.create(:ip => "#{SecureRandom.uuid}-tombstone")
-    publisher.publish_and_broadcast
-    EM.stop
-  }
-end
+Bosh::Director::Models::LocalDnsRecord.create(:ip => "#{SecureRandom.uuid}-tombstone")
+publisher.publish_and_broadcast


### PR DESCRIPTION
The DNS sync scripts were setting up EventMachine, but seemingly never made use of it.

Additionally, the AgentBroadcaster (which is used both inside the DNS sync scripts and in the Director during deploy) had a reference to a "EmReactorLoop" class. It appears this class used to use EventMachine, but now simply yields whatever block is passed to it. Since it's just calling a block method, it has been removed in favor of just the code in the block.

See also #2497, #2499 for more removals of EventMachine.
