### PR TITLE
Replace "magic" strings with constants or StringInquirer

### DIFF
--- a/src/bosh-director/spec/unit/bosh/director/errand/errand_provider_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/errand/errand_provider_spec.rb
@@ -29,10 +29,11 @@ module Bosh::Director
       let(:template_blob_cache) { instance_double(Bosh::Director::Core::Templates::TemplateBlobCache) }
       let(:runner) { instance_double(Errand::Runner) }
       let(:errand_step) { instance_double(Errand::LifecycleErrandStep) }
+      let(:current_job_state) { 'dummy'}
       let(:instance) do
         instance_double(
           DeploymentPlan::Instance,
-          current_job_state: double(:current_job_state),
+          current_job_state: current_job_state.inquiry,
           uuid: instance_model.uuid,
           model: instance_model,
         )

--- a/src/bosh-director/spec/unit/bosh/director/starter_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/starter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'active_support/core_ext/string/inquiry'
 
 module Bosh::Director
   describe Starter do
@@ -19,7 +20,7 @@ module Bosh::Director
     let(:instance) do
       instance_double(
         DeploymentPlan::Instance,
-        current_job_state: current_job_state,
+        current_job_state: current_job_state.inquiry,
       )
     end
 

--- a/src/bosh-director/spec/unit/bosh/director/stopper_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/stopper_spec.rb
@@ -34,7 +34,7 @@ module Bosh::Director
         rendered_templates_archive: nil,
         configuration_hash: { 'fake-spec' => true },
         template_hashes: [],
-        current_job_state: current_job_state,
+        current_job_state: current_job_state.inquiry,
         deployment_model: deployment_model,
       )
     end


### PR DESCRIPTION
Rather than comparing various strings this commit shifts to using constants and/or ActiveSupport's `StringInquirer`

