### PR TITLE
Add S3 checksum properties to director blobstore configuration

### DIFF
--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -442,6 +442,12 @@ properties:
     description: swift_auth_account of swift storage account
   blobstore.swift_temp_url_key:
     description: swift_temp_url_key of swift storage account
+  blobstore.request_checksum_calculation_enabled:
+    description: Whether to calculate checksums for requests to S3
+  blobstore.response_checksum_calculation_enabled:
+    description: Whether to calculate checksums for responses from S3
+  blobstore.uploader_request_checksum_calculation_enabled:
+    description: Whether to calculate checksums for uploader requests to S3
 
   director.ignore_missing_gateway:
     description: Allow gateway to be omitted from subnet configuration. Bosh lite vms(containers) do not require gateway.

--- a/jobs/director/templates/director.yml.erb
+++ b/jobs/director/templates/director.yml.erb
@@ -250,6 +250,18 @@ if p('blobstore.provider') == 's3'
   if_p('blobstore.swift_temp_url_key') do |swift_temp_url_key|
      blobstore_options['swift_temp_url_key'] = swift_temp_url_key
   end
+
+  if_p('blobstore.request_checksum_calculation_enabled') do |request_checksum_calculation_enabled|
+     blobstore_options['request_checksum_calculation_enabled'] = request_checksum_calculation_enabled
+  end
+
+  if_p('blobstore.response_checksum_calculation_enabled') do |response_checksum_calculation_enabled|
+     blobstore_options['response_checksum_calculation_enabled'] = response_checksum_calculation_enabled
+  end
+
+  if_p('blobstore.uploader_request_checksum_calculation_enabled') do |uploader_request_checksum_calculation_enabled|
+     blobstore_options['uploader_request_checksum_calculation_enabled'] = uploader_request_checksum_calculation_enabled
+  end
 elsif p('blobstore.provider') == 'gcs'
     blobstore_options = {
     'bucket_name' => p('blobstore.bucket_name'),

--- a/spec/director.yml.erb_spec.rb
+++ b/spec/director.yml.erb_spec.rb
@@ -141,6 +141,22 @@ RSpec.describe 'director.yml.erb' do
         end
       end
 
+      context 'when using s3 blobstore with checksum properties' do
+        before do
+          merged_manifest_properties['blobstore']['provider'] = 's3'
+          merged_manifest_properties['blobstore']['bucket_name'] = 'bucket'
+          merged_manifest_properties['blobstore']['request_checksum_calculation_enabled'] = false
+          merged_manifest_properties['blobstore']['response_checksum_calculation_enabled'] = false
+          merged_manifest_properties['blobstore']['uploader_request_checksum_calculation_enabled'] = false
+        end
+
+        it 'should configure the checksum properties' do
+          expect(parsed_yaml['blobstore']['options']['request_checksum_calculation_enabled']).to eq(false)
+          expect(parsed_yaml['blobstore']['options']['response_checksum_calculation_enabled']).to eq(false)
+          expect(parsed_yaml['blobstore']['options']['uploader_request_checksum_calculation_enabled']).to eq(false)
+        end
+      end
+
       context 'when using the verify-multidigest binary' do
         it 'should configure the paths' do
           expect(parsed_yaml['verify_multidigest_path']).to eq('/var/vcap/packages/verify_multidigest/bin/verify-multidigest')

--- a/src/bosh-director/lib/bosh/director/blobstore/s3cli_blobstore_client.rb
+++ b/src/bosh-director/lib/bosh/director/blobstore/s3cli_blobstore_client.rb
@@ -45,6 +45,9 @@ module Bosh::Director
           assume_role_arn: @options[:assume_role_arn],
           swift_auth_account: @options[:swift_auth_account],
           swift_temp_url_key: @options[:swift_temp_url_key],
+          request_checksum_calculation_enabled: @options[:request_checksum_calculation_enabled],
+          response_checksum_calculation_enabled: @options[:response_checksum_calculation_enabled],
+          uploader_request_checksum_calculation_enabled: @options[:uploader_request_checksum_calculation_enabled],
         }
 
         @s3cli_options.reject! { |_k, v| v.nil? }

--- a/src/bosh-director/spec/unit/bosh/director/blobstore/s3cli_blobstore_client_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/blobstore/s3cli_blobstore_client_spec.rb
@@ -121,7 +121,7 @@ module Bosh::Director::Blobstore
         end
       end
 
-      context 'when swift_auth_account is provided' do
+      context 'when swift_temp_url_key is provided' do
         it 'adds it to the config file' do
           described_class.new(options.merge(
             {
@@ -130,6 +130,23 @@ module Bosh::Director::Blobstore
           )
 
           expect(JSON.parse(stored_config_file[0])['swift_temp_url_key']).to eq('the_swift_temp_url_key')
+        end
+      end
+
+      context 'when checksum properties are provided' do
+        it 'adds them to the config file' do
+          described_class.new(options.merge(
+            {
+              request_checksum_calculation_enabled: false,
+              response_checksum_calculation_enabled: false,
+              uploader_request_checksum_calculation_enabled: false,
+            })
+          )
+
+          config = JSON.parse(stored_config_file[0])
+          expect(config['request_checksum_calculation_enabled']).to eq(false)
+          expect(config['response_checksum_calculation_enabled']).to eq(false)
+          expect(config['uploader_request_checksum_calculation_enabled']).to eq(false)
         end
       end
     end


### PR DESCRIPTION
## Summary
* Add `request_checksum_calculation_enabled`, `response_checksum_calculation_enabled`, and `uploader_request_checksum_calculation_enabled` to the director manifest spec for S3 blobstores.
* Wire these properties through the `director.yml.erb` template.
* Pass these properties to the `s3cli` config file via the `S3cliBlobstoreClient`.

## Test plan
* Unit tests added to `s3cli_blobstore_client_spec.rb` and `director.yml.erb_spec.rb`.

Made with [Cursor](https://cursor.com)