### PR TITLE
Add metrics for other unhealthy VM states

### DIFF
--- a/src/bosh-director/lib/bosh/director/metrics_collector.rb
+++ b/src/bosh-director/lib/bosh/director/metrics_collector.rb
@@ -43,10 +43,10 @@ module Bosh
           docstring: 'Number of unresponsive agents per deployment',
         )
 
-        @detached_instances = Prometheus::Client.registry.gauge(
-          :bosh_detached_instances,
+        @inactive_instances = Prometheus::Client.registry.gauge(
+          :bosh_inactive_instances,
           labels: %i[name],
-          docstring: 'Number of detached_instances per deployment',
+          docstring: 'Number of inactive or non-existing instances per deployment',
         )
 
         @scheduler = Rufus::Scheduler.new
@@ -116,8 +116,8 @@ module Bosh
 
         populate_network_metrics
 
-        populate_vm_metrics(unresponsive_agents, @unresponsive_agents)
-        populate_vm_metrics(detached_instances, @detached_instances)
+        populate_vm_metrics('/unresponsive_agents', @unresponsive_agents)
+        populate_vm_metrics('/inactive_instances', @inactive_instances)
 
         @logger.info('populated metrics')
       end

--- a/src/bosh-director/lib/bosh/director/metrics_collector.rb
+++ b/src/bosh-director/lib/bosh/director/metrics_collector.rb
@@ -43,10 +43,10 @@ module Bosh
           docstring: 'Number of unresponsive agents per deployment',
         )
 
