### PR TITLE
Revert "Add metrics for other unhealthy VM states"

### DIFF
--- a/src/bosh-director/spec/unit/metrics_collector_spec.rb
+++ b/src/bosh-director/spec/unit/metrics_collector_spec.rb
@@ -35,8 +35,6 @@ module Bosh::Director
       allow(Api::ConfigManager).to receive(:deploy_config_enabled?).and_return(true, false)
       stub_request(:get, /unresponsive_agents/)
         .to_return(status: 200, body: JSON.dump('flaky_deployment' => 1, 'good_deployment' => 0))
-      stub_request(:get, /unhealthy_instances/)
-        .to_return(status: 200, body: JSON.dump('flaky_deployment' => 1, 'good_deployment' => 0))
     end
 
     after do
@@ -46,7 +44,6 @@ module Bosh::Director
       Prometheus::Client.registry.unregister(:bosh_networks_dynamic_ips_total)
       Prometheus::Client.registry.unregister(:bosh_networks_dynamic_free_ips_total)
       Prometheus::Client.registry.unregister(:bosh_unresponsive_agents)
-      Prometheus::Client.registry.unregister(:bosh_unhealthy_instances)
     end
 
     describe '#prep' do
@@ -289,107 +286,53 @@ module Bosh::Director
       end
 
       describe 'vm metrics' do
-        context 'unresponsive agents' do
-          it 'emits the number of unresponsive agents for each deployment' do
+        it 'emits the number of unresponsive agents for each deployment' do
+          metrics_collector.start
+          metric = Prometheus::Client.registry.get(:bosh_unresponsive_agents)
+          expect(metric.get(labels: { name: 'flaky_deployment' })).to eq(1)
+          expect(metric.get(labels: { name: 'good_deployment' })).to eq(0)
+        end
+
+        context 'when the health monitor returns a non 200 response' do
+          before do
+            stub_request(:get, '127.0.0.1:12345/unresponsive_agents')
+              .to_return(status: 404)
+          end
+
+          it 'does not emit the vm metrics' do
             metrics_collector.start
             metric = Prometheus::Client.registry.get(:bosh_unresponsive_agents)
-            expect(metric.get(labels: { name: 'flaky_deployment' })).to eq(1)
-            expect(metric.get(labels: { name: 'good_deployment' })).to eq(0)
-          end
-
-          context 'when the health monitor returns a non 200 response' do
-            before do
-              stub_request(:get, '127.0.0.1:12345/unresponsive_agents')
-                .to_return(status: 404)
-            end
-
-            it 'does not emit the vm metrics' do
-              metrics_collector.start
-              metric = Prometheus::Client.registry.get(:bosh_unresponsive_agents)
-              expect(metric.values).to be_empty
-            end
-          end
-
-          context 'when the health monitor returns a non-json response' do
-            before do
-              stub_request(:get, '127.0.0.1:12345/unresponsive_agents')
-                .to_return(status: 200, body: JSON.dump('bad response'))
-            end
-
-            it 'does not emit the vm metrics' do
-              metrics_collector.start
-              metric = Prometheus::Client.registry.get(:bosh_unresponsive_agents)
-              expect(metric.values).to be_empty
-            end
-          end
-
-          context 'when a deployment is deleted after metrics are gathered' do
-            before do
-              stub_request(:get, /unresponsive_agents/)
-                .to_return(status: 200, body: JSON.dump('flaky_deployment' => 1, 'good_deployment' => 0))
-              metrics_collector.start
-
-              stub_request(:get, /unresponsive_agents/)
-                .to_return(status: 200, body: JSON.dump('good_deployment' => 0))
-              scheduler.tick
-            end
-
-            it 'resets the metrics for the deleted deployment' do
-              metric = Prometheus::Client.registry.get(:bosh_unresponsive_agents)
-              expect(metric.get(labels: { name: 'flaky_deployment' })).to eq(0)
-            end
+            expect(metric.values).to be_empty
           end
         end
 
