### PR TITLE
Fix flaky IP assignment

### DIFF
--- a/src/bosh-director/lib/bosh/director/deployment_plan/ip_provider/ip_repo.rb
+++ b/src/bosh-director/lib/bosh/director/deployment_plan/ip_provider/ip_repo.rb
@@ -116,7 +116,7 @@ module Bosh::Director::DeploymentPlan
 
     def find_next_available_ip(addresses_we_cant_allocate, first_range_address, prefix)
       # Remove IPs that are below subnet range
-      filtered_ips = addresses_we_cant_allocate.sort_by { |ip| ip.to_i }.reject { |ip| ip.to_i < first_range_address.to_i }
+      filtered_ips = addresses_we_cant_allocate.sort_by { |ip| [ip.to_i, ip.prefix] }.reject { |ip| ip.to_i < first_range_address.to_i }
 
       current_ip = to_ipaddr(first_range_address.to_i + 1)
       found = false

--- a/src/bosh-director/lib/bosh/director/ip_addr_or_cidr.rb
+++ b/src/bosh-director/lib/bosh/director/ip_addr_or_cidr.rb
@@ -44,11 +44,11 @@ module Bosh
       end
 
       def eql?(other)
-        self == other
+        other.is_a?(IpAddrOrCidr) && @ipaddr.to_i == other.to_i && @ipaddr.prefix == other.prefix
       end
 
       def hash
-        @ipaddr.hash
+        [@ipaddr.to_i, @ipaddr.prefix].hash
       end
 
       def count

--- a/src/bosh-director/lib/bosh/director/ip_addr_or_cidr.rb
+++ b/src/bosh-director/lib/bosh/director/ip_addr_or_cidr.rb
@@ -43,12 +43,32 @@ module Bosh
         end
       end
 
+      # Structural equality for use by +Set+ and +Hash+. Two instances are equal
+      # only if they share the same base address integer, prefix length, and
+      # address family. For example, +10.0.11.32/30+ and +10.0.11.32/32+ are NOT
+      # equal
+      #
+      # @param other [Object] the object to compare with
+      # @return [Boolean] +true+ if +other+ is an +IpAddrOrCidr+ with identical
+      #   address, prefix, and address family; +false+ otherwise
       def eql?(other)
-        other.is_a?(IpAddrOrCidr) && @ipaddr.to_i == other.to_i && @ipaddr.prefix == other.prefix
+        other.is_a?(IpAddrOrCidr) &&
+          @ipaddr.to_i == other.to_i &&
+          @ipaddr.prefix == other.prefix &&
+          @ipaddr.ipv4? == other.ipv4?
       end
 
+      # Returns an integer hash value derived from the address integer, prefix
+      # length, and address family - the same three fields used by {#eql?}.
+      # Satisfies Ruby's contract: if +a.eql?(b)+ then +a.hash == b.hash+.
+      #
+      # @return [Integer] hash value for use by +Set+ and +Hash+
       def hash
-        [@ipaddr.to_i, @ipaddr.prefix].hash
+        [
+          @ipaddr.to_i,
+          @ipaddr.prefix,
+          @ipaddr.ipv4?,
+        ].hash
       end
 
       def count

--- a/src/bosh-director/spec/unit/bosh/director/ip_addr_or_cidr_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/ip_addr_or_cidr_spec.rb
@@ -292,14 +292,14 @@ module Bosh::Director
 
       context 'when an IPv4 and IPv6 address have the same integer value and prefix' do
         it 'eql? returns false' do
-          ipv4 = IpAddrOrCidr.new('0.0.0.1/32')
-          ipv6 = IpAddrOrCidr.new('::1/128')
+          ipv4 = IpAddrOrCidr.new('0.0.0.0/32')
+          ipv6 = IpAddrOrCidr.new('::/32')
           expect(ipv4.eql?(ipv6)).to be false
         end
 
         it 'are stored as distinct elements in a Set' do
-          ipv4 = IpAddrOrCidr.new('0.0.0.1/32')
-          ipv6 = IpAddrOrCidr.new('::1/128')
+          ipv4 = IpAddrOrCidr.new('0.0.0.0/32')
+          ipv6 = IpAddrOrCidr.new('::/32')
           expect(Set.new([ipv4, ipv6]).size).to eq(2)
         end
       end

--- a/src/bosh-director/spec/unit/bosh/director/ip_addr_or_cidr_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/ip_addr_or_cidr_spec.rb
@@ -278,6 +278,32 @@ module Bosh::Director
         end
       end
 
+      context 'when compared to a non-IpAddrOrCidr object' do
+        it 'eql? returns false for nil' do
+          a = IpAddrOrCidr.new('10.0.11.32/30')
+          expect(a.eql?(nil)).to be false
+        end
+
+        it 'eql? returns false for a String' do
+          a = IpAddrOrCidr.new('10.0.11.32/30')
+          expect(a.eql?('10.0.11.32/30')).to be false
+        end
+      end
+
+      context 'when an IPv4 and IPv6 address have the same integer value and prefix' do
+        it 'eql? returns false' do
+          ipv4 = IpAddrOrCidr.new('0.0.0.1/32')
+          ipv6 = IpAddrOrCidr.new('::1/128')
+          expect(ipv4.eql?(ipv6)).to be false
+        end
+
+        it 'are stored as distinct elements in a Set' do
+          ipv4 = IpAddrOrCidr.new('0.0.0.1/32')
+          ipv6 = IpAddrOrCidr.new('::1/128')
+          expect(Set.new([ipv4, ipv6]).size).to eq(2)
+        end
+      end
+
       context 'hash contract (eql? implies equal hash)' do
         it 'is satisfied for equal objects' do
           a = IpAddrOrCidr.new('192.168.1.0/24')

