### PR TITLE
Remove ruby version from Gemfile

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '~> 3.2.0'
-
 gem 'bosh-core', path: 'bosh-core'
 gem 'bosh-director', path: 'bosh-director'
 gem 'bosh-director-core', path: 'bosh-director-core'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -404,8 +404,5 @@ DEPENDENCIES
   unix-crypt
   webmock
 
-RUBY VERSION
-   ruby 3.2.0p0
-
 BUNDLED WITH
    2.4.22


### PR DESCRIPTION
This is controlled by the vendored package from bosh-package-ruby-release and/or the .ruby-version file
