### PR TITLE
Handle InsufficientPermissions error from the CPI

### DIFF
--- a/src/bosh-director/lib/bosh/director/disk_manager.rb
+++ b/src/bosh-director/lib/bosh/director/disk_manager.rb
@@ -99,6 +99,9 @@ module Bosh::Director
 
           old_disk_model.update(updates)
           @logger.info("Successfully updated detached disk '#{old_disk_model.disk_cid}'")
+        rescue Bosh::Clouds::InsufficientPermissions => e
+          @logger.info("CPI update_disk for '#{old_disk_model.disk_cid}' could not be performed due to insufficient permissions: #{e.message}. " \
+                       "Will use copy path after VM recreation.")
         rescue Bosh::Clouds::NotImplemented, Bosh::Clouds::NotSupported => e
           # Only catch "not available" errors. Other CPI errors (e.g. partial failures during
           # snapshot-based migration) must propagate — the CPI may have replaced the disk and
@@ -325,7 +328,7 @@ module Bosh::Director
           instance_plan.instance.desired_variable_set,
         )
         new_disk_cid = cloud.update_disk(old_disk_model.disk_cid, new_disk.size, resolved_cloud_properties)
-      rescue Bosh::Clouds::NotImplemented, Bosh::Clouds::NotSupported => e
+      rescue Bosh::Clouds::NotImplemented, Bosh::Clouds::NotSupported, Bosh::Clouds::InsufficientPermissions => e
         @logger.info("IaaS native update not possible for disk #{old_disk_model.disk_cid}. Falling back to creating new disk.\n#{e.message}")
         attach_disk(old_disk_model, instance_plan.tags)
         update_disk(instance_plan, new_disk, old_disk)

--- a/src/bosh-director/lib/clouds/errors.rb
+++ b/src/bosh-director/lib/clouds/errors.rb
@@ -3,6 +3,7 @@ module Bosh
     class CpiError < StandardError; end
     class NotImplemented < CpiError; end
     class NotSupported < CpiError; end
+    class InsufficientPermissions < CpiError; end
     class AttachDiskResponseError < CpiError; end
 
     class CloudError < StandardError; end

--- a/src/bosh-director/lib/clouds/external_cpi.rb
+++ b/src/bosh-director/lib/clouds/external_cpi.rb
@@ -38,6 +38,7 @@ module Bosh::Clouds
       Bosh::Clouds::CpiError
       Bosh::Clouds::NotSupported
       Bosh::Clouds::NotImplemented
+      Bosh::Clouds::InsufficientPermissions
 
       Bosh::Clouds::CloudError
       Bosh::Clouds::VMNotFound


### PR DESCRIPTION
### What is this change about?

This PR aims to make the new disk update procedure introduced in https://github.com/cloudfoundry/bosh/pull/2701 backwards compatible.

This PR adds handling for a new Bosh::Clouds::InsufficientPermissions CPI error type in the director's update_disk flow.

When a CPI attempts a native disk update (e.g. changing disk type via snapshot on GCP) but the IaaS service account lacks the required permission, it can now signal this explicitly by returning Bosh::Clouds::InsufficientPermissions. The director catches this in both update_detached_disks (during VM recreation) and update_disk_cpi (during a live disk update), logs a clear message identifying the cause, and falls back to the standard copy-based disk update path.

Three changes:
- errors.rb — defines Bosh::Clouds::InsufficientPermissions < CpiError
- external_cpi.rb — adds Bosh::Clouds::InsufficientPermissions to KNOWN_RPC_ERRORS so the director can deserialise it from a CPI JSON response without treating it as an unknown error
- disk_manager.rb — catches InsufficientPermissions in both update_disk rescue blocks; in update_detached_disks it is separated into its own rescue clause with a more specific log message to distinguish a
permission problem from a capability gap

### Please provide contextual information.

This is the director-side complement to the Google CPI change in https://github.com/cloudfoundry/bosh-google-cpi-release/pull/385, which returns the Bosh::Clouds::InsufficientPermissions when the GCP service account is missing the compute.snapshots.useReadOnly permission needed to create a disk from a snapshot during a disk type change.

Without this director change the error would be treated as an unknown CPI error and propagate as a deployment failure. With it the director falls back gracefully, preserving the existing behaviour for operators who have not yet granted the new permission.

### What tests have you run against this PR?

- Unit tests

How should this change be described in bosh release notes?

When enable_cpi_update_disk is enabled and the CPI returns an InsufficientPermissions error during update_disk (e.g. because the IaaS service account lacks a required permission), the director now falls back to the standard copy-based disk update path instead of failing the deployment. A log message is emitted identifying the permission problem.

Does this PR introduce a breaking change?

No. The new error type is additive — existing CPIs that do not return Bosh::Clouds::InsufficientPermissions are unaffected. The fallback behaviour for NotImplemented and NotSupported is unchanged.