### PR TITLE
Update async-http gem which no longer uses async-io gem

### DIFF
--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -34,7 +34,6 @@ PATH
     bosh-monitor (0.0.0)
       async
       async-http
-      async-io
       cf-uaa-lib
       dogapi
       logging
@@ -90,7 +89,7 @@ GEM
       io-event (~> 1.9)
       metrics (~> 0.12)
       traces (~> 0.15)
-    async-http (0.87.0)
+    async-http (0.88.0)
       async (>= 2.10.2)
       async-pool (~> 0.9)
       io-endpoint (~> 0.14)
@@ -100,8 +99,6 @@ GEM
       protocol-http1 (~> 0.30)
       protocol-http2 (~> 0.22)
       traces (~> 0.10)
-    async-io (1.43.2)
-      async
     async-pool (0.10.3)
       async (>= 1.25)
     async-rspec (1.17.1)
@@ -164,7 +161,7 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-endpoint (0.15.2)
-    io-event (1.9.0)
+    io-event (1.10.0)
     io-stream (0.6.1)
     json (2.10.2)
     json_schemer (2.4.0)
@@ -215,7 +212,7 @@ GEM
       base64
     protocol-hpack (1.5.1)
     protocol-http (0.49.0)
-    protocol-http1 (0.30.0)
+    protocol-http1 (0.31.0)
       protocol-http (~> 0.22)
     protocol-http2 (0.22.1)
       protocol-hpack (~> 1.4)

--- a/src/Gemfile.lock
+++ b/src/Gemfile.lock
@@ -36,6 +36,7 @@ PATH
       async-http
       cf-uaa-lib
       dogapi
+      io-stream
       logging
       nats-pure
       net-smtp

--- a/src/bosh-monitor/bosh-monitor.gemspec
+++ b/src/bosh-monitor/bosh-monitor.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'async'
   spec.add_dependency 'async-http'
   spec.add_dependency 'cf-uaa-lib'
+  spec.add_dependency 'io-stream'
   spec.add_dependency 'logging'
   spec.add_dependency 'nats-pure'
   spec.add_dependency 'openssl'

--- a/src/bosh-monitor/bosh-monitor.gemspec
+++ b/src/bosh-monitor/bosh-monitor.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'async'
   spec.add_dependency 'async-http'
-  spec.add_dependency 'async-io'
   spec.add_dependency 'cf-uaa-lib'
   spec.add_dependency 'logging'
   spec.add_dependency 'nats-pure'

--- a/src/bosh-monitor/lib/bosh/monitor.rb
+++ b/src/bosh-monitor/lib/bosh/monitor.rb
@@ -17,6 +17,7 @@ require 'set'
 
 require 'async'
 require 'async/http'
+require 'io/stream'
 require 'logging'
 require 'nats/io/client'
 require 'puma'

--- a/src/bosh-monitor/lib/bosh/monitor.rb
+++ b/src/bosh-monitor/lib/bosh/monitor.rb
@@ -17,8 +17,6 @@ require 'set'
 
 require 'async'
 require 'async/http'
-require 'async/io'
-require 'async/io/stream'
 require 'logging'
 require 'nats/io/client'
 require 'puma'

--- a/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/json.rb
@@ -99,9 +99,9 @@ module Bosh::Monitor::Plugins
       Async do |task|
         stdin, stdout, stderr, wait_thr = Open3.popen3(@cmd)
 
-        @stdin = Async::IO::Stream.new(Async::IO::Generic.new(stdin))
-        @stdout = Async::IO::Stream.new(Async::IO::Generic.new(stdout))
-        @stderr = Async::IO::Stream.new(Async::IO::Generic.new(stderr))
+        @stdin = IO::Stream(stdin)
+        @stdout = IO::Stream(stdout)
+        @stderr = IO::Stream(stderr)
         @wait_thr = wait_thr
 
         task.async do

--- a/src/bosh-monitor/lib/bosh/monitor/protocols/tcp_connection.rb
+++ b/src/bosh-monitor/lib/bosh/monitor/protocols/tcp_connection.rb
@@ -25,7 +25,7 @@ module Bosh::Monitor
     def connect
       return if @connected
 