-        context 'unhealthy instances' do
-          it 'emits the number of unhealthy instances for each deployment' do
+        context 'when the health monitor returns a non-json response' do
+          before do
+            stub_request(:get, '127.0.0.1:12345/unresponsive_agents')
+              .to_return(status: 200, body: JSON.dump('bad response'))
+          end
+
+          it 'does not emit the vm metrics' do
             metrics_collector.start
-            metric = Prometheus::Client.registry.get(:bosh_unhealthy_instances)
-            expect(metric.get(labels: { name: 'flaky_deployment' })).to eq(1)
-            expect(metric.get(labels: { name: 'good_deployment' })).to eq(0)
+            metric = Prometheus::Client.registry.get(:bosh_unresponsive_agents)
+            expect(metric.values).to be_empty
+          end
+        end
+
+        context 'when a deployment is deleted after metrics are gathered' do
+          before do
+            stub_request(:get, /unresponsive_agents/)
+              .to_return(status: 200, body: JSON.dump('flaky_deployment' => 1, 'good_deployment' => 0))
+            metrics_collector.start
+
+            stub_request(:get, /unresponsive_agents/)
+              .to_return(status: 200, body: JSON.dump('good_deployment' => 0))
+            scheduler.tick
           end
 
-          context 'when the health monitor returns a non 200 response' do
-            before do
-              stub_request(:get, '127.0.0.1:12345/unhealthy_instances')
-                .to_return(status: 404)
-            end
-
-            it 'does not emit the vm metrics' do
-              metrics_collector.start
-              metric = Prometheus::Client.registry.get(:bosh_unhealthy_instances)
-              expect(metric.values).to be_empty
-            end
-          end
-
-          context 'when the health monitor returns a non-json response' do
-            before do
-              stub_request(:get, '127.0.0.1:12345/unhealthy_instances')
-                .to_return(status: 200, body: JSON.dump('bad response'))
-            end
-
-            it 'does not emit the vm metrics' do
-              metrics_collector.start
-              metric = Prometheus::Client.registry.get(:bosh_unhealthy_instances)
-              expect(metric.values).to be_empty
-            end
-          end
-
-          context 'when a deployment is deleted after metrics are gathered' do
-            before do
-              stub_request(:get, /unhealthy_instances/)
-                .to_return(status: 200, body: JSON.dump('flaky_deployment' => 1, 'good_deployment' => 0))
-              metrics_collector.start
-
-              stub_request(:get, /unhealthy_instances/)
-                .to_return(status: 200, body: JSON.dump('good_deployment' => 0))
-              scheduler.tick
-            end
-
-            it 'resets the metrics for the deleted deployment' do
-              metric = Prometheus::Client.registry.get(:bosh_unhealthy_instances)
-              expect(metric.get(labels: { name: 'flaky_deployment' })).to eq(0)
-            end
+          it 'resets the metrics for the deleted deployment' do
+            metric = Prometheus::Client.registry.get(:bosh_unresponsive_agents)
+            expect(metric.get(labels: { name: 'flaky_deployment' })).to eq(0)
           end
         end
       end

--- a/src/bosh-monitor/lib/bosh/monitor/agent.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/agent.rb
@@ -4,7 +4,7 @@ module Bosh::Monitor
     attr_reader   :discovered_at
     attr_accessor :updated_at
 
-    ATTRIBUTES = %i[deployment job index instance_id cid job_state has_processes].freeze
+    ATTRIBUTES = %i[deployment job index instance_id cid].freeze
 
     ATTRIBUTES.each do |attribute|
       attr_accessor attribute
@@ -24,8 +24,6 @@ module Bosh::Monitor
       @index = opts[:index]
       @cid = opts[:cid]
       @instance_id = opts[:instance_id]
-      @job_state = opts[:job_state]
-      @has_processes = opts[:has_processes]
     end
 
     def name
@@ -53,17 +51,11 @@ module Bosh::Monitor
       (Time.now - @discovered_at) > @intervals.rogue_agent_alert && @deployment.nil?
     end
 
