### PR TITLE
bump ruby-prof version from 1.6.3 to 1.7.0

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -24,7 +24,7 @@ gem 'json', '~>2'
 
 gem 'talentbox-delayed_job_sequel', '~>4.3'
 
-gem 'ruby-prof', '1.6.3'
+gem 'ruby-prof'
 
 group :production do
   gem 'mysql2'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
       parser (>= 3.3.1.0)
     rubocop-git (0.1.3)
       rubocop (>= 0.24.1)
-    ruby-prof (1.6.3)
+    ruby-prof (1.7.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rufus-scheduler (3.9.1)
@@ -403,7 +403,7 @@ DEPENDENCIES
   rspec-its
   rubocop
   rubocop-git
-  ruby-prof (= 1.6.3)
+  ruby-prof
   simplecov
   sinatra (>= 2.2.0)
   sinatra-contrib (>= 2.2.0)


### PR DESCRIPTION
### What is this change about?

New version of ruby-prof version (1.7.0) is available.

### How should this change be described in bosh release notes?

Updates ruby-prof from 1.6.3 to 1.7.0
