### PR TITLE
set retry interval to avoid bosh workers sleeping forever in case of error

### DIFF
--- a/src/bosh-director/lib/bosh/director/worker.rb
+++ b/src/bosh-director/lib/bosh/director/worker.rb
@@ -7,6 +7,7 @@ module Bosh
       def initialize(config, index = 0)
         @config = config
         @index = index
+        @retry_interval = 5
       end
 
       def prep
@@ -44,7 +45,7 @@ module Bosh
           @delayed_job_worker.start
         rescue StandardError => e
           @delayed_job_worker.logger.error(
-            "Something goes wrong during worker start. Attempt #{@delayed_job_worker_retries}. Error: #{e.inspect}",
+            "Something went wrong during worker start. Attempt #{@delayed_job_worker_retries}. Error: #{e.inspect}",
           )
           while @delayed_job_worker_retries < 10
             @delayed_job_worker_retries += 1


### PR DESCRIPTION
### What is this change about?

We noticed that if bosh workers fail to startup for some reason, they go to sleep forever. This is due to the @retry_interval not being set [here](https://github.com/cloudfoundry/bosh/blob/d1148167076763449bd1cd616e70200657b87353/src/bosh-director/lib/bosh/director/worker.rb#L51).
In our case the workers were not able to reach the database for some time, but instead of retrying they just went to sleep forever. Due to that the worker processes were still reported as running when doing `monit summary `. However, tasks where not picked up anymore, resulting in a long task queue. We could temporarily fix it by stopping and starting the director process:

```

monit stop director
monit start director
```

### What tests have you run against this PR?

unit tests

### How should this change be described in bosh release notes?

Fix bug leading to forever sleeping workers

### Does this PR introduce a breaking change?

no

### Tag your pair, your PM, and/or team!
@DennisAhaus 