### PR TITLE
Use subcommands with `bundle config`

### DIFF
--- a/ci/dockerfiles/integration/Dockerfile
+++ b/ci/dockerfiles/integration/Dockerfile
@@ -119,8 +119,8 @@ RUN cd /tmp  \
     && ruby-install --jobs=${NUM_CPUS} --cleanup --system ruby ${RUBY_VERSION} \
       -- --disable-install-doc --disable-install-rdoc \
     && gem update --system \
-    && bundle config --global path "${GEM_HOME}" \
-    && bundle config --global bin "${GEM_HOME}/bin"
+    && bundle config set --global path "${GEM_HOME}" \
+    && bundle config set --global bin "${GEM_HOME}/bin"
 ENV PATH=${GEM_HOME}/bin:${PATH}
 
 

--- a/packages/director/packaging
+++ b/packages/director/packaging
@@ -26,10 +26,10 @@ gem 'mysql2'
 gem 'pg'
 EOF
 
-bundle config build.mysql2 \
+bundle config set build.mysql2 \
   --with-mysql-config=$mysqlclient_dir/bin/mariadb_config-wrapper.sh
 
-bundle config build.pg \
+bundle config set build.pg \
   --with-pg-lib=$libpq_dir/lib \
   --with-pg-include=$libpq_dir/include
 


### PR DESCRIPTION
Future versions of bundler require `bundle config {set|get|...}`, not just `bundle config ...`