--- a/src/bosh-director/spec/unit/bosh/director/ip_addr_or_cidr_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/ip_addr_or_cidr_spec.rb
@@ -228,5 +228,70 @@ module Bosh::Director
         end
       end
     end
+
+    describe '#eql? and #hash' do
+      context 'when two objects have the same base address and prefix' do
+        it 'eql? returns true' do
+          a = IpAddrOrCidr.new('10.0.11.32/30')
+          b = IpAddrOrCidr.new('10.0.11.32/30')
+          expect(a.eql?(b)).to be true
+        end
+
+        it 'hash values are equal' do
+          a = IpAddrOrCidr.new('10.0.11.32/30')
+          b = IpAddrOrCidr.new('10.0.11.32/30')
+          expect(a.hash).to eq(b.hash)
+        end
+
+        it 'can be used as the same Set element' do
+          a = IpAddrOrCidr.new('10.0.11.32/30')
+          b = IpAddrOrCidr.new('10.0.11.32/30')
+          expect(Set.new([a, b]).size).to eq(1)
+        end
+      end
+
+      context 'when two objects have the same base address but different prefixes' do
+        it 'eql? returns false' do
+          a = IpAddrOrCidr.new('10.0.11.32/30')
+          b = IpAddrOrCidr.new('10.0.11.32/32')
+          expect(a.eql?(b)).to be false
+        end
+
+        it 'hash values are different' do
+          a = IpAddrOrCidr.new('10.0.11.32/30')
+          b = IpAddrOrCidr.new('10.0.11.32/32')
+          expect(a.hash).not_to eq(b.hash)
+        end
+
+        it 'are stored as distinct elements in a Set' do
+          a = IpAddrOrCidr.new('10.0.11.32/30')
+          b = IpAddrOrCidr.new('10.0.11.32/32')
+          expect(Set.new([a, b]).size).to eq(2)
+        end
+      end
+
+      context 'when using objects with different base addresses' do
+        it 'eql? returns false' do
+          a = IpAddrOrCidr.new('10.0.11.32/30')
+          b = IpAddrOrCidr.new('10.0.11.36/30')
+          expect(a.eql?(b)).to be false
+        end
+      end
+
+      context 'hash contract (eql? implies equal hash)' do
+        it 'is satisfied for equal objects' do
+          a = IpAddrOrCidr.new('192.168.1.0/24')
+          b = IpAddrOrCidr.new('192.168.1.0/24')
+          expect(a.eql?(b)).to be true
+          expect(a.hash).to eq(b.hash)
+        end
+
+        it 'is satisfied for unequal objects (different prefix)' do
+          a = IpAddrOrCidr.new('192.168.1.0/24')
+          b = IpAddrOrCidr.new('192.168.1.0/32')
+          expect(a.eql?(b)).to be false
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What is this change about?

Follow-up fix to #2657 to eliminate residual flaky behaviour in IP allocation from reserved CIDR ranges.

PR #2657 fixed the algorithmic logic in `find_next_available_ip` (pruning by last address, using `overlaps?`, capturing `blocking_ip` before mutation). However, the very second test run in Concourse failed. It looks like the issue is still present under certain Ruby hash seeds:

**Changes:**
- `IpAddrOrCidr#eql?`: now compares both `to_i` and `prefix` directly, treating objects with the same base address but different prefix lengths as distinct
- `IpAddrOrCidr#hash`: now uses `[to_i, prefix].hash` to satisfy the contract
- `find_next_available_ip` sort key: changed from `ip.to_i` to `[ip.to_i, ip.prefix]` so larger blocks (smaller prefix) always sort before the `/32`s they contain

### Please provide contextual information.

- Fixes flakiness missed by #2657
- The CI failure that prompted this investigation: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/unit-director-sqlite/builds/581

```log
 -#<Bosh::Director::IpAddrOrCidr:0x000076df19e9bb18
 - @ipaddr=#<IPAddr: IPv4:10.0.11.41/255.255.255.255>>
 +#<Bosh::Director::IpAddrOrCidr:0x000076df19f33760
 + @ipaddr=#<IPAddr: IPv4:10.0.11.34/255.255.255.255>>

 -#<Bosh::Director::IpAddrOrCidr:0x000076df199f91f0
 - @ipaddr=#<IPAddr: IPv4:10.0.11.36/255.255.255.255>>
 +#<Bosh::Director::IpAddrOrCidr:0x000076df199fe240
 + @ipaddr=#<IPAddr: IPv4:10.0.11.35/255.255.255.255>>
```

### What tests have you run against this PR?

- All existing `IpAddrOrCidr` unit specs pass (`spec/unit/bosh/director/ip_addr_or_cidr_spec.rb`)
- All existing `IpRepo` unit specs pass, including the CIDR block tests added by #2657 (`spec/unit/bosh/director/deployment_plan/ip_provider/ip_repo_spec.rb`)
- New unit tests added for `#eql?` and `#hash` covering:
  - Same base address + same prefix: `eql?` true, equal hashes, deduplicates in Set
  - Same base address + different prefix: `eql?` false, different hashes, coexist as distinct Set elements
  - Different base address: `eql?` false
  - Hash contract explicitly verified

### How should this change be described in bosh release notes?

Fixed: IP allocation could intermittently assign addresses from reserved CIDR ranges due to non-deterministic Set behaviour in the IP dedup logic.

### Does this PR introduce a breaking change?

No. This is a bug fix. The observable behaviour - that IPs are not allocated from reserved ranges - is unchanged; the fix makes it deterministic.
