### PR TITLE
CI: fix build-docker-args

### DIFF
--- a/ci/dockerfiles/integration/build-docker-args.sh
+++ b/ci/dockerfiles/integration/build-docker-args.sh
@@ -18,7 +18,7 @@ yq_cli_url="$(curl -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -s https://a
 ruby_install_url="$(curl -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -s https://api.github.com/repos/postmodern/ruby-install/releases/latest \
                     | jq -r '.assets[] | select(.name | endswith ("tar.gz")) | .browser_download_url')"
 golangci_lint_install_url="$(curl -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -s https://api.github.com/repos/golangci/golangci-lint/releases/latest \
-                    | jq -r '.assets[] | select(.name | match("golangci-lint-[0-9]+.[0-9]+.[0-9]+-linux-amd64.tar.gz")) | .browser_download_url')"
+                    | jq -r '.assets[] | select(.name | match("golangci-lint-[0-9]+.[0-9]+.[0-9]+-linux-amd64.tar.gz$")) | .browser_download_url')"
 
 uaa_release_url="$(yq -r '.[] | select(.release == "uaa").value.url' < bosh-deployment/uaa.yml)"
 java_install_prefix="/usr/lib/jvm"


### PR DESCRIPTION
Fixes:
```
Failed to parse build_args_file (docker-build-args/docker-build-args.json)
```
^ https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/build-integration/builds/679#L69e7592c:9

