### PR TITLE
Add nic_group handling for VIP networks

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/vip_network.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/vip_network.rb
@@ -50,12 +50,19 @@ module Bosh::Director
           raise NetworkReservationVipDefaultProvided, "Can't provide any defaults since this is a VIP network"
         end
 
-        {
+        config = {
           'type' => 'vip',
           'ip' => to_ipaddr(reservation.ip).base_addr,
           'cloud_properties' => @cloud_properties,
           'prefix' => @prefix
         }
+
+        nic_group = reservation.nic_group
+        unless nic_group.nil?
+          config['nic_group'] = nic_group.to_s
+        end
+
+        config
       end
 
       def vip?

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/vip_network_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/vip_network_spec.rb
@@ -58,6 +58,43 @@ describe Bosh::Director::DeploymentPlan::VipNetwork do
       )
     end
 
+    it 'should include nic_group when specified on reservation' do
+      reservation = Bosh::Director::DesiredNetworkReservation.new_static(instance_model, @network, '0.0.0.1', 1)
+
+      expect(@network.network_settings(reservation, [])).to eq(
+        'type' => 'vip',
+        'ip' => '0.0.0.1',
+        'cloud_properties' => {
+          'foz' => 'baz',
+        },
+        'prefix' => '32',
+        'nic_group' => '1',
+      )
+    end
+
+    it 'should convert nic_group to string when specified' do
+      reservation = Bosh::Director::DesiredNetworkReservation.new_static(instance_model, @network, '0.0.0.1', 5)
+
+      settings = @network.network_settings(reservation, [])
+      expect(settings['nic_group']).to eq('5')
+      expect(settings['nic_group']).to be_a(String)
+    end
+
+    it 'should omit nic_group when not specified on reservation' do
+      reservation = Bosh::Director::DesiredNetworkReservation.new_static(instance_model, @network, '0.0.0.1', nil)
+
+      settings = @network.network_settings(reservation, [])
+      expect(settings).not_to have_key('nic_group')
+    end
+
+    it 'should include nic_group 0 explicitly when specified' do
+      reservation = Bosh::Director::DesiredNetworkReservation.new_static(instance_model, @network, '0.0.0.1', 0)
+
+      settings = @network.network_settings(reservation, [])
+      expect(settings['nic_group']).to eq('0')
+      expect(settings).to have_key('nic_group')
+    end
+
     it 'should fail if there are any defaults' do
       reservation = Bosh::Director::DesiredNetworkReservation.new_static(instance_model, @network, '0.0.0.1')
 


### PR DESCRIPTION
### What is this change about?

This PR adds `nic_group` support for VIP networks in the BOSH Director, enabling operators to specify which network interface should receive an Elastic IP when deploying instances with multiple NICs.

When a VIP network includes a `nic_group` property, the Director now passes this information to the CPI in the network settings, allowing the CPI to associate the Elastic IP with the correct network interface.

### Please provide contextual information.

This change works in conjunction with the [AWS CPI PR](https://github.com/cloudfoundry/bosh-aws-cpi-release/pull/194) that implements the `nic_group` to `device_index` mapping logic.

**Changes:**
- Modified `VipNetwork#network_settings` to include `nic_group` when specified
- `nic_group` is converted to string format for CPI consumption
- Maintains backward compatibility: omits `nic_group` when not specified

### What tests have you run against this PR?

- BOSH Director unit tests
- Added 4 new unit tests

### How should this change be described in bosh release notes?

VIP networks now support the `nic_group` property in deployment manifests. When specified, the Director passes this value to the CPI to control which network interface receives an Elastic IP in multi-NIC configurations.

### Does this PR introduce a breaking change?

No. This change is backward compatible. When `nic_group` is not specified on a VIP network, the property is omitted from the network settings sent to the CPI, maintaining existing behavior.
