### PR TITLE
CI: pass setmcell-os to BDRATs specs

### DIFF
--- a/ci/tasks/test-bdrats.sh
+++ b/ci/tasks/test-bdrats.sh
@@ -5,11 +5,12 @@ set -euo 'pipefail'
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 src_dir="${script_dir}/../../.."
 
-export BOSH_RELEASE_PATH="${PWD}/bosh-release/$(basename bosh-release/*.tgz)"
+BOSH_RELEASE_PATH="${PWD}/bosh-release/$(basename bosh-release/*.tgz)"
+export BOSH_RELEASE_PATH
 
 mkdir -p bbr-binary
 export BBR_BINARY_PATH="${PWD}/bbr-binary/bbr"
-cp bbr-cli-binary/bbr-[0-9]*-linux-amd64 $BBR_BINARY_PATH
+cp bbr-cli-binary/bbr-[0-9]*-linux-amd64 "${BBR_BINARY_PATH}"
 chmod +x "${BBR_BINARY_PATH}"
 
 export OVERRIDDEN_BOSH_DEPLOYMENT="${src_dir}/bosh-deployment"
@@ -21,13 +22,16 @@ source start-bosh \
   -o bbr.yml \
   -o local-bosh-release-tarball.yml \
   -o hm/disable.yml \
-  -v local_bosh_release=${BOSH_RELEASE_PATH}
+  -v local_bosh_release="${BOSH_RELEASE_PATH}"
 
 source /tmp/local-bosh/director/env
 
 STEMCELL_PATH="${PWD}/stemcell/$(basename stemcell/*.tgz)"
 BOSH_SSH_KEY="$(bosh int /tmp/local-bosh/director/creds.yml --path /jumpbox_ssh/private_key --json | jq .Blocks[0])"
 BOSH_HOST="${BOSH_ENVIRONMENT}"
+
+stemcell_os="$(cut -d- -f8-9 < stemcell/url )"
+bosh_ca_cert_json_value="$(awk '{printf "%s\\n", $0}' "${BOSH_CA_CERT}")"
 
 cat > integration-config.json <<EOF
 {
@@ -36,29 +40,15 @@ cat > integration-config.json <<EOF
   "bosh_ssh_private_key": ${BOSH_SSH_KEY},
   "bosh_client": "${BOSH_CLIENT}",
   "bosh_client_secret": "${BOSH_CLIENT_SECRET}",
-  "bosh_ca_cert": "$(awk '{printf "%s\\n", $0}' ${BOSH_CA_CERT})",
+  "bosh_ca_cert": "${bosh_ca_cert_json_value}",
   "timeout_in_minutes": 30,
   "stemcell_src": "${STEMCELL_PATH}",
+  "stemcell_os": "${stemcell_os}",
   "include_deployment_testcase": true,
   "include_truncate_db_blobstore_testcase": true
 }
 EOF
 
-set -x # debugging info
-export INTEGRATION_CONFIG_PATH=${PWD}/integration-config.json
-export GOPATH="${PWD}/gopath"
-export PATH="${PATH}:${GOPATH}/bin"
+export INTEGRATION_CONFIG_PATH="${PWD}/integration-config.json"
 
-# Note: this must happen in the context of a `go.mod` file, otherwise `@{VERSION}` must be used
-# => https://go.dev/doc/go-get-install-deprecation
-export GINKGO_VERSION="v1.16.5"
-go install "github.com/onsi/ginkgo/ginkgo@${GINKGO_VERSION}"
-
-
-# Hotfix until PR is merged: https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/pull/41
-sed -i "s/^  os:.*/  os: $(cat stemcell/url  | cut -d- -f8-9)/g" $(find -name small-deployment.yml)
-
-export GINKGO_TIMEOUT="24h0m0s"
-pushd gopath/src/github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests
-  ./scripts/_run_acceptance_tests.sh
-popd
+./bosh-disaster-recovery-acceptance-tests/scripts/_run_acceptance_tests.sh

--- a/ci/tasks/test-bdrats.yml
+++ b/ci/tasks/test-bdrats.yml
@@ -6,7 +6,6 @@ inputs:
 - name: stemcell
 - name: bosh-release
 - name: bosh-disaster-recovery-acceptance-tests
-  path: gopath/src/github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests
 - name: bbr-cli-binary
 - name: bosh-deployment
   optional: true


### PR DESCRIPTION
Previously the stemcell os in the BDRATs fixture (small-deployment.yml) was mutated using `sed`. The BDRATs now[1] accept stemcell-os as configuration removing the need to mutuate the fixture.

[1] https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests/pull/236

