### PR TITLE
CI: update docker-cpi for cgroups v2

### DIFF
--- a/ci/dockerfiles/docker-cpi/start-bosh.sh
+++ b/ci/dockerfiles/docker-cpi/start-bosh.sh
@@ -116,7 +116,18 @@ function start_docker() {
   mkdir -p /var/log
   mkdir -p /var/run
 
+  # Let Docker/containerd know they're running inside a container
+  export container=docker
+
+  # Mount securityfs for AppArmor support inside the container
+  if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+    mount -t securityfs none /sys/kernel/security || true
+  fi
+
   sanitize_cgroups
+
+  # Make mount propagation shared for Docker-in-Docker compatibility
+  mount --make-rshared / 2>/dev/null || true
 
   # ensure systemd cgroup is present (cgroups v1 only)
   if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then


### PR DESCRIPTION
Add updates to `start_docker` to enable working in a cgroups v2 environment.

