### PR TITLE
Fix regex operator typo in health monitor spec

### DIFF
--- a/src/spec/integration/health_monitor/hm_stateless_spec.rb
+++ b/src/spec/integration/health_monitor/hm_stateless_spec.rb
@@ -140,7 +140,7 @@ describe 'health_monitor: 1', type: :integration, hm: true do
       }
 
       heartbeat_hashes_excluding_compilation = heartbeat_hashes.select do |hash|
-        hash['job'] !=~ /^compilation\-/
+        hash['job'] !~ /^compilation\-/
       end
 
       expect(heartbeat_hashes_excluding_compilation.length).to be > 0


### PR DESCRIPTION
### What is this change about?

Fixes a 9-year-old typo in the health monitor test that filters compilation job heartbeats. The test was using an invalid regex operator `!=~` instead of the correct negated match operator `!~`.

### Please provide contextual information.

It appears this was now exposed by PR #2649.
The invalid operator `!=~` (parsed as `!=` followed by `~`) always returns `true`, so compilation heartbeats weren't actually filtered out

### What tests have you run against this PR?

Ran the `spec/integration/health_monitor/hm_stateless_spec.rb` tests.

### How should this change be described in bosh release notes?

Fixed health monitor integration test that was using incorrect regex operator for filtering heartbeats.

### Does this PR introduce a breaking change?

No - this is a test-only fix.