### PR TITLE
Spec: remove error class from spec expectation

### DIFF
--- a/src/bosh-director/spec/unit/bosh/director/nats_client_cert_generator_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/nats_client_cert_generator_spec.rb
@@ -102,7 +102,7 @@ module Bosh
 
           expect { subject }.to raise_error(DeploymentNATSClientCertificateGenerationError) do |error|
             expect(error.message).to include('Error occurred while loading private key to generate NATS Client certificates')
-            expect(error.message).to include('OpenSSL::PKey::RSAError: Neither PUB key nor PRIV key')
+            expect(error.message).to include('Neither PUB key nor PRIV key')
           end
         end
 


### PR DESCRIPTION
Newer versons of the OpenSSL gem have changed the exception class returned when there are Pub or Pivate key portions missing. This change relaxes the expectation to check for the message, and not the class name.

Fixes the following error when running with `openssl-4.0.0.gem`: 
```
  1) Bosh::Director::NatsClientCertGenerator when CA or Private Key are misconfigured throws an invalid Private Key error if an error occurs while loading the certificate private key
     Failure/Error:
       expect { subject }.to raise_error(DeploymentNATSClientCertificateGenerationError) do |error|
         expect(error.message).to include('Error occurred while loading private key to generate NATS Client certificates')
         expect(error.message).to include('OpenSSL::PKey::RSAError: Neither PUB key nor PRIV key')
       end
     
       expected "Error occurred while loading private key to generate NATS Client certificates: #<OpenSSL::PKey::PKeyError: Neither PUB key nor PRIV key>" to include "OpenSSL::PKey::RSAError: Neither PUB key nor PRIV key"
     # ./spec/unit/bosh/director/nats_client_cert_generator_spec.rb:103:in `block (3 levels) in <module:Director>'
     # ./spec/spec_helper.rb:67:in `block in reset_database'
     # /usr/local/bundle/ruby/3.3.0/gems/sequel-5.99.0/lib/sequel/database/transactions.rb:257:in `_transaction'
     # /usr/local/bundle/ruby/3.3.0/gems/sequel-5.99.0/lib/sequel/database/transactions.rb:239:in `block in transaction'
     # /usr/local/bundle/ruby/3.3.0/gems/sequel-5.99.0/lib/sequel/connection_pool/timed_queue.rb:90:in `hold'
     # /usr/local/bundle/ruby/3.3.0/gems/sequel-5.99.0/lib/sequel/database/connecting.rb:283:in `synchronize'
     # /usr/local/bundle/ruby/3.3.0/gems/sequel-5.99.0/lib/sequel/database/transactions.rb:197:in `transaction'
     # /usr/local/bundle/ruby/3.3.0/gems/sequel-5.99.0/lib/sequel/core.rb:395:in `block (2 levels) in transaction'
     # /usr/local/bundle/ruby/3.3.0/gems/sequel-5.99.0/lib/sequel/core.rb:403:in `transaction'
     # ./spec/spec_helper.rb:66:in `reset_database'
     # ./spec/spec_helper.rb:156:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/ruby/3.3.0/gems/webmock-3.26.1/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'
```

Context: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/bump-deps/builds/184#L69448740:529:548