### PR TITLE
Fix Health Monitor email messages and TLS

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/plugins/email.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/email.rb
@@ -103,9 +103,8 @@ module Bosh::Monitor
         end
 
         Async do
-          smtp = Net::SMTP.new(smtp_options['host'], smtp_options['port'])
-          smtp.enable_starttls if smtp_options['tls']
-
+          starttls_mode = smtp_options['tls'] ? :always : false
+          smtp = Net::SMTP.new(smtp_options['host'], smtp_options['port'], starttls: starttls_mode)
           smtp.start(*smtp_start_params) do |smtp|
             smtp.send_message(formatted_message(headers, body), smtp_options['from'], recipients)
             logger.debug("Email sent (took #{Time.now - started} seconds)")
@@ -128,9 +127,9 @@ module Bosh::Monitor
       end
 
       def formatted_message(headers_hash, body_text)
-        headers_text = headers_hash.map { |key, value| "#{key}: #{value}" }.join('\n')
+        headers_text = headers_hash.map { |key, value| "#{key}: #{value}" }.join("\r\n")
 
-        "#{headers_text}\n\n#{body_text}"
+        "#{headers_text}\r\n\r\n#{body_text}"
       end
     end
   end


### PR DESCRIPTION
### What is this change about?

Previously, the EventMachine SMTP client was formatting the headers and body of emails sent by Health Monitor for us. When this was replaced with Net::SMTP, the headers and body were improperly formatted and thus emails were not delivered.

Additionally, this restores the STARTTLS behavior to how it worked when we used EventMachine; setting hm.email.tls to true forces a STARTTLS session, while setting it to false does not attempt a STARTTLS session even if the server supports it.

### What tests have you run against this PR?

* Ran unit tests
* Applied patch to a live director to ensure emails were being sent out in both TLS and non-TLS mode.