### PR TITLE
Fix update disk tests

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -128,6 +128,9 @@ properties:
   director.enable_cpi_resize_disk:
     description: Enable/Disable native CPI disk resizing (true|false)
     default: false
+  director.enable_cpi_update_disk:
+    description: Enable/Disable native CPI disk update (true|false)
+    default: false
   director.enable_snapshots:
     description: Enable/Disable snapshots for persistent disks (true|false)
     default: false

--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -31,6 +31,7 @@ params = {
   'enable_short_lived_nats_bootstrap_credentials' => p('director.enable_short_lived_nats_bootstrap_credentials', true),
   'enable_short_lived_nats_bootstrap_credentials_compilation_vms' => p('director.enable_short_lived_nats_bootstrap_credentials_compilation_vms', false),
   'enable_cpi_resize_disk' => p('director.enable_cpi_resize_disk'),
+  'enable_cpi_update_disk' => p('director.enable_cpi_update_disk'),
   'generate_vm_passwords' => p('director.generate_vm_passwords'),
   'remove_dev_tools' => p('director.remove_dev_tools'),
   'log_access_events' => p('director.log_access_events'),

--- a/spec/director.yml.erb_spec.rb
+++ b/spec/director.yml.erb_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe 'director.yml.erb' do
         'enable_snapshots' => true,
         'enable_nats_delivered_templates' => false,
         'enable_cpi_resize_disk' => false,
+        'enable_cpi_update_disk' => false,
         'enable_pre_ruby_3_2_equal_tilde_behavior' => false,
         'allow_errands_on_stopped_instances' => false,
         'generate_vm_passwords' => false,

--- a/src/bosh-dev/assets/sandbox/director_test.yml.erb
+++ b/src/bosh-dev/assets/sandbox/director_test.yml.erb
@@ -122,6 +122,7 @@ enable_nats_delivered_templates: <%= enable_nats_delivered_templates %>
 enable_short_lived_nats_bootstrap_credentials: <%= enable_short_lived_nats_bootstrap_credentials %>
 enable_short_lived_nats_bootstrap_credentials_compilation_vms: <%= enable_short_lived_nats_bootstrap_credentials_compilation_vms %>
 enable_cpi_resize_disk: <%= enable_cpi_resize_disk %>
+enable_cpi_update_disk: <%= enable_cpi_update_disk %>
 default_update_vm_strategy: <%= default_update_vm_strategy %>
 cpi:
   max_supported_api_version: 2

--- a/src/bosh-dev/lib/bosh/dev/sandbox/director_config.rb
+++ b/src/bosh-dev/lib/bosh/dev/sandbox/director_config.rb
@@ -25,6 +25,7 @@ module Bosh::Dev::Sandbox
                 :director_ruby_port,
                 :dns_enabled,
                 :enable_cpi_resize_disk,
+                :enable_cpi_update_disk,
                 :enable_nats_delivered_templates,
                 :enable_short_lived_nats_bootstrap_credentials,
                 :enable_short_lived_nats_bootstrap_credentials_compilation_vms,
@@ -89,6 +90,7 @@ module Bosh::Dev::Sandbox
       @trusted_certs = attrs.fetch(:trusted_certs)
       @users_in_manifest = attrs.fetch(:users_in_manifest, true)
       @enable_cpi_resize_disk = attrs.fetch(:enable_cpi_resize_disk, false)
+      @enable_cpi_update_disk = attrs.fetch(:enable_cpi_update_disk, false)
       @default_update_vm_strategy = attrs.fetch(:default_update_vm_strategy, nil)
       @enable_nats_delivered_templates = attrs.fetch(:enable_nats_delivered_templates, false)
       @enable_short_lived_nats_bootstrap_credentials = attrs.fetch(:enable_short_lived_nats_bootstrap_credentials, false)

--- a/src/bosh-dev/lib/bosh/dev/sandbox/main.rb
+++ b/src/bosh-dev/lib/bosh/dev/sandbox/main.rb
@@ -199,6 +199,7 @@ module Bosh::Dev::Sandbox
         director_ips: @director_ips,
         dns_enabled: @dns_enabled,
         enable_cpi_resize_disk: @enable_cpi_resize_disk,
+        enable_cpi_update_disk: @enable_cpi_update_disk,
         enable_nats_delivered_templates: @enable_nats_delivered_templates,
         enable_short_lived_nats_bootstrap_credentials: @enable_short_lived_nats_bootstrap_credentials,
         enable_short_lived_nats_bootstrap_credentials_compilation_vms: @enable_short_lived_nats_bootstrap_credentials_compilation_vms,
@@ -327,6 +328,7 @@ module Bosh::Dev::Sandbox
         false,
       )
       @enable_cpi_resize_disk = options.fetch(:enable_cpi_resize_disk, false)
