### PR TITLE
Health Monitor continues to log after errors

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/protocols/tcp_connection.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/protocols/tcp_connection.rb
@@ -18,6 +18,8 @@ module Bosh::Monitor
       return unless @connected
 
       @socket.write(data)
+    rescue
+      unbind
     end
 
     def connect


### PR DESCRIPTION
When health_monitor is sending metrics to, for example, graphite, and there is a network error (e.g. `Errno::EPIPE`), it stops sending metrics until health_monitor is restarted.

This was a regression due to replacing the `EventMachine` gem with the `Async` gem.

This commit fixes the regression by, when a network error occurs, attempting to re-establish the connection and continue sending data.

The attempt to re-establish the connection follows the same retry & backoff logic as when establishing the initial connection.

Note: we feel the method `unbind` is poorly named; it should be named `close_old_and_open_new_connection`.

[fixes #2522]

[#187636407]

### What is this change about?

See commit message.

### Please provide contextual information.

See #2522.

### What tests have you run against this PR?

```
be rake spec:unit:parallel
```

### How should this change be described in bosh release notes?

Health Monitor attempts to re-establish plugins' network connections when disconnected.

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!

@mingxiao @cunnie 
