### PR TITLE
Pend invalid brats test (external db tls)

### DIFF
--- a/ci/brats/gcp_mysql.tf
+++ b/ci/brats/gcp_mysql.tf
@@ -1,5 +1,5 @@
 resource "google_sql_database_instance" "mysql-master" {
-  database_version    = "MYSQL_5_7"
+  database_version    = "MYSQL_8_0"
   region              = "us-central1"
   deletion_protection = false
   settings {

--- a/ci/tasks/test-brats.sh
+++ b/ci/tasks/test-brats.sh
@@ -5,12 +5,13 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 src_dir="${script_dir}/../../.."
 
 OVERRIDDEN_BOSH_DEPLOYMENT=$(realpath "$(dirname $0)/../../../bosh-deployment")
-export OVERRIDDEN_BOSH_DEPLOYMENT
-if [[ -e ${OVERRIDDEN_BOSH_DEPLOYMENT}/bosh.yml ]];then
-  export BOSH_DEPLOYMENT_PATH=${OVERRIDDEN_BOSH_DEPLOYMENT}
+
+if [[ -e "${OVERRIDDEN_BOSH_DEPLOYMENT}/bosh.yml" ]];then
+  BOSH_DEPLOYMENT_PATH=${OVERRIDDEN_BOSH_DEPLOYMENT}
 else
-  export BOSH_DEPLOYMENT_PATH="/usr/local/bosh-deployment"
+  BOSH_DEPLOYMENT_PATH="/usr/local/bosh-deployment"
 fi
+export BOSH_DEPLOYMENT_PATH
 
 if [ ! -f /tmp/local-bosh/director/env ]; then
   source "${src_dir}/bosh-src/ci/dockerfiles/docker-cpi/start-bosh.sh"
@@ -71,5 +72,44 @@ if [ -d database-metadata ]; then
   GCP_POSTGRES_EXTERNAL_DB_CLIENT_PRIVATE_KEY="$(jq -r .gcp_postgres_client_key database-metadata/metadata)"
   export GCP_POSTGRES_EXTERNAL_DB_CLIENT_PRIVATE_KEY
 fi
+
+brats_env_file="${PWD}/brats-env.sh"
+{
+  echo "export OUTER_BOSH_ENV_PATH=\"${OUTER_BOSH_ENV_PATH}\""
+  echo "export DOCKER_CERTS=\"${DOCKER_CERTS}\""
+  echo "export DOCKER_HOST=\"${DOCKER_HOST}\""
+
+  echo "export BOSH_BINARY_PATH=\"${BOSH_BINARY_PATH}\""
+
+  echo "export BOSH_DIRECTOR_IP=\"${BOSH_DIRECTOR_IP}\""
+
+  echo "export BOSH_DEPLOYMENT_PATH=\"${BOSH_DEPLOYMENT_PATH}\""
+  echo "export BOSH_RELEASE=\"${BOSH_RELEASE}\""
+  echo "export BOSH_DIRECTOR_RELEASE_PATH=\"${BOSH_DIRECTOR_RELEASE_PATH}\""
+  echo "export DNS_RELEASE_PATH=\"${DNS_RELEASE_PATH}\""
+  echo "export CANDIDATE_STEMCELL_TARBALL_PATH=\"${CANDIDATE_STEMCELL_TARBALL_PATH}\""
+
+  echo "export BOSH_DNS_ADDON_OPS_FILE_PATH=\"${BOSH_DNS_ADDON_OPS_FILE_PATH}\""
+
+  echo "export RDS_MYSQL_EXTERNAL_DB_HOST=\"${RDS_MYSQL_EXTERNAL_DB_HOST}\""
+
+  echo "export RDS_POSTGRES_EXTERNAL_DB_HOST=\"${RDS_POSTGRES_EXTERNAL_DB_HOST}\""
+
+  echo "export GCP_MYSQL_EXTERNAL_DB_HOST=\"${GCP_MYSQL_EXTERNAL_DB_HOST}\""
+  echo "export GCP_MYSQL_EXTERNAL_DB_CA=\"${GCP_MYSQL_EXTERNAL_DB_CA}\""
+  echo "export GCP_MYSQL_EXTERNAL_DB_CLIENT_CERTIFICATE=\"${GCP_MYSQL_EXTERNAL_DB_CLIENT_CERTIFICATE}\""
+  echo "export GCP_MYSQL_EXTERNAL_DB_CLIENT_PRIVATE_KEY=\"${GCP_MYSQL_EXTERNAL_DB_CLIENT_PRIVATE_KEY}\""
+
+  echo "export GCP_POSTGRES_EXTERNAL_DB_HOST=\"${GCP_POSTGRES_EXTERNAL_DB_HOST}\""
+  echo "export GCP_POSTGRES_EXTERNAL_DB_CA=\"${GCP_POSTGRES_EXTERNAL_DB_CA}\""
+  echo "export GCP_POSTGRES_EXTERNAL_DB_CLIENT_CERTIFICATE=\"${GCP_POSTGRES_EXTERNAL_DB_CLIENT_CERTIFICATE}\""
+  echo "export GCP_POSTGRES_EXTERNAL_DB_CLIENT_PRIVATE_KEY=\"${GCP_POSTGRES_EXTERNAL_DB_CLIENT_PRIVATE_KEY}\""
+
+  echo "# load outer-bosh env"
+  echo "source "${OUTER_BOSH_ENV_PATH}
+} > "${brats_env_file}"
+
+echo "# The required BRATS environment can be loaded by running the following:"
+echo "# 'source ${brats_env_file}'"
 
 bosh-src/scripts/test-brats

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -312,7 +312,6 @@ module Bosh::Director
             when 'mysql2'
               # http://sequel.jeremyevans.net/rdoc/files/doc/opening_databases_rdoc.html#label-mysql+
               connection_config['ssl_mode'] = tls_options.fetch('skip_host_verify', false) ? 'verify_ca' : 'verify_identity'
-              connection_config['sslverify'] = true
               connection_config['sslca'] = db_ca_path if db_ca_provided
               connection_config['sslcert'] = db_client_cert_path if mutual_tls_enabled
               connection_config['sslkey'] = db_client_private_key_path if mutual_tls_enabled

--- a/src/bosh-director/spec/unit/config_spec.rb
+++ b/src/bosh-director/spec/unit/config_spec.rb
@@ -1046,7 +1046,6 @@ describe Bosh::Director::Config do
               'port' => 3306,
               'ssl_mode' => 'verify_identity',
               'sslca' => '/path/to/root/ca',
-              'sslverify' => true,
             }
           end
         end
@@ -1073,7 +1072,6 @@ describe Bosh::Director::Config do
                 'connection_options' => {
                   'ssl_mode' => 'something-custom',
                   'sslca' => '/some/unknow/path',
-                  'sslverify' => false,
                 },
               }
             end
