### PR TITLE
Unpin `riemann-client` gem and upgrade

### DIFF
--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -75,7 +75,7 @@ PATH
       net-smtp
       openssl (>= 3.2.0)
       puma
-      riemann-client (~> 0.2.6)
+      riemann-client
       sinatra (~> 2.2.0)
 
 PATH
@@ -143,7 +143,7 @@ GEM
       rspec-memory (~> 1.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    beefcake (1.0.0)
+    beefcake (1.2.0)
     bigdecimal (3.1.7)
     blue-shell (0.3.0)
       rspec
@@ -269,10 +269,9 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.6)
-    riemann-client (0.2.6)
-      beefcake (>= 0.3.5, <= 1.0.0)
+    riemann-client (1.2.1)
+      beefcake (>= 1.0.0)
       mtrc (>= 0.0.4)
-      trollop (>= 1.16.2)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -349,7 +348,6 @@ GEM
     timeout (0.4.1)
     timers (4.3.5)
     traces (0.11.1)
-    trollop (2.9.10)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2024.1)

--- a/src/bosh-monitor/bosh-monitor.gemspec
+++ b/src/bosh-monitor/bosh-monitor.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'puma'
   spec.add_dependency 'sinatra',   '~>2.2.0'
   spec.add_dependency 'dogapi',    '~> 1.45.0'
-  spec.add_dependency 'riemann-client', '~>0.2.6'
+  spec.add_dependency 'riemann-client'
   spec.add_dependency 'cf-uaa-lib',  '~>3.2.1'
   spec.add_dependency 'httpclient',  '~>2.8.3'
 

--- a/src/vendor/cache/beefcake-1.0.0.gem
+++ b/src/vendor/cache/beefcake-1.0.0.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb0161f61d46a7d0d82395d5265ca8a76dec5ec7134759f18094b67b1468f181
-size 18432

--- a/src/vendor/cache/beefcake-1.2.0.gem
+++ b/src/vendor/cache/beefcake-1.2.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:113cab805d501ab15f0b7ecd03b4384b154b35bd50a30309291ba198d3d76efc
+size 19968

--- a/src/vendor/cache/riemann-client-0.2.6.gem
+++ b/src/vendor/cache/riemann-client-0.2.6.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28ba11bd2bf7cecaeb1fa94ef486796f7b2feae313b1d42beac140e44547370b
-size 15360

--- a/src/vendor/cache/riemann-client-1.2.1.gem
+++ b/src/vendor/cache/riemann-client-1.2.1.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e0c75c7cfac076a57f6c98b86a73c16cc481c5f0942ee7d1baafd8958d9e0dd
+size 23040

--- a/src/vendor/cache/trollop-2.9.10.gem
+++ b/src/vendor/cache/trollop-2.9.10.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ceca2d91f349163d6ee3e792d356d4ded7472e6da31ac6dcc5956d1b03607bf7
-size 29696


### PR DESCRIPTION
Per the project's [Changelog](https://github.com/riemann/riemann-ruby-client/blob/main/CHANGELOG.md) there have been no breaking changes between `0.2.6` and `1.2.1`

### What is this change about?

Updating the riemann-client gem.

### Please provide contextual information.

n/a

### What tests have you run against this PR?

✅ `rake fly:unit`
✅ `rake fly:integration`

### How should this change be described in bosh release notes?

> Gem used by `bosh-minotor` Riemann plugin updated

### Does this PR introduce a breaking change?

None known.
