### PR TITLE
Remove `DB_TLS` option from integration specs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -180,8 +180,7 @@ jobs:
         file: bosh-src/ci/tasks/test-integration.yml
         image: integration-postgres-15-image
         params:
-          DB:           postgresql
-          DB_TLS:       true
+          DB: postgresql
           DB_VERSION: 15
 
   - name: integration-db-tls-postgres-hotswap
@@ -203,10 +202,9 @@ jobs:
         file: bosh-src/ci/tasks/test-integration.yml
         image: integration-postgres-15-image
         params:
-          DB:           postgresql
-          DEFAULT_UPDATE_VM_STRATEGY: create-swap-delete
-          DB_TLS:       true
+          DB: postgresql
           DB_VERSION: 15
+          DEFAULT_UPDATE_VM_STRATEGY: create-swap-delete
 
   - name: integration-db-tls-mysql
     public: true
@@ -227,8 +225,7 @@ jobs:
         file: bosh-src/ci/tasks/test-integration.yml
         image: integration-mysql-8-0-image
         params:
-          DB:           mysql
-          DB_TLS:       true
+          DB: mysql
 
   - name: candidate-release
     plan:

--- a/ci/tasks/test-integration.sh
+++ b/ci/tasks/test-integration.sh
@@ -35,18 +35,16 @@ sql-mode="STRICT_TRANS_TABLES"
 skip-log-bin
 max_connections = 1024' >> /etc/mysql/my.cnf
 
-    if [ "$DB_TLS" = true ]; then
-      echo "....... DB TLS enabled ......."
+    echo "....... DB TLS enabled ......."
 
-      export MYSQLDIR=/var/lib/mysql
-      cp bosh-src/src/bosh-dev/assets/sandbox/database/database_server/private_key $MYSQLDIR/server-key.pem
-      cp bosh-src/src/bosh-dev/assets/sandbox/database/database_server/certificate.pem $MYSQLDIR/server-cert.pem
-      echo '
+    export MYSQLDIR=/var/lib/mysql
+    cp bosh-src/src/bosh-dev/assets/sandbox/database/database_server/private_key $MYSQLDIR/server-key.pem
+    cp bosh-src/src/bosh-dev/assets/sandbox/database/database_server/certificate.pem $MYSQLDIR/server-cert.pem
+    echo '
 ssl-cert=server-cert.pem
 ssl-key=server-key.pem
 require_secure_transport=ON
 max_allowed_packet=6M' >> /etc/mysql/my.cnf
-    fi
 
     service mysql start
     sleep 5
@@ -83,24 +81,22 @@ max_allowed_packet=6M' >> /etc/mysql/my.cnf
       echo "max_connections = 1024" >> $PGDATA/postgresql.conf
       echo "shared_buffers = 240MB" >> $PGDATA/postgresql.conf
 
-      if [ "$DB_TLS" = true ]; then
-        echo "....... DB TLS enabled ......."
-        cp bosh-src/src/bosh-dev/assets/sandbox/database/database_server/private_key $PGDATA/server.key
-        cp bosh-src/src/bosh-dev/assets/sandbox/database/database_server/certificate.pem $PGDATA/server.crt
-        chown postgres $PGDATA/server.key
-        chown postgres $PGDATA/server.crt
-        su postgres -c '
-          export PGDATA=/tmp/postgres/data
-          echo "ssl = on" >> $PGDATA/postgresql.conf
-          echo "client_encoding = 'UTF8'" >> $PGDATA/postgresql.conf
-          echo "hostssl all all 127.0.0.1/32 password" > $PGDATA/pg_hba.conf
-          echo "hostssl all all 0.0.0.0/32 password" >> $PGDATA/pg_hba.conf
-          echo "hostssl all all ::1/128 password" >> $PGDATA/pg_hba.conf
-          echo "hostssl all all localhost password" >> $PGDATA/pg_hba.conf
+      echo "....... DB TLS enabled ......."
+      cp bosh-src/src/bosh-dev/assets/sandbox/database/database_server/private_key $PGDATA/server.key
+      cp bosh-src/src/bosh-dev/assets/sandbox/database/database_server/certificate.pem $PGDATA/server.crt
+      chown postgres $PGDATA/server.key
+      chown postgres $PGDATA/server.crt
+      su postgres -c '
+        export PGDATA=/tmp/postgres/data
+        echo "ssl = on" >> $PGDATA/postgresql.conf
+        echo "client_encoding = 'UTF8'" >> $PGDATA/postgresql.conf
+        echo "hostssl all all 127.0.0.1/32 password" > $PGDATA/pg_hba.conf
+        echo "hostssl all all 0.0.0.0/32 password" >> $PGDATA/pg_hba.conf
+        echo "hostssl all all ::1/128 password" >> $PGDATA/pg_hba.conf
+        echo "hostssl all all localhost password" >> $PGDATA/pg_hba.conf
 
-          chmod 600 $PGDATA/server.*
-        '
-      fi
+        chmod 600 $PGDATA/server.*
+      '
 
       su postgres -c '
         export PATH=/usr/lib/postgresql/$DB_VERSION/bin:$PATH
