### PR TITLE
Avoid unnecessary redeploys

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/manual_network_subnet.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/manual_network_subnet.rb
@@ -62,6 +62,9 @@ module Bosh::Director
 
           Config.director_ips&.each do |cidr|
             each_ip(cidr) do |ip|
+              if ip.ipv4? != range.ipv4?
+                next
+              end
               restricted_ips.add(ip)
             end
           end

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/manual_network_subnet_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/manual_network_subnet_spec.rb
@@ -351,8 +351,27 @@ include Bosh::Director::IpUtil
         [],
       )
 
-      expect(subnet.restricted_ips).to include(ip1.to_i)
-      expect(subnet.restricted_ips).to include(ip2.to_i)
+      expect(subnet.restricted_ips).to include(ip1)
+      expect(subnet.restricted_ips).to include(ip2)
+    end
+
+    it 'should only include the directors ip addresses in the reserved range if the ip versions match' do
+      ip1 = IPAddr.new('192.168.1.1')
+      ip2 = IPAddr.new('2001:db8::2')
+
+      allow(Bosh::Director::Config).to receive(:director_ips).and_return([ip1.to_s, ip2.to_s])
+      subnet = make_subnet(
+        {
+          'range' => '2001:db8::/32',
+          'reserved' => [],
+          'gateway' => '2001:db8::1',
+          'cloud_properties' => { 'foo' => 'bar' },
+        },
+        [],
+      )
+
+      expect(subnet.restricted_ips).to_not include(ip1)
+      expect(subnet.restricted_ips).to include(ip2)
     end
 
     it 'should create a subnet spec with prefix' do


### PR DESCRIPTION
### What is this change about?

If the bosh directors ip version does not match the ip version of the subnet range (ipv4 <-> ipv6), bosh will trigger a redeploy everytime it deploys the relevant deployment. This PR will avoid to add an ipv4 to the restricted ips if the range of the subnet is ipv6 and vice versa, which is the root cause of the issue and does not make any sense. I also added an integration test.

Other symptoms include:

"No more IPs available"
In debug logs: "Failed to find network <network_name> or a network with valid subnets for <ip_address>,reservation will be marked as obsolete"

### What tests have you run against this PR?

Unit tests and created a separate integration test which I ran on the concourse worker

### How should this change be described in bosh release notes?

Avoid unnecessary redeploys

### Does this PR introduce a breaking change?

No
