### PR TITLE
Replace httpclient with net/http in bosh-monitor

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -28,7 +28,6 @@ group :production do
 end
 
 group :bat do
-  gem 'httpclient'
   gem 'minitar'
   gem 'net-ssh'
 end

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -34,7 +34,6 @@ PATH
       bosh_common (~> 0.0.0)
       bosh_cpi
       cf-uaa-lib (~> 3.2.1)
-      httpclient (~> 2.8.3)
       logging
       membrane (~> 1.1.0)
       nats-pure
@@ -62,7 +61,6 @@ PATH
       async-io
       cf-uaa-lib (~> 3.2.1)
       dogapi (~> 1.45.0)
-      httpclient (~> 2.8.3)
       logging
       nats-pure
       net-smtp
@@ -380,7 +378,6 @@ DEPENDENCIES
   bundle-audit
   factory_bot
   fakefs
-  httpclient
   io-stream (<= 0.4.0)
   json (~> 2)
   minitar

--- a/src/bosh-director/bosh-director.gemspec
+++ b/src/bosh-director/bosh-director.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bcrypt',           '~>3.1.16'
   spec.add_dependency 'bosh_cpi'
   spec.add_dependency 'cf-uaa-lib',       '~>3.2.1'
-  spec.add_dependency 'httpclient',       '~>2.8.3'
   spec.add_dependency 'logging'
   spec.add_dependency 'membrane',         '~>1.1.0'
   spec.add_dependency 'nats-pure'

--- a/src/bosh-director/lib/bosh/director/config_server/retryable_http_client.rb
+++ b/src/bosh-director/lib/bosh/director/config_server/retryable_http_client.rb
@@ -1,3 +1,5 @@
+require 'net/http'
+
 module Bosh::Director::ConfigServer
   class RetryableHTTPClient
     def initialize(http_client)
@@ -25,8 +27,7 @@ module Bosh::Director::ConfigServer
           Errno::ETIMEDOUT,
           Errno::ECONNRESET,
           ::Timeout::Error,
-          ::HTTPClient::TimeoutError,
-          ::HTTPClient::KeepAliveDisconnected,
+          Net::HTTPRetriableError,
           OpenSSL::SSL::SSLError,
       ]
       Bosh::Retryable.new({sleep: 0, tries: 3, on: handled_exceptions})

--- a/src/bosh-director/lib/bosh/director/config_server/uaa_auth_provider.rb
+++ b/src/bosh-director/lib/bosh/director/config_server/uaa_auth_provider.rb
@@ -1,5 +1,5 @@
 require 'uaa'
-require 'httpclient'
+require 'net/http'
 
 module Bosh::Director::ConfigServer
   class UAAAuthProvider
@@ -55,9 +55,8 @@ module Bosh::Director::ConfigServer
           Errno::ETIMEDOUT,
           Errno::ECONNRESET,
           ::Timeout::Error,
-          ::HTTPClient::TimeoutError,
-          ::HTTPClient::KeepAliveDisconnected,
-          OpenSSL::SSL::SSLError
+          Net::HTTPRetriableError,
+          OpenSSL::SSL::SSLError,
       ]
       Bosh::Retryable.new({sleep: 0, tries: 3, on: handled_exceptions})
     end

--- a/src/bosh-director/spec/unit/config_server/auth_http_client_spec.rb
+++ b/src/bosh-director/spec/unit/config_server/auth_http_client_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'rack/test'
-require 'httpclient'
 
 describe Bosh::Director::ConfigServer::AuthHTTPClient do
   subject { Bosh::Director::ConfigServer::AuthHTTPClient.new }

--- a/src/bosh-director/spec/unit/config_server/config_server_http_client_spec.rb
+++ b/src/bosh-director/spec/unit/config_server/config_server_http_client_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'httpclient'
+
 module Bosh::Director::ConfigServer
 
   describe 'compatibility of Enabled and Disabled versions of ConfigServer HTTP Clients' do

