### PR TITLE
Fix undefined method `detached?` for String

### DIFF
--- a/src/bosh-director/lib/bosh/director.rb
+++ b/src/bosh-director/lib/bosh/director.rb
@@ -1,5 +1,11 @@
 module Bosh
   module Director
+    INSTANCE_STATE_STARTED = 'started'.freeze
+    INSTANCE_STATE_STOPPED = 'stopped'.freeze
+    INSTANCE_STATE_DETACHED = 'detached'.freeze
+
+    INSTANCE_VIRTUAL_STATE_RESTART = 'restart'.freeze
+    INSTANCE_VIRTUAL_STATE_RECREATE = 'recreate'.freeze
   end
 end
 

--- a/src/bosh-director/lib/bosh/director/deployment_plan/compilation_instance_pool.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/compilation_instance_pool.rb
@@ -168,7 +168,7 @@ module Bosh::Director
         instance = Instance.create_from_instance_group(
           compile_instance_group,
           0,
-          'started',
+          Bosh::Director::INSTANCE_STATE_STARTED,
           @deployment_plan.model,
           {},
           availability_zone,

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance.rb
@@ -5,13 +5,9 @@ module Bosh::Director
   module DeploymentPlan
     # Represents a single Instance Group instance.
     class Instance
-      RECREATE = 'recreate'.freeze
-      RESTART = 'restart'.freeze
-      STARTED = 'started'.freeze
-
       VIRTUAL_STATE_TO_STATE_MAPPING = {
-        RECREATE => STARTED,
-        RESTART => STARTED
+        Bosh::Director::INSTANCE_VIRTUAL_STATE_RESTART => Bosh::Director::INSTANCE_STATE_STARTED,
+        Bosh::Director::INSTANCE_VIRTUAL_STATE_RECREATE => Bosh::Director::INSTANCE_STATE_STARTED
       }
 
       # @return [Integer] Instance index
@@ -311,6 +307,18 @@ module Bosh::Director
         @virtual_state.to_s.inquiry
       end
 
+      def started?
+        state == Bosh::Director::INSTANCE_STATE_STARTED
+      end
+
+      def stopped?
+        state == Bosh::Director::INSTANCE_STATE_STOPPED
+      end
+
+      def detached?
+        state == Bosh::Director::INSTANCE_STATE_DETACHED
+      end
+
       ##
       # Checks if the target VM already has the same set of trusted SSL certificates
       # as the director currently wants to install on all managed VMs. This will
@@ -385,7 +393,7 @@ module Bosh::Director
         }
 
         Models::Instance.find_or_create(conditions) do |model|
-          model.state = 'started'
+          model.state = Bosh::Director::INSTANCE_STATE_STARTED
           model.compilation = @compilation
           model.uuid = SecureRandom.uuid
           model.variable_set_id = @deployment_model.current_variable_set.id

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_group.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_group.rb
@@ -14,7 +14,13 @@ module Bosh::Director
       # recreate and restart are two virtual states
       # (both set  target instance state to "started" and set
       # appropriate instance spec modifiers)
-      VALID_STATES = %w[started stopped detached recreate restart].freeze
+      VALID_STATES = [
+        Bosh::Director::INSTANCE_STATE_STARTED,
+        Bosh::Director::INSTANCE_STATE_STOPPED,
+        Bosh::Director::INSTANCE_STATE_DETACHED,
+        Bosh::Director::INSTANCE_VIRTUAL_STATE_RESTART,
+        Bosh::Director::INSTANCE_VIRTUAL_STATE_RECREATE,
+      ].freeze
 
       # @return [String] Instance group name
       attr_reader :name
@@ -159,7 +165,7 @@ module Bosh::Director
                                                      .select(&:needs_duplicate_vm?)
                                                      .reject(&:new?)
                                                      .reject(&:should_be_ignored?)
-                                                     .reject { |plan| plan.instance.state == 'detached' }
+                                                     .reject { |plan| plan.instance.detached? }
       end
 
       def add_job(job_to_add)
@@ -370,7 +376,7 @@ module Bosh::Director
 
       def instance_plans_with_missing_vms
         needed_instance_plans.reject do |instance_plan|
-          instance_plan.instance.vm_created? || instance_plan.instance.state == 'detached'
+          instance_plan.instance.vm_created? || instance_plan.instance.detached?
         end
       end
 

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_plan.rb
@@ -186,15 +186,15 @@ module Bosh
         end
 
         def state_changed?
-          if instance.state.detached? && existing_instance.state != instance.state
+          if instance.detached? && existing_instance.state != instance.state
             @logger.debug("Instance '#{instance}' needs to be detached")
             return true
           end
 
           return true if unresponsive_agent?
 
