### PR TITLE
Fix OS detection in DirectorStemcellOwner to read from system files

### DIFF
--- a/src/bosh-director/lib/bosh/director/director_stemcell_owner.rb
+++ b/src/bosh-director/lib/bosh/director/director_stemcell_owner.rb
@@ -1,7 +1,9 @@
-require 'etc'
-
 module Bosh::Director
   class DirectorStemcellOwner
+    OS_RELEASE_FILE = '/etc/os-release'.freeze
+    OPERATING_SYSTEM_FILE = '/var/vcap/bosh/etc/operating_system'.freeze
+    STEMCELL_VERSION_FILE = '/var/vcap/bosh/etc/stemcell_version'.freeze
+
     def stemcell_os
       @stemcell_os ||= os_and_version
     end
@@ -9,31 +11,48 @@ module Bosh::Director
     def stemcell_version
       return @stemcell_version unless @stemcell_version.nil?
 
-      stemcell_version_path = '/var/vcap/bosh/etc/stemcell_version'
-      return '-' unless File.exist?(stemcell_version_path)
+      return '-' unless File.exist?(STEMCELL_VERSION_FILE)
 
-      @stemcell_version = File.read(stemcell_version_path).chomp
+      @stemcell_version = File.read(STEMCELL_VERSION_FILE).chomp
     end
 
     private
 
     def os_and_version
-      results = Etc.uname[:version].scan(/~([^ ]*)-([^ ]*) .*$/)[0]
-      return '-' if Array(results).empty?
+      os = read_operating_system
+      codename = read_codename
 
-      os = results[1].downcase
-      version_number = results[0]
-      version_name = if version_number.start_with?('16.')
-                       'xenial'
-                     elsif version_number.start_with?('14.')
-                       'trusty'
-                     elsif version_number.start_with?('18.')
-                       'bionic'
-                     else
-                       version_number
-                     end
+      return '-' if os.nil? || codename.nil?
 
-      "#{os}-#{version_name}"
+      "#{os}-#{codename}"
+    end
+
+    def read_operating_system
+      if File.exist?(OPERATING_SYSTEM_FILE)
+        return File.read(OPERATING_SYSTEM_FILE).chomp.downcase
+      end
+
+      return nil unless File.exist?(OS_RELEASE_FILE)
+
+      File.readlines(OS_RELEASE_FILE).each do |line|
+        if line =~ /^ID=(.+)$/
+          return ::Regexp.last_match(1).strip.delete('"').downcase
+        end
+      end
+
+      nil
+    end
+
+    def read_codename
+      return nil unless File.exist?(OS_RELEASE_FILE)
+
+      File.readlines(OS_RELEASE_FILE).each do |line|
+        if line =~ /^UBUNTU_CODENAME=(.+)$/
+          return ::Regexp.last_match(1).strip.delete('"')
+        end
+      end
+
+      nil
     end
   end
 end


### PR DESCRIPTION
### What is this change about?

The DirectorStemcellOwner class was using regex parsing of uname output and hardcoded version-to-codename mappings, which was unmaintainable and failed for modern Ubuntu versions like Jammy.

This fix refactors the implementation to read OS information directly from system files:
- Operating system name: /var/vcap/bosh/etc/operating_system (with fallback to /etc/os-release ID field)
- Codename: /etc/os-release UBUNTU_CODENAME field

This approach is more reliable, requires no maintenance for new Ubuntu releases, and fixes the director info endpoint which was returning "-" instead of "ubuntu-jammy" for the Director Stemcell OS on Jammy-based stemcells.

**Before (`bosh env` output):**

  * `Director Stemcell  -/1.943`

**After (`bosh env` output):**

  * `Director Stemcell  ubuntu-jammy/1.943`

### What tests have you run against this PR?

```sh
bundle exec rake spec:unit:director
```

### How should this change be described in bosh release notes?

Fix parsing of Stemcell OS from system files

### Does this PR introduce a breaking change?

No