-    def is_not_running?
-      @job_state.to_s != 'running' || @has_processes == false
-    end
-
     def update_instance(instance)
       @job = instance.job
       @index = instance.index
       @cid = instance.cid
       @instance_id = instance.id
-      @job_state = instance.job_state
-      @has_processes = instance.has_processes
     end
   end
 end

--- a/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/api_controller.rb
@@ -40,13 +40,5 @@ module Bosh::Monitor
         status(503)
       end
     end
-
-    get '/unhealthy_instances' do
-      if @instance_manager.director_initial_deployment_sync_done
-        JSON.generate(@instance_manager.unhealthy_instances)
-      else
-        status(503)
-      end
-    end
   end
 end

--- a/src/bosh-monitor/lib/bosh/monitor/director.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/director.rb
@@ -31,52 +31,6 @@ module Bosh::Monitor
       parse_json(body, Array)
     end
 
-    def get_deployment_instances_full(name, recursive_counter=0)
-      body, status, headers = perform_request(:get, "/deployments/#{name}/instances?format=full")
-      sleep_amount_seconds = 1
-      location = headers['location']
-      unless !location.nil? && location.include?('task')
-        raise DirectorError, "Can not find 'location' response header to retrieve the task location"
-      end
-      counter = 0
-      # States are documented here: https://bosh.io/docs/director-api-v1/#list-tasks
-      truthy_states = %w(cancelled cancelling done error timeout)
-      falsy_states = %w(queued processing)
-      body = nil, status = nil, state = nil
-      loop do
-        counter = counter + 1
-        body, status = perform_request(:get, location)
-        if status == 206 || body.nil? || body.empty?
-          sleep_amount_seconds = counter + sleep_amount_seconds
-          sleep(sleep_amount_seconds)
-          next
-        end
-        json_output = parse_json(body, Hash)
-        state = json_output['state']
-        if truthy_states.include?(state) || counter > 5
-          @logger.warn("The number of retries to fetch instance details for deployment '#{name}' has exceeded. Could not get the expected response from '#{location}'")
-          break
-        end
-        sleep_amount_seconds = counter + sleep_amount_seconds
-        sleep(sleep_amount_seconds)
-      end
-      updated_body = nil
-      if state == 'done'
-        body, status = perform_request(:get, "#{location}/output?type=result")
-        if status!= 200 || body.nil? || body.empty?
-          raise DirectorError, "Fetching full instance details for deployment '#{name}' failed"
-        end
-        updated_body = "[#{body.chomp.gsub(/\R+/, ',')}]"
-        return parse_json(updated_body, Array)
-      else
-        if recursive_counter > 0
-          return updated_body, state
-        end
-        @logger.warn("Could not fetch instance details for deployment '#{name}' in the first attempt, retrying once more ...")
-        return get_deployment_instances_full(name, recursive_counter + 1)
-      end
-    end
-
     private
 
     def endpoint
@@ -96,12 +50,10 @@ module Bosh::Monitor
     end
 
     def perform_request(method, request_path, options = {})
-      if !request_path.nil?
-       request_path = request_path.sub(endpoint, '')
-      end
-      parsed_endpoint = URI.parse(endpoint + (request_path || ''))
-      headers = options['headers'] || {}
+      parsed_endpoint = URI.parse(endpoint + request_path)
+      headers = {}
       headers['authorization'] = auth_provider.auth_header unless options.fetch(:no_login, false)
+
       ssl_context = OpenSSL::SSL::SSLContext.new
       ssl_context.set_params(verify_mode: OpenSSL::SSL::VERIFY_NONE)
       async_endpoint = Async::HTTP::Endpoint.parse(parsed_endpoint.to_s, ssl_context: ssl_context)
@@ -110,7 +62,7 @@ module Bosh::Monitor
       body   = response.read
       status = response.status
 
