### PR TITLE
Use `NetAddr::CIDR.create` instead of `CIDRv{4,6}.new`

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/ip_provider/ip_repo.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/ip_provider/ip_repo.rb
@@ -85,9 +85,9 @@ module Bosh::Director::DeploymentPlan
       addresses_we_cant_allocate.merge(subnet.static_ips.to_a) unless subnet.static_ips.empty?
       addr = find_first_available_address(addresses_we_cant_allocate, first_range_address)
       if subnet.range.version == 6
-        ip_address = NetAddr::CIDRv6.new(addr)
+        ip_address = NetAddr::CIDR.create(addr, Version: 6)
       else
-        ip_address = NetAddr::CIDRv4.new(addr)
+        ip_address = NetAddr::CIDR.create(addr, Version: 4)
       end
 
       unless subnet.range == ip_address || subnet.range.contains?(ip_address)
@@ -115,7 +115,7 @@ module Bosh::Director::DeploymentPlan
 
       raise NoMoreIPsAvailableAndStopRetrying if available_ips.empty?
 
-      ip_address = NetAddr::CIDRv4.new(available_ips.first)
+      ip_address = NetAddr::CIDR.create(available_ips.first, Version: 4)
 
       save_ip(ip_address, reservation, false)
 

--- a/src/bosh-director/lib/cloud/dummy.rb
+++ b/src/bosh-director/lib/cloud/dummy.rb
@@ -96,7 +96,7 @@ module Bosh
             elsif cloud_properties['az_name']
               ip_address = cmd.ip_address_for_az(cloud_properties['az_name'])
             else
-              ip_address =  NetAddr::CIDRv4.new(rand(0..4294967295)).ip #collisions?
+              ip_address =  NetAddr::CIDR.create(rand(0..4294967295), Version: 4).ip #collisions?
             end
 
             if ip_address


### PR DESCRIPTION
### What is this change about?

The sub-classes of `CIDR` do not define an `#initialize` method so these end up calling `CIDR#initialize` which has the following documentation:

> This method performs absolutely no error checking, and is meant to be
> used only by other internal methods for the sake of the speedier
> creation of CIDR objects. [snip]

See: https://github.com/dspinhirne/netaddr-rb/blob/version-1.5.2/lib/cidr.rb#L205-L216

This commit switches to `CIDR.create(..., Version: {4,6})` so that the address type is still explicitly set.

### Please provide contextual information.

n/a

### What tests have you run against this PR?

✅ `rake fly:unit`
✅ `rake fly:integration`

### How should this change be described in bosh release notes?

[nternal change, none needed]

### Does this PR introduce a breaking change?

No.