-        @inactive_instances = Prometheus::Client.registry.gauge(
-          :bosh_inactive_instances,
+        @unhealthy_instances = Prometheus::Client.registry.gauge(
+          :bosh_unhealthy_instances,
           labels: %i[name],
-          docstring: 'Number of inactive or non-existing instances per deployment',
+          docstring: 'Number of unhealthy instances per deployment',
         )
 
         @scheduler = Rufus::Scheduler.new
@@ -117,7 +117,7 @@ module Bosh
         populate_network_metrics
 
         populate_vm_metrics('/unresponsive_agents', @unresponsive_agents)
-        populate_vm_metrics('/inactive_instances', @inactive_instances)
+        populate_vm_metrics('/unhealthy_instances', @unhealthy_instances)
 
         @logger.info('populated metrics')
       end

--- a/src/bosh-monitor/lib/bosh/monitor/agent.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/agent.rb
@@ -51,6 +51,10 @@ module Bosh::Monitor
       (Time.now - @discovered_at) > @intervals.rogue_agent_alert && @deployment.nil?
     end
 
+    def is_detached?
+      (Time.now - @updated_at) > @intervals.agent_timeout
+    end
+
     def update_instance(instance)
       @job = instance.job
       @index = instance.index

--- a/src/bosh-monitor/lib/bosh/monitor/agent.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/agent.rb
@@ -4,7 +4,7 @@ module Bosh::Monitor
     attr_reader   :discovered_at
     attr_accessor :updated_at
 
-    ATTRIBUTES = %i[deployment job index instance_id cid].freeze
+    ATTRIBUTES = %i[deployment job index instance_id cid job_state has_processes].freeze
 
     ATTRIBUTES.each do |attribute|
       attr_accessor attribute
@@ -51,15 +51,8 @@ module Bosh::Monitor
       (Time.now - @discovered_at) > @intervals.rogue_agent_alert && @deployment.nil?
     end
 
-    def is_inactive?
-      @logger.info("ABCDEF Job: #{@job}")
-      @logger.info("ABCDEF Deployment: #{@deployment}")
-      @logger.info("ABCDEF Instance agent id: #{@instance.agent_id}")
-      @logger.info("ABCDEF Instance VM cid: #{@instance.vm_cid}")
-      @logger.info("ABCDEF Expects VM: #{@instance.expects_vm}")
-      @logger.info("ABCDEF Instance Job state: #{@instance.job_state}")
-      @logger.info("ABCDEF Instance state: #{@instance.state}")
-      (Time.now - @updated_at) > @intervals.agent_timeout
+    def is_not_running?
+      @job_state.to_s != 'running' || @has_processes == false
     end
 
     def update_instance(instance)
@@ -67,7 +60,8 @@ module Bosh::Monitor
       @index = instance.index
       @cid = instance.cid
       @instance_id = instance.id
-      @instance = instance
+      @job_state = instance.job_state
+      @has_processes = instance.has_processes
     end
   end
 end

--- a/src/bosh-monitor/lib/bosh/monitor/agent.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/agent.rb
@@ -51,7 +51,14 @@ module Bosh::Monitor
       (Time.now - @discovered_at) > @intervals.rogue_agent_alert && @deployment.nil?
     end
 
-    def is_detached?
+    def is_inactive?
+      @logger.info("ABCDEF Job: #{@job}")
+      @logger.info("ABCDEF Deployment: #{@deployment}")
+      @logger.info("ABCDEF Instance agent id: #{@instance.agent_id}")
+      @logger.info("ABCDEF Instance VM cid: #{@instance.vm_cid}")
+      @logger.info("ABCDEF Expects VM: #{@instance.expects_vm}")
+      @logger.info("ABCDEF Instance Job state: #{@instance.job_state}")
+      @logger.info("ABCDEF Instance state: #{@instance.state}")
       (Time.now - @updated_at) > @intervals.agent_timeout
     end
 
@@ -60,6 +67,7 @@ module Bosh::Monitor
       @index = instance.index
       @cid = instance.cid
       @instance_id = instance.id
+      @instance = instance
     end
   end
 end

--- a/src/bosh-monitor/lib/bosh/monitor/agent.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/agent.rb
@@ -24,6 +24,8 @@ module Bosh::Monitor
       @index = opts[:index]
       @cid = opts[:cid]
       @instance_id = opts[:instance_id]
+      @job_state = opts[:job_state]
+      @has_processes = opts[:has_processes]
     end
 
     def name

--- a/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
@@ -40,5 +40,13 @@ module Bosh::Monitor
         status(503)
       end
     end
+
+    get '/detached_instances' do
+      if @instance_manager.director_initial_deployment_sync_done
+        JSON.generate(@instance_manager.detached_instances)
+      else
+        status(503)
+      end
+    end
   end
 end

--- a/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
@@ -41,9 +41,9 @@ module Bosh::Monitor
       end
     end
 
-    get '/inactive_instances' do
+    get '/unhealthy_instances' do
       if @instance_manager.director_initial_deployment_sync_done
-        JSON.generate(@instance_manager.inactive_instances)
+        JSON.generate(@instance_manager.unhealthy_instances)
       else
         status(503)
       end

--- a/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
@@ -41,9 +41,9 @@ module Bosh::Monitor
       end
     end
 
-    get '/detached_instances' do
+    get '/inactive_instances' do
       if @instance_manager.director_initial_deployment_sync_done
-        JSON.generate(@instance_manager.detached_instances)
+        JSON.generate(@instance_manager.inactive_instances)
       else
         status(503)
       end

--- a/src/bosh-monitor/lib/bosh/monitor/director.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/director.rb
@@ -31,6 +31,14 @@ module Bosh::Monitor
       parse_json(body, Array)
     end
 
+    def get_deployment_instances_full(name)
+      body, status = perform_request(:get, "/deployments/#{name}/instances?format=full")
+
+      raise DirectorError, "Cannot get deployment '#{name}' from director at #{endpoint}/deployments/#{name}/instances?format=full: #{status} #{body}" if status != 200
+
+      parse_json(body, Array)
+    end
+
     private
 
     def endpoint

--- a/src/bosh-monitor/lib/bosh/monitor/director.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/director.rb
@@ -36,7 +36,7 @@ module Bosh::Monitor
       sleep_amount_seconds = 1
       location = headers['location']
       unless !location.nil? && location.include?('task')
-        raise DirectorError, "Cannot find any task to retrieve vm stats"
+        raise DirectorError, "Can not find 'location' response header to retrieve the task location"
       end
       counter = 0
       # States are documented here: https://bosh.io/docs/director-api-v1/#list-tasks
@@ -54,7 +54,7 @@ module Bosh::Monitor
         json_output = parse_json(body, Hash)
         state = json_output['state']
         if truthy_states.include?(state) || counter > 5
-          @logger.warn("The number of retries to fetch instance details for deployment #{name} has exceeded. Could not get the expected response from #{location}")
+          @logger.warn("The number of retries to fetch instance details for deployment '#{name}' has exceeded. Could not get the expected response from '#{location}'")
           break
         end
         sleep_amount_seconds = counter + sleep_amount_seconds
@@ -64,7 +64,7 @@ module Bosh::Monitor
       if state == 'done'
         body, status = perform_request(:get, "#{location}/output?type=result")
         if status!= 200 || body.nil? || body.empty?
-          raise DirectorError, "Fetching full instance details for deployment #{name} failed"
+          raise DirectorError, "Fetching full instance details for deployment '#{name}' failed"
         end
         updated_body = "[#{body.chomp.gsub(/\R+/, ',')}]"
         return parse_json(updated_body, Array)
@@ -72,7 +72,7 @@ module Bosh::Monitor
         if recursive_counter > 0
           return updated_body, state
         end
-        @logger.warn("Could not fetch instance details for deployment #{name} in the first attempt, retrying once more ...")
+        @logger.warn("Could not fetch instance details for deployment '#{name}' in the first attempt, retrying once more ...")
         return get_deployment_instances_full(name, recursive_counter + 1)
       end
     end

--- a/src/bosh-monitor/lib/bosh/monitor/instance.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/instance.rb
@@ -1,7 +1,7 @@
 module Bosh::Monitor
   class Instance
-    attr_reader :id, :agent_id, :job, :index, :cid, :expects_vm
-    attr_accessor :deployment
+    attr_reader :id, :agent_id, :job, :index, :cid, :expects_vm, :job_state, :has_processes
+    attr_accessor :deployment, :job_state
 
     def initialize(instance_data)
       @logger = Bosh::Monitor.logger
@@ -11,6 +11,8 @@ module Bosh::Monitor
       @index = instance_data['index']
       @cid = instance_data['cid']
       @expects_vm = instance_data['expects_vm']
+      @job_state = instance_data['job_state']
+      @has_processes = instance_data['has_processes']
     end
 
     def self.create(instance_data)
@@ -30,11 +32,11 @@ module Bosh::Monitor
     def name
       if @job
         identifier = "#{@job}(#{@id})"
-        attributes = create_optional_attributes(%i[agent_id index])
+        attributes = create_optional_attributes(%i[agent_id index job_state has_processes])
         attributes += create_mandatory_attributes([:cid])
       else
         identifier = "instance #{@id}"
-        attributes = create_optional_attributes(%i[agent_id job index cid expects_vm])
+        attributes = create_optional_attributes(%i[agent_id job index cid expects_vm job_state has_processes])
       end
 
       "#{@deployment}: #{identifier} [#{attributes.join(', ')}]"

--- a/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
@@ -121,10 +121,10 @@ module Bosh::Monitor
       agents_hash
     end
 
-    def detached_instances
+    def inactive_instances
       instances = {}
       @deployment_name_to_deployments.each do |name, deployment|
-        instances[name] = deployment.agents.count(&:is_detached?)
+        instances[name] = deployment.agents.count(&:is_inactive?)
       end
 
       instances

--- a/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
@@ -34,6 +34,12 @@ module Bosh::Monitor
 
         @logger.debug("Fetching instances information for '#{deployment_name}'...")
         instances_data = director.get_deployment_instances(deployment_name)
+        instances_data_full = director.get_deployment_instances_full(deployment_name)
+        instances_data_hash = instances_data.to_h {|element| [element['id'], element] }
+        instances_data_full.each do |instance_full|
+          instances_data_hash[instance_full['id']]['job_state'] = instance_full['job_state']
+          instances_data_hash[instance_full['id']]['has_processes'] = !instance_full['processes'].empty?
+        end
         sync_deployment_state(deployment, instances_data)
       end
       @director_initial_deployment_sync_done = true
@@ -121,10 +127,10 @@ module Bosh::Monitor
       agents_hash
     end
 
-    def inactive_instances
+    def unhealthy_instances # See: https://bosh.io/docs/director-api-v1/#list-instances-detailed (if job is not runnung => state is unhealthy)
       instances = {}
       @deployment_name_to_deployments.each do |name, deployment|
-        instances[name] = deployment.agents.count(&:is_inactive?)
+        instances[name] = deployment.agents.count(&:is_not_running?)
       end
 
       instances

--- a/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
@@ -121,6 +121,15 @@ module Bosh::Monitor
       agents_hash
     end
 
+    def detached_instances
+      instances = {}
+      @deployment_name_to_deployments.each do |name, deployment|
+        instances[name] = deployment.agents.count(&:is_detached?)
+      end
+
+      instances
+    end
+
     def analyze_agents
       @logger.info('Analyzing agents...')
       started = Time.now

--- a/src/bosh-monitor/spec/unit/bosh/monitor/agent_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/agent_spec.rb
@@ -21,6 +21,19 @@ describe Bosh::Monitor::Agent do
     expect(agent.timed_out?).to be(true)
   end
 
+  it 'knows if it is not running' do
+    agent = make_agent('007')
+    allow(agent).to receive(:job_state).and_return('running')
+    allow(agent).to receive(:has_processes).and_return(true)
+    expect(agent.is_not_running?).to be(false)
+
+    allow(agent).to receive(:has_processes).and_return(false)
+    expect(agent.is_not_running?).to be(true)
+
+    allow(agent).to receive(:job_state).and_return('not-running')
+    expect(agent.is_not_running?).to be(true)
+  end
+
   it "knows if it is rogue if it isn't associated with deployment for :rogue_agent_alert seconds" do
     now = Time.now
     agent = make_agent('007')

--- a/src/bosh-monitor/spec/unit/bosh/monitor/agent_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/agent_spec.rb
@@ -22,15 +22,17 @@ describe Bosh::Monitor::Agent do
   end
 
   it 'knows if it is not running' do
-    agent = make_agent('007')
-    allow(agent).to receive(:job_state).and_return('running')
-    allow(agent).to receive(:has_processes).and_return(true)
-    expect(agent.is_not_running?).to be(false)
 
-    allow(agent).to receive(:has_processes).and_return(false)
+    agent = Bosh::Monitor::Agent.new('007', opts = {job_state: 'running', has_processes: true})
+    expect(agent.is_not_running?).to be(false)
+    
+    agent = Bosh::Monitor::Agent.new('007', opts = {job_state: 'running', has_processes: false})
     expect(agent.is_not_running?).to be(true)
 
-    allow(agent).to receive(:job_state).and_return('not-running')
+    agent = Bosh::Monitor::Agent.new('007', opts = {job_state: 'not-running', has_processes: false})
+    expect(agent.is_not_running?).to be(true)
+
+    agent = Bosh::Monitor::Agent.new('007', opts = {job_state: 'not-running', has_processes: true})
     expect(agent.is_not_running?).to be(true)
   end
 
@@ -66,7 +68,7 @@ describe Bosh::Monitor::Agent do
   describe '#update_instance' do
     context 'when given an instance' do
       let(:instance) do
-        double('instance', job: 'job', index: 1, cid: 'cid', id: 'id')
+        double('instance', job: 'job', index: 1, cid: 'cid', id: 'id', job_state: 'job_state', has_processes: 'has_processes')
       end
 
       it 'populates the corresponding attributes' do
@@ -78,6 +80,8 @@ describe Bosh::Monitor::Agent do
         expect(agent.index).to eq(instance.index)
         expect(agent.cid).to eq(instance.cid)
         expect(agent.instance_id).to eq(instance.id)
+        expect(agent.job_state).to eq(instance.job_state)
+        expect(agent.has_processes).to eq(instance.has_processes)
       end
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/api_controller_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/api_controller_spec.rb
@@ -85,4 +85,35 @@ describe Bosh::Monitor::ApiController do
 
     end
   end
+
+  describe '/unhealthy_instances' do
+    let(:unhealthy_instances) do
+      {
+        'first_deployment' => 2,
+        'second_deployment' => 0,
+      }
+    end
+    before do
+      allow(Bosh::Monitor.instance_manager).to receive(:unhealthy_instances).and_return(unhealthy_instances)
+      allow(Bosh::Monitor.instance_manager).to receive(:director_initial_deployment_sync_done).and_return(true)
+    end
+
+    it 'renders the unhealthy instances' do
+      get '/unhealthy_instances'
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq(JSON.generate(unhealthy_instances))
+    end
+
+    context 'When director initial deployment sync has not completed' do
+      before do
+        allow(Bosh::Monitor.instance_manager).to receive(:director_initial_deployment_sync_done).and_return(false)
+      end
+
+      it 'returns 503 when /unhealthy_instances is requested' do
+        get '/unhealthy_instances'
+        expect(last_response.status).to eq(503)
+      end
+
+    end
+  end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/director_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/director_spec.rb
@@ -224,7 +224,7 @@ describe 'Bosh::Monitor::Director' do
       it 'raises a DirectorError' do
         expect {
         director.get_deployment_instances_full('foo')
-        }.to raise_error(Bosh::Monitor::DirectorError, "Cannot find any task to retrieve vm stats")
+        }.to raise_error(Bosh::Monitor::DirectorError, "Can not find 'location' response header to retrieve the task location")
       end
     end
 
