### PR TITLE
update java to jdk 17

### DIFF
--- a/ci/dockerfiles/integration/install-java.sh
+++ b/ci/dockerfiles/integration/install-java.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-PACKAGE_NAME="zulu11.72.19-ca-jdk11.0.23-linux_x64.tar.gz"
-PACKAGE_MD5="d8983bdc4fb7bd394e6dd73618e9c288"
+PACKAGE_NAME="zulu17.50.19-ca-jre17.0.11-linux_x64.tar.gz"
+PACKAGE_MD5="0b25f460b11f53325ba130283d1d4aad"
 PACKAGE_TMP="/tmp/${PACKAGE_NAME}"
 PACKAGE_URL="http://cdn.azul.com/zulu/bin/${PACKAGE_NAME}"
 INSTALL_PREFIX="/usr/lib/jvm"


### PR DESCRIPTION
a follow up to:
fc9bf3827341072771de3604dbe9a34bd70b4e22

shortly after requiring jdk11, credhub updated once again to require jdk17: https://github.com/cloudfoundry/credhub/commit/f1897e453508e5cf855f705aad5fc2bd9addb587

unfortunately that wasn't noticed when creating the previous jdk11 update.

### What is this change about?

_Describe the change and why it's needed._

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What tests have you run against this PR?

_Include a comprehensive list of all tests run successfully._

### How should this change be described in bosh release notes?

_Something brief that conveys the change and is written with the Operator audience in mind.
See [previous release notes](https://github.com/cloudfoundry/bosh/releases) for examples._


### Does this PR introduce a breaking change?

_Does this introduce changes that would require operators to take care in order to upgrade without a failure?_

### Tag your pair, your PM, and/or team!
_It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
