### PR TITLE
Add shared ci task that can be used by release authors to test template rendering

### DIFF
--- a/ci/tasks/shared/test-release-template-rendering.sh
+++ b/ci/tasks/shared/test-release-template-rendering.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+start-bosh
+
+source /tmp/local-bosh/director/env
+
+stemcell_url="$(bosh interpolate /usr/local/bosh-deployment/warden/cpi.yml --path /name=stemcell/value/url)"
+bosh upload-stemcell "${stemcell_url}"
+
+cat <<EOF > /tmp/defaults.yml
+- type: replace
+  path: /name?
+  value: rendering_test
+- type: replace
+  path: /stemcells?/alias=default
+  value:
+    alias: default
+    version: latest
+    os: $(echo "${stemcell_url}" | grep -oE "ubuntu-[^-]+")
+- type: replace
+  path: /update?
+  value:
+    canaries: 1
+    max_in_flight: 1
+    canary_watch_time: 1000-30000
+    update_watch_time: 1000-30000
+- type: replace
+  path: /instance_groups/0/stemcell?
+  value: default
+- type: replace
+  path: /instance_groups/0/vm_type?
+  value: default
+- type: replace
+  path: /instance_groups/0/networks?
+  value: [{name: default}]
+- type: replace
+  path: /instance_groups/0/azs?
+  value: [z1]
+EOF
+
+export BOSH_DEPLOYMENT="rendering_test"
+
+pushd release > /dev/null
+  if "${DEV_RELEASE}" == "true"; then
+    bosh create-release --force
+  fi
+  bosh upload-release
+popd
+
+for manifest in "${MANIFEST_FOLDER}"/*.yml; do
+  bosh -n deploy --dry-run \
+    -o /tmp/defaults.yml \
+    "${manifest}"
+done

--- a/ci/tasks/shared/test-release-template-rendering.yml
+++ b/ci/tasks/shared/test-release-template-rendering.yml
@@ -1,0 +1,39 @@
+---
+# This task can be used to test the template rendering for a bosh release. It performs a "--dry-run" bosh deployment
+# so no jobs will actually be run. The bosh director used within the docker image is rebuilt after each release
+# of the bosh director.
+
+# This task must be run as a privileged container.
+
+# The bosh director repository is a required input, as is your release. You may specify an additional "manifests" input
+# for the manifests to deploy or you can use manifests within your release repository. The MANIFESTS_FOLDER param should
+# point to the relative path of your manifests: i.e. "release/tests/manifests"
+
+# If DEV_RELEASE is set to "true" the task will create a dev release and upload that. Otherwise it will simply run
+# "bosh upload-release" which will upload the most recent final release.
+
+# The test manifests do not need to be complete valid deployment manifests, the task will fill in the infrastructure
+# details such as stemcell, vm_types, networks, azs and the update section. They will need to include a single instance
+# group that includes any jobs you want to render templates for.
+
+# Variables can be defined and referenced from the job properties if needed.
+
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: bosh/warden-cpi
+
+inputs:
+- name: bosh
+- name: release
+- name: manifests
+  optional: true
+
+run:
+  path: bosh/ci/tasks/shared/test-release-template-rendering.sh
+
+params:
+  MANIFEST_FOLDER:
+  DEV_RELEASE: false


### PR DESCRIPTION
This makes it easier for release authors to test their template rendering against the latest bosh director.

We've broken template rendering a few times in the last couple years due to director changes.