### PR TITLE
Add `ostruct` as an explicit dependency

### DIFF
--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -39,6 +39,7 @@ PATH
       membrane (~> 1.1.0)
       nats-pure
       openssl
+      ostruct
       prometheus-client (~> 2.1.0)
       puma
       rack-test
@@ -66,6 +67,7 @@ PATH
       nats-pure
       net-smtp
       openssl
+      ostruct
       puma
       riemann-client
       sinatra (~> 2.2.0)
@@ -86,6 +88,7 @@ PATH
     bosh-template (0.0.0)
       activesupport
       openssl
+      ostruct
       semi_semantic (~> 1.2.0)
 
 PATH
@@ -225,6 +228,7 @@ GEM
     netrc (0.11.0)
     nio4r (2.7.3)
     openssl (3.2.0)
+    ostruct (0.6.0)
     parallel (1.26.3)
     parallel_tests (2.32.0)
       parallel

--- a/src/bosh-director/bosh-director.gemspec
+++ b/src/bosh-director/bosh-director.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'membrane',         '~>1.1.0'
   spec.add_dependency 'nats-pure'
   spec.add_dependency 'openssl'
+  spec.add_dependency 'ostruct'
   spec.add_dependency 'prometheus-client','~>2.1.0'
   spec.add_dependency 'puma'
   spec.add_dependency 'rack-test'

--- a/src/bosh-monitor/bosh-monitor.gemspec
+++ b/src/bosh-monitor/bosh-monitor.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nats-pure'
   spec.add_dependency 'net-smtp'
   spec.add_dependency 'openssl'
+  spec.add_dependency 'ostruct'
   spec.add_dependency 'puma'
   spec.add_dependency 'sinatra',   '~>2.2.0'
   spec.add_dependency 'dogapi',    '~> 1.45.0'

--- a/src/bosh-template/bosh-template.gemspec
+++ b/src/bosh-template/bosh-template.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'semi_semantic', '~>1.2.0'
   spec.add_dependency 'activesupport'
   spec.add_dependency 'openssl'
+  spec.add_dependency 'ostruct'
 end

--- a/src/vendor/cache/ostruct-0.6.0.gem
+++ b/src/vendor/cache/ostruct-0.6.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b1736c99f4d985de36bde1155be5e22aaf6e564b30ff9bd481e2ef7c2d9ba85
+size 11776


### PR DESCRIPTION
The `ostruct` gem historicially was shipped as part of Ruby. This is going to change in Ruby 3.5.0, and currently not specifiying it causues warning errors which are breaking tests.

This commit adds `ostruct` as a dependency in the bosh gems where it is used.