+      @enable_cpi_update_disk = options.fetch(:enable_cpi_update_disk, false)
       @default_update_vm_strategy = options.fetch(:default_update_vm_strategy, ENV['DEFAULT_UPDATE_VM_STRATEGY'])
       @generate_vm_passwords = options.fetch(:generate_vm_passwords, false)
       @remove_dev_tools = options.fetch(:remove_dev_tools, false)

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -24,6 +24,7 @@ module Bosh::Director
         :default_update_vm_strategy,
         :dns,
         :enable_cpi_resize_disk,
+        :enable_cpi_update_disk,
         :enable_short_lived_nats_bootstrap_credentials,
         :enable_short_lived_nats_bootstrap_credentials_compilation_vms,
         :enable_snapshots,
@@ -226,6 +227,7 @@ module Bosh::Director
         end
         @verify_multidigest_path = config['verify_multidigest_path']
         @enable_cpi_resize_disk = config.fetch('enable_cpi_resize_disk', false)
+        @enable_cpi_update_disk = config.fetch('enable_cpi_update_disk', false)
         @default_update_vm_strategy = config.fetch('default_update_vm_strategy', nil)
         @parallel_problem_resolution = config.fetch('parallel_problem_resolution', true)
 

--- a/src/bosh-director/lib/bosh/director/disk_manager.rb
+++ b/src/bosh-director/lib/bosh/director/disk_manager.rb
@@ -30,10 +30,12 @@ module Bosh::Director
         new_disk = disk_pair[:new]
         old_disk = disk_pair[:old]
 
-        @logger.info("CPI resize disk enabled: #{Config.enable_cpi_resize_disk}")
-
         if use_iaas_native_disk_resize?(old_disk, new_disk)
+          @logger.info("CPI is using native disk resize")
           resize_disk(instance_plan, new_disk, old_disk)
+        elsif use_iaas_native_disk_update?(old_disk, new_disk)
+          @logger.info("CPI is using native disk update")
+          update_disk_cpi(instance_plan, new_disk, old_disk)
         else
           update_disk(instance_plan, new_disk, old_disk)
         end
@@ -90,6 +92,14 @@ module Bosh::Director
         new_disk.managed? &&
         new_disk.size_diff_only?(old_disk) &&
         new_disk.is_bigger_than?(old_disk)
+    end
+
+    def use_iaas_native_disk_update?(old_disk, new_disk)
+      Config.enable_cpi_update_disk &&
+        new_disk &&
+        old_disk &&
+        new_disk.managed? &&
+        old_disk.managed?
     end
 
     def add_event(action, deployment_name, instance_name, object_name = nil, parent_id = nil, error = nil)
@@ -225,6 +235,35 @@ module Bosh::Director
       end
 
       disk_model
