### PR TITLE
Add `spec_helper` for release template specs

### DIFF
--- a/spec/blobstore.conf.erb_spec.rb
+++ b/spec/blobstore.conf.erb_spec.rb
@@ -1,11 +1,7 @@
-require 'rspec'
-require 'yaml'
-require 'json'
-require 'bosh/template/evaluation_context'
-require_relative './template_example_group'
+require 'spec_helper'
 
-describe 'blobstore.conf.erb' do
-  let(:spec_yaml) { YAML.load_file(File.join(File.dirname(__FILE__), '../jobs/blobstore/spec')) }
+RSpec.describe 'blobstore.conf.erb' do
+  let(:spec_yaml) { YAML.load_file(File.join(RELEASE_ROOT, 'jobs/blobstore/spec')) }
 
   context 'when nginx.enable_metrics_endpoint is not set' do
     it 'it defaults to false' do
@@ -15,7 +11,7 @@ describe 'blobstore.conf.erb' do
 
   context 'nginx.enable_metrics_endpoint is true' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/blobstore/templates/blobstore.conf.erb' }
+      let(:file_name) { 'jobs/blobstore/templates/blobstore.conf.erb' }
       let(:properties) do
         {
           'properties' => {
@@ -109,7 +105,7 @@ server {
 
   context 'allow_http is true' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/blobstore/templates/blobstore.conf.erb' }
+      let(:file_name) { 'jobs/blobstore/templates/blobstore.conf.erb' }
       let(:properties) do
         {
           'properties' => {
@@ -194,7 +190,7 @@ server {
 
   context 'allow_http is false' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/blobstore/templates/blobstore.conf.erb' }
+      let(:file_name) { 'jobs/blobstore/templates/blobstore.conf.erb' }
       let(:properties) do
         {
           'properties' => {
@@ -277,7 +273,7 @@ server {
 
   context 'ipv6_listen is true' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/blobstore/templates/blobstore.conf.erb' }
+      let(:file_name) { 'jobs/blobstore/templates/blobstore.conf.erb' }
       let(:properties) do
         {
           'properties' => {
@@ -362,7 +358,7 @@ server {
 
   context 'ipv6_listen is false' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/blobstore/templates/blobstore.conf.erb' }
+      let(:file_name) { 'jobs/blobstore/templates/blobstore.conf.erb' }
       let(:properties) do
         {
           'properties' => {
@@ -446,7 +442,7 @@ server {
   end
 
   context 'enable_signed_urls is false' do
-    let(:file_name) { '../jobs/blobstore/templates/blobstore.conf.erb' }
+    let(:file_name) { 'jobs/blobstore/templates/blobstore.conf.erb' }
     let(:properties) do
       {
         'properties' => {
@@ -469,7 +465,7 @@ server {
       }
     end
 
-    let(:template) { File.read(File.join(File.dirname(__FILE__), file_name)) }
+    let(:template) { File.read(File.join(RELEASE_ROOT, file_name)) }
 
     let(:rendered_template) do
       binding = Bosh::Template::EvaluationContext.new(properties, nil).get_binding
@@ -483,7 +479,7 @@ server {
   end
 
   context 'enable_signed_urls is true' do
-    let(:file_name) { '../jobs/blobstore/templates/blobstore.conf.erb' }
+    let(:file_name) { 'jobs/blobstore/templates/blobstore.conf.erb' }
     let(:properties) do
       {
         'properties' => {
@@ -507,7 +503,7 @@ server {
       }
     end
 
-    let(:template) { File.read(File.join(File.dirname(__FILE__), file_name)) }
+    let(:template) { File.read(File.join(RELEASE_ROOT, file_name)) }
 
     let(:rendered_template) do
       binding = Bosh::Template::EvaluationContext.new(properties, nil).get_binding
@@ -551,7 +547,7 @@ end
 describe 'server_tls_cert.pem.erb' do
   context 'should render the pem file' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/blobstore/templates/server_tls_cert.pem.erb' }
+      let(:file_name) { 'jobs/blobstore/templates/server_tls_cert.pem.erb' }
       let(:properties) do
         {
           'properties' => {
@@ -579,7 +575,7 @@ end
 describe 'server_tls_private_key.pem.erb' do
   context 'should render the pem file' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/blobstore/templates/server_tls_private_key.pem.erb' }
+      let(:file_name) { 'jobs/blobstore/templates/server_tls_private_key.pem.erb' }
       let(:properties) do
         {
           'properties' => {
@@ -607,7 +603,7 @@ end
 describe 'ngnix.conf.erb' do
   context 'should updated number of ngnix workers to user provided value' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/blobstore/templates/nginx.conf.erb' }
+      let(:file_name) { 'jobs/blobstore/templates/nginx.conf.erb' }
       let(:properties) do
         {
           'properties' => {

--- a/spec/blobstore_bbr_backup_restore_spec.rb
+++ b/spec/blobstore_bbr_backup_restore_spec.rb
@@ -1,9 +1,7 @@
-require 'rspec'
-require 'tempfile'
-require 'bosh/template/test'
+require 'spec_helper'
 
-describe 'blobstore' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '..')) }
+RSpec.describe 'blobstore' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(RELEASE_ROOT) }
   let(:job) { release.job('blobstore') }
   let(:rendered) { template.render(properties) }
   let(:tempfile) { Tempfile.new('bbr_backup') }

--- a/spec/director.yml.erb_spec.rb
+++ b/spec/director.yml.erb_spec.rb
@@ -1,11 +1,6 @@
-require 'rspec'
-require 'yaml'
-require 'json'
-require 'bosh/template/test'
-require 'bosh/template/evaluation_context'
-require_relative './template_example_group'
+require 'spec_helper'
 
-describe 'director.yml.erb' do
+RSpec.describe 'director.yml.erb' do
   let(:merged_manifest_properties) do
     {
       'agent' => {
@@ -603,7 +598,7 @@ describe 'director.yml.erb' do
 
   describe Bosh::Template::Test do
     subject(:parsed_yaml) do
-      release = Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../'))
+      release = Bosh::Template::Test::ReleaseDir.new(RELEASE_ROOT)
       job = release.job('director')
       template = job.template('config/director.yml')
       YAML.load(template.render(merged_manifest_properties))
@@ -613,7 +608,7 @@ describe 'director.yml.erb' do
   end
 
   describe Bosh::Template::EvaluationContext do
-    let(:erb_yaml) { File.read(File.join(File.dirname(__FILE__), '../jobs/director/templates/director.yml.erb')) }
+    let(:erb_yaml) { File.read(File.join(RELEASE_ROOT, 'jobs/director/templates/director.yml.erb')) }
 
     subject(:parsed_yaml) do
       binding = Bosh::Template::EvaluationContext.new(
@@ -630,7 +625,7 @@ describe 'director.yml.erb' do
   describe 'director' do
     describe 'nats_client_certificate.pem.erb' do
       it_should_behave_like 'a rendered file' do
-        let(:file_name) { '../jobs/director/templates/nats_client_certificate.pem.erb' }
+        let(:file_name) { 'jobs/director/templates/nats_client_certificate.pem.erb' }
         let(:properties) do
           {
             'properties' => {
@@ -649,7 +644,7 @@ describe 'director.yml.erb' do
 
     describe 'nats_client_private_key.erb' do
       it_should_behave_like 'a rendered file' do
-        let(:file_name) { '../jobs/director/templates/nats_client_private_key.erb' }
+        let(:file_name) { 'jobs/director/templates/nats_client_private_key.erb' }
         let(:properties) do
           {
             'properties' => {
@@ -668,7 +663,7 @@ describe 'director.yml.erb' do
 
     describe 'db_ca.pem.erb' do
       it_should_behave_like 'a rendered file' do
-        let(:file_name) { '../jobs/director/templates/db_ca.pem.erb' }
+        let(:file_name) { 'jobs/director/templates/db_ca.pem.erb' }
         let(:properties) do
           {
             'properties' => {
@@ -689,7 +684,7 @@ describe 'director.yml.erb' do
 
     context 'director.cpi.preferred_api_version' do
       subject(:parsed_yaml) do
-        release = Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../'))
+        release = Bosh::Template::Test::ReleaseDir.new(RELEASE_ROOT)
         job = release.job('director')
         template = job.template('config/director.yml')
         YAML.load(template.render(merged_manifest_properties))
@@ -752,7 +747,7 @@ describe 'director.yml.erb' do
   describe 'client ca' do
     describe 'nats_client_ca_certificate.pem.erb' do
       it_should_behave_like 'a rendered file' do
-        let(:file_name) { '../jobs/director/templates/nats_client_ca_certificate.pem.erb' }
+        let(:file_name) { 'jobs/director/templates/nats_client_ca_certificate.pem.erb' }
         let(:properties) do
           {
             'properties' => {
@@ -771,7 +766,7 @@ describe 'director.yml.erb' do
 
     describe 'nats_client_ca_private_key.erb' do
       it_should_behave_like 'a rendered file' do
-        let(:file_name) { '../jobs/director/templates/nats_client_ca_private_key.erb' }
+        let(:file_name) { 'jobs/director/templates/nats_client_ca_private_key.erb' }
         let(:properties) do
           {
             'properties' => {

--- a/spec/director_spec_spec.rb
+++ b/spec/director_spec_spec.rb
@@ -1,8 +1,7 @@
-require 'rspec'
-require 'yaml'
+require 'spec_helper'
 
-describe 'director job spec' do
-  let(:spec_yaml) { YAML.load_file(File.join(File.dirname(__FILE__), '../jobs/director/spec')) }
+RSpec.describe 'director job spec' do
+  let(:spec_yaml) { YAML.load_file(File.join(RELEASE_ROOT, 'jobs/director/spec')) }
 
   it 'defaults director.trusted_certs to empty string' do
     expect(spec_yaml['properties']['director.trusted_certs']['default']).to eq('')

--- a/spec/director_templates_spec.rb
+++ b/spec/director_templates_spec.rb
@@ -1,12 +1,7 @@
-require 'rspec'
-require 'json'
-require 'bosh/template/test'
-require 'bosh/template/evaluation_context'
-require 'openssl'
-require_relative './template_example_group'
+require 'spec_helper'
 
-describe 'director templates' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '..')) }
+RSpec.describe 'director templates' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(RELEASE_ROOT) }
   let(:job) { release.job('director') }
   let(:properties) { default_properties }
   let(:default_properties) do
@@ -40,7 +35,7 @@ describe 'director templates' do
     describe 'nats related templates' do
       describe 'nats_client_certificate.pem.erb' do
         it_should_behave_like 'a rendered file' do
-          let(:file_name) { '../jobs/director/templates/nats_client_certificate.pem.erb' }
+          let(:file_name) { 'jobs/director/templates/nats_client_certificate.pem.erb' }
           let(:properties) do
             {
               'properties' => {
@@ -59,7 +54,7 @@ describe 'director templates' do
 
       describe 'nats_client_private_key.erb' do
         it_should_behave_like 'a rendered file' do
-          let(:file_name) { '../jobs/director/templates/nats_client_private_key.erb' }
+          let(:file_name) { 'jobs/director/templates/nats_client_private_key.erb' }
           let(:properties) do
             {
               'properties' => {
@@ -78,7 +73,7 @@ describe 'director templates' do
 
       describe 'nats_client_ca_certificate.pem.erb' do
         it_should_behave_like 'a rendered file' do
-          let(:file_name) { '../jobs/director/templates/nats_client_ca_certificate.pem.erb' }
+          let(:file_name) { 'jobs/director/templates/nats_client_ca_certificate.pem.erb' }
           let(:properties) do
             {
               'properties' => {
@@ -97,7 +92,7 @@ describe 'director templates' do
 
       describe 'nats_client_ca_private_key.erb' do
         it_should_behave_like 'a rendered file' do
-          let(:file_name) { '../jobs/director/templates/nats_client_ca_private_key.erb' }
+          let(:file_name) { 'jobs/director/templates/nats_client_ca_private_key.erb' }
           let(:properties) do
             {
               'properties' => {
@@ -118,7 +113,7 @@ describe 'director templates' do
     describe 'database related templates' do
       describe 'db_ca.pem.erb' do
         it_should_behave_like 'a rendered file' do
-          let(:file_name) { '../jobs/director/templates/db_ca.pem.erb' }
+          let(:file_name) { 'jobs/director/templates/db_ca.pem.erb' }
           let(:properties) do
             {
               'properties' => {
@@ -138,7 +133,7 @@ describe 'director templates' do
 
         context 'when cert property is not provided' do
           it_should_behave_like 'a rendered file' do
-            let(:file_name) { '../jobs/director/templates/db_ca.pem.erb' }
+            let(:file_name) { 'jobs/director/templates/db_ca.pem.erb' }
             let(:expected_content) { "\n" }
             let(:properties) do
               {
@@ -159,7 +154,7 @@ describe 'director templates' do
 
       describe 'db_client_certificate.pem.erb' do
         it_should_behave_like 'a rendered file' do
-          let(:file_name) { '../jobs/director/templates/db_client_certificate.pem.erb' }
+          let(:file_name) { 'jobs/director/templates/db_client_certificate.pem.erb' }
           let(:properties) do
             {
               'properties' => {
@@ -179,7 +174,7 @@ describe 'director templates' do
 
         context 'when certificate property is not provided' do
           it_should_behave_like 'a rendered file' do
-            let(:file_name) { '../jobs/director/templates/db_client_certificate.pem.erb' }
+            let(:file_name) { 'jobs/director/templates/db_client_certificate.pem.erb' }
             let(:expected_content) { "\n" }
             let(:properties) do
               {
@@ -200,7 +195,7 @@ describe 'director templates' do
 
       describe 'db_client_private_key.pem.erb' do
         it_should_behave_like 'a rendered file' do
-          let(:file_name) { '../jobs/director/templates/db_client_private_key.key.erb' }
+          let(:file_name) { 'jobs/director/templates/db_client_private_key.key.erb' }
           let(:properties) do
             {
               'properties' => {
@@ -220,7 +215,7 @@ describe 'director templates' do
 
         context 'when private_key property is not provided' do
           it_should_behave_like 'a rendered file' do
-            let(:file_name) { '../jobs/director/templates/db_client_private_key.key.erb' }
+            let(:file_name) { 'jobs/director/templates/db_client_private_key.key.erb' }
             let(:expected_content) { "\n" }
             let(:properties) do
               {
@@ -381,7 +376,7 @@ describe 'director templates' do
       end
 
       it_should_behave_like 'a rendered file' do
-        let(:file_name) { '../jobs/director/templates/certificate_expiry.json.erb' }
+        let(:file_name) { 'jobs/director/templates/certificate_expiry.json.erb' }
         let(:properties) do
           {
             'properties' => {

--- a/spec/health_monitor_templates_spec.rb
+++ b/spec/health_monitor_templates_spec.rb
@@ -1,10 +1,6 @@
-require 'rspec'
-require 'yaml'
-require 'bosh/template/evaluation_context'
-require 'json'
-require_relative './template_example_group'
+require 'spec_helper'
 
-describe 'health_monitor.yml.erb' do
+RSpec.describe 'health_monitor.yml.erb' do
   let(:deployment_manifest_fragment) do
     {
       'properties' => {
@@ -52,7 +48,7 @@ describe 'health_monitor.yml.erb' do
     }
   end
 
-  let(:erb_yaml) { File.read(File.join(File.dirname(__FILE__), '../jobs/health_monitor/templates/health_monitor.yml.erb')) }
+  let(:erb_yaml) { File.read(File.join(RELEASE_ROOT, 'jobs/health_monitor/templates/health_monitor.yml.erb')) }
 
   subject(:parsed_yaml) do
     binding = Bosh::Template::EvaluationContext.new(deployment_manifest_fragment, nil).get_binding
@@ -321,7 +317,7 @@ end
 describe 'tls' do
   describe 'nats_server_ca.pem.erb' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/health_monitor/templates/nats_server_ca.pem.erb' }
+      let(:file_name) { 'jobs/health_monitor/templates/nats_server_ca.pem.erb' }
       let(:properties) do
         {
           'properties' => {
@@ -338,7 +334,7 @@ describe 'tls' do
 
   describe 'nats_client_certificate.pem.erb' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/health_monitor/templates/nats_client_certificate.pem.erb' }
+      let(:file_name) { 'jobs/health_monitor/templates/nats_client_certificate.pem.erb' }
       let(:properties) do
         {
           'properties' => {
@@ -357,7 +353,7 @@ describe 'tls' do
 
   describe 'nats_client_private_key.erb' do
     it_should_behave_like 'a rendered file' do
-      let(:file_name) { '../jobs/health_monitor/templates/nats_client_private_key.erb' }
+      let(:file_name) { 'jobs/health_monitor/templates/nats_client_private_key.erb' }
       let(:properties) do
         {
           'properties' => {

--- a/spec/nats_templates_spec.rb
+++ b/spec/nats_templates_spec.rb
@@ -1,14 +1,8 @@
-# frozen_string_literal: true
+require 'spec_helper'
 
-require 'rspec'
-require 'yaml'
-require 'json'
-require 'bosh/template/evaluation_context'
-require_relative './template_example_group'
-
-describe 'bosh_nats_sync_config.yml.erb' do
+RSpec.describe 'bosh_nats_sync_config.yml.erb' do
   it_should_behave_like 'a rendered file' do
-    let(:file_name) { '../jobs/nats/templates/bosh_nats_sync_config.yml.erb' }
+    let(:file_name) { 'jobs/nats/templates/bosh_nats_sync_config.yml.erb' }
     let(:properties) do
       {
         'properties' => {
@@ -60,7 +54,7 @@ end
 
 describe 'nats.cfg.erb' do
   it_should_behave_like 'a rendered file' do
-    let(:file_name) { '../jobs/nats/templates/nats.cfg.erb' }
+    let(:file_name) { 'jobs/nats/templates/nats.cfg.erb' }
     let(:properties) do
       {
         'properties' => {
@@ -134,7 +128,7 @@ end
 
 describe 'nats_client_ca.pem.erb' do
   it_should_behave_like 'a rendered file' do
-    let(:file_name) { '../jobs/nats/templates/nats_client_ca.pem.erb' }
+    let(:file_name) { 'jobs/nats/templates/nats_client_ca.pem.erb' }
     let(:properties) do
       {
         'properties' => {
@@ -151,7 +145,7 @@ end
 
 describe 'nats_director_client_certificate.pem.erb' do
   it_should_behave_like 'a rendered file' do
-    let(:file_name) { '../jobs/nats/templates/nats_director_client_certificate.pem.erb' }
+    let(:file_name) { 'jobs/nats/templates/nats_director_client_certificate.pem.erb' }
     let(:properties) do
       {
         'properties' => {
@@ -170,7 +164,7 @@ end
 
 describe 'nats_hm_client_certificate.pem.erb' do
   it_should_behave_like 'a rendered file' do
-    let(:file_name) { '../jobs/nats/templates/nats_hm_client_certificate.pem.erb' }
+    let(:file_name) { 'jobs/nats/templates/nats_hm_client_certificate.pem.erb' }
     let(:properties) do
       {
         'properties' => {
@@ -189,7 +183,7 @@ end
 
 describe 'nats_server_certificate.pem.erb' do
   it_should_behave_like 'a rendered file' do
-    let(:file_name) { '../jobs/nats/templates/nats_server_certificate.pem.erb' }
+    let(:file_name) { 'jobs/nats/templates/nats_server_certificate.pem.erb' }
     let(:properties) do
       {
         'properties' => {
@@ -208,7 +202,7 @@ end
 
 describe 'nats_server_private_key.erb' do
   it_should_behave_like 'a rendered file' do
-    let(:file_name) { '../jobs/nats/templates/nats_server_private_key.erb' }
+    let(:file_name) { 'jobs/nats/templates/nats_server_private_key.erb' }
     let(:properties) do
       {
         'properties' => {

--- a/spec/postgres_bpm_spec.rb
+++ b/spec/postgres_bpm_spec.rb
@@ -1,9 +1,7 @@
-require 'yaml'
-require 'bosh/template/evaluation_context'
-require_relative './template_example_group'
+require 'spec_helper'
 
-shared_examples 'rendered postgres* bpm.yml' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '..')) }
+RSpec.shared_examples 'rendered postgres* bpm.yml' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(RELEASE_ROOT) }
   let(:template) { job.template('config/bpm.yml') }
 
   subject(:rendered_template) do
@@ -30,14 +28,16 @@ shared_examples 'rendered postgres* bpm.yml' do
   end
 end
 
-describe 'postgres job' do
-  it_should_behave_like 'rendered postgres* bpm.yml' do
-    let(:job) { release.job('postgres') }
+RSpec.describe 'postgres job rendering' do
+  describe 'postgres job' do
+    it_should_behave_like 'rendered postgres* bpm.yml' do
+      let(:job) { release.job('postgres') }
+    end
   end
-end
 
-describe 'postgres-10 job' do
-  it_should_behave_like 'rendered postgres* bpm.yml' do
-    let(:job) { release.job('postgres-10') }
+  describe 'postgres-10 job' do
+    it_should_behave_like 'rendered postgres* bpm.yml' do
+      let(:job) { release.job('postgres-10') }
+    end
   end
 end

--- a/spec/read_write_users.erb_spec.rb
+++ b/spec/read_write_users.erb_spec.rb
@@ -1,8 +1,7 @@
-require 'bosh/template/evaluation_context'
-require_relative './template_example_group'
+require 'spec_helper'
 
-shared_examples 'rendered *_users.erb' do
-  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '..')) }
+RSpec.shared_examples 'rendered *_users.erb' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(RELEASE_ROOT) }
   let(:job) { release.job('blobstore') }
   let(:template) { job.template(rendered_erb_file_name) }
 
@@ -107,14 +106,16 @@ shared_examples 'rendered *_users.erb' do
   end
 end
 
-describe 'read_users.erb' do
-  it_should_behave_like 'rendered *_users.erb' do
-    let(:rendered_erb_file_name) { 'config/read_users' }
+RSpec.describe 'rendering users templates' do
+  describe 'read_users.erb' do
+    it_should_behave_like 'rendered *_users.erb' do
+      let(:rendered_erb_file_name) { 'config/read_users' }
+    end
   end
-end
 
-describe 'write_users.erb' do
-  it_should_behave_like 'rendered *_users.erb' do
-    let(:rendered_erb_file_name) { 'config/write_users' }
+  describe 'write_users.erb' do
+    it_should_behave_like 'rendered *_users.erb' do
+      let(:rendered_erb_file_name) { 'config/write_users' }
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,23 @@
+SPEC_ROOT = File.dirname(__FILE__)
+RELEASE_ROOT = File.expand_path(File.join(SPEC_ROOT, '..'))
+
+require File.expand_path('../src/spec/shared/spec_helper', SPEC_ROOT)
+
+require 'json'
+require 'openssl'
+require 'tempfile'
+require 'yaml'
+
+require 'bosh/template/evaluation_context'
+
+require 'bosh/template/test'
+
+require_relative './support/template_example_group'
+
+def spec_asset(name)
+  File.join(SPEC_ROOT, 'support', name)
+end
+
+def template_file(template_name)
+  File.expand_path(File.join(RELEASE_ROOT, template_name))
+end

--- a/spec/support/ps_utils_tests.sh
+++ b/spec/support/ps_utils_tests.sh
@@ -2,7 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-source $DIR/../jobs/director/templates/ps_utils.sh
+source "${DIR}/../../jobs/director/templates/ps_utils.sh"
 
 function test_pid_exists {
   echo "an existing PID should exist"

--- a/spec/support/template_example_group.rb
+++ b/spec/support/template_example_group.rb
@@ -1,4 +1,4 @@
-shared_examples_for "a rendered file" do
+RSpec.shared_examples_for 'a rendered file' do
   let(:content) { 'file content' }
   let(:expected_content) { "file content\n" }
   let(:file_name) do
@@ -9,7 +9,7 @@ shared_examples_for "a rendered file" do
     raise 'Override this for binding properties'
   end
 
-  let(:template) { File.read(File.join(File.dirname(__FILE__), file_name)) }
+  let(:template) { File.read(template_file(file_name)) }
 
   subject(:rendered_template) do
     binding = Bosh::Template::EvaluationContext.new(properties, nil).get_binding

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,9 +1,8 @@
-require 'rspec'
+require 'spec_helper'
 
-describe 'ps_utils' do
-
+RSpec.describe 'ps_utils' do
   it 'checks bash utils' do
-    expect(`#{File.dirname(__FILE__)}/ps_utils_tests.sh`).to eq(
+    expect(`#{spec_asset('ps_utils_tests.sh')}`).to eq(
         'an existing PID should exist
 a non-existing PID should NOT exist
 two kills should be sent to process 1

--- a/src/bosh-dev/lib/bosh/dev/tasks/spec.rake
+++ b/src/bosh-dev/lib/bosh/dev/tasks/spec.rake
@@ -144,6 +144,15 @@ namespace :spec do
       end
     end
 
+    namespace :release do
+      task :parallel do
+        puts 'Run unit tests for the release (ERB templates)'
+        Dir.chdir '..' do
+          sh(runner.unit_parallel('release'))
+        end
+      end
+    end
+
     runner.unit_builds.each do |component_subdir|
       component_symbol = component_subdir.sub(/^bosh[_-]/, '').to_sym
 
@@ -175,7 +184,7 @@ namespace :spec do
     end
 
     desc 'Run all unit tests in parallel'
-    task parallel: %w[spec:unit:release spec:unit:ruby_parallel spec:template_test_unit]
+    task parallel: %w[spec:unit:release:parallel spec:unit:ruby_parallel spec:template_test_unit]
   end
 
   desc 'Run all unit tests'

--- a/src/spec/shared/spec_helper.rb
+++ b/src/spec/shared/spec_helper.rb
@@ -22,15 +22,12 @@ require 'rspec/its'
 # Useful to see that tests are using expected version of Ruby in CI
 puts "Using #{RUBY_DESCRIPTION}"
 
-Dir.glob(File.expand_path('support/**/*.rb', __dir__)).each { |f| require(f) }
-
 RSpec.configure do |config|
-  # config.deprecation_stream = StringIO.new
-
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
     mocks.verify_doubled_constant_names = true
   end
 end
 
+Dir.glob(File.expand_path('support/**/*.rb', __dir__)).each { |f| require(f) }
 # It must stay minimal!


### PR DESCRIPTION
This allows the specs to be run using `parallel_test` and reduces some duplication in the specs themselves.

Adds a `spec:unit:release:parallel` task and calls this when running `spec:unit:parallel`
