### PR TITLE
Replace blue shell

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -18,7 +18,6 @@ group :development, :test do
   gem 'pry'
 
   gem 'async-rspec'
-  gem 'blue-shell'
   gem 'factory_bot'
   gem 'fakefs'
   gem 'minitar'

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -119,8 +119,6 @@ GEM
     beefcake (1.2.0)
     benchmark (0.4.0)
     bigdecimal (3.1.8)
-    blue-shell (0.3.0)
-      rspec
     bosh_cpi (2.6.0)
       httpclient (~> 2.8.3)
       membrane (~> 1.1.0)
@@ -325,7 +323,6 @@ PLATFORMS
 
 DEPENDENCIES
   async-rspec
-  blue-shell
   bosh-director!
   bosh-monitor!
   bosh-nats-sync!

--- a/src/bosh-director/spec/unit/bosh_director_drain_workers_spec.rb
+++ b/src/bosh-director/spec/unit/bosh_director_drain_workers_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'blue-shell'
 
 describe '#bosh-director-drain-workers', truncation: true do
   let(:tmpdir) { Dir.mktmpdir }

--- a/src/spec/integration/uaa/login_spec.rb
+++ b/src/spec/integration/uaa/login_spec.rb
@@ -75,13 +75,13 @@ describe 'Logging into a director with UAA authentication', type: :integration d
       expect(output).to match(/not logged in/)
     end
 
-    #FIXME: doesn't seem like bosh requires ca-cert to be provided when doing a log-in command. Maybe makes sense since it's needed for basically everything else.
-    # it 'fails to log in with a useful message when cli fails to validate server and no cert was specified' do
-    #   bosh_runner.run("env #{current_sandbox.director_url}")
-    #   bosh_runner.run_interactively('log-in', no_ca_cert: true, include_credentials: false) do |runner|
-    #     expect(runner).to have_output 'Invalid SSL Cert. Use --ca-cert option when setting target to specify SSL certificate'
-    #   end
-    # end
+    it 'fails to log in with a useful message when cli fails to validate server and no cert was specified' do
+      pending "FIXME: doesn't seem like bosh requires ca-cert to be provided when doing a log-in command. Maybe makes sense since it's needed for basically everything else."
+      bosh_runner.run("env #{current_sandbox.director_url}")
+      bosh_runner.run_interactively('log-in', no_ca_cert: true, include_credentials: false) do |runner|
+        expect(runner).to have_output 'Invalid SSL Cert. Use --ca-cert option when setting target to specify SSL certificate'
+      end
+    end
 
     it 'it fails to log in if the director cert is invalid' do
       invalid_ca_cert = <<CERT

--- a/src/spec/integration_support/custom_blue_shell_matcher.rb
+++ b/src/spec/integration_support/custom_blue_shell_matcher.rb
@@ -1,0 +1,15 @@
+require 'blue-shell'
+
+BlueShell.timeout = 180 # the cli can be pretty slow
+
+module IntegrationSupport
+  module CustomBlueShellMatcher
+    def have_output(expected_code)
+      BlueShell::Matchers::OutputMatcher.new(expected_code)
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include(IntegrationSupport::CustomBlueShellMatcher)
+end

--- a/src/spec/integration_support/have_output_matcher.rb
+++ b/src/spec/integration_support/have_output_matcher.rb
@@ -1,15 +1,14 @@
 require 'blue-shell'
 
-BlueShell.timeout = 180 # the cli can be pretty slow
-
 module IntegrationSupport
-  module CustomBlueShellMatcher
+  module HaveOutputMatcher
     def have_output(expected_code)
+      BlueShell.timeout = 180 # the cli can be pretty slow
       BlueShell::Matchers::OutputMatcher.new(expected_code)
     end
   end
 end
 
 RSpec.configure do |c|
-  c.include(IntegrationSupport::CustomBlueShellMatcher)
+  c.include(IntegrationSupport::HaveOutputMatcher)
 end

--- a/src/spec/integration_support/have_output_matcher.rb
+++ b/src/spec/integration_support/have_output_matcher.rb
@@ -1,10 +1,38 @@
-require 'blue-shell'
-
 module IntegrationSupport
+  class OutputMatcher
+    def initialize(expected_output)
+      @expected_output = expected_output
+    end
+
+    def matches?(runner)
+      raise Errors::InvalidInputError unless runner.respond_to?(:expect)
+      @matched = runner.expect(@expected_output)
+      @full_output = runner.output
+      !!@matched
+    end
+
+    def failure_message
+      "expected '#{@expected_output}' to be printed, but it wasn't. full output:\n#{@full_output}"
+    end
+
+    def failure_message_when_negated
+      "expected '#{@expected_output}' to not be printed, but it was. full output:\n#{@full_output}"
+    end
+  end
+
   module HaveOutputMatcher
-    def have_output(expected_code)
-      BlueShell.timeout = 180 # the cli can be pretty slow
-      BlueShell::Matchers::OutputMatcher.new(expected_code)
+    def have_output(string_or_regexp)
+      pattern =
+        case string_or_regexp
+        when String
+          Regexp.new(Regexp.quote(string_or_regexp))
+        when Regexp
+          string_or_regexp
+        else
+          raise TypeError, "unsupported pattern class: #{string_or_regexp.class}"
+        end
+
+      OutputMatcher.new(pattern)
     end
   end
 end

