### PR TITLE
(Deployment-Wise) Retention Period for Scheduled Task Cleanup

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -118,6 +118,9 @@ properties:
   director.tasks_retention_period:
     description: the retention period for tasks and their log files
     default: ''
+  director.tasks_deployments_retention_period:
+    description: the retention period for tasks and their log files of specific deployments
+    default: ''
   director.max_threads:
     description: Max number of director concurrent threads
     default: 32

--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -115,6 +115,9 @@ properties:
   director.max_tasks:
     description: Max number of tasks per each type to keep in disk
     default: 2000
+  director.tasks_retention_period:
+    description: the retention period for tasks and their log files
+    default: ''
   director.max_threads:
     description: Max number of director concurrent threads
     default: 32

--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -8,6 +8,7 @@ params = {
   'port' => p('director.backend_port'),
   'max_tasks' => p('director.max_tasks'),
   'tasks_retention_period' => p('director.tasks_retention_period'),
+  'tasks_deployments_retention_period' => p('director.tasks_deployments_retention_period'),
   'max_threads' => p('director.max_threads'),
   'puma_workers' => p('director.puma_workers'),
   'logging' => {

--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -7,6 +7,7 @@ params = {
   },
   'port' => p('director.backend_port'),
   'max_tasks' => p('director.max_tasks'),
+  'tasks_retention_period' => p('director.tasks_retention_period'),
   'max_threads' => p('director.max_threads'),
   'puma_workers' => p('director.puma_workers'),
   'logging' => {

--- a/packages/director/packaging
+++ b/packages/director/packaging
@@ -7,10 +7,6 @@ mysqlclient_dir=/var/vcap/packages/mysql
 
 source /var/vcap/packages/director-ruby-3.2/bosh/compile.env
 
-for gemspec in $( find . -maxdepth 2 -name ._*.gemspec ); do
-    rm -f "$gemspec"
-done
-
 for gemspec in $( find . -maxdepth 2 -name *.gemspec ); do
   gem_name="$( basename "$( dirname "$gemspec" )" )"
   gem_spec="$( basename "$gemspec" )"

--- a/packages/director/packaging
+++ b/packages/director/packaging
@@ -7,6 +7,10 @@ mysqlclient_dir=/var/vcap/packages/mysql
 
 source /var/vcap/packages/director-ruby-3.2/bosh/compile.env
 
+for gemspec in $( find . -maxdepth 2 -name ._*.gemspec ); do
+    rm -f "$gemspec"
+done
+
 for gemspec in $( find . -maxdepth 2 -name *.gemspec ); do
   gem_name="$( basename "$( dirname "$gemspec" )" )"
   gem_spec="$( basename "$gemspec" )"

--- a/src/bosh-director/lib/bosh/director/api/task_remover.rb
+++ b/src/bosh-director/lib/bosh/director/api/task_remover.rb
@@ -1,27 +1,31 @@
 require 'date'
-require 'logger'
 
 module Bosh::Director::Api
   class TaskRemover
-    def initialize(max_tasks, retention_period)
+    def initialize(max_tasks, retention_period, deployment_retention_period)
       @max_tasks = max_tasks
       @retention_period = retention_period
-      @logger = Logger.new('/var/vcap/sys/log/director/task_remover.log', level: Logger::DEBUG)
-      @logger.info("task remover initialize retention time: #{@retention_period}")
+      @deployment_retention_period = deployment_retention_period
     end
 
     def remove(type)
-      @logger.info("remove begin retention time: #{@retention_period}")
       tasks_removed = 0
       removal_max_tasks_candidates_dataset(type).paged_each(strategy: :filter, stream: false) do |task|
         tasks_removed += 1
         remove_task(task)
       end
-      @logger.info("retention time: #{@retention_period}")
       unless @retention_period == ''
         removal_retention_candidates_dataset(type).paged_each(strategy: :filter, stream: false) do |task|
           tasks_removed += 1
           remove_task(task)
+        end
+      end
+      unless @deployment_retention_period == ''
+        @deployment_retention_period.each do |d|
+          removal_deployment_retention_candidates_dataset(type, d).paged_each(strategy: :filter, stream: false) do |task|
+            tasks_removed += 1
+            remove_task(task)
+          end
         end
       end
       tasks_removed
@@ -37,7 +41,7 @@ module Bosh::Director::Api
         # both could get the same results from removal_candidates_dataset,
         # but only the first would succeed at deletion; ignore failure of
         # subsequent attempts
-        @logger.debug("TaskRemover: Sequel::NoExistingObject, attempting to remove #{task}.")
+        Bosh::Director::Config.logger.debug("TaskRemover: Sequel::NoExistingObject, attempting to remove #{task}.")
       end
     end
 
@@ -47,7 +51,6 @@ module Bosh::Director::Api
       base_filter = Bosh::Director::Models::Task.where(type: type)
         .exclude(state: %w[processing queued])
         .select(:id, :output).order { Sequel.desc(:id) }
-
       starting_id = base_filter.limit(1, @max_tasks).first&.id || 0
 
       base_filter.where { id <= starting_id }
@@ -61,9 +64,17 @@ module Bosh::Director::Api
                                   .select(:id, :output)
     end
 
+    def removal_deployment_retention_candidates_dataset(type, deployment_with_retention_period)
+      retention_time = DateTime.now.to_time - convert_to_time_duration(deployment_with_retention_period['retention_period'])
+      Bosh::Director::Models::Task.where(type: type)
+                                  .where(deployment_name: deployment_with_retention_period['deployment'])
+                                  .where { checkpoint_time < retention_time }
+                                  .exclude(state: %w[processing queued])
+                                  .select(:id, :output)
+    end
+
     def convert_to_time_duration(string)
       multipliers = { "d" => 24*60*60, "h" => 60*60, "m" => 60, "s" => 1 }
-
       segments = string.scan(/(\d+)([a-z])/)
 
       segments.inject(0) do |total, (value, unit)|

--- a/src/bosh-director/lib/bosh/director/api/task_remover.rb
+++ b/src/bosh-director/lib/bosh/director/api/task_remover.rb
@@ -1,14 +1,28 @@
+require 'date'
+require 'logger'
+
 module Bosh::Director::Api
   class TaskRemover
-    def initialize(max_tasks)
+    def initialize(max_tasks, retention_period)
       @max_tasks = max_tasks
+      @retention_period = retention_period
+      @logger = Logger.new('/var/vcap/sys/log/director/task_remover.log', level: Logger::DEBUG)
+      @logger.info("task remover initialize retention time: #{@retention_period}")
     end
 
     def remove(type)
+      @logger.info("remove begin retention time: #{@retention_period}")
       tasks_removed = 0
-      removal_candidates_dataset(type).paged_each(strategy: :filter, stream: false) do |task|
+      removal_max_tasks_candidates_dataset(type).paged_each(strategy: :filter, stream: false) do |task|
         tasks_removed += 1
         remove_task(task)
+      end
+      @logger.info("retention time: #{@retention_period}")
+      unless @retention_period == ''
+        removal_retention_candidates_dataset(type).paged_each(strategy: :filter, stream: false) do |task|
+          tasks_removed += 1
+          remove_task(task)
+        end
       end
       tasks_removed
     end
@@ -23,13 +37,13 @@ module Bosh::Director::Api
         # both could get the same results from removal_candidates_dataset,
         # but only the first would succeed at deletion; ignore failure of
         # subsequent attempts
-        Bosh::Director::Config.logger.debug("TaskRemover: Sequel::NoExistingObject, attempting to remove #{task}.")
+        @logger.debug("TaskRemover: Sequel::NoExistingObject, attempting to remove #{task}.")
       end
     end
 
     private
 
-    def removal_candidates_dataset(type)
+    def removal_max_tasks_candidates_dataset(type)
       base_filter = Bosh::Director::Models::Task.where(type: type)
         .exclude(state: %w[processing queued])
         .select(:id, :output).order { Sequel.desc(:id) }
@@ -37,6 +51,24 @@ module Bosh::Director::Api
       starting_id = base_filter.limit(1, @max_tasks).first&.id || 0
 
       base_filter.where { id <= starting_id }
+    end
+
+    def removal_retention_candidates_dataset(type)
+      retention_time = DateTime.now.to_time - convert_to_time_duration(@retention_period)
+      Bosh::Director::Models::Task.where(type: type)
+                                  .where { checkpoint_time < retention_time }
+                                  .exclude(state: %w[processing queued])
+                                  .select(:id, :output)
+    end
+
+    def convert_to_time_duration(string)
+      multipliers = { "d" => 24*60*60, "h" => 60*60, "m" => 60, "s" => 1 }
+
+      segments = string.scan(/(\d+)([a-z])/)
+
+      segments.inject(0) do |total, (value, unit)|
+        total + value.to_i * multipliers[unit]
+      end
     end
   end
 end

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -37,6 +37,7 @@ module Bosh::Director
         :logger,
         :max_tasks,
         :tasks_retention_period,
+        :tasks_deployments_retention_period,
         :max_threads,
         :max_vm_create_tries,
         :name,
@@ -132,8 +133,9 @@ module Bosh::Director
         # by default keep only last 2000 tasks of each type in disk
         @max_tasks = config.fetch('max_tasks', 2000).to_i
 
-        # by default keep last 30 days tasks of each type in disk
+        # by default keep all tasks of each type in disk if retention period is not set
         @tasks_retention_period = config.fetch('tasks_retention_period', '')
+        @tasks_deployments_retention_period = config.fetch('tasks_deployments_retention_period', '')
 
         @max_threads = config.fetch('max_threads', 32).to_i
 

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -36,6 +36,7 @@ module Bosh::Director
         :local_dns,
         :logger,
         :max_tasks,
+        :tasks_retention_period,
         :max_threads,
         :max_vm_create_tries,
         :name,
@@ -130,6 +131,9 @@ module Bosh::Director
 
         # by default keep only last 2000 tasks of each type in disk
         @max_tasks = config.fetch('max_tasks', 2000).to_i
+
+        # by default keep last 30 days tasks of each type in disk
+        @tasks_retention_period = config.fetch('tasks_retention_period', '')
 
         @max_threads = config.fetch('max_threads', 32).to_i
 

--- a/src/bosh-director/lib/bosh/director/jobs/scheduled_tasks_cleanup.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/scheduled_tasks_cleanup.rb
@@ -14,7 +14,11 @@ module Bosh::Director
       end
 
       def initialize(_param = {})
-        @task_remover = Bosh::Director::Api::TaskRemover.new(Config.max_tasks, Config.tasks_retention_period)
+        @task_remover = Bosh::Director::Api::TaskRemover.new(
+          Config.max_tasks,
+          Config.tasks_retention_period,
+          Config.tasks_deployments_retention_period
+        )
       end
 
       def update_orphaned_tasks_with_state_error(result)
@@ -54,7 +58,6 @@ module Bosh::Director
       def perform
         result = "Deleted tasks and logs for\n"
 
-        Bosh::Director::Config.logger.info("getting type")
         task_types.each do |type|
           tasks_removed = @task_remover.remove(type)
           result << "#{tasks_removed} task(s) of type '#{type}'\n"

--- a/src/bosh-director/lib/bosh/director/jobs/scheduled_tasks_cleanup.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/scheduled_tasks_cleanup.rb
@@ -14,7 +14,7 @@ module Bosh::Director
       end
 
       def initialize(_param = {})
-        @task_remover = Bosh::Director::Api::TaskRemover.new(Config.max_tasks)
+        @task_remover = Bosh::Director::Api::TaskRemover.new(Config.max_tasks, Config.tasks_retention_period)
       end
 
       def update_orphaned_tasks_with_state_error(result)
@@ -54,6 +54,7 @@ module Bosh::Director
       def perform
         result = "Deleted tasks and logs for\n"
 
+        Bosh::Director::Config.logger.info("getting type")
         task_types.each do |type|
           tasks_removed = @task_remover.remove(type)
           result << "#{tasks_removed} task(s) of type '#{type}'\n"

--- a/src/bosh-director/spec/assets/test-director-config.yml
+++ b/src/bosh-director/spec/assets/test-director-config.yml
@@ -5,6 +5,12 @@ port: 8081
 logging:
   level: ERROR
 
+max_tasks: 2000
+tasks_retention_period: 20d
+tasks_deployments_retention_period:
+  - deployment: fake-deployment
+    retention_period: 30d
+
 dir: /tmp/boshdir
 director_certificate_expiry_json_path: /tmp/boshdir/certificate_expiry.json
 db:

--- a/src/bosh-director/spec/unit/config_spec.rb
+++ b/src/bosh-director/spec/unit/config_spec.rb
@@ -445,6 +445,15 @@ describe Bosh::Director::Config do
         expect(described_class.nats_config_fingerprint).to eq(Digest::SHA1.hexdigest("client_ca_certificate_pathclient_ca_private_key_pathserver_ca_path"))
       end
     end
+
+    describe 'task remover configurations' do
+      it 'returns the task remover configurations' do
+        described_class.configure(test_config)
+        expect(described_class.max_tasks).to eq(2000)
+        expect(described_class.tasks_retention_period).to eq('20d')
+        expect(described_class.tasks_deployments_retention_period).to eq([{'deployment' => 'fake-deployment', 'retention_period' => '30d'}])
+      end
+    end
   end
 
   describe '#identity_provider' do


### PR DESCRIPTION
### What is this change about?

Currently the debug logs of bosh tasks are cleaned up by [ScheduledTasksCleanup](https://github.com/cloudfoundry/bosh/blob/main/src/bosh-director/lib/bosh/director/jobs/scheduled_tasks_cleanup.rb) module. We can configure the [crontab schedule and max_tasks](https://github.com/cloudfoundry/bosh/blob/4e9d023febe841b909f200e08d5eb4bed68fb0dd/jobs/director/spec#L112-L117) for the job. But the max_tasks is dependent on the platform size and hard to determine.

Describe the solution you'd like
During administration we think that it makes more sense that we have another config parameter retention_period for the job. The scheduled job will always delete the logs if the task is out dated.

### Please provide contextual information.

[Issue #2508 ](https://github.com/cloudfoundry/bosh/issues/2508)

### What tests have you run against this PR?

Unittests in bosh/src/bosh-director
Tested on a dev landscape

### How should this change be described in bosh release notes?

Implement the (Deployment-Wise) Retention Period for Scheduled Task Cleanup


### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@fearoffish
