### PR TITLE
Add swift options to s3 blobstore options

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -420,6 +420,10 @@ properties:
     description: container_name of azure storage account
   blobstore.account_key:
     description: account_key of azure storage account
+  blobstore.swift_auth_account:
+    description: swift_auth_account of swift storage account
+  blobstore.swift_temp_url_key:
+    description: swift_temp_url_key of swift storage account
 
   director.ignore_missing_gateway:
     description: Allow gateway to be omitted from subnet configuration. Boshlite vms(containers) do not require gateway.

--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -230,6 +230,14 @@ if p('blobstore.provider') == 's3'
   if_p('blobstore.sse_kms_key_id') do |sse_kms_key_id|
      blobstore_options['sse_kms_key_id'] = sse_kms_key_id
   end
+
+  if_p('blobstore.swift_auth_account') do |swift_auth_account|
+     blobstore_options['swift_auth_account'] = swift_auth_account
+  end
+
+  if_p('blobstore.swift_temp_url_key') do |swift_temp_url_key|
+     blobstore_options['swift_temp_url_key'] = swift_temp_url_key
+  end
 elsif p('blobstore.provider') == 'gcs'
     blobstore_options = {
     'bucket_name' => p('blobstore.bucket_name'),

--- a/src/bosh-director/lib/bosh/blobstore_client/s3cli_blobstore_client.rb
+++ b/src/bosh-director/lib/bosh/blobstore_client/s3cli_blobstore_client.rb
@@ -42,6 +42,8 @@ module Bosh::Blobstore
         server_side_encryption: @options[:server_side_encryption],
         sse_kms_key_id: @options[:sse_kms_key_id],
         assume_role_arn: @options[:assume_role_arn],
+        swift_auth_account: @options[:swift_auth_account],
+        swift_temp_url_key: @options[:swift_temp_url_key],
       }
 
       @s3cli_options.reject! { |_k, v| v.nil? }

--- a/src/bosh-director/spec/unit/blobstore_client/s3cli_blobstore_client_spec.rb
+++ b/src/bosh-director/spec/unit/blobstore_client/s3cli_blobstore_client_spec.rb
@@ -109,6 +109,30 @@ module Bosh::Blobstore
           expect(File.exist?(File.join(s3cli_config_path, 'blobstore-config'))).to eq(true)
         end
       end
+
+      context 'when swift_auth_account is provided' do
+        it 'adds it to the config file' do
+          described_class.new(options.merge(
+            {
+              swift_auth_account: 'the_swift_auth_account',
+            })
+          )
+
+          expect(JSON.parse(stored_config_file[0])['swift_auth_account']).to eq('the_swift_auth_account')
+        end
+      end
+
+      context 'when swift_auth_account is provided' do
+        it 'adds it to the config file' do
+          described_class.new(options.merge(
+            {
+              swift_temp_url_key: 'the_swift_temp_url_key',
+            })
+          )
+
+          expect(JSON.parse(stored_config_file[0])['swift_temp_url_key']).to eq('the_swift_temp_url_key')
+        end
+      end
     end
 
     describe '#delete' do


### PR DESCRIPTION
### What is this change about?

A while ago we added signed url support for swift blobstore to the S3cli.
With that we introduced two new parameters `swift_auth_account` and `swift_temp_url_key ` into the S3cli.
With this PR the director now forwards the parameters to the S3cli if they are set in the deployment manifest.

### Please provide contextual information.

- https://github.com/cloudfoundry/bosh-s3cli/pull/37
- https://github.com/cloudfoundry/bosh-s3cli/pull/38
- https://github.com/cloudfoundry/bosh-s3cli/pull/39

### What tests have you run against this PR?

we tested the integration with s3cli and ran the required unit tests

### How should this change be described in bosh release notes?

Add support of signed for s3 compatible swift blobstores

### Does this PR introduce a breaking change?

 nope

### Tag your pair, your PM, and/or team!
@anshrupani, @a-hassanin 
