### PR TITLE
CI: fix deprecated property

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -83,7 +83,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ unit-common ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -103,7 +104,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ unit-monitor ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -123,7 +125,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ unit-nats-sync ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -143,7 +146,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ unit-release ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -163,7 +167,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ unit-director-sqlite ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -183,7 +188,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ unit-director-mysql-8 ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -205,7 +211,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ unit-director-postgres-13 ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -227,7 +234,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ unit-director-postgres-15 ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -249,7 +257,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ run-bundle-audit ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - get: bosh
         trigger: true
@@ -284,7 +293,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ integration-postgres ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -313,7 +323,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ integration-postgres-hotswap ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -341,7 +352,8 @@ jobs:
     public: true
     serial: true
     serial_groups: [ integration-mysql ]
-    build_logs_to_retain: 250
+    build_log_retention:
+      builds: 250
     plan:
       - in_parallel:
           - get: bosh-ci


### PR DESCRIPTION
build_logs_to_retain => build_log_retention

fixes a deprecation in concourse jobs yaml