### PR TITLE
Use ruby 3.3 for packaging and jobs

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -47,7 +47,7 @@ packages:
 - nginx
 - libpq
 - mysql
-- director-ruby-3.2
+- director-ruby-3.3
 - s3cli
 - azure-storage-cli
 - davcli

--- a/jobs/director/templates/env.erb
+++ b/jobs/director/templates/env.erb
@@ -1,4 +1,4 @@
-source /var/vcap/packages/director-ruby-3.2/bosh/runtime.env
+source /var/vcap/packages/director-ruby-3.3/bosh/runtime.env
 export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
 export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/3.2.0
 

--- a/jobs/health_monitor/spec
+++ b/jobs/health_monitor/spec
@@ -12,7 +12,7 @@ templates:
 
 packages:
   - health_monitor
-  - director-ruby-3.2
+  - director-ruby-3.3
 
 properties:
   #

--- a/jobs/health_monitor/templates/health_monitor
+++ b/jobs/health_monitor/templates/health_monitor
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-source /var/vcap/packages/director-ruby-3.2/bosh/runtime.env
+source /var/vcap/packages/director-ruby-3.3/bosh/runtime.env
 exec /var/vcap/packages/health_monitor/bin/bosh-monitor -c /var/vcap/jobs/health_monitor/config/health_monitor.yml

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -17,7 +17,7 @@ templates:
 
 packages:
   - nats
-  - director-ruby-3.2
+  - director-ruby-3.3
 
 properties:
   nats.listen_address:

--- a/jobs/nats/templates/bosh_nats_sync
+++ b/jobs/nats/templates/bosh_nats_sync
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-source /var/vcap/packages/director-ruby-3.2/bosh/runtime.env
+source /var/vcap/packages/director-ruby-3.3/bosh/runtime.env
 exec /var/vcap/packages/nats/bin/bosh-nats-sync -c /var/vcap/jobs/nats/config/bosh_nats_sync_config.yml

--- a/packages/director-ruby-3.2/spec.lock
+++ b/packages/director-ruby-3.2/spec.lock
@@ -1,2 +1,0 @@
-name: director-ruby-3.2
-fingerprint: c62c3fe5f10b2a35d33a9788d1b87fb2678d688421ab1151df09bf1ca0c33967

--- a/packages/director/packaging
+++ b/packages/director/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/{bin,gem_home}
 libpq_dir=/var/vcap/packages/libpq
 mysqlclient_dir=/var/vcap/packages/mysql
 
-source /var/vcap/packages/director-ruby-3.2/bosh/compile.env
+source /var/vcap/packages/director-ruby-3.3/bosh/compile.env
 
 for gemspec in $( find . -maxdepth 2 -name *.gemspec ); do
   gem_name="$( basename "$( dirname "$gemspec" )" )"

--- a/packages/director/spec
+++ b/packages/director/spec
@@ -4,7 +4,7 @@ name: director
 dependencies:
 - libpq
 - mysql
-- director-ruby-3.2
+- director-ruby-3.3
 
 files:
 - bosh-director/**/*

--- a/packages/health_monitor/packaging
+++ b/packages/health_monitor/packaging
@@ -2,7 +2,7 @@ set -e
 
 mkdir -p ${BOSH_INSTALL_TARGET}/{bin,gem_home}
 
-source /var/vcap/packages/director-ruby-3.2/bosh/compile.env
+source /var/vcap/packages/director-ruby-3.3/bosh/compile.env
 
 cat > Gemfile <<EOF
 # Explicitly require vendored version to avoid requiring builtin json gem

--- a/packages/health_monitor/spec
+++ b/packages/health_monitor/spec
@@ -1,7 +1,7 @@
 ---
 name: health_monitor
 dependencies:
-- director-ruby-3.2
+- director-ruby-3.3
 
 files:
 - bosh-monitor/**/*

--- a/packages/nats/packaging
+++ b/packages/nats/packaging
@@ -9,7 +9,7 @@ chmod +x ${BOSH_INSTALL_TARGET}/bin/nats-server
 
 mkdir -p ${BOSH_INSTALL_TARGET}/{bin,gem_home}
 
-source /var/vcap/packages/director-ruby-3.2/bosh/compile.env
+source /var/vcap/packages/director-ruby-3.3/bosh/compile.env
 
 cat > Gemfile <<EOF
 # Explicitly require vendored version to avoid requiring builtin json gem

--- a/packages/nats/spec
+++ b/packages/nats/spec
@@ -2,7 +2,7 @@
 name: nats
 
 dependencies:
-- director-ruby-3.2
+- director-ruby-3.3
 
 files:
 - nats/nats-server-v*-linux-amd64.tar.gz


### PR DESCRIPTION
Previously, we added the ruby 3.3 package and bumped the .ruby-version file accordingly. However, all of the packaging scripts and jobs still referred to ruby 3.2. This remove ruby 3.2 and switches everything to ruby 3.3.

