### PR TITLE
🐞 Use Rake's `sh` method to execute `TestRunner`'s command

### DIFF
--- a/src/bosh-dev/lib/bosh/dev/tasks/spec.rake
+++ b/src/bosh-dev/lib/bosh/dev/tasks/spec.rake
@@ -146,14 +146,18 @@ namespace :spec do
       desc "Run unit tests for the #{build} component"
       task build.sub(/^bosh[_-]/, '').intern do
         trap('INT') { exit }
-        runner.unit_exec(build)
+        Dir.chdir build do
+          sh("#{runner.unit_cmd(build)}")
+        end
       end
 
       namespace build.sub(/^bosh[_-]/, '').intern do
         desc "Run parallel unit tests for the #{build} component"
         task :parallel do
           trap('INT') { exit }
-          runner.unit_exec(build, parallel: true)
+          Dir.chdir build do
+            sh("#{runner.unit_parallel(build)}")
+          end
         end
       end
     end

--- a/src/bosh-dev/lib/bosh/dev/test_runner.rb
+++ b/src/bosh-dev/lib/bosh/dev/test_runner.rb
@@ -31,6 +31,30 @@ module Bosh::Dev
       end
     end
 
+    def unit_cmd(log_file = nil)
+      "".tap do |cmd|
+        cmd << 'rspec --tty --backtrace -c -f p spec'
+        cmd << " > #{log_file} 2>&1" if log_file
+      end
+    end
+
+    def unit_parallel(build_name, log_file = nil)
+      cmd = "parallel_test --test-options '--no-fail-fast' --type rspec --runtime-log /tmp/bosh_#{build_name}_parallel_runtime_rspec.log spec"
+      cmd << " > #{log_file} 2>&1" if log_file
+      cmd
+    end
+
+    def unit_builds
+      @unit_builds ||= begin
+                         builds = Dir['*'].select do |f|
+                           File.directory?(f) && File.exist?("#{f}/spec")
+                         end.sort
+                         builds -= %w(bat)
+                       end
+    end
+
+    private
+
     def unit_exec(build, log_file: nil, parallel: false)
       lines = []
       command = parallel ? unit_parallel(build, log_file) : unit_cmd(log_file)
@@ -53,28 +77,6 @@ module Bosh::Dev
 
         {:lines => lines, :error => true}
       end
-    end
-
-    def unit_cmd(log_file = nil)
-      "".tap do |cmd|
-        cmd << 'rspec --tty --backtrace -c -f p spec'
-        cmd << " > #{log_file} 2>&1" if log_file
-      end
-    end
-
-    def unit_parallel(build_name, log_file = nil)
-      cmd = "parallel_test --test-options '--no-fail-fast' --type rspec --runtime-log /tmp/bosh_#{build_name}_parallel_runtime_rspec.log spec"
-      cmd << " > #{log_file} 2>&1" if log_file
-      cmd
-    end
-
-    def unit_builds
-      @unit_builds ||= begin
-                         builds = Dir['*'].select do |f|
-                           File.directory?(f) && File.exist?("#{f}/spec")
-                         end.sort
-                         builds -= %w(bat)
-                       end
     end
   end
 end

--- a/src/bosh-dev/spec/unit/bosh/dev/test_runner_spec.rb
+++ b/src/bosh-dev/spec/unit/bosh/dev/test_runner_spec.rb
@@ -58,13 +58,13 @@ module Bosh::Dev
 
       it 'changes directory to the build and shells out to #unit_cmd' do
         expect(Kernel).to receive(:system).with({ 'BOSH_BUILD_NAME' => build }, "cd #{build} && #{runner.unit_cmd}")
-        runner.unit_exec(build)
+        runner.send(:unit_exec, build)
       end
 
       it 'signals failure if the command fails' do
         allow(Kernel).to receive(:system).and_return(false)
 
-        retval = runner.unit_exec(build)
+        retval = runner.send(:unit_exec, build)
         expect(retval[:error]).to equal(true)
       end
     end


### PR DESCRIPTION
It turns out that using `TestRunner#unit_execute` with `parallel: true` always exits cleanly when called. Instead it passes back a hash containing an `error:` key.

This change modifies the rake task to insead use Rake's built in `sh` method to execute the `parallel_test` commmand generated by `TestRunner` which allows the rake task to fail correctly when there are spec failures.

*Note*: this change exposes failures in Github Actions which were incorrectly passing:
- https://github.com/cloudfoundry/bosh/actions/runs/10857032783/job/30132767865#step:7:216