-      [body, status, response.headers]
+      [body, status]
     rescue URI::Error
       raise DirectorError, "Invalid URI: #{endpoint + request_path}"
     rescue => e

--- a/src/bosh-monitor/lib/bosh/monitor/instance.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/instance.rb
@@ -1,7 +1,7 @@
 module Bosh::Monitor
   class Instance
-    attr_reader :id, :agent_id, :job, :index, :cid, :expects_vm, :job_state, :has_processes
-    attr_accessor :deployment, :job_state
+    attr_reader :id, :agent_id, :job, :index, :cid, :expects_vm
+    attr_accessor :deployment
 
     def initialize(instance_data)
       @logger = Bosh::Monitor.logger
@@ -11,8 +11,6 @@ module Bosh::Monitor
       @index = instance_data['index']
       @cid = instance_data['cid']
       @expects_vm = instance_data['expects_vm']
-      @job_state = instance_data['job_state']
-      @has_processes = instance_data['has_processes']
     end
 
     def self.create(instance_data)
@@ -32,11 +30,11 @@ module Bosh::Monitor
     def name
       if @job
         identifier = "#{@job}(#{@id})"
-        attributes = create_optional_attributes(%i[agent_id index job_state has_processes])
+        attributes = create_optional_attributes(%i[agent_id index])
         attributes += create_mandatory_attributes([:cid])
       else
         identifier = "instance #{@id}"
-        attributes = create_optional_attributes(%i[agent_id job index cid expects_vm job_state has_processes])
+        attributes = create_optional_attributes(%i[agent_id job index cid expects_vm])
       end
 
       "#{@deployment}: #{identifier} [#{attributes.join(', ')}]"

--- a/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/instance_manager.rb
@@ -34,12 +34,6 @@ module Bosh::Monitor
 
         @logger.debug("Fetching instances information for '#{deployment_name}'...")
         instances_data = director.get_deployment_instances(deployment_name)
-        instances_data_full = director.get_deployment_instances_full(deployment_name)
-        instances_data_hash = instances_data.to_h {|element| [element['id'], element] }
-        instances_data_full.each do |instance_full|
-          instances_data_hash[instance_full['id']]['job_state'] = instance_full['job_state']
-          instances_data_hash[instance_full['id']]['has_processes'] = !instance_full['processes'].empty?
-        end
         sync_deployment_state(deployment, instances_data)
       end
       @director_initial_deployment_sync_done = true
@@ -125,15 +119,6 @@ module Bosh::Monitor
       end
 
       agents_hash
-    end
-
-    def unhealthy_instances # See: https://bosh.io/docs/director-api-v1/#list-instances-detailed (if job is not runnung => state is unhealthy)
-      instances = {}
-      @deployment_name_to_deployments.each do |name, deployment|
-        instances[name] = deployment.agents.count(&:is_not_running?)
-      end
-
-      instances
     end
 
     def analyze_agents

--- a/src/bosh-monitor/spec/unit/bosh/monitor/agent_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/agent_spec.rb
@@ -21,21 +21,6 @@ describe Bosh::Monitor::Agent do
     expect(agent.timed_out?).to be(true)
   end
 
-  it 'knows if it is not running' do
-
-    agent = Bosh::Monitor::Agent.new('007', opts = {job_state: 'running', has_processes: true})
-    expect(agent.is_not_running?).to be(false)
-    
-    agent = Bosh::Monitor::Agent.new('007', opts = {job_state: 'running', has_processes: false})
-    expect(agent.is_not_running?).to be(true)
-
-    agent = Bosh::Monitor::Agent.new('007', opts = {job_state: 'not-running', has_processes: false})
-    expect(agent.is_not_running?).to be(true)
-
-    agent = Bosh::Monitor::Agent.new('007', opts = {job_state: 'not-running', has_processes: true})
-    expect(agent.is_not_running?).to be(true)
-  end
-
   it "knows if it is rogue if it isn't associated with deployment for :rogue_agent_alert seconds" do
     now = Time.now
     agent = make_agent('007')
