### PR TITLE
CI/Dev: remove `fly sync` from fly rake task

### DIFF
--- a/src/tasks/fly.rake
+++ b/src/tasks/fly.rake
@@ -103,8 +103,6 @@ namespace :fly do
   def execute(task, command_options = nil, additional_env = {})
     env = prepare_env(additional_env)
 
-    sh("#{env} fly #{concourse_target} sync")
-
     execute_cmd = [
       'execute',
       concourse_tag,


### PR DESCRIPTION
Running this on an M-series mac results in failure because Concourse's web instance does not provide a downloadable ARM binary for macOS.

