### PR TITLE
Fix: update integration sandbox manifest generation

### DIFF
--- a/src/spec/assets/sandbox/health_monitor.yml.erb
+++ b/src/spec/assets/sandbox/health_monitor.yml.erb
@@ -14,7 +14,7 @@ director: &director
   password: pass
   client_id: hm
   client_secret: secret
-  ca_cert: <%= certificate_path %>
+  director_ca_cert: <%= certificate_path %>
 
 intervals:
   poll_director: 5

--- a/src/spec/assets/sandbox/health_monitor_with_json_logging.yml.erb
+++ b/src/spec/assets/sandbox/health_monitor_with_json_logging.yml.erb
@@ -14,7 +14,7 @@ director: &director
   password: pass
   client_id: hm
   client_secret: secret
-  ca_cert: <%= certificate_path %>
+  director_ca_cert: <%= certificate_path %>
 
 intervals:
   poll_director: 5


### PR DESCRIPTION
Manifest properties for Health Monitor changed in `61bab34c69` resulting in integration specs failing:
```
./spec/integration/config_server/config_server_links_spec.rb:417
./spec/integration/config_server/config_server_spec.rb:380
./spec/integration/health_monitor/hm_stateless_spec.rb:96
./spec/integration/uaa/login_spec.rb:128
```

since the integration sandbox test tooling does not use the standard `job/.../templates/` content.

This commit updates the sanbox internal templates to use the new configuration params (`ca_cert` => `director_ca_cert`).
