### PR TITLE
CI: stop using spot-instance BATs directors

### DIFF
--- a/ci/bats/iaas/gcp/director-vars
+++ b/ci/bats/iaas/gcp/director-vars
@@ -4,7 +4,6 @@
 exec jq '{
   "project_id": .project_id,
   "zone": .zone,
-  "preemptible": true,
   "tags": ["bosh-director"],
   "director_name": "director",
   "internal_cidr": .internal_cidr,

--- a/ci/bats/iaas/gcp/prepare-bats-config.sh
+++ b/ci/bats/iaas/gcp/prepare-bats-config.sh
@@ -41,7 +41,6 @@ cpi: google
 properties:
   availability_zone: "$(terraform_output "zone")"
   zone: "$(terraform_output "zone")"
-  preemptible: true
   pool_size: 1
   instances: 1
   second_static_ip: "$(terraform_output "second_static_ip_first_network")"


### PR DESCRIPTION
Remove `preemptible: true` from BATs director configurations. This flag causes GCP spot-instances to be used which are unreliable.