-          if instance.state.stopped? && instance.current_job_state.running? ||
-              instance.state.started? && !instance.current_job_state.running?
+          if (instance.stopped? && instance.current_job_state.running?) ||
+             (instance.started? && !instance.current_job_state.running?)
             @logger.debug("Instance state is '#{instance.state}' and agent reports '#{instance.current_job_state}'")
             return true
           end

--- a/src/bosh-director/lib/bosh/director/deployment_plan/instance_repository.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/instance_repository.rb
@@ -120,7 +120,7 @@ module Bosh::Director::DeploymentPlan
       instance = Instance.create_from_instance_group(
         desired_instance.instance_group,
         index,
-        'started',
+        Bosh::Director::INSTANCE_STATE_STARTED,
         desired_instance.deployment.model,
         nil,
         desired_instance.az,

--- a/src/bosh-director/lib/bosh/director/deployment_plan/planner.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/planner.rb
@@ -260,7 +260,7 @@ module Bosh::Director
           if instance_group.service?
             instance_groups << instance_group
           elsif instance_group.errand?
-            if instance_group.instances.any?(&:vm_created?) || instance_group.instances.any? { |i| i.model.state == 'detached' }
+            if instance_group.instances.any?(&:vm_created?) || instance_group.instances.any? { |i| i.model.detached? }
               instance_groups << instance_group
             end
           end

--- a/src/bosh-director/lib/bosh/director/instance_deleter.rb
+++ b/src/bosh-director/lib/bosh/director/instance_deleter.rb
@@ -78,7 +78,7 @@ module Bosh::Director
     end
 
     def stop(instance_plan)
-      Stopper.stop(intent: @stop_intent, instance_plan: instance_plan, target_state: 'stopped', logger: @logger)
+      Stopper.stop(intent: @stop_intent, instance_plan: instance_plan, target_state: Bosh::Director::INSTANCE_STATE_STOPPED, logger: @logger)
     end
 
     # FIXME: why do we hate dependency injection?

--- a/src/bosh-director/lib/bosh/director/instance_updater/state_applier.rb
+++ b/src/bosh-director/lib/bosh/director/instance_updater/state_applier.rb
@@ -17,7 +17,7 @@ module Bosh::Director
       @instance.update_templates(@instance_plan.templates)
       @rendered_job_templates_cleaner.clean
 
-      start(update_config, wait_for_running) if @instance.state == 'started'
+      start(update_config, wait_for_running) if @instance.started?
     end
 
     private

--- a/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/attach_disk.rb
@@ -53,7 +53,7 @@ module Bosh::Director
               'Attaching disks to ignored instances is not allowed.'
         end
 
-        if instance.state != 'detached' && instance.state != 'stopped'
+        unless instance.detached? || instance.stopped?
           raise AttachDiskInvalidInstanceState, "Instance '#{@job_name}/#{@instance_id}' in deployment '#{@deployment_name}' must be in 'bosh stopped' state"
         end
       end
@@ -66,7 +66,7 @@ module Bosh::Director
           @cloud_properties = previous_persistent_disk.cloud_properties
         end
 
-        if instance.state == 'stopped'
+        if instance.stopped?
           @disk_manager.detach_disk(previous_persistent_disk)
         end
 
@@ -88,7 +88,7 @@ module Bosh::Director
           )
         end
 
-        if instance.state == 'stopped'
+        if instance.stopped?
           @disk_manager.attach_disk(disk, instance.deployment.tags)
         end
       end

--- a/src/bosh-director/lib/bosh/director/jobs/update_instance.rb
+++ b/src/bosh-director/lib/bosh/director/jobs/update_instance.rb
@@ -106,7 +106,7 @@ module Bosh::Director
         instance_plan = DeploymentPlan::InstancePlanFromDB.create_from_instance_model(
           instance_model,
           deployment_plan,
-          'started',
+          Bosh::Director::INSTANCE_STATE_STARTED,
           @logger,
         )
 
@@ -145,14 +145,14 @@ module Bosh::Director
 
         DeploymentPlan::Steps::DeleteVmStep.new(true, false, Config.enable_virtual_delete_vms).perform(instance_report)
         @logger.debug("Setting instance #{@instance_id} state to detached")
-        instance_model.update(state: 'detached')
+        instance_model.update(state: Bosh::Director::INSTANCE_STATE_DETACHED)
       end
 
       def stop(instance_model, instance_plan)
         task_checkpoint
 
         intent = @options['hard'] ? :delete_vm : :keep_vm
