### PR TITLE
Passes a String to a function that requires one

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/director.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/director.rb
@@ -56,7 +56,7 @@ module Bosh::Monitor
 
       ssl_context = OpenSSL::SSL::SSLContext.new
       ssl_context.set_params(verify_mode: OpenSSL::SSL::VERIFY_NONE)
-      async_endpoint = Async::HTTP::Endpoint.parse(parsed_endpoint, ssl_context: ssl_context)
+      async_endpoint = Async::HTTP::Endpoint.parse(parsed_endpoint.to_s, ssl_context: ssl_context)
       response = Async::HTTP::Internet.send(method.to_sym, async_endpoint, headers)
 
       body   = response.read


### PR DESCRIPTION
A heavily-elided stack trace from the troublesome environment in question follows. It may or may not be helpful context.

```
E, [2024-12-03T02:50:26.105758 #6] ERROR : Unable to send get /deployments to director: Invalid URI: 'https://10.50.4.42:25555/info' -- /var/vcap/data/packages/director-ruby-3.2/0272ccbfccc42016eee9ff4d650e36c6bcadefb4/lib/ruby/3.2.0/uri/rfc3986_parser.rb:17:in `rescue in split': bad URI(is not URI?): #<URI::HTTPS https://10.50.4.42:25555/info> (URI::InvalidURIError)
        from /var/vcap/data/packages/director-ruby-3.2/0272ccbfccc42016eee9ff4d650e36c6bcadefb4/lib/ruby/3.2.0/uri/rfc3986_parser.rb:14:in `split'
...
        from /var/vcap/data/packages/health_monitor/d17d70b0dde3173e76cc1924bb9a1fceb045a9e2/gem_home/ruby/3.2.0/gems/bosh-monitor-0.0.0/lib/bosh/monitor/director.rb:59:in `perform_request'
...
        from /var/vcap/data/packages/health_monitor/d17d70b0dde3173e76cc1924bb9a1fceb045a9e2/gem_home/ruby/3.2.0/gems/async-2.20.0/lib/async/task.rb:435:in `block in schedule'
/var/vcap/data/packages/director-ruby-3.2/0272ccbfccc42016eee9ff4d650e36c6bcadefb4/lib/ruby/3.2.0/uri/rfc3986_parser.rb:15:in `split': undefined method `to_str' for #<URI::HTTPS https://10.50.4.42:25555/info> (NoMethodError)

        uri = uri.to_str
                 ^^^^^^^
Did you mean?  to_s
        from /var/vcap/data/packages/director-ruby-3.2/0272ccbfccc42016eee9ff4d650e36c6bcadefb4/lib/ruby/3.2.0/uri/rfc3986_parser.rb:71:in `parse'
...
        from /var/vcap/data/packages/health_monitor/d17d70b0dde3173e76cc1924bb9a1fceb045a9e2/gem_home/ruby/3.2.0/gems/bosh-monitor-0.0.0/lib/bosh/monitor/director.rb:59:in `perform_request'
...
        from /var/vcap/data/packages/health_monitor/d17d70b0dde3173e76cc1924bb9a1fceb045a9e2/gem_home/ruby/3.2.0/gems/async-2.20.0/lib/async/task.rb:435:in `block in schedule'

E, [2024-12-03T02:50:26.105953 #6] ERROR : /var/vcap/data/packages/health_monitor/d17d70b0dde3173e76cc1924bb9a1fceb045a9e2/gem_home/ruby/3.2.0/gems/bosh-monitor-0.0.0/lib/bosh/monitor/director.rb:69:in `rescue in perform_request' /var/vcap/data/packages/health_monitor/d17d70b0dde3173e76cc1924bb9a1fceb045a9e2/gem_home/ruby/3.2.0/gems/bosh-monitor-0.0.0/lib/bosh/monitor/director.rb:66:in `perform_request'
...
```

### What is this change about?

This commit fixes a production problem in certain environments with Bosh Director v280.1.10 and presumably later. For reasons unknown to us, in these environments, the 'to_str' function is not defined on the URI::HTTPS class. However, in MOST environments, it totally is. This is important, because the URI#parse function (which
Async::HTTP::Endpoint.parse eventually calls) calls 'to_str' on the argument passed to it.

### Please provide contextual information.

Rather than figure out what's suddenly stopped injecting 'to_str' on the URI::HTTPS class, we're just passing in the type of data the functions require, rather than hoping it'll get automagically converted into the correct type.

### What tests have you run against this PR?

We have run no tests because the existing tests never caught the problem, and we have no idea what was actually causing it.

### How should this change be described in bosh release notes?

> Fixes Bosh Health Monitor "'split': undefined method 'to_str' for #<URI::HTTPS>" failure in certain environments, which caused Health Monitor log spam.

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!
@xtreme-nitin-ravindran