### PR TITLE
CI uses noble now, we can use the compiled bpm release

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -470,7 +470,6 @@ jobs:
                   BAT_INFRASTRUCTURE: gcp
                   GCP_JSON_KEY: ((gcp_json_key))
                   DEPLOY_ARGS: |-
-                    -o bosh-deployment/misc/source-releases/bpm.yml
                     -o bosh-deployment/external-ip-not-recommended.yml
               - task: prepare-bats-config
                 file: bosh-ci/ci/bats/iaas/gcp/prepare-bats-config.yml


### PR DESCRIPTION
This was originally put in place because the CI pipelines ran on ubuntu-jammy after the releases started being compiled for ubuntu-noble