-        target_state = @options['hard'] ? 'detached' : 'stopped'
+        target_state = @options['hard'] ? Bosh::Director::INSTANCE_STATE_DETACHED : Bosh::Director::INSTANCE_STATE_STOPPED
         parent_event = add_event('stop', instance_model)
 
         Stopper.stop(intent: intent, instance_plan: instance_plan, target_state: target_state, logger: @logger)

--- a/src/bosh-director/lib/bosh/director/stopper.rb
+++ b/src/bosh-director/lib/bosh/director/stopper.rb
@@ -77,8 +77,8 @@ module Bosh::Director
       end
 
       def needs_shutdown?(instance_plan, target_state)
-        target_state == 'stopped' ||
-          target_state == 'detached' ||
+        target_state == Bosh::Director::INSTANCE_STATE_STOPPED ||
+          target_state == Bosh::Director::INSTANCE_STATE_DETACHED ||
           instance_plan.needs_shutting_down? ||
           instance_plan.persistent_disk_changed?
       end

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/instance_group_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/instance_group_spec.rb
@@ -1111,7 +1111,15 @@ describe Bosh::Director::DeploymentPlan::InstanceGroup do
   end
 
   describe '#unignored_instance_plans_needing_duplicate_vm' do
-    let(:instance_plan_instance) { instance_double(Bosh::Director::DeploymentPlan::Instance, vm_created?: true, state: 'started') }
+    let(:instance_state) { 'started' }
+    let(:instance_plan_instance) do
+      instance_double(Bosh::Director::DeploymentPlan::Instance,
+                      vm_created?: true,
+                      state: instance_state,
+                      detached?: instance_state == 'detached',
+                      started?: instance_state == 'started',
+      )
+    end
     let(:instance_plan) do
       instance_double(Bosh::Director::DeploymentPlan::InstancePlan, instance: instance_plan_instance, new?: false, needs_duplicate_vm?: true, should_be_ignored?: false)
     end
@@ -1128,9 +1136,7 @@ describe Bosh::Director::DeploymentPlan::InstanceGroup do
     end
 
     context 'when instance group contains detached instance plan' do
-      before do
-        allow(instance_plan_instance).to receive(:state).and_return('detached')
-      end
+      let(:instance_state) { 'detached' }
 
       it 'should filter detached instance plans' do
         expect(instance_group.unignored_instance_plans_needing_duplicate_vm).to be_empty

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/instance_plan_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/instance_plan_spec.rb
@@ -1358,7 +1358,7 @@ module Bosh::Director::DeploymentPlan
       end
 
       context 'when instance is not being recreated' do
-        let(:instance_state) { 'stopped' }
+        let(:instance_state) { Bosh::Director::INSTANCE_STATE_STOPPED }
 
         it 'should return false when desired instance is in any another state' do
           expect(instance_plan.recreation_requested?).to be_falsey

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/planner_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/planner_spec.rb
@@ -300,6 +300,7 @@ module Bosh::Director
 
           context 'with errand not running' do
             before do
+              instance_state = 'started'
               allow(job2)
                 .to receive(:instances)
                 .and_return(
@@ -307,7 +308,7 @@ module Bosh::Director
                     instance_double(
                       'Bosh::Director::DeploymentPlan::Instance',
                       vm_created?: false,
-                      model: instance_double('Bosh::Director::Models::Instance', state: 'started'),
+                      model: instance_double('Bosh::Director::Models::Instance', state: instance_state, detached?: instance_state == 'detached'),
                     ),
                   ],
                 )

--- a/src/bosh-director/spec/unit/bosh/director/instance_updater/update_procedure_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/instance_updater/update_procedure_spec.rb
@@ -90,6 +90,8 @@ module Bosh::Director
           name: instance_name,
           vms: instance_vms,
           managed_persistent_disk: persistent_disk,
+          stopped?: instance_model_state == 'stopped',
+          detached?: instance_model_state == 'detached',
         )
       end
 
@@ -102,6 +104,9 @@ module Bosh::Director
           model: instance_model,
           update_instance_settings: nil,
           update_state: nil,
+          detached?: instance_state == 'detached',
+          stopped?: instance_state == 'stopped',
+          started?: instance_state == 'started',
         )
       end
 


### PR DESCRIPTION
Following on PR #2659 which broke the integration tests for BOSH:
`instance.state.detached?` is called, but `instance.state` returns a String (not a StringInquirer), so it doesn't have the `.detached?` method.

### Changes
- **Add state constants** to `DeploymentPlan::Instance`:
  - `STATE_STARTED`, `STATE_STOPPED`, `STATE_DETACHED`
- **Add predicate methods** to `DeploymentPlan::Instance`:
  - `started?`, `stopped?`, `detached?`
- **Refactor all state checks** to use predicate methods across:
- Fix lint warning
- Remove duplicate `attr_accessor` declarations in `instance_group.rb`