@@ -255,7 +255,7 @@ describe 'Bosh::Monitor::Director' do
         allow(logger).to receive(:warn)
         expect {
         director.get_deployment_instances_full('foo')
-        }.to raise_error(Bosh::Monitor::DirectorError, "Fetching full instance details for deployment foo failed")
+        }.to raise_error(Bosh::Monitor::DirectorError, "Fetching full instance details for deployment 'foo' failed")
       end
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/director_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/director_spec.rb
@@ -7,6 +7,7 @@ describe 'Bosh::Monitor::Director' do
   # Director client uses event loop and fibers to perform HTTP queries asynchronosuly.
   # However we don't test that here, we only test the synchronous interface.
   # This is way overmocked so it needs an appropriate support from integration tests.
+  let(:logger) { instance_double("Logger") }
   subject(:director) do
     Bosh::Monitor::Director.new(
       {
@@ -16,12 +17,18 @@ describe 'Bosh::Monitor::Director' do
         'client_id' => 'hm',
         'client_secret' => 'secret',
         'ca_cert' => 'fake-ca-cert',
-      }, double(:logger)
+      }, logger
     )
   end
 
   let(:deployments) { [{ 'name' => 'a' }, { 'name' => 'b' }] }
   let(:resurrection_config) { [{ 'content' => '--- {}', 'id' => '1', 'type' => 'resurrection', 'name' => 'some-name' }] }
