### PR TITLE
Fix CLI Output for prefix ip addresses

### DIFF
--- a/src/bosh-director/lib/bosh/director/models/vm.rb
+++ b/src/bosh-director/lib/bosh/director/models/vm.rb
@@ -25,11 +25,11 @@ module Bosh::Director::Models
         else
           cidr_ip
         end
-      end
+      end.uniq.sort_by { |ip| Bosh::Director::IpAddrOrCidr.new(ip).to_i }
     end
 
     def ips_cidr
-      manual_or_vip_ips.concat(dynamic_ips).uniq
+      manual_or_vip_ips.concat(dynamic_ips)
     end
 
     private
@@ -39,7 +39,7 @@ module Bosh::Director::Models
     end
 
     def dynamic_ips
-      network_spec.map { |_, network| network['ip'] }
+      network_spec.map { |_, network| "#{network['ip']}/#{network['prefix']}" }
     end
   end
 end

--- a/src/bosh-director/spec/unit/bosh/director/models/vm_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/models/vm_spec.rb
@@ -43,13 +43,14 @@ module Bosh::Director
       describe '#ips' do
         let!(:ip_address) { FactoryBot.create(:models_ip_address, vm: vm, address_str: to_ipaddr('1.1.1.1/32').to_s) }
         let!(:ip_address2) { FactoryBot.create(:models_ip_address, vm: vm, address_str: to_ipaddr('1.1.1.2/32').to_s) }
+        let!(:ip_address3) { FactoryBot.create(:models_ip_address, vm: vm, address_str: to_ipaddr('1.1.1.16/28').to_s) }
 
         before do
-          vm.network_spec = { 'some' => { 'ip' => '1.1.1.3/32' } }
+          vm.network_spec = { 'some' => { 'ip' => '2001:db8::1', 'prefix' => '64' }, 'some_other' => { 'ip' => '1.1.1.4', 'prefix' => '32' } }
         end
 
-        it 'returns all ips for the vm' do
-          expect(vm.ips).to match_array(['1.1.1.1', '1.1.1.2', '1.1.1.3'])
+        it 'returns ips without prefix for single ips and with prefix for prefix ips order by size of the integer representation' do
+          expect(vm.ips).to match_array(['1.1.1.1', '1.1.1.2', '1.1.1.16/28', '1.1.1.4', '2001:db8::1/64'])
         end
       end
     end


### PR DESCRIPTION
### What is this change about?

Currently the CLI output looks a little weird when a prefix address is allocated. This PR does two things:

1. Avoids showing duplicate base addresses of the prefix
2. Sort the ips by the size of the integer representation

### Please provide contextual information.

This commit accidentally removed the prefix information when reading the ip address from the network_spec_json in the vms database table: https://github.com/cloudfoundry/bosh/commit/5b453b685ee9fe265a726f0301dcac21eda93ff5 

This way the cli output looks like this at the moment if a prefix address is assigned:

<img width="1488" height="263" alt="image" src="https://github.com/user-attachments/assets/495f59af-180a-4f55-a571-ff2f4d8156d5" />

You can see that the base address of the prefix is being shown twice, once with prefix (correct) and once without prefix (incorrect).

### What tests have you run against this PR?

Extended the existing unit tests to take care of this scenario

### How should this change be described in bosh release notes?

Fix CLI Output for prefix ip addresses

### Does this PR introduce a breaking change?

No
