### PR TITLE
adapt create_vm and attach_disk call for new cpi version 3

### DIFF
--- a/src/bosh-director/lib/clouds/external_cpi_response_wrapper.rb
+++ b/src/bosh-director/lib/clouds/external_cpi_response_wrapper.rb
@@ -39,10 +39,9 @@ module Bosh::Clouds
       cpi_response = @cpi.create_vm(*args)
 
       response = []
-      case @cpi_api_version
-      when 2
+      if @cpi_api_version >= 2
         response = cpi_response
-      when 1
+      else
         response << cpi_response
       end
 
@@ -62,11 +61,10 @@ module Bosh::Clouds
     def attach_disk(*args)
       cpi_response = @cpi.attach_disk(*args)
 
-      case @cpi_api_version
-      when 2
+      if @cpi_api_version >= 2
         raise Bosh::Clouds::AttachDiskResponseError, 'No disk_hint' if cpi_response.nil? || cpi_response.empty?
         cpi_response
-      when 1
+      else
         nil
       end
     end

--- a/src/bosh-director/spec/unit/clouds/external_cpi_response_wrapper_spec.rb
+++ b/src/bosh-director/spec/unit/clouds/external_cpi_response_wrapper_spec.rb
@@ -11,7 +11,7 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
   let(:cpi_log_path) { '/var/vcap/task/5/cpi' }
 
   let(:logger) { double(:logger, debug: nil) }
-  let(:config) { double('Bosh::Director::Config', logger: logger, cpi_task_log: cpi_log_path, preferred_cpi_api_version: 2) }
+  let(:config) { double('Bosh::Director::Config', logger: logger, cpi_task_log: cpi_log_path, preferred_cpi_api_version: 3) }
   let(:cloud) { Bosh::Clouds::ExternalCpi.new('/path/to/fake-cpi/bin/cpi', 'fake-director-uuid', logger) }
 
   let(:wait_thread) do
@@ -377,8 +377,8 @@ describe Bosh::Clouds::ExternalCpiResponseWrapper do
     end
   end
 
-  describe 'when cpi_version is 2' do
-    let(:cpi_api_version) { 2 }
+  describe 'when cpi_version is 2 or higher' do
+    let(:cpi_api_version) { 3 }
 
     describe '#create_vm' do
       let(:redacted_network_settings) { nil }


### PR DESCRIPTION
### What is this change about?

Bosh director should handle all CPI API Versions correctly.

This will solve the failing BATS for the aws cpi: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-aws-cpi/jobs/bats


### Please provide contextual information.

The AWS CPI API Version was recently [bumped to version 3](https://github.com/cloudfoundry/bosh-aws-cpi-release/commit/1d03941083988d1cb61c22419f3ffb9c817047dc). This leads to issues when the director tries to create a vm because the response is cleared unexpectedly as previously there is only handling for version 1 and 2. Back then the update to support version 3 was only done for the create_stemcell method. I changed this to be compatible with all versions higher than 2. To me this change appears pretty straightforward, however I could see that this coding was like this already in the past, but was changed to the case statement. This was done [7 years ago](https://github.com/cloudfoundry/bosh/commit/eaeae57f4508812c35ba5bf66f12bd1fd9f8c9a0) so probably the reason why this was changed is not valid anymore? Otherwise we could also change it back to a case statement instead just including version 3.

### What tests have you run against this PR?

Unit Tests

### How should this change be described in bosh release notes?

Introduce support for CPI API Versions higher than 2 for create_vm and attach_disk.

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@Ivaylogi98 