--- a/src/bosh-director/spec/unit/config_server/retryable_http_client_spec.rb
+++ b/src/bosh-director/spec/unit/config_server/retryable_http_client_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'httpclient'
 
 describe Bosh::Director::ConfigServer::RetryableHTTPClient do
   subject { Bosh::Director::ConfigServer::RetryableHTTPClient.new(http_client) }
@@ -14,8 +13,7 @@ describe Bosh::Director::ConfigServer::RetryableHTTPClient do
       Errno::ETIMEDOUT,
       Errno::ECONNRESET,
       Timeout::Error,
-      HTTPClient::TimeoutError,
-      HTTPClient::KeepAliveDisconnected,
+      Net::HTTPRetriableError,
       OpenSSL::SSL::SSLError,
     ]
   end

--- a/src/bosh-director/spec/unit/config_server/uaa_auth_provider_spec.rb
+++ b/src/bosh-director/spec/unit/config_server/uaa_auth_provider_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'rack/test'
-require 'httpclient'
 
 describe Bosh::Director::ConfigServer::UAAAuthProvider do
   include Support::UaaHelpers
@@ -145,9 +144,8 @@ describe Bosh::Director::ConfigServer::UAAAuthProvider do
           Errno::ETIMEDOUT,
           Errno::ECONNRESET,
           Timeout::Error,
-          HTTPClient::TimeoutError,
-          HTTPClient::KeepAliveDisconnected,
-          OpenSSL::SSL::SSLError
+          Net::HTTPRetriableError,
+          OpenSSL::SSL::SSLError,
       ]
 
       retryable = double("Bosh::Retryable")

--- a/src/bosh-monitor/bosh-monitor.gemspec
+++ b/src/bosh-monitor/bosh-monitor.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dogapi',    '~> 1.45.0'
   spec.add_dependency 'riemann-client'
   spec.add_dependency 'cf-uaa-lib',  '~>3.2.1'
-  spec.add_dependency 'httpclient',  '~>2.8.3'
 
   spec.add_development_dependency 'async-rspec'
   spec.add_development_dependency 'timecop'

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/event_logger.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/event_logger.rb
@@ -80,7 +80,7 @@ module Bosh::Monitor
 
         director_info_url = @url.dup
         director_info_url.path = '/info'
-        body, status = send_http_get_request(director_info_url.to_s)
+        body, status = send_http_get_request_synchronous(director_info_url.to_s)
         return nil if status != 200
 
         @director_info = JSON.parse(body)

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/event_logger.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/event_logger.rb
@@ -78,12 +78,12 @@ module Bosh::Monitor
       def director_info
         return @director_info if @director_info
 
-        director_info_url      = @url.dup
+        director_info_url = @url.dup
         director_info_url.path = '/info'
-        response               = send_http_get_request(director_info_url.to_s)
-        return nil if response.status_code != 200
+        body, status = send_http_get_request(director_info_url.to_s)
+        return nil if status != 200
 
-        @director_info = JSON.parse(response.body)
+        @director_info = JSON.parse(body)
       end
     end
   end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/http_request_helper.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/http_request_helper.rb
@@ -14,7 +14,7 @@ module Bosh::Monitor::Plugins
       process_async_http_request(method: :post, uri: uri, headers: request.fetch(:head, {}), body: request.fetch(:body, nil), proxy: request.fetch(:proxy, nil))
     end
 
-    def send_http_get_request(uri, headers = nil)
+    def send_http_get_request_synchronous(uri, headers = nil)
       parsed_uri = URI.parse(uri.to_s)
 
       # we are interested in response, so send sync request
@@ -27,7 +27,7 @@ module Bosh::Monitor::Plugins
       [response.body, response.code.to_i]
     end
 
