### PR TITLE
remove the `tag` on the ubuntu docker image

### DIFF
--- a/ci/tasks/prepare-container-bosh-docker-build-context.yml
+++ b/ci/tasks/prepare-container-bosh-docker-build-context.yml
@@ -5,7 +5,6 @@ image_resource:
   type: docker-image
   source:
     repository: ubuntu
-    tag: "14.04"
 
 inputs:
   - name: bosh-src

--- a/ci/tasks/prepare-container-docker-cpi-build-context.yml
+++ b/ci/tasks/prepare-container-docker-cpi-build-context.yml
@@ -5,7 +5,6 @@ image_resource:
   type: docker-image
   source:
     repository: ubuntu
-    tag: xenial
 
 inputs:
   - name: bosh-src


### PR DESCRIPTION
These tags are outdated, xenial and trusty, are out of support. Implicity use `latest`, the tasks are using common commands like `cp` and `mkdir`

[#187900893]

### What is this change about?

remove the `tag` on the ubuntu docker image
    
These tags are outdated, xenial and trusty, are out of support. Implicity use `latest`, the tasks are using common commands like `cp` and `mkdir`
    

### Please provide contextual information.

_Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### What tests have you run against this PR?

None, these are pipeline changes.

### How should this change be described in bosh release notes?

There is no impact on release notes, these are pipeline changes


### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@rajathagasthya 
