### PR TITLE
Fix tags extraction from runtime config

### DIFF
--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -368,8 +368,8 @@ end
 cpi_job_name = p('director.cpi_job')
 
 cpi = {
-  'max_supported_api_version' => 2,
-  'preferred_api_version' => 2,
+  'max_supported_api_version' => 3,
+  'preferred_api_version' => 3,
 }
 
 if_p('director.cpi.preferred_api_version') do |preferred_api_version|

--- a/spec/director.yml.erb_spec.rb
+++ b/spec/director.yml.erb_spec.rb
@@ -691,7 +691,7 @@ RSpec.describe 'director.yml.erb' do
         YAML.load(template.render(merged_manifest_properties))
       end
 
-      let(:max_cpi_api_version) { 2 }
+      let(:max_cpi_api_version) { 3 }
 
       before do
         merged_manifest_properties['director']['cpi_job'] = 'test-cpi'

--- a/src/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_stemcell.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'yaml'
 
 module Bosh::Director
   module Jobs
@@ -152,10 +153,14 @@ module Bosh::Director
         runtime_configs = Bosh::Director::Api::RuntimeConfigManager.new.list(1, "default")
         if !runtime_configs.nil?
           raw = runtime_configs[0]
-          if !raw.nil? 
-            hash = raw.to_hash
-            if !hash.nil? && !hash["tags"].nil?
-              tags.merge!(hash["tags"])
+          if !raw.nil?
+            raw_hash = raw.to_hash
+            if !raw_hash.nil?
+              raw_hash_content = raw_hash[:content]
+              hash = YAML.safe_load(raw_hash_content)
+              if !hash.nil? && !hash["tags"].nil?
+                tags.merge!(hash["tags"])
+              end
             end
           end
         end

--- a/src/bosh-director/spec/unit/bosh/director/jobs/update_stemcell_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/jobs/update_stemcell_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Bosh::Director::Jobs::UpdateStemcell do
   before do
-    allow(Bosh::Director::Config).to receive(:preferred_cpi_api_version).and_return(2)
+    allow(Bosh::Director::Config).to receive(:preferred_cpi_api_version).and_return(3)
   end
 
   describe 'DJ job class expectations' do
@@ -62,7 +62,7 @@ describe Bosh::Director::Jobs::UpdateStemcell do
 
       allow(Bosh::Director::Api::RuntimeConfigManager).to receive(:new).and_return(runtime_config_manager)
       allow(Bosh::Director::Models::Config).to receive(:new).and_return(config)
-      allow(config).to receive(:to_hash).and_return({"tags" => {"any"=> "value"}})
+      allow(config).to receive(:to_hash).and_return({:content => "---\ntags:\n  test-tag: test-value\n"})
       allow(runtime_config_manager).to receive(:list).with(1, 'default').and_return(runtime_config_list)
 
 


### PR DESCRIPTION
### What is this change about?

These changes fix the way tags are extracted from the runtime config when creating a stemcell (the tags are then sent to the cpi).

### Please provide contextual information.

[Extend bosh tagging for cpi #2603](https://github.com/cloudfoundry/bosh/pull/2603)

### What tests have you run against this PR?

Unit tests and manual tests against a development environment.

### How should this change be described in bosh release notes?

Fixes tag (for cpi on stemcell creation) extraction from the default runtime config.

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@DennisAhausSAP, @a-hassanin
