### PR TITLE
Unlock io-stream gem

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -6,7 +6,6 @@ gem 'bosh-nats-sync', path: 'bosh-nats-sync'
 gem 'bosh-template', path: 'bosh-template'
 gem 'bosh_common', path: 'bosh_common'
 
-gem 'io-stream', '<= 0.4.0' # TODO unpin; v0.4.1 "expected `[#<Socket:(closed)>].empty?` to be truthy, got false"
 gem 'mysql2'
 gem 'pg'
 gem 'sequel', '~> 5.29.0'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -105,14 +105,14 @@ GEM
       console (~> 1.26)
       fiber-annotation
       io-event (~> 1.6, >= 1.6.5)
-    async-http (0.81.0)
+    async-http (0.82.1)
       async (>= 2.10.2)
       async-pool (~> 0.9)
       io-endpoint (~> 0.14)
-      io-stream (~> 0.4)
+      io-stream (~> 0.6)
       metrics (~> 0.12)
       protocol-http (~> 0.37)
-      protocol-http1 (~> 0.27)
+      protocol-http1 (>= 0.28.1)
       protocol-http2 (~> 0.19)
       traces (~> 0.10)
     async-io (1.43.2)
@@ -184,7 +184,7 @@ GEM
       concurrent-ruby (~> 1.0)
     io-endpoint (0.14.0)
     io-event (1.7.2)
-    io-stream (0.4.0)
+    io-stream (0.6.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     little-plugger (1.1.4)
@@ -227,7 +227,7 @@ GEM
     prometheus-client (4.2.3)
       base64
     protocol-hpack (1.5.1)
-    protocol-http (0.41.0)
+    protocol-http (0.42.0)
     protocol-http1 (0.28.1)
       protocol-http (~> 0.22)
     protocol-http2 (0.19.3)
@@ -357,7 +357,6 @@ DEPENDENCIES
   bundle-audit
   factory_bot
   fakefs
-  io-stream (<= 0.4.0)
   minitar
   mysql2
   parallel_tests

--- a/src/vendor/cache/async-http-0.81.0.gem
+++ b/src/vendor/cache/async-http-0.81.0.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d5668c97594216b2d869b7003fbc43b9445470efdf364014b77f90cfe8ad8013
-size 33792

--- a/src/vendor/cache/async-http-0.82.1.gem
+++ b/src/vendor/cache/async-http-0.82.1.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5be01491bb783ae700d569f0ee111727e8c6dfecf099522584edebf32815636
+size 33792

--- a/src/vendor/cache/io-stream-0.4.0.gem
+++ b/src/vendor/cache/io-stream-0.4.0.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2dcb9f3a39a2ec9670e3d70f8df156eb31f4b73411b0c645f92f9791df346e5
-size 14336

--- a/src/vendor/cache/io-stream-0.6.0.gem
+++ b/src/vendor/cache/io-stream-0.6.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a7867b2a89ad4e14529e5374d9369aec2984d6651aeed69a90ec24bd4d363f5
+size 14848

--- a/src/vendor/cache/protocol-http-0.41.0.gem
+++ b/src/vendor/cache/protocol-http-0.41.0.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ca71b6982772732d78991ada8363d2e1b7249b5081a33dca578e35e7c4df7dc
-size 32768

--- a/src/vendor/cache/protocol-http-0.42.0.gem
+++ b/src/vendor/cache/protocol-http-0.42.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:047fb5532e6b1f552089cd11fef92646966f1ac1b3a0808a723271a0f4a24289
+size 32768


### PR DESCRIPTION
As part of resolving errors after upgrading io-stream, we have switched to the recommended Async::HTTP::Internet class for `async-http`.

This commit also backfills specs for proxy settings when using the `async-http` gem.