### PR TITLE
Add shellwords to template rendering

### DIFF
--- a/src/bosh-template/lib/bosh/template/evaluation_context.rb
+++ b/src/bosh-template/lib/bosh/template/evaluation_context.rb
@@ -10,6 +10,7 @@ require 'bosh/template/manual_link_dns_encoder'
 # Include for backward compatibility within ERB template rendering
 require 'active_support'
 require 'active_support/core_ext/object/blank'
+require 'shellwords'
 
 module Bosh
   module Template


### PR DESCRIPTION
Shellwords was previously required by eventmachine (we believe), so when that was removed, any release templates that were trying to use shellwords without requiring it started failing.

Errors seen in template rendering:
```
undefined method `shellescape' for "":String
```