### PR TITLE
When adding a new tombstone record, delete all the older ones

### DIFF
--- a/src/bosh-director/lib/bosh/director/models/local_dns_record.rb
+++ b/src/bosh-director/lib/bosh/director/models/local_dns_record.rb
@@ -3,7 +3,9 @@ module Bosh::Director::Models
     many_to_one :instance
 
     def self.insert_tombstone
-      create(:ip => "#{SecureRandom.uuid}-tombstone")
+      tombstone_record = create(:ip => "#{SecureRandom.uuid}-tombstone")
+      where{id < tombstone_record.id}.where(Sequel.like(:ip, '%-tombstone')).delete
+      tombstone_record
     end
 
     def links=(value)

--- a/src/bosh-director/spec/unit/models/local_dns_record_spec.rb
+++ b/src/bosh-director/spec/unit/models/local_dns_record_spec.rb
@@ -11,5 +11,12 @@ module Bosh::Director::Models
 
       expect(Bosh::Director::Models::LocalDnsRecord.first.instance).to be_nil
     end
+
+    it 'removes old tombstone records' do
+      previous_record = Bosh::Director::Models::LocalDnsRecord.insert_tombstone
+      new_record = Bosh::Director::Models::LocalDnsRecord.insert_tombstone
+      expect(Bosh::Director::Models::LocalDnsRecord.where(id: previous_record.id).first).to be_nil
+      expect(Bosh::Director::Models::LocalDnsRecord.where(id: new_record.id).first).not_to be_nil
+    end
   end
 end


### PR DESCRIPTION
Noticed that these are never cleaned up currently. There may be a performance hit when the first new tombstone record is added and thousands of old ones are destroyed but it shouldn't be terrible.