-    def send_http_post_sync_request(uri, request)
+    def send_http_post_request_synchronous_with_tls_verify_peer(uri, request)
       parsed_uri = URI.parse(uri.to_s)
 
       net_http = sync_client(parsed_uri, OpenSSL::SSL::VERIFY_PEER)

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/pagerduty.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/pagerduty.rb
@@ -35,7 +35,7 @@ module Bosh::Monitor
         request[:proxy] = options['http_proxy'] if options['http_proxy']
 
         Async do
-          send_http_post_sync_request(API_URI, request)
+          send_http_post_request_synchronous_with_tls_verify_peer(API_URI, request)
         rescue StandardError => e
           logger.error("Error sending pagerduty event: #{e}")
         end

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/pagerduty.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/pagerduty.rb
@@ -34,6 +34,11 @@ module Bosh::Monitor
 
         request[:proxy] = options['http_proxy'] if options['http_proxy']
 
+        # Note this appears to be the only use of `#send_http_post_request_synchronous_with_tls_verify_peer` from git
+        # history it appears that the previous asynchronous implementation (EventMachine) was not able to use
+        # TLS-proxies, so a synchronous call was made from asynchronously.
+        # This should probably be re-implemented to use the asynchronous `HttpRequestHelper#send_http_post_request`
+        # method _however_ that method should be updated to use `OpenSSL::SSL::VERIFY_PEER`.
         Async do
           send_http_post_request_synchronous_with_tls_verify_peer(API_URI, request)
         rescue StandardError => e

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/resurrector.rb
@@ -116,12 +116,12 @@ module Bosh::Monitor
           'Content-Type' => 'application/json',
         }
         url.query = URI.encode_www_form({ deployment: deployment_name, state: 'queued,processing', verbose: 2 })
-        body, status = send_http_get_request(url.to_s, headers)
+        body, status = send_http_get_request_synchronous(url.to_s, headers)
 
         # Getting the current tasks may fail. In a situation where the director is already dealing with lots of scan and fix tasks,
         # we may want to postpone adding another one to the queue to give the director time to deal with the currently scheduled tasks.
         # In the case of the tasks endpoint misbehaving ( status != 200 ) we can safely skip scheduling the the scan and fix in the current iteration.
-        # The alerts about missing healthchecks will trigger again some time later (when the director is under less pressure).
+        # The alerts about missing health-checks will trigger again some time later (when the director is under less pressure).
         return true if status != 200
 
         queued_scan_and_fix = JSON.parse(body).select do |task|
@@ -142,7 +142,7 @@ module Bosh::Monitor
 
         url = @uri.dup
         url.path = '/info'
-        body, status = send_http_get_request(url.to_s)
+        body, status = send_http_get_request_synchronous(url.to_s)
         return nil if status != 200
 
         @director_info = JSON.parse(body)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
@@ -56,7 +56,7 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
     end
   end
 
-  describe '#send_http_get_request' do
+  describe '#send_http_get_request_synchronous' do
     let(:some_uri) { URI.parse('https://send-http-get-request.example.com/some-path') }
     let(:some_uri_response) { 'hello send_http_get_request' }
 
@@ -100,7 +100,7 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
       end
 
       it 'configures the SSL Verify mode' do
-        send_http_get_request(some_uri)
+        send_http_get_request_synchronous(some_uri)
 
         expect(Net::HTTP).to have_received(:new).with(some_uri.host, some_uri.port)
         expect(http_client).to have_received(:use_ssl=).with(true)
@@ -109,7 +109,7 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
 
       context 'when URI#find_proxy is nil' do
         it 'does not set any proxy value on the client' do
-          send_http_get_request(some_uri)
+          send_http_get_request_synchronous(some_uri)
 
           expect(http_client).to_not have_received(:proxy_address=)
           expect(http_client).to_not have_received(:proxy_port=)
@@ -122,7 +122,7 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
         let(:proxy_uri) { URI.parse('https://proxy-user:proxy-pass@proxy.example.com:8080/proxy-path') }
 
         it 'sets proxy values on the client' do
