### PR TITLE
Cloud properties pw use

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/steps/create_vm_step.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/steps/create_vm_step.rb
@@ -125,7 +125,10 @@ module Bosh::Director
           end
 
           password = env.fetch('bosh', {}).fetch('password', "")
-          if Config.generate_vm_passwords && password == ""
+          if !cloud_properties.dig('vcap_password').nil?
+            env['bosh'] ||= {}
+            env['bosh']['password'] = cloud_properties['vcap_password']
+          elsif Config.generate_vm_passwords && password == ""
             env['bosh'] ||= {}
             env['bosh']['password'] = sha512_hashed_password
           end

--- a/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/steps/create_vm_step_spec.rb
@@ -692,6 +692,28 @@ module Bosh
                 subject.perform(report)
               end
             end
+
+            context 'password is specified in cloud_properties' do
+              let(:custom_cloud_properties) do
+                {
+                  'ram' => '4gb',
+                  'disk' => '20gb',
+                  'vcap_password' => 'foo123'
+                }
+              end
+
+              before do
+                allow(instance).to receive(:cloud_properties).and_return(custom_cloud_properties)
+              end
+
+              it 'calls perform with custom cloud_properties' do
+                  expect(cloud_wrapper).to receive(:create_vm) do |_, _, _, _, _, env|
+                    expect(env['bosh']['password']).to eq('foo123')
+                  end.and_return(create_vm_response)
+
+                  subject.perform(report)
+              end
+            end
           end
 
           context 'Config.generate_vm_passwords flag is false' do


### PR DESCRIPTION
### What is this change about?

We saw now in several situations that we are unable to solve issues fast, if we cannot access a failed or broken vm. We need access to the VM if the agent fails to startup so we can debug. 

We want to have control over vcap password without interfering with other deployments.

### Please provide contextual information.

https://www.starkandwayne.com/blog/how-to-lock-vcap-password-for-bosh-vms/index.html

### What tests have you run against this PR?

- A Unittest in create_vm_step_spec.rb
- We uploaded the code in the local dev landscape and deployed a VM. The password defined in cloud-config was taken by the vm
- Ran all unittest in this repository 

### How should this change be described in bosh release notes?

In case of fixed vcap-password in cloud-config the corresponding password is set during deployment of VM’s.


### Does this PR introduce a breaking change?

No as long no one configure a vcap password in cloud-config. 

### Tag your pair, your PM, and/or team!
@ansh-SAP @anshrupani  @a-hassanin  @Sascha-Stoj  @cf-bosh 
