### PR TITLE
CI: switch internal CIDR away from 10.0.0.0

### DIFF
--- a/ci/bats/iaas/gcp/terraform/inputs.tf
+++ b/ci/bats/iaas/gcp/terraform/inputs.tf
@@ -11,11 +11,11 @@ variable "name" {
 }
 
 variable "internal_cidr" {
-  default = "10.0.0.0/24"
+  default = "10.0.11.0/24"
 }
 
 variable "second_internal_cidr" {
-  default = "10.0.1.0/24"
+  default = "10.0.22.0/24"
 }
 
 variable "zone" {


### PR DESCRIPTION
This is confilicting with something in CI[1] changing to a less common prefix in hopes of avoiding conflicts.

[1]
- https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/upgrade-mysql/builds/195#L68edf430:455:469
- https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/upgrade-mysql/builds/196#L68edfda8:346:351