-          send_http_get_request(some_uri)
+          send_http_get_request_synchronous(some_uri)
 
           expect(http_client).to have_received(:proxy_address=).with(proxy_uri.host)
           expect(http_client).to have_received(:proxy_port=).with(proxy_uri.port)
@@ -135,14 +135,14 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
     context 'making the request' do
       context 'when headers are NOT specified' do
         it 'sends a get request' do
-          body, status = send_http_get_request(some_uri)
+          body, status = send_http_get_request_synchronous(some_uri)
 
           expect(status).to eq(200)
           expect(body).to eq(some_uri_response)
         end
 
         it 'logs the request' do
-          send_http_get_request(some_uri)
+          send_http_get_request_synchronous(some_uri)
 
           expect(logger).to have_received(:debug).with("Sending GET request to #{some_uri}")
         end
@@ -157,14 +157,14 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
         end
 
         it 'sends a get request with custom headers' do
-          body, status = send_http_get_request(some_uri, custom_headers)
+          body, status = send_http_get_request_synchronous(some_uri, custom_headers)
 
           expect(status).to eq(200)
           expect(body).to eq(some_uri_response)
         end
 
         it 'logs the request' do
-          send_http_get_request(some_uri, custom_headers)
+          send_http_get_request_synchronous(some_uri, custom_headers)
 
           expect(logger).to have_received(:debug).with("Sending GET request to #{some_uri}")
         end
@@ -172,7 +172,7 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
     end
   end
 
-  describe '#send_http_post_sync_request' do
+  describe '#send_http_post_request_synchronous_with_tls_verify_peer' do
     let(:some_uri) { URI.parse('https://send-http-post-sync-request.example.com/some-path') }
     let(:some_uri_response) { 'hello send_http_post_sync_request' }
     let(:request) do
@@ -208,7 +208,7 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
       end
 
       it 'configures the SSL Verify mode' do
-        send_http_post_sync_request(some_uri, request)
+        send_http_post_request_synchronous_with_tls_verify_peer(some_uri, request)
 
         expect(Net::HTTP).to have_received(:new).with(some_uri.host, some_uri.port)
         expect(http_client).to have_received(:use_ssl=).with(true)
@@ -217,7 +217,7 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
 
       context 'when URI#find_proxy is nil' do
         it 'does not set any proxy value on the client' do
-          send_http_post_sync_request(some_uri, request)
+          send_http_post_request_synchronous_with_tls_verify_peer(some_uri, request)
 
           expect(http_client).to_not have_received(:proxy_address=)
           expect(http_client).to_not have_received(:proxy_port=)
@@ -230,7 +230,7 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
         let(:proxy_uri) { URI.parse('https://proxy-user:proxy-pass@proxy.example.com:8080/proxy-path') }
 
         it 'sets proxy values on the client' do
-          send_http_post_sync_request(some_uri, request)
+          send_http_post_request_synchronous_with_tls_verify_peer(some_uri, request)
 
           expect(http_client).to have_received(:proxy_address=).with(proxy_uri.host)
           expect(http_client).to have_received(:proxy_port=).with(proxy_uri.port)
@@ -242,7 +242,7 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
 
     context 'making the request' do
       it 'sends a get request' do
-        body, status = send_http_post_sync_request(some_uri, request)
+        body, status = send_http_post_request_synchronous_with_tls_verify_peer(some_uri, request)
 
         expect(status).to eq(200)
         expect(body).to eq(some_uri_response)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/http_request_helper_spec.rb
@@ -57,78 +57,88 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
   end
 
   describe '#send_http_get_request' do
-    let(:some_uri) { 'https://send-http-get-request.example.com/some-path' }
+    let(:some_uri) { URI.parse('https://send-http-get-request.example.com/some-path') }
     let(:some_uri_response) { 'hello send_http_get_request' }
 
