### PR TITLE
Extend bosh tagging for cpi

### DIFF
--- a/src/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
@@ -109,7 +109,16 @@ module Bosh::Director
             upload_suffix = ' (already exists, skipped)' unless needs_upload
             track_and_log("Uploading stemcell #{@name}/#{@version} to the cloud#{cpi_suffix}#{upload_suffix}") do
               if needs_upload
-                stemcell.cid = cloud.create_stemcell(@stemcell_image, @cloud_properties, {})
+                tags = {}
+                runtime_configs = Bosh::Director::Api::RuntimeConfigManager.new.list(1, "default")
+                if !runtime_configs.nil? && !runtime_configs[0].nil?
+                  raw = runtime_configs[0]
+                  if !raw.nil? 
+                    hash = raw.to_hash
+                    tags.merge!(hash["tags"])
+                  end
+                end
+                stemcell.cid = cloud.create_stemcell(@stemcell_image, @cloud_properties, {"tags" => tags})
                 logger.info("Cloud created stemcell#{cpi_suffix}: #{stemcell.cid}")
               else
                 logger.info("Skipping stemcell upload, already exists#{cpi_suffix}")

--- a/src/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
@@ -109,7 +109,7 @@ module Bosh::Director
             upload_suffix = ' (already exists, skipped)' unless needs_upload
             track_and_log("Uploading stemcell #{@name}/#{@version} to the cloud#{cpi_suffix}#{upload_suffix}") do
               if needs_upload
-                stemcell.cid = cloud.create_stemcell(@stemcell_image, @cloud_properties)
+                stemcell.cid = cloud.create_stemcell(@stemcell_image, @cloud_properties, {})
                 logger.info("Cloud created stemcell#{cpi_suffix}: #{stemcell.cid}")
               else
                 logger.info("Skipping stemcell upload, already exists#{cpi_suffix}")

--- a/src/bosh-director/spec/unit/jobs/update_stemcell_spec.rb
+++ b/src/bosh-director/spec/unit/jobs/update_stemcell_spec.rb
@@ -52,7 +52,22 @@ describe Bosh::Director::Jobs::UpdateStemcell do
       end
     end
 
+
+      let(:runtime_config_manager) { instance_double(Bosh::Director::Api::RuntimeConfigManager) }
+      let(:config) { instance_double(Bosh::Director::Models::Config) }
+      let(:runtime_config_list) do
+        [config]
+
+    end
+
     before do
+
+      allow(Bosh::Director::Api::RuntimeConfigManager).to receive(:new).and_return(runtime_config_manager)
+      allow(Bosh::Director::Models::Config).to receive(:new).and_return(config)
+      allow(config).to receive(:to_hash).and_return({"tags"=> {"any"=> "value"}})
+      allow(runtime_config_manager).to receive(:list).with(1, 'default').and_return(runtime_config_list)
+
+
       allow(Bosh::Director::Config).to receive(:event_log).and_return(event_log)
       allow(Bosh::Director::Config).to receive(:uuid).and_return('meow-uuid')
       allow(Bosh::Director::Config).to receive(:cloud_options).and_return({'provider' => {'path' => '/path/to/default/cpi'}})
@@ -78,7 +93,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
       context 'uploading a local stemcell' do
         it 'should upload a local stemcell' do
           expect(cloud).to receive(:info).and_return('stemcell_formats' => ['dummy'])
-          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
             contents = File.open(image, &:read)
             expect(contents).to eq(stemcell_image_content)
             'stemcell-cid'
@@ -115,7 +130,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
           it 'should upload a local stemcell' do
             expect(cloud).to receive(:info).and_return('stemcell_formats' => ['dummy'])
-            expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+            expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
               contents = File.open(image, &:read)
               expect(contents).to eq(stemcell_image_content)
               'stemcell-cid'
@@ -143,7 +158,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
         it 'should upload a remote stemcell' do
           expect(cloud).to receive(:info).and_return('stemcell_formats' => ['dummy'])
-          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
             contents = File.open(image, &:read)
             expect(contents).to eql(stemcell_image_content)
             'stemcell-cid'
@@ -199,7 +214,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
           it 'should upload a remote stemcell' do
             expect(cloud).to receive(:info).and_return('stemcell_formats' => ['dummy'])
-            expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+            expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
               contents = File.open(image, &:read)
               expect(contents).to eql(stemcell_image_content)
               'stemcell-cid'
@@ -227,7 +242,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
       it 'should cleanup the stemcell file' do
         expect(cloud).to receive(:info).and_return('stemcell_formats' => ['dummy'])
