### PR TITLE
Ensure Health Monitor HTTP connections are closed

### DIFF
--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
@@ -16,11 +16,11 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
         send_http_put_request('http://some-uri/some-path', { body: 'some-request' })
       end
 
-      response = task.wait
+      body, status = task.wait
 
       expect(WebMock).to have_requested(:put, 'http://some-uri/some-path').with(body: 'some-request')
-      expect(response.read).to eq('response')
-      expect(response.status).to eq(200)
+      expect(body).to eq('response')
+      expect(status).to eq(200)
     end
 
     context 'when passed a proxy URI' do
@@ -31,11 +31,11 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
           send_http_put_request('http://some-uri/some-path', { body: 'some-request', proxy: 'https://proxy.local:1234' })
         end
 
-        response = task.wait
+        body, status = task.wait
 
         expect(WebMock).to have_requested(:put, 'http://some-uri/some-path').with(body: 'some-request')
-        expect(response.read).to eq('response')
-        expect(response.status).to eq(200)
+        expect(body).to eq('response')
+        expect(status).to eq(200)
       end
     end
   end
@@ -48,11 +48,11 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
         send_http_post_request('http://some-uri/some-path', { body: 'some-request' })
       end
 
-      response = task.wait
+      body, status = task.wait
 
       expect(WebMock).to have_requested(:post, 'http://some-uri/some-path').with(body: 'some-request')
-      expect(response.read).to eq('response')
-      expect(response.status).to eq(200)
+      expect(body).to eq('response')
+      expect(status).to eq(200)
     end
   end
 


### PR DESCRIPTION
### What is this change about?

When EventMachine was removed from Health Monitor in favor of async-http, it neglected to explicitly close the Async::Http::Client objects. This results in connections to the Director on port 25555 to constantly accumulate and remain in a CLOSE_WAIT state. This can result in problems with NATS, such as the bosh-nats-sync process being unable to connect to the Director to get a list of valid clients.

Fixes #2509 

### What tests have you run against this PR?

* Applied changes to a live Director and restarted the `health_monitor` process. Observed HM logs and open connections with `netstat` during normal operation + when the resurrector plugin was triggered.
* Ran unit tests locally