+  let(:auth_provider) { double }
+
+  before do
+    # Stub the sleep method to avoid actual waiting in tests
+    allow_any_instance_of(Bosh::Monitor::Director).to receive(:sleep).and_return(0)
+  end
 
   context 'when director is running in non-UAA mode' do
     before do
@@ -132,6 +139,127 @@ describe 'Bosh::Monitor::Director' do
       expect(director.deployments).to eq(deployments)
     end
   end
+
+  describe '#get_deployment_instances_full' do
+    before do
+      stub_request(:get, 'http://localhost:8080/director/info')
+        .to_return(body: json_dump({}), status: 200)
+    end
+    context 'when the task succeeds with state done' do
+      let(:task_location) { '/task/123' }
+      let(:task_result) { "{\"vm\": \"details1\"}\n{\"vm\": \"details2\"}\n" }
+      let(:auth_header) { { 'Authorization' => 'Basic YWRtaW46YWRtaW4=', 'Accept-Encoding' => 'gzip' } }
+
+      before do
+        # Stub initial request to get task location
+        stub_request(:get, "http://localhost:8080/director/deployments/foo/instances?format=full")
+        .with(headers: auth_header)
+        .with(basic_auth: %w[admin admin])
+        .to_return(status: 200, headers: { 'location' => task_location })
+
+        # Stub requests for task status
+        stub_request(:get, "http://localhost:8080/director#{task_location}")
+        .with(headers: auth_header)
+        .to_return(
+        { status: 206, body: "" },
+        { status: 200, body: '{"state":"done"}' }
+        )
+
+        # Stub final request to get task result
+        stub_request(:get, "http://localhost:8080/director#{task_location}/output?type=result")
+        .with(headers: auth_header)
+        .to_return(status: 200, body: task_result)
+      end
+
+      it 'returns parsed instance details' do
+        allow(Logging).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:warn)
+        expect(director.get_deployment_instances_full('foo')).to eq([{"vm"=>"details1"}, {"vm"=>"details2"}])
+      end
+    end
+
+    context 'when the task fails with an error state' do
+      let(:task_location) { '/task/123' }
+      let(:auth_header) { { 'Authorization' => 'Basic YWRtaW46YWRtaW4=', 'Accept-Encoding' => 'gzip' } }
+      before do
+        # Stub request to get instance info leading to a task
+        stub_request(:get, "http://localhost:8080/director/deployments/foo/instances?format=full")
+        .with(headers: auth_header)
+        .to_return(status: 302, headers: { 'location' => task_location })
+        
+        # Stub task status checks
+        stub_request(:get, "http://localhost:8080/director#{task_location}")
+        .with(headers: auth_header)
+        .to_return(
+        { status: 200, body: '{"state":"queued"}' },
+        { status: 200, body: '{"state":"processing"}' },
+        { status: 200, body: '{"state":"error"}' } # Simulate eventual 'error' state
+        )
+        
+        # Final stub to avoid errors on log completion attempt
+        stub_request(:get, "http://localhost:8080/director#{task_location}/output?type=result")
+        .with(headers: auth_header)
+        .to_return(status: 500, body: '') # Simulate failure response on output fetch
+      end
+    
+      it 'logs a warning and returns nil' do
+        allow(Logging).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:warn)
+        expect(logger).to receive(:warn).with(/The number of retries to fetch instance details for deployment/)
+        result, state = director.get_deployment_instances_full('foo', 1)
+        expect(result).to be_nil
+        expect(state).to eq('error')
+      end
+    end
+
+    context 'when task location cannot be found' do
+      let(:auth_header) { { 'Authorization' => 'Basic YWRtaW46YWRtaW4=', 'Accept-Encoding' => 'gzip' } }
+      before do
+        stub_request(:get, "http://localhost:8080/director/deployments/foo/instances?format=full")
+        .with(headers: auth_header)
+        .with(basic_auth: %w[admin admin])
+        .to_return(status: 200)
+      end
+
+      it 'raises a DirectorError' do
+        expect {
+        director.get_deployment_instances_full('foo')
+        }.to raise_error(Bosh::Monitor::DirectorError, "Cannot find any task to retrieve vm stats")
+      end
+    end
+
+    context 'when task result fetching fails' do
+      let(:task_location) { '/task/123' }
+      let(:auth_header) { { 'Authorization' => 'Basic YWRtaW46YWRtaW4=', 'Accept-Encoding' => 'gzip' } }
+
+      before do
+        # Stub initial request to get task location
+        stub_request(:get, "http://localhost:8080/director/deployments/foo/instances?format=full")
+        .with(headers: auth_header)
+        .with(basic_auth: %w[admin admin])
+        .to_return(status: 200, headers: { 'location' => task_location })
+
+        # Stub requests for task status
+        stub_request(:get, "http://localhost:8080/director#{task_location}")
+        .with(headers: auth_header)
+        .to_return(status: 200, body: '{"state":"done"}')
+
+        # Stub final request to get task result
+        stub_request(:get, "http://localhost:8080/director#{task_location}/output?type=result")
+        .with(headers: auth_header)
+        .to_return(status: 500, body: 'error message')
+      end
+
+      it 'raises a DirectorError' do
+        allow(Logging).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:warn)
+        expect {
+        director.get_deployment_instances_full('foo')
+        }.to raise_error(Bosh::Monitor::DirectorError, "Fetching full instance details for deployment foo failed")
+      end
+    end
+  end
+
 
   def json_dump(data)
     JSON.dump(data)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
