### PR TITLE
CI: possible fix for upgrade-<db> concourse jobs

### DIFF
--- a/ci/tasks/deploy-zookeeper.sh
+++ b/ci/tasks/deploy-zookeeper.sh
@@ -31,6 +31,24 @@ bosh-cli update-cloud-config "bosh-deployment/${CPI}/cloud-config.yml" \
 
 bosh-cli upload-stemcell stemcell/*.tgz
 
+# Disable the resurrector for the remainder of this director's lifetime.
+# The director is ephemeral and is torn down at the end of the CI job, so
+# resurrection is not re-enabled after this point.
+#
+# Without this, a race condition causes persistent disks to disappear:
+#   1. bosh deploy --recreate (attempt 1) times out on get_state for an agent
+#   2. The 60-second retry delay begins
+#   3. The BOSH Health Monitor sees unresponsive agents and triggers the resurrector
+#   4. The resurrector calls delete_vm — the GCP CPI deletes the VM and, due to the
+#      way GCP handles attached disks during force-deletion, the persistent disk is also
+#      removed from GCP
+#   5. bosh deploy --recreate (attempt 2) finds no VM CID ("Creating missing vms") and
+#      fails immediately with DiskNotFound for every instance
+#
+# With the resurrector off, VMs survive the retry window so attempt 2 can proceed
+# against the same instances (stop → delete VM → create VM → reattach disk → start).
+bosh-cli update-resurrection off
+
 MAX_DEPLOY_ATTEMPTS=${MAX_DEPLOY_ATTEMPTS:-3}
 DEPLOY_RETRY_DELAY=${DEPLOY_RETRY_DELAY:-60}
 

--- a/ci/tasks/wait-for-agents.sh
+++ b/ci/tasks/wait-for-agents.sh
@@ -23,12 +23,18 @@ export BOSH_CA_CERT
 export BOSH_CLIENT_SECRET
 export BOSH_NON_INTERACTIVE=true
 
+# Phase 1: wait for all agents to appear in "running" state in the director DB.
+# bosh vms reads last-known heartbeat state — it does NOT send a live get_state to each
+# agent. So this phase only confirms that agents have reconnected to NATS after the
+# director upgrade; it does not guarantee the agents can handle a live get_state request.
 MAX_ATTEMPTS=60
 SLEEP_INTERVAL=10
 TOTAL_TIMEOUT=$((MAX_ATTEMPTS * SLEEP_INTERVAL))
 
-echo "Waiting up to ${TOTAL_TIMEOUT}s for all zookeeper agents to become responsive..."
+echo "Phase 1: Waiting up to ${TOTAL_TIMEOUT}s for all zookeeper agents to appear running..."
 
+total=0
+phase1_success=false
 for i in $(seq 1 "${MAX_ATTEMPTS}"); do
   set +e
   vms_json=$(bosh-cli -d zookeeper vms --json)
@@ -40,11 +46,12 @@ for i in $(seq 1 "${MAX_ATTEMPTS}"); do
     total=$(echo "${zookeeper_instances_json}" | jq -r '. | length')
     running=$(echo "${zookeeper_instances_json}" | jq -r '[.[] | select(.process_state == "running")] | length')
 
-    echo "  Attempt $i/${MAX_ATTEMPTS}: ${running}/${total} agents responsive"
+    echo "  Attempt $i/${MAX_ATTEMPTS}: ${running}/${total} agents in running state"
 
     if [ "$running" -eq "$total" ] && [ "$total" -gt 0 ]; then
-      echo "All ${total} agents are responsive after $(((i - 1) * SLEEP_INTERVAL)) seconds."
-      exit 0
+      echo "All ${total} agents appear running after $(((i - 1) * SLEEP_INTERVAL)) seconds."
+      phase1_success=true
+      break
     fi
   else
     echo "  Attempt $i/${MAX_ATTEMPTS}: bosh vms failed (director may still be starting)"
@@ -53,7 +60,50 @@ for i in $(seq 1 "${MAX_ATTEMPTS}"); do
   sleep "${SLEEP_INTERVAL}"
 done
 
-echo "ERROR: Not all agents became responsive within ${TOTAL_TIMEOUT}s."
-echo "Final VM state:"
-bosh-cli -d zookeeper vms || true
+if [ "${phase1_success}" != "true" ]; then
+  echo "ERROR: Not all agents became running within ${TOTAL_TIMEOUT}s."
+  echo "Final VM state:"
+  bosh-cli -d zookeeper vms || true
+  exit 1
+fi
+
+# Phase 2: verify live agent responsiveness and ZK process health.
+# bosh instances --processes sends a live list_processes to each agent via NATS.
+# This confirms the agent can handle live director commands (the same code-path that
+# bosh deploy --recreate exercises during "Preparing deployment" with get_state).
+# It also confirms that the ZK process itself is up inside each instance — preventing
+# smoke-tests from running against a cluster still in leader election.
+PROC_MAX_ATTEMPTS=30
+PROC_SLEEP_INTERVAL=10
+PROC_TOTAL_TIMEOUT=$((PROC_MAX_ATTEMPTS * PROC_SLEEP_INTERVAL))
+
+echo "Phase 2: Waiting up to ${PROC_TOTAL_TIMEOUT}s for ZK processes to be healthy (live agent check)..."
+
+for j in $(seq 1 "${PROC_MAX_ATTEMPTS}"); do
+  set +e
+  instances_json=$(bosh-cli -d zookeeper instances --processes --json)
+  proc_exit=$?
+  set -e
+
+  if [ $proc_exit -eq 0 ]; then
+    # Process-level rows have .process == "zookeeper"; instance-level rows have .process == "".
+    zk_proc_total=$(echo "${instances_json}" | jq '[.Tables[].Rows[] | select((.process // "") == "zookeeper")] | length')
+    zk_proc_running=$(echo "${instances_json}" | jq '[.Tables[].Rows[] | select((.process // "") == "zookeeper") | select(.process_state == "running")] | length')
+
+    echo "  Attempt $j/${PROC_MAX_ATTEMPTS}: ${zk_proc_running}/${zk_proc_total} ZK processes healthy"
+
+    if [ "${zk_proc_running}" -eq "${total}" ] && [ "${zk_proc_total}" -eq "${total}" ] && [ "${total}" -gt 0 ]; then
+      echo "All ${total} ZK processes are healthy after $(((j - 1) * PROC_SLEEP_INTERVAL)) seconds."
+      exit 0
+    fi
+  else
+    echo "  Attempt $j/${PROC_MAX_ATTEMPTS}: bosh instances --processes failed (agent may not be fully ready)"
+  fi
+
+  sleep "${PROC_SLEEP_INTERVAL}"
+done
+
+echo "ERROR: Not all ZK processes became healthy within ${PROC_TOTAL_TIMEOUT}s."
+echo "Final instance state:"
+bosh-cli -d zookeeper instances --processes || true
 exit 1


### PR DESCRIPTION
Agent Summary:

Fixes Applied
ci/tasks/wait-for-agents.sh — Two-phase readiness check Phase 1 (unchanged behavior): poll bosh vms --json until all agents show "running" in the director DB.

Phase 2 (new): poll bosh instances --processes --json. This command sends a live list_processes call to each agent via NATS — the same code path that bosh deploy exercises during "Preparing deployment" with get_state. It also verifies that the zookeeper process itself is running inside each VM (not just that the BOSH agent connected). Only after all 3 processes report "running" from a live query does the task succeed. This directly addresses both failure modes:

Agents that can respond to list_processes can respond to get_state → no more 45-second timeouts The ZK process being "running" on all 3 nodes means leader election has completed → no more smoke-test auth failures ci/tasks/deploy-zookeeper.sh — Disable resurrector before deploy Added bosh-cli update-resurrection off immediately before the deploy loop. With the resurrector disabled, if the first deploy attempt fails, the VMs remain in GCP during the retry wait. Attempt 2 can then send get_state, get a response from agents that have now had time to stabilize, and proceed with the controlled stop → delete VM → create VM → reattach disk → start sequence. Since this director is ephemeral (torn down at end of the CI job), leaving resurrection disabled for its lifetime is safe.


