### PR TITLE
CI: stop installing clang on integration image

### DIFF
--- a/ci/dockerfiles/integration/Dockerfile
+++ b/ci/dockerfiles/integration/Dockerfile
@@ -77,19 +77,6 @@ RUN apt-get update -y \
         vim \
         openssh-client \
         openssh-server \
-        clang \
-        clang-14 \
-        lib32gcc-s1 \
-        lib32stdc++6 \
-        libc6-i386 \
-        libclang-common-14-dev \
-        libclang-cpp14 \
-        libclang1-14 \
-        libgc1 \
-        libllvm14 \
-        libobjc-11-dev \
-        libobjc4 \
-        llvm-14-linker-tools \
         mysql-client \
         libmysqlclient-dev \
         postgresql-client-${POSTGRES_MAJOR_VERSION} \
@@ -120,7 +107,6 @@ RUN yq_cli_path="/usr/local/bin/yq" \
     && chmod +x "${yq_cli_path}"
 
 
-ENV CC="/usr/bin/clang" CXX="/usr/bin/clang++"
 RUN cd /tmp  \
     && curl --show-error -sL "${RUBY_INSTALL_URL}" \
       | tar -xzf - \
@@ -132,7 +118,6 @@ RUN cd /tmp  \
     && NUM_CPUS=$(grep -c ^processor /proc/cpuinfo) \
     && ruby-install --jobs=${NUM_CPUS} --cleanup --system ruby ${RUBY_VERSION} \
       -- --disable-install-doc --disable-install-rdoc \
-      -- CC=clang \
     && gem update --system \
     && bundle config --global path "${GEM_HOME}" \
     && bundle config --global bin "${GEM_HOME}/bin"


### PR DESCRIPTION
After switching to noble the clang installed on the container image began failing to compile nginx:

```
/usr/bin/clang -c -pipe  -O -Wall -Wextra -Wpointer-arith -Wconditional-uninitialized -Wno-unused-parameter -Werror -g   -I src/core -I src/event -I src/event/modules -I src/event/quic -I src/os/unix -I ../../pcre-8.45 -I objs -I src/http -I src/http/modules \
	-o objs/addon/src/ngx_http_headers_more_headers_in.o \
	../../headers-more-nginx-module-0.34/src/ngx_http_headers_more_headers_in.c
../../headers-more-nginx-module-0.34/src/ngx_http_headers_more_headers_in.c:766:24: error: variable 'nelts' set but not used [-Werror,-Wunused-but-set-variable]
  766 |     int                nelts;
      |                        ^
1 error generated.
make[1]: *** [objs/Makefile:1300: objs/addon/src/ngx_http_headers_more_headers_in.o] Error 1
make[1]: Leaving directory '/tmp/build/04d13fd0/bosh/src/tmp/nginx-work/nginx-src/nginx-1.29.3'
make: *** [Makefile:10: build] Error 2
rake aborted!
```
Ex: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/integration-postgres/builds/820#L6915ad9f:1953

Related to Noble https://github.com/cloudfoundry/community/issues/892