+    let(:custom_headers) { {} }
+
+    before do
+      stub_request(:get, some_uri)
+        .with { |request_signature|
+          expect(request_signature.headers['Accept']).to eq('*/*')
+          expect(request_signature.headers['User-Agent']).to match(/ruby/i)
+
+          custom_headers.each do |h, v|
+            expect(request_signature.headers[h]).to eq(v)
+          end
+        }
+        .to_return(status: 200, body: some_uri_response)
+
+      allow(logger).to receive(:debug)
+    end
+
     describe 'configuring the http client' do
-      let(:ssl_config) { double(HTTPClient::SSLConfig) }
-      let(:http_client) { instance_double(HTTPClient) }
+      let(:http_client) { Net::HTTP.new(some_uri.host, some_uri.port) }
       let(:proxy_uri) { nil }
 
       before do
-        allow(HTTPClient).to receive(:new).and_return(http_client)
-        allow(http_client).to receive(:ssl_config).and_return(ssl_config)
-        allow(http_client).to receive(:proxy=)
+        allow(ENV).to receive(:[]).and_wrap_original do |method, arg|
+          if proxy_uri && arg == "#{some_uri.scheme}_proxy"
+            proxy_uri.to_s
+          else
+            method.call(arg)
+          end
+        end
 
-        parsed_uri = instance_double(URI::Generic)
-        allow(parsed_uri).to receive(:find_proxy).and_return(proxy_uri)
-        allow(URI).to receive(:parse).with(some_uri.to_s).and_return(parsed_uri)
-
-        allow(ssl_config).to receive(:verify_mode=)
-        allow(http_client).to receive(:get)
+        allow(Net::HTTP).to receive(:new).and_return(http_client)
+        allow(http_client).to receive(:use_ssl=).and_call_original
+        allow(http_client).to receive(:verify_mode=).and_call_original
+        allow(http_client).to receive(:proxy_address=)
+        allow(http_client).to receive(:proxy_port=)
+        allow(http_client).to receive(:proxy_user=)
+        allow(http_client).to receive(:proxy_pass=)
       end
 
       it 'configures the SSL Verify mode' do
         send_http_get_request(some_uri)
 