@@ -134,7 +130,7 @@ pushd bosh-src/src
 
   bundle_exit_code=$?
 
-  if [[ "$DB" = "mysql" && "$DB_TLS" = true ]]; then
+  if [[ "$DB" = "mysql" ]]; then
     service mysql stop
   fi
 popd

--- a/ci/tasks/test-integration.yml
+++ b/ci/tasks/test-integration.yml
@@ -19,13 +19,12 @@ run:
   path: bosh-src/ci/tasks/test-integration.sh
 
 params:
-  RUBY_VERSION:            3.1.2
-  DB:                      postgresql
-  LOG_LEVEL:               ERROR
-  SPEC_PATH:               ~
-  SHA2_MODE:               ~
-  DB_TLS:                  false
+  RUBY_VERSION:               3.2.0
+  DB:                         postgresql
+  DB_VERSION:                 15
+  LOG_LEVEL:                  ERROR
+  SPEC_PATH:                  ~
+  SHA2_MODE:                  ~
   DEFAULT_UPDATE_VM_STRATEGY: "delete-create"
   NUM_PROCESSES:
-  GOOS:                    linux
-  DB_VERSION:   13
+  GOOS:                       linux

--- a/src/bosh-dev/assets/sandbox/director_test.yml.erb
+++ b/src/bosh-dev/assets/sandbox/director_test.yml.erb
@@ -27,10 +27,8 @@ db: &bosh_db
   port: <%= database.port %>
   user: <%= database.username %>
   password: <%= database.password %>
-
-  <% if database.tls_enabled %>
   tls:
-    enabled: <%= database.tls_enabled %>
+    enabled: true
     cert:
       ca: <%= database.ca_path %>
       certificate: "/not-used/path/in/integration/tests"
@@ -38,13 +36,6 @@ db: &bosh_db
     bosh_internal:
       ca_provided: true
       mutual_tls_enabled: false
-
-  <% else %>
-  # Failure to set `sslmode` will produce following error
-  # 'PG::Error: SSL error: decryption failed or bad record mac:'
-  sslmode: "disable"
-  <% end %>
-
   connection_options:
     max_connections: 32
     pool_timeout: 10

--- a/src/bosh-dev/lib/bosh/dev/sandbox/mysql.rb
+++ b/src/bosh-dev/lib/bosh/dev/sandbox/mysql.rb
@@ -3,7 +3,7 @@ require 'bosh/core/shell'
 
 module Bosh::Dev::Sandbox
   class Mysql
-    attr_reader :db_name, :username, :password, :adapter, :port, :host, :ca_path, :tls_enabled
+    attr_reader :db_name, :username, :password, :adapter, :port, :host, :ca_path
 
     def initialize(db_name, runner, logger, options = {})
       @db_name = db_name
@@ -16,7 +16,6 @@ module Bosh::Dev::Sandbox
       @port = options.fetch(:port, 3306)
       @host = options.fetch(:host, 'localhost')
       @ca_path = options.fetch(:ca_path, nil)
-      @tls_enabled = options.fetch(:tls_enabled, false)
     end
 
     def connection_string

--- a/src/bosh-dev/lib/bosh/dev/sandbox/postgresql.rb
+++ b/src/bosh-dev/lib/bosh/dev/sandbox/postgresql.rb
@@ -4,7 +4,7 @@ require 'shellwords'
 
 module Bosh::Dev::Sandbox
   class Postgresql
-    attr_reader :db_name, :username, :password, :adapter, :port, :host, :ca_path, :tls_enabled
+    attr_reader :db_name, :username, :password, :adapter, :port, :host, :ca_path
 
     def initialize(db_name, runner, logger, options = {})
       @db_name = db_name
@@ -17,7 +17,6 @@ module Bosh::Dev::Sandbox
       @port = options.fetch(:port, 5432)
       @host = options.fetch(:host, '127.0.0.1')
       @ca_path = options.fetch(:ca_path, nil)
-      @tls_enabled = options.fetch(:tls_enabled, false)
     end
 
     def connection_string

--- a/src/bosh-dev/lib/bosh/dev/tasks/fly.rake
+++ b/src/bosh-dev/lib/bosh/dev/tasks/fly.rake
@@ -97,7 +97,6 @@ namespace :fly do
 
   def prepare_env(additional_env = {})
     env = {
-      DB_TLS: ENV.fetch('DB_TLS', true), # specs only ever use TLS, however this value needs to be set
       RUBY_VERSION: ENV['RUBY_VERSION'] || RUBY_VERSION,
     }
     env.merge!(additional_env)


### PR DESCRIPTION
We never run specs w/o DB_TLS so there's no need for this conditionality.

### What is this change about?

Remove untested code path from test infrastructure.

### What tests have you run against this PR?

> executing build 147400459 at https://bosh.ci.cloudfoundry.org/builds/147400459

### How should this change be described in bosh release notes?

n/a

### Does this PR introduce a breaking change?

This change is only to the test execution code not in bosh itself.