--- a/src/spec/integration_support/minimal_runner.rb
+++ b/src/spec/integration_support/minimal_runner.rb
@@ -1,0 +1,147 @@
+require 'pty'
+require 'timeout'
+require 'blue-shell'
+
+# BlueShell::Runner#send_keys
+# BlueShell::Runner#exit_code
+# BlueShell::Runner#output
+
+module IntegrationSupport
+  class MinimalRunner
+    EXECUTION_TIMEOUT = 180
+
+    def initialize(command)
+      @stdout, pseudo_terminal = PTY.open
+      system('stty raw', in: pseudo_terminal)
+      read, @stdin = IO.pipe
+
+      @pid = spawn({}, command, in: read, out: pseudo_terminal, err: pseudo_terminal)
+
+      @expector = BufferedReaderExpector.new(@stdout)
+
+      if block_given?
+        yield self
+      else
+        wait_for_exit
+      end
+    end
+
+    def expect(matcher)
+      raise "Unsupported matcher: #{matcher.inspect}" if matcher.is_a?(Hash)
+
+      @expector.expect(matcher)
+    end
+
+    def send_keys(text_to_send)
+      @stdin.puts(text_to_send)
+    end
+
+    def exit_code
+      return @code if @code
+
+      code = nil
+      begin
+        Timeout.timeout(EXECUTION_TIMEOUT) do
+          code = Process.waitpid2(@pid)[1]
+        end
+      rescue Timeout::Error
+        raise ::Timeout::Error, "execution expired, output was:\n#{@expector.read_to_end}"
+      end
+
+      @code = numeric_exit_code(code)
+    end
+
+    alias_method :wait_for_exit, :exit_code
+
+    def output
+      @expector.output
+    end
+
+    private
+
+    def numeric_exit_code(status)
+      status.exitstatus
+    rescue NoMethodError
+      status
+    end
+
+    class BufferedReaderExpector
+      attr_reader :output
+
+      def initialize(out)
+        @out = out
+        @unused = ""
+        @output = ""
+      end
+
+      def expect(pattern)
+        case pattern
+        when String
+          pattern = Regexp.new(Regexp.quote(pattern))
+        when Regexp
+          # noop
+        else
+          raise TypeError, "unsupported pattern class: #{pattern.class}"
+        end
+
+        result, buffer = read_pipe(EXECUTION_TIMEOUT, pattern)
+
+        @output << buffer
+
+        result
+      end
+
+      def read_to_end
+        _, buffer = read_pipe(0.01)
+        @output << buffer
+      end
+
+      private
+
+      def read_pipe(timeout, pattern = nil)
+        buffer = ""
+        result = nil
+        position = 0
+
+        while true
+          if !@unused.empty?
+            c = @unused.slice!(0).chr
+          elsif output_ended?(timeout)
+            @unused = buffer
+            break
+          else
+            c = @out.getc.chr
+          end
+
+          # wear your flip-flops
+          unless (c == "\e") .. (c == "m")
+            if c == "\b"
+              if position > 0 && buffer[position - 1] && buffer[position - 1].chr != "\n"
+                position -= 1
+              end
+            else
+              if buffer.size > position
+                buffer[position] = c
+              else
+                buffer << c
+              end
+
+              position += 1
+            end
+          end
+
+          if pattern && (matches = pattern.match(buffer))
+            result = [buffer, *matches.to_a[1..-1]]
+            break
+          end
+        end
+
+        [result, buffer]
+      end
+
+      def output_ended?(timeout)
+        !@out.wait_readable(timeout) || @out.eof?
+      end
+    end
+  end
+end

--- a/src/spec/integration_support/minimal_runner.rb
+++ b/src/spec/integration_support/minimal_runner.rb
@@ -23,15 +23,6 @@ module IntegrationSupport
     end
 
     def expect(pattern)
-      case pattern
-      when String
-        pattern = Regexp.new(Regexp.quote(pattern))
-      when Regexp
-        # noop
-      else
-        raise TypeError, "unsupported pattern class: #{pattern.class}"
-      end
-
       result, buffer = read_pipe(EXECUTION_TIMEOUT, pattern)
 
       @output << buffer

--- a/src/spec/support/blueshell.rb
+++ b/src/spec/support/blueshell.rb
@@ -1,7 +1,0 @@
-require 'blue-shell'
-
-BlueShell.timeout = 180 # the cli can be pretty slow
-
-RSpec.configure do |c|
-  c.include(BlueShell::Matchers)
-end

--- a/src/vendor/cache/blue-shell-0.3.0.gem
+++ b/src/vendor/cache/blue-shell-0.3.0.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d7f7e6d45e0b8be242470a9cfdd684b696ebbdc725f61e698345f362a918f08
-size 9728


### PR DESCRIPTION
Inline the parts of the `blue-shell` gem functionality which we use in the bosh integration specs since https://github.com/vmware-archive/blue-shell is archived and no longer maintined.