+    end
+
+    def update_disk_cpi(instance_plan, new_disk, old_disk)
+      old_disk_model = old_disk&.model
+      if old_disk_model.nil?
+        @logger.info("Perform disk create or update, as disk was not found.")
+        update_disk(instance_plan, new_disk, old_disk)
+        return
+      end
+
+      @logger.info("Starting IaaS native update of disk '#{old_disk_model.disk_cid}' with new size '#{new_disk.size}' and cloud properties '#{new_disk.cloud_properties}'")
+      detach_disk(old_disk_model)
+
+      begin
+        cloud = cloud_for_cpi(old_disk_model.instance.active_vm.cpi)
+        cloud.update_disk(old_disk_model.disk_cid, new_disk.size, new_disk.cloud_properties)
+      rescue Bosh::Clouds::NotImplemented, Bosh::Clouds::NotSupported => e
+        @logger.info("IaaS native update not possible for disk #{old_disk_model.disk_cid}. Falling back to creating new disk.\n#{e.message}")
+        attach_disk(old_disk_model, instance_plan.tags)
+        update_disk(instance_plan, new_disk, old_disk)
+
+        return
+      end
+
+      attach_disk(old_disk_model, instance_plan.tags)
+
+      old_disk_model.update(size: new_disk.size)
+      old_disk_model.update(cloud_properties: new_disk.cloud_properties)
+      @logger.info("Finished IaaS native update of disk '#{old_disk_model.disk_cid}'")
     end
 
     def update_disk(instance_plan, new_disk, old_disk)

--- a/src/bosh-director/lib/cloud/dummy.rb
+++ b/src/bosh-director/lib/cloud/dummy.rb
@@ -285,7 +285,7 @@ module Bosh
         File.write(disk_info_file, JSON.generate(disk_info))
       end
 
-      UPDATE_DISK_SCHEMA = Membrane::SchemaParser.parse { {disk_id: String, size: Integer, cloud_properties: Hash} }
+      UPDATE_DISK_SCHEMA = Membrane::SchemaParser.parse { {disk_id: String, new_size: Integer, cloud_properties: Hash} }
       def update_disk(disk_id, new_size, cloud_properties)
         validate_and_record_inputs(UPDATE_DISK_SCHEMA, __method__, disk_id, new_size, cloud_properties)
 