@@ -68,7 +53,7 @@ describe Bosh::Monitor::Agent do
   describe '#update_instance' do
     context 'when given an instance' do
       let(:instance) do
-        double('instance', job: 'job', index: 1, cid: 'cid', id: 'id', job_state: 'job_state', has_processes: 'has_processes')
+        double('instance', job: 'job', index: 1, cid: 'cid', id: 'id')
       end
 
       it 'populates the corresponding attributes' do
@@ -80,8 +65,6 @@ describe Bosh::Monitor::Agent do
         expect(agent.index).to eq(instance.index)
         expect(agent.cid).to eq(instance.cid)
         expect(agent.instance_id).to eq(instance.id)
-        expect(agent.job_state).to eq(instance.job_state)
-        expect(agent.has_processes).to eq(instance.has_processes)
       end
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/api_controller_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/api_controller_spec.rb
@@ -85,35 +85,4 @@ describe Bosh::Monitor::ApiController do
 
     end
   end
-
-  describe '/unhealthy_instances' do
-    let(:unhealthy_instances) do
-      {
-        'first_deployment' => 2,
-        'second_deployment' => 0,
-      }
-    end
-    before do
-      allow(Bosh::Monitor.instance_manager).to receive(:unhealthy_instances).and_return(unhealthy_instances)
-      allow(Bosh::Monitor.instance_manager).to receive(:director_initial_deployment_sync_done).and_return(true)
-    end
-
-    it 'renders the unhealthy instances' do
-      get '/unhealthy_instances'
-      expect(last_response.status).to eq(200)
-      expect(last_response.body).to eq(JSON.generate(unhealthy_instances))
-    end
-
-    context 'When director initial deployment sync has not completed' do
-      before do
-        allow(Bosh::Monitor.instance_manager).to receive(:director_initial_deployment_sync_done).and_return(false)
-      end
-
-      it 'returns 503 when /unhealthy_instances is requested' do
-        get '/unhealthy_instances'
-        expect(last_response.status).to eq(503)
-      end
-
-    end
-  end
 end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/director_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/director_spec.rb
@@ -7,7 +7,6 @@ describe 'Bosh::Monitor::Director' do
   # Director client uses event loop and fibers to perform HTTP queries asynchronosuly.
   # However we don't test that here, we only test the synchronous interface.
   # This is way overmocked so it needs an appropriate support from integration tests.
-  let(:logger) { instance_double("Logger") }
   subject(:director) do
     Bosh::Monitor::Director.new(
       {
@@ -17,18 +16,12 @@ describe 'Bosh::Monitor::Director' do
         'client_id' => 'hm',
         'client_secret' => 'secret',
         'ca_cert' => 'fake-ca-cert',
-      }, logger
+      }, double(:logger)
     )
   end
 
   let(:deployments) { [{ 'name' => 'a' }, { 'name' => 'b' }] }
   let(:resurrection_config) { [{ 'content' => '--- {}', 'id' => '1', 'type' => 'resurrection', 'name' => 'some-name' }] }
-  let(:auth_provider) { double }
-
-  before do
-    # Stub the sleep method to avoid actual waiting in tests
-    allow_any_instance_of(Bosh::Monitor::Director).to receive(:sleep).and_return(0)
-  end
 
   context 'when director is running in non-UAA mode' do
     before do
@@ -139,127 +132,6 @@ describe 'Bosh::Monitor::Director' do
       expect(director.deployments).to eq(deployments)
     end
   end
