### PR TITLE
CI: Allow ops files for BRATS dns

### DIFF
--- a/ci/shared/brats/test-acceptance.sh
+++ b/ci/shared/brats/test-acceptance.sh
@@ -110,6 +110,13 @@ bosh -n update-cloud-config \
   -o "${REPO_ROOT}/ci/dockerfiles/docker-cpi/gcp-internal-dns-ops.yml" \
   -v network=director_network
 
+if [ -n "${BRATS_DNS_MANIFEST_OPS_FILES:-}" ]; then
+  DNS_MANIFEST="${REPO_ROOT}/src/brats/assets/dns-with-templates-manifest.yml"
+  # shellcheck disable=SC2086
+  bosh int "${DNS_MANIFEST}" ${BRATS_DNS_MANIFEST_OPS_FILES} > /tmp/brats-dns-manifest-modified.yml
+  cp /tmp/brats-dns-manifest-modified.yml "${DNS_MANIFEST}"
+fi
+
 pushd "${REPO_ROOT}/src/brats/acceptance"
   go run github.com/onsi/ginkgo/v2/ginkgo \
     -r -v --race --timeout=24h \


### PR DESCRIPTION
This will allow the bosh-dns pipeline to pass in some jammy-specific overrides (most of BRATs is hardcoded for noble).