### PR TITLE
Exclude dev/test gems with GPL license to simplify license compliance

### DIFF
--- a/packages/director/spec
+++ b/packages/director/spec
@@ -15,3 +15,6 @@ files:
 - vendor/cache/*.gem
 - vendor/cache/extensions/**
 - vendor/cache/netaddr-rb-*/**
+
+excluded_files:
+- vendor/cache/{bundle-audit,bundler-audit,coderay}-*.gem # test dependency with GPL license

--- a/packages/health_monitor/spec
+++ b/packages/health_monitor/spec
@@ -7,3 +7,6 @@ files:
 - bosh-monitor/**/*
 - vendor/cache/*.gem
 - vendor/cache/extensions/**
+
+excluded_files:
+- vendor/cache/{bundle-audit,bundler-audit,coderay}-*.gem # test dependency with GPL license

--- a/packages/nats/spec
+++ b/packages/nats/spec
@@ -9,3 +9,6 @@ files:
 - bosh-nats-sync/**/*
 - vendor/cache/*.gem
 - vendor/cache/extensions/**
+
+excluded_files:
+- vendor/cache/{bundle-audit,bundler-audit,coderay}-*.gem # test dependency with GPL license


### PR DESCRIPTION
While looking at BlackDuck scan results I noticed that there are a few dev/test gems that bring (strong) copy left licenses. 
Since these gems are not a runtime dependency, let's try and exclude these from our final releases.