-
-  describe '#get_deployment_instances_full' do
-    before do
-      stub_request(:get, 'http://localhost:8080/director/info')
-        .to_return(body: json_dump({}), status: 200)
-    end
-    context 'when the task succeeds with state done' do
-      let(:task_location) { '/task/123' }
-      let(:task_result) { "{\"vm\": \"details1\"}\n{\"vm\": \"details2\"}\n" }
-      let(:auth_header) { { 'Authorization' => 'Basic YWRtaW46YWRtaW4=', 'Accept-Encoding' => 'gzip' } }
-
-      before do
-        # Stub initial request to get task location
-        stub_request(:get, "http://localhost:8080/director/deployments/foo/instances?format=full")
-        .with(headers: auth_header)
-        .with(basic_auth: %w[admin admin])
-        .to_return(status: 200, headers: { 'location' => task_location })
-
-        # Stub requests for task status
-        stub_request(:get, "http://localhost:8080/director#{task_location}")
-        .with(headers: auth_header)
-        .to_return(
-        { status: 206, body: "" },
-        { status: 200, body: '{"state":"done"}' }
-        )
-
-        # Stub final request to get task result
-        stub_request(:get, "http://localhost:8080/director#{task_location}/output?type=result")
-        .with(headers: auth_header)
-        .to_return(status: 200, body: task_result)
-      end
-
-      it 'returns parsed instance details' do
-        allow(Logging).to receive(:logger).and_return(logger)
-        allow(logger).to receive(:warn)
-        expect(director.get_deployment_instances_full('foo')).to eq([{"vm"=>"details1"}, {"vm"=>"details2"}])
-      end
-    end
-
-    context 'when the task fails with an error state' do
-      let(:task_location) { '/task/123' }
-      let(:auth_header) { { 'Authorization' => 'Basic YWRtaW46YWRtaW4=', 'Accept-Encoding' => 'gzip' } }
-      before do
-        # Stub request to get instance info leading to a task
-        stub_request(:get, "http://localhost:8080/director/deployments/foo/instances?format=full")
-        .with(headers: auth_header)
-        .to_return(status: 302, headers: { 'location' => task_location })
-        
-        # Stub task status checks
-        stub_request(:get, "http://localhost:8080/director#{task_location}")
-        .with(headers: auth_header)
-        .to_return(
-        { status: 200, body: '{"state":"queued"}' },
-        { status: 200, body: '{"state":"processing"}' },
-        { status: 200, body: '{"state":"error"}' } # Simulate eventual 'error' state
-        )
-        
-        # Final stub to avoid errors on log completion attempt
-        stub_request(:get, "http://localhost:8080/director#{task_location}/output?type=result")
-        .with(headers: auth_header)
-        .to_return(status: 500, body: '') # Simulate failure response on output fetch
-      end
-    
-      it 'logs a warning and returns nil' do
-        allow(Logging).to receive(:logger).and_return(logger)
-        allow(logger).to receive(:warn)
-        expect(logger).to receive(:warn).with(/The number of retries to fetch instance details for deployment/)
-        result, state = director.get_deployment_instances_full('foo', 1)
-        expect(result).to be_nil
-        expect(state).to eq('error')
-      end
-    end
-
-    context 'when task location cannot be found' do
-      let(:auth_header) { { 'Authorization' => 'Basic YWRtaW46YWRtaW4=', 'Accept-Encoding' => 'gzip' } }
-      before do
-        stub_request(:get, "http://localhost:8080/director/deployments/foo/instances?format=full")
-        .with(headers: auth_header)
-        .with(basic_auth: %w[admin admin])
-        .to_return(status: 200)
-      end
-
-      it 'raises a DirectorError' do
-        expect {
-        director.get_deployment_instances_full('foo')
-        }.to raise_error(Bosh::Monitor::DirectorError, "Can not find 'location' response header to retrieve the task location")
-      end
-    end
-
-    context 'when task result fetching fails' do
-      let(:task_location) { '/task/123' }
-      let(:auth_header) { { 'Authorization' => 'Basic YWRtaW46YWRtaW4=', 'Accept-Encoding' => 'gzip' } }
-
-      before do
-        # Stub initial request to get task location
-        stub_request(:get, "http://localhost:8080/director/deployments/foo/instances?format=full")
-        .with(headers: auth_header)
-        .with(basic_auth: %w[admin admin])
-        .to_return(status: 200, headers: { 'location' => task_location })
-
-        # Stub requests for task status
-        stub_request(:get, "http://localhost:8080/director#{task_location}")
-        .with(headers: auth_header)
-        .to_return(status: 200, body: '{"state":"done"}')
-
-        # Stub final request to get task result
-        stub_request(:get, "http://localhost:8080/director#{task_location}/output?type=result")
-        .with(headers: auth_header)
-        .to_return(status: 500, body: 'error message')
-      end
-
-      it 'raises a DirectorError' do
-        allow(Logging).to receive(:logger).and_return(logger)
-        allow(logger).to receive(:warn)
-        expect {
-        director.get_deployment_instances_full('foo')
-        }.to raise_error(Bosh::Monitor::DirectorError, "Fetching full instance details for deployment 'foo' failed")
-      end
-    end
-  end
-
 
   def json_dump(data)
     JSON.dump(data)