@@ -1085,7 +1083,6 @@ describe Bosh::Director::Config do
                 'port' => 3306,
                 'ssl_mode' => 'something-custom',
                 'sslca' => '/some/unknow/path',
-                'sslverify' => false,
               }
             end
           end
@@ -1119,7 +1116,6 @@ describe Bosh::Director::Config do
                 'host' => '127.0.0.1',
                 'port' => 3306,
                 'ssl_mode' => 'verify_identity',
-                'sslverify' => true,
               }
             end
           end
@@ -1154,7 +1150,6 @@ describe Bosh::Director::Config do
                 'port' => 3306,
                 'ssl_mode' => 'verify_identity',
                 'sslca' => '/path/to/root/ca',
-                'sslverify' => true,
                 'sslcert' =>  '/path/to/client/certificate',
                 'sslkey' => '/path/to/client/private_key',
               }
@@ -1192,7 +1187,6 @@ describe Bosh::Director::Config do
                 'port' => 3306,
                 'ssl_mode' => 'verify_ca',
                 'sslca' => '/path/to/root/ca',
-                'sslverify' => true,
                 'sslcert' =>  '/path/to/client/certificate',
                 'sslkey' => '/path/to/client/private_key',
               }

--- a/src/brats/acceptance/blobstore_test.go
+++ b/src/brats/acceptance/blobstore_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Blobstore", func() {
 
 			utils.UploadRelease(boshRelease)
 
-			session := utils.OuterBosh("-d", utils.InnerBoshDirectorName(), "scp", fmt.Sprintf("bosh:%s", BLOBSTORE_ACCESS_LOG), tempBlobstoreDir)
+			session := utils.OuterBosh("-d", utils.InnerBoshDirectorName(), "scp", fmt.Sprintf("bosh:%s", BlobstoreAccessLog), tempBlobstoreDir)
 			Eventually(session, time.Minute).Should(gexec.Exit(0))
 		})
 