-        expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+        expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
           contents = File.open(image, &:read)
           expect(contents).to eql(stemcell_image_content)
           'stemcell-cid'
@@ -311,8 +326,8 @@ describe Bosh::Director::Jobs::UpdateStemcell do
         end
 
         it 'creates multiple stemcell records with different cpi attributes' do
-          expect(cloud1).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }).and_return('stemcell-cid1')
-          expect(cloud3).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }).and_return('stemcell-cid3')
+          expect(cloud1).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}).and_return('stemcell-cid1')
+          expect(cloud3).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}).and_return('stemcell-cid3')
 
           expect(cloud1).to receive(:info).and_return('stemcell_formats' => ['dummy'])
           expect(cloud2).to receive(:info).and_return('stemcell_formats' => ['dummy1'])
@@ -367,7 +382,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
         end
 
         it 'skips creating a stemcell match when a CPI fails' do
-          expect(cloud1).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }).and_raise('I am flaky')
+          expect(cloud1).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}).and_raise('I am flaky')
           expect(cloud1).to receive(:info).and_return('stemcell_formats' => ['dummy'])
           expect(cloud_factory).to receive(:get).with('cloud1').and_return(cloud1)
           expect(cloud_factory).to receive(:all_names).exactly(3).times.and_return(['cloud1'])
@@ -393,7 +408,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
             expect(cloud2).to receive(:info).and_return('stemcell_formats' => ['dummy1'])
             expect(cloud3).to receive(:info).and_return('stemcell_formats' => ['dummy'])
 
-            expect(cloud3).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }).and_return('stemcell-cid3')
+            expect(cloud3).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}).and_return('stemcell-cid3')
 
             expect(Bosh::Director::Models::Stemcell.all.count).to eq(1)
             expect(Bosh::Director::Models::StemcellUpload.all.count).to eq(1)
@@ -419,7 +434,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
         it 'still works with the default cpi' do
           expect(cloud).to receive(:info).and_return('stemcell_formats' => ['dummy'])
-          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }).and_return('stemcell-cid')
+          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}).and_return('stemcell-cid')
 
           expect(cloud_factory).to receive(:get_cpi_aliases).with('').and_return([''])
           expect(cloud_factory).to receive(:all_names).exactly(3).times.and_return([''])
@@ -460,7 +475,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
       context 'when stemcell does not have stemcell formats' do
         it 'should not fail' do
           expect(cloud).to receive(:info).and_return('stemcell_formats' => ['dummy'])
-          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
             contents = File.open(image, &:read)
             expect(contents).to eql(stemcell_image_content)
             'stemcell-cid'
@@ -482,7 +497,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
         it 'should not fail' do
           expect(cloud).to receive(:info).and_return({})
-          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
             contents = File.open(image, &:read)
             expect(contents).to eql(stemcell_image_content)
             'stemcell-cid'
@@ -504,7 +519,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
         it 'should not fail' do
           expect(cloud).to receive(:info).and_raise(Bosh::Clouds::NotImplemented)
-          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+          expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
             contents = File.open(image, &:read)
             expect(contents).to eql(stemcell_image_content)
             'stemcell-cid'
@@ -527,7 +542,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
       it 'should not fail' do
         expect(cloud).to receive(:info).and_return('stemcell_formats' => ['dummy'])
-        expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+        expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
           contents = File.open(image, &:read)
           expect(contents).to eql(stemcell_image_content)
           'stemcell-cid'
@@ -553,7 +568,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
       it 'should update api_version' do
         expect(cloud).to receive(:info).and_return('stemcell_formats' => ['dummy'])
-        expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }) do |image, _|
+        expect(cloud).to receive(:create_stemcell).with(anything, { 'ram' => '2gb' }, {"tags"=>{"any"=>"value"}}) do |image, _|
           contents = File.open(image, &:read)
           expect(contents).to eq(stemcell_image_content)
           'stemcell-cid'


### PR DESCRIPTION
### What is this change about?

This change provides the default runtime tags to the upload stemcell cpi call. With this a stemcell can be tagged when it is uploaded.

### Please provide contextual information.

We wanted to have a possibility to tag all relevant and "bound" resources. With tags clean ups of cloud resources is much easier because it is clear which resources belong together and have certain tags how to handle them. In this PR we want to provide the tags for the cpi.

### What tests have you run against this PR?

Unit tests

### How should this change be described in bosh release notes?

Provides default runtime tags to the cpi when a stemmcell is created.


### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@anshrupani, @fmoehler
