### PR TITLE
CI: Allow additional ops file for docker start-bosh

### DIFF
--- a/ci/dockerfiles/docker-cpi/gcp-internal-dns-ops.yml
+++ b/ci/dockerfiles/docker-cpi/gcp-internal-dns-ops.yml
@@ -2,5 +2,4 @@
 - path: /networks/name=default/subnets/0/dns?
   type: replace
   value:
-  - 8.8.8.8
-  - 169.254.169.254 # GCP internal DNS
+  - 169.254.169.254

--- a/ci/dockerfiles/docker-cpi/start-bosh.sh
+++ b/ci/dockerfiles/docker-cpi/start-bosh.sh
@@ -235,11 +235,12 @@ function main() {
 }
 EOF
 
-  # shellcheck disable=SC2068
+  # shellcheck disable=SC2068,SC2086
   bosh int "${BOSH_DEPLOYMENT_PATH}/bosh.yml" \
     -o "${BOSH_DEPLOYMENT_PATH}/docker/cpi.yml" \
     -o "${BOSH_DEPLOYMENT_PATH}/jumpbox-user.yml" \
     -o /usr/local/ops-files/local-releases.yml \
+    ${ADDITIONAL_DIRECTOR_OPS_FILES:-} \
     -v director_name=docker \
     -v internal_cidr="${docker_network_cidr}" \
     -v internal_gw=10.245.0.1 \


### PR DESCRIPTION
Also, revert the gcp-internal-dns-ops file to _only_ use gcp internal DNS.