### PR TITLE
bump-ruby-package job updates `.ruby-version` file

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1003,6 +1003,7 @@ jobs:
             options:
               credentials_source: static
               json_key: '((bosh_release_blobs_gcp_credentials_json))'
+        RUBY_VERSION_PATH: src/.ruby-version
     - task: bump-bosh-blobstore-dav
       file: bosh-src/ci/tasks/bump-blobstore-cli.yml
       input_mapping:


### PR DESCRIPTION
### What is this change about?

Keeping `src/.ruby-version` in sync with the version of the bosh ruby-package.