### PR TITLE
Fix VM state parsing without network prefix

### DIFF
--- a/src/bosh-director/lib/bosh/director/models/vm.rb
+++ b/src/bosh-director/lib/bosh/director/models/vm.rb
@@ -39,7 +39,9 @@ module Bosh::Director::Models
     end
 
     def dynamic_ips
-      network_spec.map { |_, network| "#{network['ip']}/#{network['prefix']}" }
+      network_spec.map do |_, network|
+        network['prefix'].nil? || network['prefix'].empty? ? network['ip'] : "#{network['ip']}/#{network['prefix']}"
+      end
     end
   end
 end

--- a/src/bosh-director/spec/unit/bosh/director/models/vm_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/models/vm_spec.rb
@@ -52,6 +52,16 @@ module Bosh::Director
         it 'returns ips without prefix for single ips and with prefix for prefix ips order by size of the integer representation' do
           expect(vm.ips).to match_array(['1.1.1.1', '1.1.1.2', '1.1.1.16/28', '1.1.1.4', '2001:db8::1/64'])
         end
+
+        context 'with old VMs that do not have a prefix' do
+          before do
+            vm.network_spec = { 'some' => { 'ip' => '2001:db8::1' }, 'some_other' => { 'ip' => '1.1.1.4' } }
+          end
+
+          it 'returns ips without prefix for single ips and with prefix for prefix ips order by size of the integer representation' do
+            expect(vm.ips).to match_array(['1.1.1.1', '1.1.1.2', '1.1.1.16/28', '1.1.1.4', '2001:db8::1'])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### What is this change about?

This change fixes parsing VM state for VMs that don't advertise network prefix.

### Please provide contextual information.

Deploying latest BOSH Director results in error when trying to upgrade the deployment and running "bosh vms":

```
E, [2025-11-18T21:17:37.791883 #156126] [] ERROR -- DirectorJobRunner: Worker thread raised exception: Invalid IP or CIDR format: 88.0.0.15/ - /var/vcap/data/packages/director-ruby-3.3/03a91e3ec846a70ba11be6cddd0cadf1c62e30c9/lib/ruby/3.3.0/ipaddr.rb:692:in `in6_addr'
/var/vcap/data/packages/director-ruby-3.3/03a91e3ec846a70ba11be6cddd0cadf1c62e30c9/lib/ruby/3.3.0/ipaddr.rb:628:in `initialize'
/var/vcap/data/packages/director-ruby-3.3/03a91e3ec846a70ba11be6cddd0cadf1c62e30c9/lib/ruby/3.3.0/ipaddr.rb:538:in `new'
/var/vcap/data/packages/director-ruby-3.3/03a91e3ec846a70ba11be6cddd0cadf1c62e30c9/lib/ruby/3.3.0/ipaddr.rb:538:in `mask!'
/var/vcap/data/packages/director-ruby-3.3/03a91e3ec846a70ba11be6cddd0cadf1c62e30c9/lib/ruby/3.3.0/ipaddr.rb:636:in `initialize'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/ip_addr_or_cidr.rb:18:in `new'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/ip_addr_or_cidr.rb:18:in `initialize'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/models/vm.rb:29:in `new'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/models/vm.rb:29:in `block in ips'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/models/vm.rb:29:in `each'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/models/vm.rb:29:in `sort_by'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/models/vm.rb:29:in `ips'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/jobs/vm_state.rb:60:in `process_vm_for_instance'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/jobs/vm_state.rb:39:in `block in process_instance'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/jobs/vm_state.rb:38:in `map'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/jobs/vm_state.rb:38:in `process_instance'
/var/vcap/data/packages/director/f07b4d0cb6b30216153f910db6878c368f6cb21e/gem_home/ruby/3.3.0/gems/bosh-director-0.0.0/lib/bosh/director/jobs/vm_state.rb:24:in `block (3 levels) in perform'
```

Deployment upgrade is failing since compilation VMs fail to connect to NATS. The reason for NATS connection failure is that bosh-nats-sync does not succeed to allow ping messages from compilation VMs. The following error is in bosh-nats-sync job:

```
E, [2025-11-18T21:16:51.425112 #84007] ERROR : Could not query all running vms: Cannot access: /deployments/cf-b2beb1d76a2f1277b3f5/vms, Status Code: 500,
I, [2025-11-18T21:16:51.425676 #84007]  INFO : NATS config file is not empty, doing nothing.
I, [2025-11-18T21:16:51.425776 #84007]  INFO : Finishing NATS Users Synchronization
I, [2025-11-18T21:17:01.533295 #84007]  INFO : Executing NATS Users Synchronization
E, [2025-11-18T21:17:01.626389 #84007] ERROR : Could not query all running vms: Cannot access: /deployments/cf-b2beb1d76a2f1277b3f5/vms, Status Code: 500,
I, [2025-11-18T21:17:01.626622 #84007]  INFO : NATS config file is not empty, doing nothing.
I, [2025-11-18T21:17:01.626674 #84007]  INFO : Finishing NATS Users Synchronization
```

### What tests have you run against this PR?

1. All the unit tests
2. Updated director with the change and got "bosh vms" to succeed
3. "bosh deploy" succeeded as well

### Does this PR introduce a breaking change?

No