-      endpoint = Async::IO::Endpoint.tcp(@host, @port)
+      endpoint = IO::Endpoint.tcp(@host, @port)
       @socket = endpoint.connect
       connection_completed
     rescue

--- a/src/bosh-monitor/spec/spec_helper.rb
+++ b/src/bosh-monitor/spec/spec_helper.rb
@@ -4,7 +4,6 @@ $LOAD_PATH << SPEC_ROOT
 require File.expand_path('../../spec/shared/spec_helper', SPEC_ROOT)
 
 require 'async/rspec'
-require 'async/io'
 require 'tempfile'
 require 'bosh/monitor'
 

--- a/src/bosh-monitor/spec/unit/bosh/monitor/protocols/tcp_connection_spec.rb
+++ b/src/bosh-monitor/spec/unit/bosh/monitor/protocols/tcp_connection_spec.rb
@@ -65,7 +65,7 @@ describe Bosh::Monitor::TcpConnection do
         expect(endpoint).to receive(:connect).and_return(socket).twice
         allow(socket).to receive(:write).with('some-data').and_raise("some-error")
         expect(socket).to receive(:write).with('data-after-initial-socket-was-closed')
-        expect(Async::IO::Endpoint).to receive(:tcp).and_return(endpoint).twice
+        expect(IO::Endpoint).to receive(:tcp).and_return(endpoint).twice
 
         tcp_connection.connect
         expect { tcp_connection.send_data('some-data') }.to_not raise_error

--- a/src/vendor/cache/async-http-0.87.0.gem
+++ b/src/vendor/cache/async-http-0.87.0.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb5ff0db7bb77b1ee352cad62488be4c7f77ba27713757b266ec7766b4001a80
-size 34816

--- a/src/vendor/cache/async-http-0.88.0.gem
+++ b/src/vendor/cache/async-http-0.88.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c568743f0606f283b208b7c6adee9070c5e8f59867bf17028bafa5a6ea412f99
+size 36864

--- a/src/vendor/cache/async-io-1.43.2.gem
+++ b/src/vendor/cache/async-io-1.43.2.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:892eaf0a427a2fafe998bf8a7cb7ef88f43f469a1f4b89069c005cabd7cd5ec7
-size 26112

--- a/src/vendor/cache/ffi-1.17.1-arm64-darwin.gem
+++ b/src/vendor/cache/ffi-1.17.1-arm64-darwin.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8e04f79d375742c54ee7f9fff4b4022b87200a4ec0eb082128d3b6559e67b4d
+size 599552

--- a/src/vendor/cache/io-event-1.10.0.gem
+++ b/src/vendor/cache/io-event-1.10.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4e1f5bf01a1a8b8484db3c5d99b431eb3609dbc988b96622d14d77993e0e9dc
+size 43008

--- a/src/vendor/cache/io-event-1.9.0.gem
+++ b/src/vendor/cache/io-event-1.9.0.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c262b6610ad643a2be75e892135aca4fa67edc67d1944c0ae6b6e5dd73f4fc1
-size 46592

--- a/src/vendor/cache/protocol-http1-0.30.0.gem
+++ b/src/vendor/cache/protocol-http1-0.30.0.gem
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9492961a4cca6909fe4d23d60e2cac36b8feb9b4c129c4428fbcf3f973cac36a
-size 18432

--- a/src/vendor/cache/protocol-http1-0.31.0.gem
+++ b/src/vendor/cache/protocol-http1-0.31.0.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4a593693e37d10255824019a8a34417d293d4ca62e610acf995ad3106d95cc3
+size 18432

--- a/src/vendor/cache/sqlite3-2.6.0-arm64-darwin.gem
+++ b/src/vendor/cache/sqlite3-2.6.0-arm64-darwin.gem
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88a793bf0010339e85657e460ab3ad2c7e9ee5d0e468b9dea383ff1039380056
+size 3157504


### PR DESCRIPTION
bump-gems [CI job](https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/bump-deps/builds/124) failing because async-http has made breaking changes.

Not 100% sure about the changes to src/bosh-monitor/lib/bosh/monitor/plugins/json.rb