### PR TITLE
(feat) - add storage-cli to blob.yml

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1617,6 +1617,12 @@ resources:
       access_key_id: ((bosh_s3cli_pipeline_aws_access_key.username))
       secret_access_key: ((bosh_s3cli_pipeline_aws_access_key.password))
 
+  - name: bosh-blobstore-storage-cli-s3
+    type: s3
+    source:
+      regexp: storage-cli-(.*)-linux-amd64
+      bucket: capi-release-blobs
+
   - name: bosh-blobstore-azure-storage
     type: s3
     source:


### PR DESCRIPTION
### What is this change about?

This change is to bring new strorage-cli https://github.com/cloudfoundry/storage-cli/tree/main/s3 later to migrate from bosh-s3cli. 

https://github.com/cloudfoundry/bosh/compare/main...gowrisankar22:bosh:support-storage-cli?expand=1#diff-4773dca3c56343b4eb62c73e472115949bc2b7d384e82b6b9ebf00efe0451675L263

### Does this PR introduce a breaking change?
NO
