### PR TITLE
CI: use git-lfs when checking for CVEs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1043,6 +1043,7 @@ jobs:
             input_repo: bosh
             version: current-version
           params:
+            ENABLE_GIT_LFS: true
             SEVERITY: CRITICAL,HIGH
           on_success:
             do:


### PR DESCRIPTION
NOTE: pipeline is already configured

Gems are vendored via git-lfs often and this ensure that the repo is in a valid state before checking for CVEs.