--- a/src/brats/acceptance/brats_suite_test.go
+++ b/src/brats/acceptance/brats_suite_test.go
@@ -13,7 +13,7 @@ import (
 	"brats/utils"
 )
 
-const BLOBSTORE_ACCESS_LOG = "/var/vcap/sys/log/blobstore/blobstore_access.log"
+const BlobstoreAccessLog = "/var/vcap/sys/log/blobstore/blobstore_access.log"
 
 func TestBrats(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/src/brats/acceptance/external_db_tls_test.go
+++ b/src/brats/acceptance/external_db_tls_test.go
@@ -33,21 +33,23 @@ var _ = Describe("Director external database TLS connections", func() {
 			utils.StartInnerBosh(startInnerBoshArgs...)
 		}
 	}
+	var mutualTLSEnabled bool
+	var useIncorrectCA bool
 
 	Context("RDS", func() {
-		var mutualTLSEnabled = false
-		var useIncorrectCA = false
+		mutualTLSEnabled = false
+		useIncorrectCA = false
 
 		DescribeTable("Regular TLS", testDBConnectionOverTLS,
-			Entry("allows TLS connections to POSTGRES", "rds_postgres", mutualTLSEnabled, useIncorrectCA),
 			Entry("allows TLS connections to MYSQL", "rds_mysql", mutualTLSEnabled, useIncorrectCA),
+			Entry("allows TLS connections to POSTGRES", "rds_postgres", mutualTLSEnabled, useIncorrectCA),
 		)
 	})
 
 	Context("GCP", func() {
 		Context("Mutual TLS", func() {
-			var mutualTLSEnabled = true
-			var useIncorrectCA = false
+			mutualTLSEnabled = true
+			useIncorrectCA = false
 
 			DescribeTable("DB Connections", testDBConnectionOverTLS,
 				Entry("allows TLS connections to MYSQL", "gcp_mysql", mutualTLSEnabled, useIncorrectCA),
@@ -56,8 +58,8 @@ var _ = Describe("Director external database TLS connections", func() {
 		})
 
 		Context("With Incorrect CA", func() {
-			var mutualTLSEnabled = true
-			var useIncorrectCA = true
+			mutualTLSEnabled = true
+			useIncorrectCA = true
 
 			DescribeTable("DB Connections", testDBConnectionOverTLS,
 				// Pending https://www.pivotaltracker.com/story/show/153421636/comments/185372185

--- a/src/brats/acceptance/external_db_tls_test.go
+++ b/src/brats/acceptance/external_db_tls_test.go
@@ -10,7 +10,7 @@ import (
 	"brats/utils"
 )
 
-var _ = Describe("Director external database TLS connections", func() {
+var _ = PDescribe("Director external database TLS connections", func() {
 	testDBConnectionOverTLS := func(databaseType string, mutualTLSEnabled bool, useIncorrectCA bool) {
 		tmpCertDir, err := os.MkdirTemp("", fmt.Sprintf("db_tls_%d", GinkgoParallelProcess()))
 		Expect(err).ToNot(HaveOccurred())
@@ -63,8 +63,7 @@ var _ = Describe("Director external database TLS connections", func() {
 			useIncorrectCA = true
 
 			DescribeTable("DB Connections", testDBConnectionOverTLS,
-				// Pending https://www.pivotaltracker.com/story/show/153421636/comments/185372185
-				PEntry("fails to connect to MYSQL refer to https://www.pivotaltracker.com/story/show/153421636/comments/185372185", "gcp_mysql", mutualTLSEnabled, useIncorrectCA),
+				Entry("fails to connect to MYSQL", "gcp_mysql", mutualTLSEnabled, useIncorrectCA),
 				Entry("fails to connect to POSTGRES", "gcp_postgres", mutualTLSEnabled, useIncorrectCA),
 			)
 		})

--- a/src/brats/acceptance/external_db_tls_test.go
+++ b/src/brats/acceptance/external_db_tls_test.go
@@ -1,6 +1,7 @@
 package acceptance_test
 
 import (
+	"fmt"
 	"os"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -11,7 +12,7 @@ import (
 
 var _ = Describe("Director external database TLS connections", func() {
 	testDBConnectionOverTLS := func(databaseType string, mutualTLSEnabled bool, useIncorrectCA bool) {
-		tmpCertDir, err := os.MkdirTemp("", "db_tls")
+		tmpCertDir, err := os.MkdirTemp("", fmt.Sprintf("db_tls_%d", GinkgoParallelProcess()))
 		Expect(err).ToNot(HaveOccurred())
 		dbConfig := utils.LoadExternalDBConfig(databaseType, mutualTLSEnabled, tmpCertDir)
 		utils.CreateDB(dbConfig)

--- a/src/brats/acceptance/metrics_test.go
+++ b/src/brats/acceptance/metrics_test.go
@@ -47,11 +47,11 @@ var _ = Describe("nginx with ngx_http_stub_status_module compiled", func() {
 		Expect(string(contents)).To(ContainSubstring("bosh_networks_dynamic_ips_total"))
 		Expect(string(contents)).To(ContainSubstring("bosh_networks_dynamic_free_ips_total"))
 
-		api_metrics_resp, err := metricsClient.Get(fmt.Sprintf("https://%s:9091/api_metrics", utils.InnerDirectorIP()))
+		apiMetricsResp, err := metricsClient.Get(fmt.Sprintf("https://%s:9091/api_metrics", utils.InnerDirectorIP()))
 		Expect(err).NotTo(HaveOccurred())
-		defer api_metrics_resp.Body.Close()
+		defer apiMetricsResp.Body.Close()
 
-		contents, err = io.ReadAll(api_metrics_resp.Body)
+		contents, err = io.ReadAll(apiMetricsResp.Body)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(contents)).To(ContainSubstring("http_server_requests_total"))
 		Expect(string(contents)).To(ContainSubstring("http_server_request_duration_seconds"))

--- a/src/brats/assets/external_db/gcp_mysql.yml
+++ b/src/brats/assets/external_db/gcp_mysql.yml
@@ -1,4 +1,2 @@
 external_db_port: 3306
 external_db_adapter: mysql2
-
-

--- a/src/brats/assets/external_db/gcp_mysql_connection_options.yml
+++ b/src/brats/assets/external_db/gcp_mysql_connection_options.yml
@@ -1,13 +1,11 @@
 ---
 # We need to override the ssl_mode to verify_ca (instead of verify_identity)
 # because GCP MYSQL server does not contain the server FQDN in its certificate CN.
-# Also sslverify is set to false because of this bug: https://www.pivotaltracker.com/story/show/154927488
 
 - type: replace
   path: /instance_groups/name=bosh/properties/director/db/connection_options?
   value:
     ssl_mode: verify_ca
-    sslverify: false
     read_timeout: 120
     write_timeout: 120
     connect_timeout: 120

--- a/src/brats/performance/performance_suite_test.go
+++ b/src/brats/performance/performance_suite_test.go
@@ -18,10 +18,7 @@ func TestPerformance(t *testing.T) {
 	RunSpecs(t, "Performance Suite")
 }
 
-var (
-	boshRelease,
-	candidateWardenLinuxStemcellPath string
-)
+var candidateWardenLinuxStemcellPath string
 
 var _ = SynchronizedBeforeSuite(func() {
 	utils.Bootstrap()

--- a/src/brats/utils/utils.go
+++ b/src/brats/utils/utils.go
@@ -416,7 +416,7 @@ func InnerBoshWithExternalDBOptions(dbConfig *ExternalDBConfig) []string {
 		"-o", BoshDeploymentAssetPath("experimental/db-enable-tls.yml"),
 		"-o", AssetPath(dbConfig.ConnectionOptionsFile),
 		"--vars-file", AssetPath(dbConfig.ConnectionVarFile),
-		fmt.Sprintf("--var-file=db_ca=%s", dbConfig.CACertPath),
+		fmt.Sprintf("--var=db_ca=%s", dbConfig.CACertPath),
 		"-v", fmt.Sprintf("external_db_host=%s", dbConfig.Host),
 		"-v", fmt.Sprintf("external_db_user=%s", dbConfig.User),
 		"-v", fmt.Sprintf("external_db_password=%s", dbConfig.Password),
@@ -427,8 +427,8 @@ func InnerBoshWithExternalDBOptions(dbConfig *ExternalDBConfig) []string {
 		options = append(options,
 			fmt.Sprintf("-o %s", BoshDeploymentAssetPath("experimental/db-enable-mutual-tls.yml")),
 			fmt.Sprintf("-o %s", AssetPath("tls-skip-host-verify.yml")),
-			fmt.Sprintf("--var-file=db_client_certificate=%s", dbConfig.ClientCertPath),
-			fmt.Sprintf("--var-file=db_client_private_key=%s", dbConfig.ClientKeyPath),
+			fmt.Sprintf("--var=db_client_certificate=%s", dbConfig.ClientCertPath),
+			fmt.Sprintf("--var=db_client_private_key=%s", dbConfig.ClientKeyPath),
 		)
 	}
 

--- a/src/brats/utils/utils_suite_test.go
+++ b/src/brats/utils/utils_suite_test.go
@@ -1,0 +1,13 @@
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/src/brats/utils/utils_test.go
+++ b/src/brats/utils/utils_test.go
@@ -1,0 +1,321 @@
+package utils_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"brats/utils"
+)
+
+var _ = Describe("Utils", func() {
+	var dbHost string
+	var dbUser string
+	var dbPass string
+	var dbName string
+
+	var certTmpDir string
+
+	BeforeEach(func() {
+		dbHost = "fake-db.example.com"
+		dbUser = "fake-db-user"
+		dbPass = "fake-db-pass"
+
+		certTmpDir = GinkgoT().TempDir()
+	})
+
+	Context("LoadExternalDBConfig", func() {
+		var iaasAndDbName string
+		var mTlsEnabled bool
+
+		var connectionVarsFile string
+		var connectionOptionsFile string
+
+		Context("when IaaS and DB is 'gcp_mysql'", func() {
+			BeforeEach(func() {
+				iaasAndDbName = "gcp_mysql"
+				dbName = fmt.Sprintf("db_mysql_%d", GinkgoParallelProcess())
+
+				connectionVarsFile = fmt.Sprintf("external_db/%s.yml", iaasAndDbName)
+				connectionOptionsFile = fmt.Sprintf("external_db/%s_connection_options.yml", iaasAndDbName)
+
+				GinkgoT().Setenv(
+					fmt.Sprintf("%s_EXTERNAL_DB_HOST", strings.ToUpper(iaasAndDbName)),
+					dbHost,
+				)
+
+				GinkgoT().Setenv(
+					fmt.Sprintf("%s_EXTERNAL_DB_USER", strings.ToUpper(iaasAndDbName)),
+					dbUser,
+				)
+
+				GinkgoT().Setenv(
+					fmt.Sprintf("%s_EXTERNAL_DB_PASSWORD", strings.ToUpper(iaasAndDbName)),
+					dbPass,
+				)
+			})
+
+			Context("when an ENV var for the External DB's CA present", func() {
+				BeforeEach(func() {
+					GinkgoT().Setenv(
+						fmt.Sprintf("%s_EXTERNAL_DB_CA", strings.ToUpper(iaasAndDbName)),
+						"-----FAKE DB_CA-----",
+					)
+				})
+
+				Context("when mTLS is NOT enabled", func() {
+					BeforeEach(func() {
+						mTlsEnabled = false
+					})
+
+					It("creates the expected ExternalDBConfig", func() {
+						externalDBConfig := utils.LoadExternalDBConfig(iaasAndDbName, mTlsEnabled, certTmpDir)
+
+						expectedExternalDBConfig := &utils.ExternalDBConfig{
+							Type:                  "mysql",
+							Host:                  dbHost,
+							User:                  dbUser,
+							Password:              dbPass,
+							DBName:                dbName,
+							ConnectionVarFile:     connectionVarsFile,
+							ConnectionOptionsFile: connectionOptionsFile,
+							CACertPath:            filepath.Join(certTmpDir, "db_ca"),
+						}
+
+						Expect(externalDBConfig).To(Equal(expectedExternalDBConfig))
+					})
+				})
+
+				Context("when mTLS is enabled", func() {
+					BeforeEach(func() {
+						mTlsEnabled = true
+
+						GinkgoT().Setenv(
+							fmt.Sprintf("%s_EXTERNAL_DB_CLIENT_CERTIFICATE", strings.ToUpper(iaasAndDbName)),
+							"-----FAKE DB_CLIENT_CERTIFICATE-----",
+						)
+
+						GinkgoT().Setenv(
+							fmt.Sprintf("%s_EXTERNAL_DB_CLIENT_PRIVATE_KEY", strings.ToUpper(iaasAndDbName)),
+							"-----FAKE EXTERNAL_DB_CLIENT_PRIVATE_KEY-----",
+						)
+					})
+
+					It("creates the expected ExternalDBConfig", func() {
+						externalDBConfig := utils.LoadExternalDBConfig(iaasAndDbName, mTlsEnabled, certTmpDir)
+
+						expectedExternalDBConfig := &utils.ExternalDBConfig{
+							Type:                  "mysql",
+							Host:                  dbHost,
+							User:                  dbUser,
+							Password:              dbPass,
+							DBName:                dbName,
+							ConnectionVarFile:     connectionVarsFile,
+							ConnectionOptionsFile: connectionOptionsFile,
+							CACertPath:            filepath.Join(certTmpDir, "db_ca"),
+							ClientCertPath:        filepath.Join(certTmpDir, "client_cert"),
+							ClientKeyPath:         filepath.Join(certTmpDir, "client_key"),
+						}
+
+						Expect(externalDBConfig).To(Equal(expectedExternalDBConfig))
+					})
+				})
+			})
+		})
+	})
+
+	Context("GenerateMySQLCommand", func() {
+		var externalDBConfig *utils.ExternalDBConfig
+		var dbType = "mysql"
+		var sqlToExecute string
+
+		BeforeEach(func() {
+			sqlToExecute = "FAKE SQL TO EXECUTE;"
+		})
+
+		Context("ClientCertPath and ClientKeyPath are empty", func() {
+			BeforeEach(func() {
+				externalDBConfig = &utils.ExternalDBConfig{
+					Type:       dbType,
+					Host:       dbHost,
+					User:       dbUser,
+					Password:   dbPass,
+					DBName:     dbName,
+					CACertPath: "fake/ca_cert/path",
+				}
+			})
+
+			It("generates the expected args", func() {
+				expectedAgs := []string{
+					"-h",
+					dbHost,
+					fmt.Sprintf("--user=%s", dbUser),
+					fmt.Sprintf("--password=%s", dbPass),
+					"-e",
+					sqlToExecute,
+					"--ssl-ca=fake/ca_cert/path",
+					"--ssl-mode=VERIFY_IDENTITY",
+				}
+
+				Expect(utils.GenerateMySQLCommand(sqlToExecute, externalDBConfig)).To(Equal(expectedAgs))
+			})
+		})
+
+		Context("ClientCertPath is empty", func() {
+			BeforeEach(func() {
+				externalDBConfig = &utils.ExternalDBConfig{
+					Type:          dbType,
+					Host:          dbHost,
+					User:          dbUser,
+					Password:      dbPass,
+					DBName:        dbName,
+					CACertPath:    "fake/ca_cert/path",
+					ClientKeyPath: "fake/client_key/path",
+				}
+			})
+
+			It("generates the expected args", func() {
+				expectedAgs := []string{
+					"-h",
+					dbHost,
+					fmt.Sprintf("--user=%s", dbUser),
+					fmt.Sprintf("--password=%s", dbPass),
+					"-e",
+					sqlToExecute,
+					"--ssl-ca=fake/ca_cert/path",
+					"--ssl-cert=",
+					"--ssl-key=fake/client_key/path",
+					"--ssl-mode=VERIFY_CA",
+				}
+
+				Expect(utils.GenerateMySQLCommand(sqlToExecute, externalDBConfig)).To(Equal(expectedAgs))
+			})
+		})
+
+		Context("ClientKeyPath is empty", func() {
+			BeforeEach(func() {
+				externalDBConfig = &utils.ExternalDBConfig{
+					Type:           dbType,
+					Host:           dbHost,
+					User:           dbUser,
+					Password:       dbPass,
+					DBName:         dbName,
+					CACertPath:     "fake/ca_cert/path",
+					ClientCertPath: "fake/client_cert/path",
+				}
+			})
+
+			It("generates the expected args", func() {
+				expectedAgs := []string{
+					"-h",
+					dbHost,
+					fmt.Sprintf("--user=%s", dbUser),
+					fmt.Sprintf("--password=%s", dbPass),
+					"-e",
+					sqlToExecute,
+					"--ssl-ca=fake/ca_cert/path",
+					"--ssl-cert=fake/client_cert/path",
+					"--ssl-key=",
+					"--ssl-mode=VERIFY_CA",
+				}
+
+				Expect(utils.GenerateMySQLCommand(sqlToExecute, externalDBConfig)).To(Equal(expectedAgs))
+			})
+		})
+	})
+
+	Context("GeneratePSQLCommand", func() {
+		var externalDBConfig *utils.ExternalDBConfig
+		var dbType = "postgres"
+
+		var sqlToExecute string
+
+		BeforeEach(func() {
+			dbName = "fake-db-name"
+			sqlToExecute = "FAKE SQL TO EXECUTE;"
+		})
+
+		Context("ClientCertPath and ClientKeyPath are empty", func() {
+			BeforeEach(func() {
+				externalDBConfig = &utils.ExternalDBConfig{
+					Type:       dbType,
+					Host:       dbHost,
+					User:       dbUser,
+					Password:   dbPass,
+					DBName:     dbName,
+					CACertPath: "fake/ca_cert/path",
+				}
+			})
+
+			It("generates the expected args", func() {
+				expectedAgs := []string{
+					fmt.Sprintf(
+						"dbname=%s host=%s user=%s password=%s sslrootcert=%s sslmode=verify-full ",
+						dbType, dbHost, dbUser, dbPass, "fake/ca_cert/path",
+					),
+					"-c",
+					sqlToExecute,
+				}
+
+				Expect(utils.GeneratePSQLCommand(sqlToExecute, externalDBConfig)).To(Equal(expectedAgs))
+			})
+		})
+
+		Context("ClientCertPath is empty", func() {
+			BeforeEach(func() {
+				externalDBConfig = &utils.ExternalDBConfig{
+					Type:          dbType,
+					Host:          dbHost,
+					User:          dbUser,
+					Password:      dbPass,
+					DBName:        dbName,
+					CACertPath:    "fake/ca_cert/path",
+					ClientKeyPath: "fake/client_key/path",
+				}
+			})
+
+			It("generates the expected args", func() {
+				expectedAgs := []string{
+					fmt.Sprintf(
+						"dbname=%s host=%s user=%s password=%s sslrootcert=%s sslcert= sslkey=%s sslmode=verify-ca ",
+						dbType, dbHost, dbUser, dbPass, "fake/ca_cert/path", "fake/client_key/path",
+					),
+					"-c",
+					sqlToExecute,
+				}
+
+				Expect(utils.GeneratePSQLCommand(sqlToExecute, externalDBConfig)).To(Equal(expectedAgs))
+			})
+		})
+
+		Context("ClientKeyPath is empty", func() {
+			BeforeEach(func() {
+				externalDBConfig = &utils.ExternalDBConfig{
+					Type:           dbType,
+					Host:           dbHost,
+					User:           dbUser,
+					Password:       dbPass,
+					DBName:         dbName,
+					CACertPath:     "fake/ca_cert/path",
+					ClientCertPath: "fake/client_cert/path",
+				}
+			})
+
+			It("generates the expected args", func() {
+				expectedAgs := []string{
+					fmt.Sprintf(
+						"dbname=%s host=%s user=%s password=%s sslrootcert=%s sslcert=%s sslkey= sslmode=verify-ca ",
+						dbType, dbHost, dbUser, dbPass, "fake/ca_cert/path", "fake/client_cert/path",
+					),
+					"-c",
+					sqlToExecute,
+				}
+
+				Expect(utils.GeneratePSQLCommand(sqlToExecute, externalDBConfig)).To(Equal(expectedAgs))
+			})
+		})
+	})
+})


### PR DESCRIPTION
These tests have been invalid since their creation. From the beginning they have passed certificate material in the director deployment manifest, however the director itself has (always?) expected to be passed _paths_ to the certificates.

Original tests here:
https://github.com/cloudfoundry/bosh/commit/f97c5565dba9dfa9445a08ee2d7e495b1d5efccd#diff-ab90421945d114536b0c024f3cbaee7f4566c79a592ba9d46b395f0771745b42R293-R306

and

Director config here:
https://github.com/cloudfoundry/bosh/blob/c095b06c91f14ef51b5a8bcea20c3ec3651590b8/src/bosh-director/lib/bosh/director/config.rb#L303-L318