### PR TITLE
Remove deprecated hm.syslog_event_forwarder_enabled property

### DIFF
--- a/jobs/health_monitor/spec
+++ b/jobs/health_monitor/spec
@@ -231,9 +231,6 @@ properties:
     description: Should we treat all heartbeats as alerts as well?
     default: false
 
-  hm.syslog_event_forwarder_enabled:
-    description: Removed. Please co-locate the syslog-release instead to forward your logs.
-
   env.http_proxy:
     description: HTTP proxy that the health monitor should use
   env.https_proxy:

--- a/jobs/health_monitor/templates/health_monitor.yml.erb
+++ b/jobs/health_monitor/templates/health_monitor.yml.erb
@@ -203,10 +203,6 @@ if p('hm.graphite_enabled')
   params['plugins'] << graphite_plugin
 end
 
-if_p('hm.syslog_event_forwarder_enabled') do |_|
-  raise 'property hm.syslog_event_forwarder_enabled has been removed. Please co-locate the syslog-release instead to forward your logs.'
-end
-
 if p('hm.consul_event_forwarder_enabled')
   consul_event_forwarder_plugin = {
     'name' => 'consul_event_forwarder',


### PR DESCRIPTION
This property was first deprecated in 2016, time to remove it.
