### PR TITLE
fix 2da3812 use jdk not jre tarball

### DIFF
--- a/ci/dockerfiles/integration/install-java.sh
+++ b/ci/dockerfiles/integration/install-java.sh
@@ -2,8 +2,8 @@
 set -e
 set -x
 
-PACKAGE_NAME="zulu17.50.19-ca-jre17.0.11-linux_x64.tar.gz"
-PACKAGE_MD5="0b25f460b11f53325ba130283d1d4aad"
+PACKAGE_NAME="zulu17.50.19-ca-jdk17.0.11-linux_x64.tar.gz"
+PACKAGE_MD5="6497ded4396d535611ec401d785d440e"
 PACKAGE_TMP="/tmp/${PACKAGE_NAME}"
 PACKAGE_URL="http://cdn.azul.com/zulu/bin/${PACKAGE_NAME}"
 INSTALL_PREFIX="/usr/lib/jvm"


### PR DESCRIPTION
unfortunately the last commit mindlessly copied the jre tarball instead of the required jdk tarball.
