### PR TITLE
Automate bumping brats golang deps

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,15 @@
+name: go
+on: [push, pull_request]
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: src/brats/go.mod
+    - uses: golangci/golangci-lint-action@v6
+      with:
+        working-directory: src/brats/

--- a/ci/dockerfiles/integration/Dockerfile
+++ b/ci/dockerfiles/integration/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:jammy
 
 ARG BOSH_CLI_URL
 ARG META4_CLI_URL
+ARG GOLANGCI_LINT_INSTALL_URL
 ARG YQ_CLI_URL
 
 ARG RUBY_INSTALL_URL
@@ -83,6 +84,14 @@ RUN meta4_cli_path="/usr/local/bin/meta4" \
     && curl --show-error -sL "${META4_CLI_URL}" \
       > "${meta4_cli_path}" \
     && chmod +x "${meta4_cli_path}"
+
+RUN cd /tmp \
+    && golangci_lint_path="/usr/local/bin/golangci-lint" \
+    && curl --show-error -sL "${GOLANGCI_LINT_INSTALL_URL}" \
+      | tar -xzf - \
+    && mv golangci-lint-*-linux-amd64/golangci-lint "${golangci_lint_path}" \
+    && rm -rf golangci-lint-*-linux-amd64 \
+    && chmod +x "${golangci_lint_path}"
 
 RUN yq_cli_path="/usr/local/bin/yq" \
     && curl --show-error -sL "${YQ_CLI_URL}" \

--- a/ci/dockerfiles/integration/build-docker-args.sh
+++ b/ci/dockerfiles/integration/build-docker-args.sh
@@ -9,6 +9,8 @@ yq_cli_url="$(curl -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -s https://a
                 | jq -r '.assets[] | select(.name | endswith ("linux_amd64")) | .browser_download_url')"
 ruby_install_url="$(curl -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -s https://api.github.com/repos/postmodern/ruby-install/releases/latest \
                     | jq -r '.assets[] | select(.name | endswith ("tar.gz")) | .browser_download_url')"
+golangci_lint_install_url="$(curl -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -s https://api.github.com/repos/golangci/golangci-lint/releases/latest \
+                    | jq -r '.assets[] | select(.name | match("golangci-lint-[0-9]+.[0-9]+.[0-9]+-linux-amd64.tar.gz")) | .browser_download_url')"
 
 uaa_release_url="$(bosh int bosh-deployment/uaa.yml --path /release=uaa/value/url)"
 java_install_prefix="/usr/lib/jvm"
@@ -22,6 +24,7 @@ cat << JSON > docker-build-args/docker-build-args.json
 {
   "BOSH_CLI_URL": "${bosh_cli_url}",
   "META4_CLI_URL": "${meta4_cli_url}",
+  "GOLANGCI_LINT_INSTALL_URL":"${golangci_lint_install_url}",
   "YQ_CLI_URL": "${yq_cli_url}",
 
   "RUBY_INSTALL_URL": "${ruby_install_url}",

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,6 +4,7 @@ groups:
     jobs:
       - gate
       - bump-deps
+      - bump-golang-deps
       - bump-packages
       - unit-common
       - unit-core
@@ -1080,6 +1081,31 @@ jobs:
         repository: bosh-src-out
         rebase: true
 
+  - name: bump-golang-deps
+    public: true
+    plan:
+    - get: weekly
+      trigger: true
+    - get: bosh-src
+    - get: golang-release
+    - get: integration-image
+    - task: bump-deps
+      file: golang-release/ci/tasks/shared/bump-deps.yml
+      input_mapping:
+        input_repo: bosh-src
+      output_mapping:
+        output_repo: bosh-src-out
+      params:
+        SOURCE_PATH: bosh-src/src/brats/
+    - task: lint-brats
+      input_mapping:
+        bosh-src: bosh-src-out
+      file: bosh-src/ci/tasks/lint-brats.yml
+# TODO: uncomment after verifying that this task does what we expect
+#    - put: bosh-src
+#      params:
+#        repository: bosh-src-out
+
   - name: bump-packages
     serial: true
     plan:
@@ -1559,6 +1585,12 @@ resources:
     source:
       branch: main
       uri: https://github.com/cloudfoundry/bosh-package-nginx-release.git
+
+  - name: golang-release
+    type: git
+    source:
+      uri: https://github.com/cloudfoundry/bosh-package-golang-release.git
+      branch: main
 
   - name: ruby-release
     type: git

--- a/ci/tasks/lint-brats.sh
+++ b/ci/tasks/lint-brats.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+cd bosh-src/src/brats/
+
+golangci-lint run ./...

--- a/ci/tasks/lint-brats.yml
+++ b/ci/tasks/lint-brats.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    repository: bosh/integration
+
+inputs:
+- name: bosh-src
+
+run:
+  path: bosh-src/ci/tasks/lint-brats.sh

--- a/src/brats/.golangci.yml
+++ b/src/brats/.golangci.yml
@@ -1,0 +1,11 @@
+# https://golangci-lint.run/usage/configuration/
+run:
+  timeout: 3m # 1m default times out on github-action runners
+
+linters:
+  enable:
+  - goimports
+
+output:
+  # Sort results by: filepath, line and column.
+  sort-results: true


### PR DESCRIPTION
Includes:
- updates `bosh/integration` image to include `golangci-lint`
- task to run `golangci-lint` in CI (concourse)
- task to bump Golang dependencies for `src/brats/`
  - runs `lint` task to validate updates
- github action workflow to run `golangci-lint`
- fixes for `golangci-lint` errors in `src/brats/`

The `pipeline.yml` changes have not yet been validated. These should be tested and applied after the changes are merged and a new version of `bosh/integration` has been created so that `golangci-lint` is present on that image.