--- a/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/instance_manager_spec.rb
@@ -4,7 +4,6 @@ module Bosh::Monitor
   describe InstanceManager do
     let(:event_processor) { double(Bosh::Monitor::EventProcessor) }
     let(:manager) { described_class.new(event_processor) }
-    let(:director) { double }
 
     before do
       allow(event_processor).to receive(:process)
@@ -558,41 +557,6 @@ module Bosh::Monitor
         expect do
           manager.setup_events
         end.to raise_error(Bosh::Monitor::PluginError, "Cannot find 'joes_plugin_thing' plugin")
-      end
-    end
-
-    describe '#fetch_deployments' do
-      let(:deployments) { [{ 'name' => 'my_deployment' }] }
-      let(:instances_data) { [{ 'id' => 'instance-1-id', 'job' => 'test-job', 'agent_id' => 'agent-1' }] }
-      let(:instances_data_full) { [{ 'id' => 'instance-1-id', 'job_state' => 'running', 'processes' => [] }] }
-
-      before do
-        allow(director).to receive(:deployments).and_return(deployments)
-        allow(director).to receive(:get_deployment_instances).with('my_deployment').and_return(instances_data)
-        allow(director).to receive(:get_deployment_instances_full).with('my_deployment').and_return(instances_data_full)
-      end
-
-      it 'updates instance data with full instance information' do
-        manager.fetch_deployments(director)
-
-        deployment = manager.instance_variable_get(:@deployment_name_to_deployments)['my_deployment']
-        instance = deployment.instances.find { |i| i.id == 'instance-1-id' }
-
-        expect(instance.job_state).to eq('running')
-        expect(instance.has_processes).to be false
-      end
-    end
-
-    describe '#unhealthy_instances' do
-      it 'can return number of unhealthy instances for each deployment' do
-        instance1 = Bosh::Monitor::Instance.create('id' => 'iuuid1', 'agent_id' => '007', 'index' => '0', 'job' => 'mutator', 'job_state' => 'running', 'has_processes' => true)
-        instance2 = Bosh::Monitor::Instance.create('id' => 'iuuid2', 'agent_id' => '008', 'index' => '0', 'job' => 'nats', 'job_state' => 'not-running', 'has_processes' => true)
-        instance3 = Bosh::Monitor::Instance.create('id' => 'iuuid3', 'agent_id' => '009', 'index' => '28', 'job' => 'mysql_node', 'job_state' => 'running', 'has_processes' => false)
-
-        manager.sync_deployments([{ 'name' => 'mycloud' }])
-        manager.sync_agents('mycloud', [instance1, instance2, instance3])
-
-        expect(manager.unhealthy_instances).to eq('mycloud' => 2)
       end
     end
   end

--- a/src/bosh-monitor/spec/unit/bosh/monitor/instance_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/instance_spec.rb
@@ -17,8 +17,6 @@ describe Bosh::Monitor::Instance do
       'index' => '0',
       'cid' => 'cuuid',
       'expects_vm' => true,
-      'job_state' => 'running',
-      'has_processes' => true
     )
 
     expect(instance).to be_a(Bosh::Monitor::Instance)
