### PR TITLE
Add 'file' package to Dockerfile dependencies for intergration

### DIFF
--- a/ci/dockerfiles/integration/Dockerfile
+++ b/ci/dockerfiles/integration/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update -y \
         coreutils \
         default-libmysqlclient-dev \
         dnsutils \
+        file \
         git \
         git-lfs \
         google-cloud-cli \


### PR DESCRIPTION
file package is missing since latest update from ubuntu docker image. 
this is needed for some ci tasks within the bosh ecosystem

