### PR TITLE
🐞 Health Monitor properly feeds plugins

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor.rb
+++ b/src/bosh-monitor/lib/bosh/monitor.rb
@@ -19,6 +19,7 @@ require 'set'
 
 require 'async'
 require 'async/http'
+require 'async/io'
 require 'logging'
 require 'nats/io/client'
 require 'puma'


### PR DESCRIPTION
Health Monitor needs the gem "async/io" to properly feed messages to plugins such as Graphite.

Previously "async/io" was a dependency of "async/http", so it did not need to be explicitly required; however, that has recently changed.

The symptom we witnessed was health messages were NOT forwarded to Graphite using the latest Director. The error was tracked to the following in `tcp_connection.rb`:

```
uninitialized constant Async::IO
```

This commit fixes that error by explicitly requiring "async/io"

### What is this change about?

See above.

### Please provide contextual information.

This [similar commit](https://github.com/cloudfoundry/bosh/commit/64e423479d53cfeda73a420ffc2eaf5d84f3f391) explicitly adds `async/io`.

### What tests have you run against this PR?

- Ran the tests in `src/bosh-monitor/spec/unit`
- Also hot-patched a Director to make sure it worked.

### How should this change be described in bosh release notes?

Health monitor properly forwards messages to plugins.

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!

@gm2552 @mingxiao @jpalermo 