@@ -28,8 +26,6 @@ describe Bosh::Monitor::Instance do
     expect(instance.index).to eq('0')
     expect(instance.cid).to eq('cuuid')
     expect(instance.expects_vm).to be_truthy
-    expect(instance.job_state).to eq('running')
-    expect(instance.has_processes).to be_truthy
   end
 
   describe '#vm?' do
@@ -41,8 +37,6 @@ describe Bosh::Monitor::Instance do
           'job' => 'zb',
           'index' => '0',
           'expects_vm' => true,
-          'job_state' => 'running',
-          'has_processes' => false
         )
 
         expect(instance.vm?).to be_falsey
@@ -58,8 +52,6 @@ describe Bosh::Monitor::Instance do
           'index' => '0',
           'cid' => 'cuuid',
           'expects_vm' => true,
-          'job_state' => 'running',
-          'has_processes' => true
         )
 
         expect(instance.vm?).to be_truthy
@@ -76,8 +68,6 @@ describe Bosh::Monitor::Instance do
         'index' => '0',
         'cid' => 'cuuid',
         'expects_vm' => true,
-        'job_state' => 'running',
-        'has_processes' => true
       )
     end
 
@@ -87,7 +77,7 @@ describe Bosh::Monitor::Instance do
 
     context 'instance has all attributes' do
       it 'returns full name' do
-        expect(instance.name).to eq('my_deployment: zb(iuuid) [agent_id=auuid, index=0, job_state=running, has_processes=true, cid=cuuid]')
+        expect(instance.name).to eq('my_deployment: zb(iuuid) [agent_id=auuid, index=0, cid=cuuid]')
       end
     end
 
@@ -101,7 +91,7 @@ describe Bosh::Monitor::Instance do
 
     context 'instance has no job' do
       let(:instance) do
-        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'index' => '0', 'cid' => 'cuuid', 'expects_vm' => true, 'job_state' => nil, 'has_processes' => false)
+        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'index' => '0', 'cid' => 'cuuid', 'expects_vm' => true)
       end
 
       it 'returns name without job' do
@@ -111,17 +101,17 @@ describe Bosh::Monitor::Instance do
 
     context 'instance has no index' do
       let(:instance) do
-        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'job' => 'zb', 'cid' => 'cuuid', 'expects_vm' => true, 'job_state' => 'failing', 'has_processes' => false)
+        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'job' => 'zb', 'cid' => 'cuuid', 'expects_vm' => true)
       end
 
       it 'returns name without index' do
-        expect(instance.name).to eq('my_deployment: zb(iuuid) [agent_id=auuid, job_state=failing, cid=cuuid]')
+        expect(instance.name).to eq('my_deployment: zb(iuuid) [agent_id=auuid, cid=cuuid]')
       end
     end
 
     context 'instance has no agent_id' do
       let(:instance) do
-        Bosh::Monitor::Instance.create('id' => 'iuuid', 'job' => 'zb', 'index' => '0', 'cid' => 'cuuid', 'expects_vm' => true, 'job_state' => nil, 'has_processes' => false)
+        Bosh::Monitor::Instance.create('id' => 'iuuid', 'job' => 'zb', 'index' => '0', 'cid' => 'cuuid', 'expects_vm' => true)
       end
 
       it 'returns name without agent_id ' do
@@ -131,7 +121,7 @@ describe Bosh::Monitor::Instance do
 
     context 'instance has no cid' do
       let(:instance) do
-        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'job' => 'zb', 'index' => '0', 'expects_vm' => true, 'job_state' => nil, 'has_processes' => false)
+        Bosh::Monitor::Instance.create('id' => 'iuuid', 'agent_id' => 'auuid', 'job' => 'zb', 'index' => '0', 'expects_vm' => true)
       end
 
       it 'returns name without cid' do


### PR DESCRIPTION
Reverts cloudfoundry/bosh#2597

There are some broken tests, but a bigger concern is the health monitor triggering a query of all VMs with a new API call to the bosh director.

Details in the original PR.