@@ -4,6 +4,7 @@ module Bosh::Monitor
   describe InstanceManager do
     let(:event_processor) { double(Bosh::Monitor::EventProcessor) }
     let(:manager) { described_class.new(event_processor) }
+    let(:director) { double }
 
     before do
       allow(event_processor).to receive(:process)
@@ -557,6 +558,41 @@ module Bosh::Monitor
         expect do
           manager.setup_events
         end.to raise_error(Bosh::Monitor::PluginError, "Cannot find 'joes_plugin_thing' plugin")
+      end
+    end
+
+    describe '#fetch_deployments' do
+      let(:deployments) { [{ 'name' => 'my_deployment' }] }
+      let(:instances_data) { [{ 'id' => 'instance-1-id', 'job' => 'test-job', 'agent_id' => 'agent-1' }] }
+      let(:instances_data_full) { [{ 'id' => 'instance-1-id', 'job_state' => 'running', 'processes' => [] }] }
+
+      before do
+        allow(director).to receive(:deployments).and_return(deployments)
+        allow(director).to receive(:get_deployment_instances).with('my_deployment').and_return(instances_data)
+        allow(director).to receive(:get_deployment_instances_full).with('my_deployment').and_return(instances_data_full)
+      end
+
+      it 'updates instance data with full instance information' do
+        manager.fetch_deployments(director)
+
+        deployment = manager.instance_variable_get(:@deployment_name_to_deployments)['my_deployment']
+        instance = deployment.instances.find { |i| i.id == 'instance-1-id' }
+
+        expect(instance.job_state).to eq('running')
+        expect(instance.has_processes).to be false
+      end
+    end
+
+    describe '#unhealthy_instances' do
+      it 'can return number of unhealthy instances for each deployment' do
+        instance1 = Bosh::Monitor::Instance.create('id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'job_state' => 'running', 'has_processes' => true)
+        instance2 = Bosh::Monitor::Instance.create('id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'job' => 'nats', 'job_state' => 'not-running', 'has_processes' => true)
+        instance3 = Bosh::Monitor::Instance.create('id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node', 'job_state' => 'running', 'has_processes' => false)
+
+        manager.sync_deployments([{ 'name' => 'mycloud' }])
+        manager.sync_agents('mycloud', [instance1, instance2, instance3])
+
+        expect(manager.unhealthy_instances).to eq('mycloud' => 2)
       end
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/instance_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/instance_spec.rb
@@ -17,6 +17,8 @@ describe Bosh::Monitor::Instance do
       'index' => '0',
       'cid' => 'cuuid',
       'expects_vm' => true,
+      'job_state' => 'running',
+      'has_processes' => true
     )
 
     expect(instance).to be_a(Bosh::Monitor::Instance)
@@ -26,6 +28,8 @@ describe Bosh::Monitor::Instance do
     expect(instance.index).to eq('0')
     expect(instance.cid).to eq('cuuid')
     expect(instance.expects_vm).to be_truthy
+    expect(instance.job_state).to eq('running')
+    expect(instance.has_processes).to be_truthy
   end
 
   describe '#vm?' do
@@ -37,6 +41,8 @@ describe Bosh::Monitor::Instance do
           'job' => 'zb',
           'index' => '0',
           'expects_vm' => true,
+          'job_state' => 'running',
+          'has_processes' => false
         )
 
         expect(instance.vm?).to be_falsey
