### PR TITLE
Add syslog gem for Ruby 3.4+ compatibility

### DIFF
--- a/src/Gemfile
+++ b/src/Gemfile
@@ -7,6 +7,7 @@ gem 'bosh-common', path: 'bosh-common'
 
 gem 'mysql2'
 gem 'pg'
+gem 'syslog'
 
 group :development, :test do
   gem 'bundle-audit'


### PR DESCRIPTION
Takes care of the following error and any potential issues when we move to Ruby 3.4+:
```
warning: syslog was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
```