--- a/src/bosh-director/lib/cloud/external_cpi.rb
+++ b/src/bosh-director/lib/cloud/external_cpi.rb
@@ -91,6 +91,7 @@ module Bosh::Clouds
     def snapshot_disk(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def delete_snapshot(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def resize_disk(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
+    def update_disk(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def get_disks(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def ping(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def calculate_vm_cloud_properties(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end

--- a/src/bosh-director/lib/cloud/external_cpi_response_wrapper.rb
+++ b/src/bosh-director/lib/cloud/external_cpi_response_wrapper.rb
@@ -26,6 +26,7 @@ module Bosh::Clouds
     def snapshot_disk(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def delete_snapshot(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def resize_disk(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
+    def update_disk(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def get_disks(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def ping(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end
     def calculate_vm_cloud_properties(*arguments); invoke_cpi_method(__method__.to_s, *arguments); end

--- a/src/bosh-director/spec/unit/config_spec.rb
+++ b/src/bosh-director/spec/unit/config_spec.rb
@@ -736,6 +736,33 @@ describe Bosh::Director::Config do
     end
   end
 
+  describe 'enable_cpi_update_disk' do
+    it 'defaults to false' do
+      described_class.configure(test_config)
+      expect(described_class.enable_cpi_update_disk).to be_falsey
+    end
+
+    context 'when explicitly set' do
+      context 'when set to true' do
+        before { test_config['enable_cpi_update_disk'] = true }
+
+        it 'resolves to true' do
+          described_class.configure(test_config)
+          expect(described_class.enable_cpi_update_disk).to be_truthy
+        end
+      end
+
+      context 'when set to false' do
+        before { test_config['enable_cpi_update_disk'] = false }
+
+        it 'resolves to false' do
+          described_class.configure(test_config)
+          expect(described_class.enable_cpi_update_disk).to be_falsey
+        end
+      end
+    end
+  end
+
   describe 'parallel_problem_resolution' do
     it 'defaults to true' do
       described_class.configure(test_config)

--- a/src/bosh-director/spec/unit/disk_manager_spec.rb
+++ b/src/bosh-director/spec/unit/disk_manager_spec.rb
@@ -6,6 +6,7 @@ module Bosh::Director
 
     let(:cloud) { instance_double(Bosh::Clouds::ExternalCpi) }
     let(:enable_cpi_resize_disk) { false }
+    let(:enable_cpi_update_disk) { false }
     let(:cloud_factory) { instance_double(CloudFactory) }
     let(:variables_interpolator) { instance_double(Bosh::Director::ConfigServer::VariablesInterpolator) }
     let(:instance_plan) do
@@ -66,6 +67,7 @@ module Bosh::Director
       allow(agent_client).to receive(:list_disk).and_return(['disk123'])
       allow(cloud).to receive(:create_disk).and_return('new-disk-cid')
       allow(cloud).to receive(:resize_disk)
+      allow(cloud).to receive(:update_disk)
       allow(cloud).to receive(:attach_disk)
       allow(cloud).to receive(:detach_disk)
       allow(agent_client).to receive(:stop)
@@ -78,6 +80,7 @@ module Bosh::Director
       allow(agent_client).to receive(:add_persistent_disk)
       allow(Config).to receive(:current_job).and_return(update_job)
       allow(Config).to receive(:enable_cpi_resize_disk).and_return(enable_cpi_resize_disk)
+      allow(Config).to receive(:enable_cpi_update_disk).and_return(enable_cpi_update_disk)
       allow(CloudFactory).to receive(:create).and_return(cloud_factory)
       allow(DeploymentPlan::Stages::Report).to receive(:new).and_return(step_report)
       allow(step_report).to receive(:disk_hint).and_return(disk_hint)
@@ -166,6 +169,111 @@ module Bosh::Director
         ).and_return([])
 
         disk_manager.update_persistent_disk(instance_plan)
+      end
+
+      context 'when `enable_cpi_update_disk` is enabled' do
+        let(:enable_cpi_update_disk) { true }
+        let(:job_persistent_disk_size) { 4096 }
+        let(:cloud_properties) do
+          { 'new' => 'properties' }
+        end
+
+        context 'when disk size and properties change' do
+          it 'updates the disk via cpi' do
+            disk_manager.update_persistent_disk(instance_plan)
+
+            expect(agent_client).to have_received(:unmount_disk)
+            expect(agent_client).to have_received(:remove_persistent_disk)
+            expect(cloud).to have_received(:detach_disk).with('vm234', 'disk123')
+            expect(cloud).to have_received(:update_disk).with('disk123', 4096, { "new" => "properties" })
+            expect(cloud).to have_received(:attach_disk).with('vm234', 'disk123')
+            expect(agent_client).to have_received(:mount_disk)
+          end
+
+          it 'updates the disk size and cloud properties in the db' do
+            disk_manager.update_persistent_disk(instance_plan)
+
+            model = Models::PersistentDisk.where(disk_cid: 'disk123').first
+            expect(model.size).to eq(job_persistent_disk_size)
+            expect(model.cloud_properties).to eq(cloud_properties)
+          end
+        end
+
+        context 'when the new disk is unmanaged' do
+          let(:disk_collection) do
+            collection = DeploymentPlan::PersistentDiskCollection.new(logger)
+            collection.add_by_disk_name_and_type('unmanaged-disk-name', disk_type)
+            collection
+          end
+
+          context 'when the old disk is unmanaged' do
+            let(:disk_name) { 'unmanaged-disk-name' }
+
+            it 'does not use cpi update_disk' do
+              disk_manager.update_persistent_disk(instance_plan)
+
+              expect(cloud).to_not have_received(:update_disk)
+            end
+          end
+
+          context 'when the old disk is managed' do
+            let(:disk_name) { '' }
+
+            it 'does not use cpi update_disk' do
+              expect do
+                disk_manager.update_persistent_disk(instance_plan)
+              end.not_to raise_error
+
+              expect(cloud).to_not have_received(:update_disk)
+            end
+          end
+        end
+
+        context 'when update_disk is not implemented' do
+          it 'falls back to manually copying disk' do
+            allow(cloud).to receive(:update_disk).and_raise(Bosh::Clouds::NotImplemented)
+
+            disk_manager.update_persistent_disk(instance_plan)
+
+            expect(cloud).to have_received(:detach_disk).with('vm234', 'disk123').twice
+            expect(cloud).to have_received(:update_disk)
+            expect(cloud).to have_received(:create_disk).with(4096, { 'new' => 'properties' }, 'vm234')
+            expect(cloud).to have_received(:attach_disk).with('vm234', 'disk123')
+            expect(cloud).to have_received(:attach_disk).with('vm234', 'new-disk-cid')
+          end
+        end
+
+        context 'when update_disk is not supported' do
+          let(:job_persistent_disk_size) { 3072 }
+
+          it 'falls back to manually copying disk' do
+            allow(cloud).to receive(:update_disk).and_raise(Bosh::Clouds::NotSupported)
+
+            disk_manager.update_persistent_disk(instance_plan)
+
+            expect(cloud).to have_received(:detach_disk).with('vm234', 'disk123').twice
+            expect(cloud).to have_received(:update_disk)
+            expect(cloud).to have_received(:create_disk).with(3072, { 'new' => 'properties' }, 'vm234')
+            expect(cloud).to have_received(:attach_disk).with('vm234', 'disk123')
+            expect(cloud).to have_received(:attach_disk).with('vm234', 'new-disk-cid')
+          end
+        end
+      end
+
+      context 'when `enable_cpi_update_disk` is disabled' do
+        let(:enable_cpi_update_disk) { false }
+        let(:cloud_properties) do
+          { 'other' => 'properties' }
+        end
+
+        it 'falls back to manually copying disk' do
+          disk_manager.update_persistent_disk(instance_plan)
+
+          expect(cloud).not_to have_received(:update_disk)
+          expect(cloud).to have_received(:create_disk).with(1024, { 'other' => 'properties' }, 'vm234')
+          expect(cloud).to have_received(:attach_disk).with('vm234', 'new-disk-cid')
+          expect(cloud).to have_received(:detach_disk).with('vm234', 'disk123')
+        end
       end
 
       context 'when `enable_cpi_disk_resize` is enabled' do

--- a/src/spec/integration/deploy_with_update_disk_spec.rb
+++ b/src/spec/integration/deploy_with_update_disk_spec.rb
@@ -1,0 +1,100 @@
+require_relative '../spec_helper'
+require 'fileutils'
+
+describe 'deploy with update_disk', type: :integration do
+
+  let(:cloud_config) do
+    {
+      'networks' => [{
+        'name' => 'default',
+        'type' => 'dynamic'
+      }],
+      'vm_types' => [{
+        'name' => 'tiny'
+      }],
+      'disk_types' => [{
+          'name' => 'disk_a',
+          'disk_size' => 123
+      }, {
+          'name' => 'disk_b',
+          'disk_size' => 456,
+          'cloud_properties' => {
+            'foos' => 'ball'
+          }
+      }],
+      'compilation' => {
+        'workers' => 1,
+        'reuse_compilation_vms' => true,
+        'vm_type' => 'tiny',
+        'network' => 'default'
+      }
+    }
+  end
+
+  let(:manifest) do
+    {
+      'name' => 'simple',
+      'releases' => [{ 'name' => 'bosh-release', 'version' => 'latest' }],
+      'stemcells' => [{ 'alias' => 'ubuntu', 'os' => 'toronto-os', 'version' => 'latest' }],
+      'instance_groups' => [{
+        'name' => 'foobar',
+        'instances' => 1,
+        'vm_type' => 'tiny',
+        'stemcell' => 'ubuntu',
+        'networks' => [{ 'name' => 'default' }],
+        'jobs' => [{ 'name' => 'foobar', 'release' => 'bosh-release' }],
+        'persistent_disk_type' => 'disk_a'
+      }],
+      'update' => {
+        'canaries' => 1,
+        'max_in_flight' => 10,
+        'canary_watch_time' => '1000-30000',
+        'update_watch_time' => '1000-30000'
+      }
+    }
+  end
+
+  context 'with `enable_cpi_update_disk` true' do
+    with_reset_sandbox_before_each(enable_cpi_update_disk: true)
+
+    it 'updates the disk with the iaas native update method' do
+      deploy_update_deploy
+
+      invocations = current_sandbox.cpi.invocations_for_method('update_disk')
+      expect(invocations.count).to be > 0
+    end
+
+    context 'when CPI does not implement update_disk' do
+
+      it 'handles the exception' do
+        current_sandbox.cpi.commands.make_update_disk_to_raise_not_implemented
+
+        deploy_update_deploy
+
+        invocations = current_sandbox.cpi.invocations_for_method('update_disk')
+        expect(invocations.count).to be > 0
+      end
+    end
+  end
+
+  context 'with `enable_cpi_update_disk` false' do
+    with_reset_sandbox_before_each(enable_cpi_update_disk: false)
+
+    it 'does not use the iaas native update' do
+      deploy_update_deploy
+
+      invocations = current_sandbox.cpi.invocations_for_method('update_disk')
+      expect(invocations.count).to be_zero
+    end
+  end
+end
+
+def deploy_update_deploy
+  cloud_config['instance_groups'][0]['persistent_disk_type'] = 'disk_a'
+  prepare_for_deploy(cloud_config_hash: cloud_config)
+  deploy_simple_manifest(manifest_hash: manifest)
+
+  cloud_config['instance_groups'][0]['persistent_disk_type'] = 'disk_b'
+  upload_cloud_config(cloud_config_hash: cloud_config)
+  deploy_simple_manifest(manifest_hash: manifest)
+end


### PR DESCRIPTION
## Summary

This change brings back the `update_disk` method which was introduced with https://github.com/cloudfoundry/bosh/pull/2555 and got reverted by https://github.com/cloudfoundry/bosh/pull/2570, due to failing integration tests.

## Test Output

```sh
❯ bundle exec rspec spec/integration/deploy_with_update_disk_spec.rb
/workspaces/bosh/src/bosh-director/lib/bosh/director.rb:11: warning: syslog was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add syslog to your Gemfile or gemspec to silence this warning.
/usr/local/bundle/ruby/3.3.0/gems/httpclient-2.8.3/lib/httpclient.rb:19: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add mutex_m to your Gemfile or gemspec to silence this warning.
Installed SIGQUIT stack trace handler on PID 10308
Skipping postgresql-only tests
Skipping create-swap-delete tests
Run options: exclude {:create_swap_delete=>true, :db=>:postgresql}
.....WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
...

Finished in 4 minutes 32.8 seconds (files took 1.02 seconds to load)
8 examples, 0 failures
```

## Additional Info

I faced some challenges getting integration tests to run on my M3 MacBook due to various issues (building nginx from source was one of the them). However, using the [ci's integration-test dockerfile](https://github.com/cloudfoundry/bosh/blob/main/ci/dockerfiles/integration/Dockerfile) and [devcontainers](https://github.com/cloudfoundry/bosh/compare/main...s4heid:bosh:devcontainer) helped solve the problem, though currently, it only works on a Linux host. On my mac the integration dockerfile cannot be built as it is, because installation of packages `lib32gcc-s1`, `lib32stdc++6`, `libc6-i386` fails.