@@ -52,6 +58,8 @@ describe Bosh::Monitor::Instance do
           'index' => '0',
           'cid' => 'cuuid',
           'expects_vm' => true,
+          'job_state' => 'running',
+          'has_processes' => true
         )
 
         expect(instance.vm?).to be_truthy
@@ -68,6 +76,8 @@ describe Bosh::Monitor::Instance do
         'index' => '0',
         'cid' => 'cuuid',
         'expects_vm' => true,
+        'job_state' => 'running',
+        'has_processes' => true
       )
     end
 
@@ -77,7 +87,7 @@ describe Bosh::Monitor::Instance do
 
     context 'instance has all attributes' do
       it 'returns full name' do
-        expect(instance.name).to eq('my_deployment: zb(iuuid) [agent_id=auuid, index=0, cid=cuuid]')
+        expect(instance.name).to eq('my_deployment: zb(iuuid) [agent_id=auuid, index=0, job_state=running, has_processes=true, cid=cuuid]')
       end
     end
 
@@ -91,7 +101,7 @@ describe Bosh::Monitor::Instance do
 
     context 'instance has no job' do
       let(:instance) do
-        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'index' => '0', 'cid' => 'cuuid', 'expects_vm' => true)
+        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'index' => '0', 'cid' => 'cuuid', 'expects_vm' => true, 'job_state' => nil, 'has_processes' => false)
       end
 
       it 'returns name without job' do
