### PR TITLE
Update mariadb connector packaging script to allow upgrades to 3.4

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1388,7 +1388,7 @@ resources:
     type: http-resource
     source:
       index: "https://mariadb.org/connector-c/all-releases/"
-      regex: '>(?P<version>3\.3.\d+)</a></td><td>\d{4}-\d{2}-\d{2}</td><td>Stable'
+      regex: '>(?P<version>3\.\d+.\d+)</a></td><td>\d{4}-\d{2}-\d{2}</td><td>Stable'
       uri: "https://ftp.osuosl.org/pub/mariadb/connector-c-{version}/mariadb-connector-c-{version}-src.tar.gz"
 
   - name: postgres-10-src

--- a/packages/mysql/packaging
+++ b/packages/mysql/packaging
@@ -1,15 +1,15 @@
 # abort script on any command that exit with a non zero value
 set -e
 
-(
-  set -e
-  tar xzf mysql/mariadb-connector-c-*-src.tar.gz
-  cd mariadb-connector-c-*-src
-  mkdir bld
-  cd bld
-  cmake .. -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET}
-  make
-  make install
-)
-
+mkdir -p ${BOSH_INSTALL_TARGET}/bin/
 cp mysql-customization/mariadb_config-wrapper.sh ${BOSH_INSTALL_TARGET}/bin/
+
+tar xzf mysql/mariadb-connector-c-*-src.tar.gz
+cd mariadb-connector-c-*-src
+cmake \
+  -DCMAKE_INSTALL_PREFIX=${BOSH_INSTALL_TARGET} \
+  -DDEFAULT_SSL_VERIFY_SERVER_CERT=0
+# ^ Needed for mariadb-connector-c >3.4.0 due to changes in default TLS mode. May be removable if mysql2 gem gets updated: https://github.com/brianmario/mysql2/issues/1379
+
+make
+make install


### PR DESCRIPTION
A previous upgrade to 3.4.1 broke when trying to connect to a mysql server with TLS disabled
