### PR TITLE
Finish removing legacy deployment helper ("ignoring cloud config when `networks` are present" feature)

### DIFF
--- a/src/bosh-director/lib/bosh/director/manifest/manifest.rb
+++ b/src/bosh-director/lib/bosh/director/manifest/manifest.rb
@@ -88,9 +88,6 @@ module Bosh::Director
 
     def self.load_manifest(manifest_hash, manifest_text, cloud_config, runtime_config, options = {})
       resolve_interpolation = options.fetch(:resolve_interpolation, true)
-      ignore_cloud_config = options.fetch(:ignore_cloud_config, false)
-
-      cloud_config = nil if ignore_cloud_config
 
       cloud_config_hash = cloud_config.raw_manifest if cloud_config
       runtime_config_hash = runtime_config.raw_manifest

--- a/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -2444,7 +2444,7 @@ module Bosh::Director
                   :manifest => YAML.dump(manifest_hash)
                 )
 
-                Models::Config.make(:cloud, raw_manifest: {'networks'=>[{'name'=>'very-cloudy-network'}]})
+                Models::Config.make(:cloud, content: YAML.dump({'networks'=>[{'name'=>'very-cloudy-network'}]}))
 
                 manifest_hash['networks'] = [{'name'=> 'network2'}]
                 diff = post '/fake-dep-name-no-cloud-conf/diff', YAML.dump(manifest_hash), {'CONTENT_TYPE' => 'text/yaml'}

--- a/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
+++ b/src/bosh-director/spec/unit/api/controllers/deployments_controller_spec.rb
@@ -2429,32 +2429,6 @@ module Bosh::Director
               expect(JSON.parse(last_response.body)['error']).to include('Unable to diff manifest')
             end
 
-            context 'when cloud config exists' do
-              let(:manifest_hash) do
-                {
-                  'instance_groups' => [],
-                  'releases' => [{ 'name' => 'simple', 'version' => 5 }],
-                  'networks' => [{ 'name' => 'non-cloudy-network' }],
-                }
-              end
-
-              it 'ignores cloud config if network section exists' do
-                Models::Deployment.create(
-                  :name => 'fake-dep-name-no-cloud-conf',
-                  :manifest => YAML.dump(manifest_hash)
-                )
-
-                Models::Config.make(:cloud, content: YAML.dump({'networks'=>[{'name'=>'very-cloudy-network'}]}))
-
-                manifest_hash['networks'] = [{'name'=> 'network2'}]
-                diff = post '/fake-dep-name-no-cloud-conf/diff', YAML.dump(manifest_hash), {'CONTENT_TYPE' => 'text/yaml'}
-
-                expect(diff).not_to match(/very-cloudy-network/)
-                expect(diff).to match(/non-cloudy-network/)
-                expect(diff).to match(/network2/)
-              end
-            end
-
             context 'existing deployment' do
               let(:deployment) do
                 Models::Deployment.make(name: 'existing-name', manifest: '{}').tap { |d| d.teams = [dev_team] }

--- a/src/bosh-director/spec/unit/manifest/manifest_spec.rb
+++ b/src/bosh-director/spec/unit/manifest/manifest_spec.rb
@@ -72,14 +72,6 @@ module Bosh::Director
         expect(result.runtime_config_hash).to eq('my_runtime' => 'foo_value')
       end
 
-      it 'ignores cloud config when ignore_cloud_config is true' do
-        result = Manifest.load_from_model(deployment_model, ignore_cloud_config: true)
-        expect(result.manifest_hash).to eq('name' => 'a_deployment', 'name-1' => 'my-name-1')
-        expect(result.manifest_text).to eq(manifest_text)
-        expect(result.cloud_config_hash).to eq(nil)
-        expect(result.runtime_config_hash).to eq('my_runtime' => 'foo_value')
-      end
-
       context 'when empty manifests exist' do
         before do
           allow(deployment_model).to receive(:manifest).and_return(nil)
@@ -87,18 +79,10 @@ module Bosh::Director
           allow(deployment_model).to receive(:cloud_configs).and_return([cloud_config])
           allow(deployment_model).to receive(:runtime_configs).and_return([])
           allow(Bosh::Director::RuntimeConfig::RuntimeConfigsConsolidator).to receive(:new).with([]).and_return(consolidated_runtime_config)
-          args = []
+
           allow(consolidated_runtime_config).to receive(:raw_manifest).and_return({})
           allow(consolidated_runtime_config).to receive(:interpolate_manifest_for_deployment).and_return({})
           allow(variables_interpolator).to receive(:interpolate_deployment_manifest).and_return({})
-        end
-
-        it 'creates a manifest object from a manifest, a cloud config, and a runtime config correctly' do
-          result =  Manifest.load_from_model(deployment_model, ignore_cloud_config: false)
-          expect(result.manifest_hash).to eq({})
-          expect(result.manifest_text).to eq('{}')
-          expect(result.cloud_config_hash).to eq(cloud_config.raw_manifest)
-          expect(result.runtime_config_hash).to eq({})
         end
       end
 
@@ -164,13 +148,6 @@ module Bosh::Director
         expect(
           Manifest.load_from_hash(manifest_hash, manifest_text, [cloud_config], runtime_configs).to_yaml,
         ).to eq(manifest_object.to_yaml)
-      end
-
-      it 'ignores cloud config when ignore_cloud_config is true' do
-        result = Manifest.load_from_hash(manifest_hash, YAML.dump(manifest_hash), [cloud_config], runtime_configs, ignore_cloud_config: true)
-        expect(result.manifest_hash).to eq({})
-        expect(result.cloud_config_hash).to eq(nil)
-        expect(result.runtime_config_hash).to eq(runtime_config_hash)
       end
 
       context 'when resolving manifest' do


### PR DESCRIPTION
The capability to "[ignore] cloud config when `networks` are present" was removed on May 21, 2019
- https://github.com/cloudfoundry/bosh/commit/1be5ead462a3257259ff4c8b67c04ae54b3f3b29