@@ -101,17 +111,17 @@ describe Bosh::Monitor::Instance do
 
     context 'instance has no index' do
       let(:instance) do
-        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'job' => 'zb', 'cid' => 'cuuid', 'expects_vm' => true)
+        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'job' => 'zb', 'cid' => 'cuuid', 'expects_vm' => true, 'job_state' => 'failing', 'has_processes' => false)
       end
 
       it 'returns name without index' do
-        expect(instance.name).to eq('my_deployment: zb(iuuid) [agent_id=auuid, cid=cuuid]')
+        expect(instance.name).to eq('my_deployment: zb(iuuid) [agent_id=auuid, job_state=failing, cid=cuuid]')
       end
     end
 
     context 'instance has no agent_id' do
       let(:instance) do
-        Bosh::Monitor::Instance.create('id' => 'iuuid', 'job' => 'zb', 'index' => '0', 'cid' => 'cuuid', 'expects_vm' => true)
+        Bosh::Monitor::Instance.create('id' => 'iuuid', 'job' => 'zb', 'index' => '0', 'cid' => 'cuuid', 'expects_vm' => true, 'job_state' => nil, 'has_processes' => false)
       end
 
       it 'returns name without agent_id ' do
@@ -121,7 +131,7 @@ describe Bosh::Monitor::Instance do
 
     context 'instance has no cid' do
       let(:instance) do
-        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'job' => 'zb', 'index' => '0', 'expects_vm' => true)
+        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'job' => 'zb', 'index' => '0', 'expects_vm' => true, 'job_state' => nil, 'has_processes' => false)
       end
 
       it 'returns name without cid' do


### PR DESCRIPTION
### What is this change about?

As of now, bosh does not collect metrics regarding VMs which are unhealthy (basically any state that is not running). With this PR, we now introduce a new metric: bosh_unhealthy_instances, which basically reports the same.

### What tests have you run against this PR?

We tested a bosh dev release on our development environments for the new metric, and it worked fine. We also ran the bosh-monitor unit tests, and added more as needed.

### How should this change be described in bosh release notes?

Bosh now emits a new metric: "bosh_unhealthy_instances", which can be used to track unhealthy instances per deployment over time.

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@DennisAhaus
