### PR TITLE
Fixes a bug where a VM ends up in a state where it does not have a "rendered_templates_archive" in the spec json

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
@@ -148,6 +148,13 @@ module Bosh::Director
         @model = existing_instance_model
         @desired_variable_set = @deployment_model.last_successful_variable_set || @deployment_model.current_variable_set
         @previous_variable_set = existing_instance_model.variable_set
+        templates_archive = existing_instance_model.latest_rendered_templates_archive
+        if templates_archive
+          self.rendered_templates_archive = Core::Templates::RenderedTemplatesArchive.new(
+            templates_archive.blobstore_id,
+            templates_archive.sha1,
+          )
+        end
       end
 
       def bind_existing_reservations(reservations)

--- a/src/bosh-director/lib/bosh/director/rendered_templates_persister.rb
+++ b/src/bosh-director/lib/bosh/director/rendered_templates_persister.rb
@@ -81,6 +81,10 @@ module Bosh::Director
 
       rendered_templates_archive = instance_plan.rendered_templates.persist_through_agent(instance.agent_client)
 
+      instance.model.add_rendered_templates_archive(rendered_templates_archive.spec.merge({
+        content_sha1: instance.configuration_hash,
+        created_at: Time.now,
+      }))
       instance.rendered_templates_archive = rendered_templates_archive
     end
   end

--- a/src/bosh-director/spec/unit/deployment_plan/instance_spec.rb
+++ b/src/bosh-director/spec/unit/deployment_plan/instance_spec.rb
@@ -96,6 +96,17 @@ module Bosh::Director::DeploymentPlan
           expect(instance.previous_variable_set).to eq(variable_set_model)
         end
       end
+
+      context 'if there is an existing rendered_templates_archive for the model' do
+        let!(:rendered_templates_archive) { FactoryBot.create(:models_rendered_templates_archive, instance: instance_model) }
+
+        it 'configures the instance to have the same rendered_templates_archive as the existing model' do
+          instance.bind_existing_instance_model(instance_model)
+
+          expect(instance.rendered_templates_archive.sha1).to eq(rendered_templates_archive.sha1)
+          expect(instance.rendered_templates_archive.blobstore_id).to eq(rendered_templates_archive.blobstore_id)
+        end
+      end
     end
 
     describe '#bind_new_instance_model' do


### PR DESCRIPTION
Steps to reproduce:
- Deploy a VM
- Redeploy the VM without making any changes (this updates the spec json in the instances table to no longer have the rendered_templates_archive data since no templates were rendered)
- bosh restart vm/0 --no-converge

The restart action won't cause templates to be re-rendered, but will cause an update of the VM. Since rendered_templates_archive is no longer part of the spec json, the agent thinks it should not be starting any jobs and "monit summary" will be empty.

This fix makes two changes.
- When sending rendered templates over the NATS bus to VMs, rather than through the blobstore, it will persist the entry into the "rendered_templates_archive" table. This seems a bit weird since the templates aren't actually in the blobstore, but this odd pattern is already in use. The spec json on the VM always has a "blobstore_id" even though the templates never went through the blobstore. So it's a bit odd, but it is consistent.
- When constructing the instances in the deployment plan from existing instance models, it will check if the database has the existing rendered templates archive and will merge that into the instance plan model. During a normal deploy, this will simply get replaced after the templates are rendered as part of the deployment process. However, this makes the template archive details available for deploys that do not end up rendering templates.