-        expect(http_client).to have_received(:get).with(some_uri)
-        expect(ssl_config).to have_received(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
+        expect(Net::HTTP).to have_received(:new).with(some_uri.host, some_uri.port)
+        expect(http_client).to have_received(:use_ssl=).with(true)
+        expect(http_client).to have_received(:verify_mode=).with(OpenSSL::SSL::VERIFY_NONE)
       end
 
-      context 'when URI#finx_proxy is nil' do
+      context 'when URI#find_proxy is nil' do
         it 'does not set any proxy value on the client' do
           send_http_get_request(some_uri)
 
-          expect(http_client).to_not have_received(:proxy=)
+          expect(http_client).to_not have_received(:proxy_address=)
+          expect(http_client).to_not have_received(:proxy_port=)
+          expect(http_client).to_not have_received(:proxy_user=)
+          expect(http_client).to_not have_received(:proxy_pass=)
         end
       end
 
-      context 'when URI#finx_proxy is NOT nil' do
-        let(:proxy_uri) { 'https://proxy-user:proxy-pass@proxy.example.com:8080/proxy-path' }
+      context 'when URI#find_proxy is NOT nil' do
+        let(:proxy_uri) { URI.parse('https://proxy-user:proxy-pass@proxy.example.com:8080/proxy-path') }
 
         it 'sets proxy values on the client' do
           send_http_get_request(some_uri)
 
-          expect(http_client).to have_received(:proxy=).with(proxy_uri)
+          expect(http_client).to have_received(:proxy_address=).with(proxy_uri.host)
+          expect(http_client).to have_received(:proxy_port=).with(proxy_uri.port)
+          expect(http_client).to have_received(:proxy_user=).with(proxy_uri.user)
+          expect(http_client).to have_received(:proxy_pass=).with(proxy_uri.password)
         end
       end
     end
 
     context 'making the request' do
-      let(:custom_headers) { {} }
-
-      before do
-        stub_request(:get, some_uri)
-          .with { |request_signature|
-            expect(request_signature.headers['Accept']).to eq('*/*')
-            expect(request_signature.headers['Date']).to match(/#{Time.now.getutc.strftime('%a, %d %b %Y')} \d\d:\d\d:\d\d GMT/)
-            expect(request_signature.headers['User-Agent']).to match(/ruby/)
-
-            custom_headers.each do |h, v|
-              expect(request_signature.headers[h]).to eq(v)
-            end
-          }
-          .to_return(status: 200, body: some_uri_response)
-
-        allow(logger).to receive(:debug)
-      end
-
       context 'when headers are NOT specified' do
         it 'sends a get request' do
-          response = send_http_get_request(some_uri)
+          body, status = send_http_get_request(some_uri)
 
-          expect(response.status_code).to eq(200)
-          expect(response.body).to eq(some_uri_response)
+          expect(status).to eq(200)
+          expect(body).to eq(some_uri_response)
         end
 
         it 'logs the request' do
@@ -147,10 +157,10 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
         end
 
         it 'sends a get request with custom headers' do
-          response = send_http_get_request(some_uri, custom_headers)
+          body, status = send_http_get_request(some_uri, custom_headers)
 
-          expect(response.status_code).to eq(200)
-          expect(response.body).to eq(some_uri_response)
+          expect(status).to eq(200)
+          expect(body).to eq(some_uri_response)
         end
 
         it 'logs the request' do
@@ -163,76 +173,79 @@ describe Bosh::Monitor::Plugins::HttpRequestHelper do
   end
 
   describe '#send_http_post_sync_request' do
-    let(:some_uri) { 'https://send-http-post-sync-request.example.com/some-path' }
+    let(:some_uri) { URI.parse('https://send-http-post-sync-request.example.com/some-path') }
     let(:some_uri_response) { 'hello send_http_post_sync_request' }
     let(:request) do
       { body: 'send_http_post_sync_request request body', proxy: nil }
     end
 
+    before do
+      stub_request(:post, some_uri)
+        .with(body: { 'send_http_post_sync_request request body' => nil })
+        .to_return(status: 200, body: some_uri_response)
+    end
+
     describe 'configuring the http client' do
-      let(:ssl_config) { double(HTTPClient::SSLConfig) }
-      let(:http_client) { instance_double(HTTPClient) }
+      let(:http_client) { Net::HTTP.new(some_uri.host, some_uri.port) }
       let(:proxy_uri) { nil }
 
       before do
-        allow(HTTPClient).to receive(:new).and_return(http_client)
-        allow(http_client).to receive(:ssl_config).and_return(ssl_config)
-        allow(http_client).to receive(:proxy=)
+        allow(ENV).to receive(:[]).and_wrap_original do |method, arg|
+          if proxy_uri && arg == "#{some_uri.scheme}_proxy"
+            proxy_uri.to_s
+          else
+            method.call(arg)
+          end
+        end
 
-        parsed_uri = instance_double(URI::Generic)
-        allow(parsed_uri).to receive(:find_proxy).and_return(proxy_uri)
-        allow(URI).to receive(:parse).with(some_uri.to_s).and_return(parsed_uri)
-
-        allow(ssl_config).to receive(:verify_mode=)
-        allow(http_client).to receive(:post)
+        allow(Net::HTTP).to receive(:new).and_return(http_client)
+        allow(http_client).to receive(:use_ssl=).and_call_original
+        allow(http_client).to receive(:verify_mode=).and_call_original
+        allow(http_client).to receive(:proxy_address=)
+        allow(http_client).to receive(:proxy_port=)
+        allow(http_client).to receive(:proxy_user=)
+        allow(http_client).to receive(:proxy_pass=)
       end
 
       it 'configures the SSL Verify mode' do
         send_http_post_sync_request(some_uri, request)
 
-        expect(http_client).to have_received(:post).with(some_uri, request[:body])
-        expect(ssl_config).to have_received(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
+        expect(Net::HTTP).to have_received(:new).with(some_uri.host, some_uri.port)
+        expect(http_client).to have_received(:use_ssl=).with(true)
+        expect(http_client).to have_received(:verify_mode=).with(OpenSSL::SSL::VERIFY_PEER)
       end
 
-      context 'when URI#finx_proxy is nil' do
+      context 'when URI#find_proxy is nil' do
         it 'does not set any proxy value on the client' do
           send_http_post_sync_request(some_uri, request)
 
-          expect(http_client).to_not have_received(:proxy=)
+          expect(http_client).to_not have_received(:proxy_address=)
+          expect(http_client).to_not have_received(:proxy_port=)
+          expect(http_client).to_not have_received(:proxy_user=)
+          expect(http_client).to_not have_received(:proxy_pass=)
         end
       end
 
-      context 'when URI#finx_proxy is nil' do
-        it 'does not set any proxy value on the client' do
-          send_http_post_sync_request(some_uri, request)
-
-          expect(http_client).to_not have_received(:proxy=)
-        end
-      end
-
-      context 'when URI#finx_proxy is NOT nil' do
-        let(:proxy_uri) { 'https://proxy-user:proxy-pass@proxy.example.com:8080/proxy-path' }
+      context 'when URI#find_proxy is NOT nil' do
+        let(:proxy_uri) { URI.parse('https://proxy-user:proxy-pass@proxy.example.com:8080/proxy-path') }
 
         it 'sets proxy values on the client' do
           send_http_post_sync_request(some_uri, request)
 
-          expect(http_client).to have_received(:proxy=).with(proxy_uri)
+          expect(http_client).to have_received(:proxy_address=).with(proxy_uri.host)
+          expect(http_client).to have_received(:proxy_port=).with(proxy_uri.port)
+          expect(http_client).to have_received(:proxy_user=).with(proxy_uri.user)
+          expect(http_client).to have_received(:proxy_pass=).with(proxy_uri.password)
         end
       end
     end
 
     context 'making the request' do
-      before do
-        stub_request(:post, some_uri)
-          .with(body: { 'send_http_post_sync_request request body' => nil })
-          .to_return(status: 200, body: some_uri_response)
-      end
-
       it 'sends a get request' do
-        response = send_http_post_sync_request(some_uri, request)
+        body, status = send_http_post_sync_request(some_uri, request)
 
-        expect(response.status_code).to eq(200)
-        expect(response.body).to eq(some_uri_response)
+        expect(status).to eq(200)
+        expect(body).to eq(some_uri_response)
       end
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/plugins/pagerduty_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/plugins/pagerduty_spec.rb
@@ -59,8 +59,8 @@ describe Bhm::Plugins::Pagerduty do
     Sync do
       @plugin.run
 
-      expect(@plugin).to receive(:send_http_post_sync_request).with(uri, alert_request)
-      expect(@plugin).to receive(:send_http_post_sync_request).with(uri, heartbeat_request)
+      expect(@plugin).to receive(:send_http_post_request_synchronous_with_tls_verify_peer).with(uri, alert_request)
+      expect(@plugin).to receive(:send_http_post_request_synchronous_with_tls_verify_peer).with(uri, heartbeat_request)
 
       @plugin.process(alert)
       @plugin.process(heartbeat)


### PR DESCRIPTION
Two methods in `Plugins::HttpRequestHelper` used the [httpclient](https://github.com/nahi/httpclient) gem to make HTTP(S) requests. This PR replaces that gem with Ruby's built-in `net/http` gem.

This change required modifying some of the callers of `HttpRequestHelper` (in bosh-director) since the response object from `net/http` differs slightly from `httpclient`'s, as well as the more mocked portions of the spec for `HttpRequestHelper` which relied on `httpclient` internals.
