### PR TITLE
CI: Add optional dns-ops-file-source input to brats

### DIFF
--- a/ci/shared/brats/test-acceptance.yml
+++ b/ci/shared/brats/test-acceptance.yml
@@ -13,6 +13,8 @@ inputs:
     optional: true
   - name: bosh-deployment
     optional: true
+  - name: dns-ops-file-source
+    optional: true
 
 run:
   path: bosh-ci/ci/shared/brats/test-acceptance.sh


### PR DESCRIPTION
The bosh dns pipeline needs to pass an ops file in to make it work on jammy, but it also overwrites the ci directory with a candidate release, so we need to pass an additional input.