### PR TITLE
Fix Sequel postgres SQL threading race condition

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ azure-storage-cli/azure-storage-cli-0.0.235-linux-amd64:
   size: 10689393
   object_id: f95d3ee8-0e9b-4fa3-4b12-06041bd41e1c
   sha: sha256:ccfcb612148e0cfe9966a4bfcb17045e4433cd19888abcba8f42fdfb7fbab238
-bosh-gcscli/bosh-gcscli-0.0.384-linux-amd64:
-  size: 46744554
-  object_id: 102e96d3-7a74-4726-6c96-55a1006bb525
-  sha: sha256:49c68b870f4f2727875a129c53d4a3171e7639e068f6c3db612acc4220bf408d
+bosh-gcscli/bosh-gcscli-0.0.385-linux-amd64:
+  size: 46910425
+  object_id: 52ce9e21-b958-4d47-7f9c-46c5c1af4488
+  sha: sha256:644476a06860d2f5db38d5c03d12376382ee9df09fdb97a60ca42b73a184facd
 davcli/davcli-0.0.479-linux-amd64:
   size: 10441226
   object_id: a4888470-54e3-4455-4fad-930ec3b19adb

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -350,6 +350,8 @@ module Bosh::Director
 
         db = wait_for_db_connection(connection_config, connection_wait_timeout)
 
+        apply_postgres_thread_safety_patch(connection_config['adapter'])
+
         Bosh::Common.retryable(sleep: DEFAULT_DB_CONNECTION_RETRY_INTERVAL, tries: 20, on: [Exception]) do
           db.extension :connection_validator
           true
@@ -363,6 +365,32 @@ module Bosh::Director
         end
 
         db
+      end
+
+      # Sequel's Dataset#select_sql caches and returns the same mutable
+      # String object to all concurrent callers. Under high concurrency, log_connection_yield
+      # prepends a "(conn: NNNNN)" debug prefix in-place to this shared string, which is then
+      # sent verbatim to Postgres as SQL, causing:
+      #   PG::SyntaxError: ERROR: syntax error at or near "conn"
+      #
+      # Fix: String.new(sql) forces a memcpy, giving each execute_query call its own independent
+      # C-level string buffer so concurrent PQexec calls cannot interfere.
+      #
+      # Must run after Sequel.connect (when the postgres adapter module is first loaded).
+      # Guarded against double-application in case configure_db is called more than once.
+      def apply_postgres_thread_safety_patch(adapter_name)
+        return unless %w[postgres postgresql].include?(adapter_name)
+        return unless defined?(Sequel::Postgres::Adapter)
+        return if @postgres_thread_safety_patched
+
+        @postgres_thread_safety_patched = true
+        Sequel::Postgres::Adapter.prepend(Module.new do
+          private
+
+          def execute_query(sql, args)
+            super(String.new(sql).freeze, args)
+          end
+        end)
       end
 
       def wait_for_db_connection(connection_config, timeout)

--- a/src/bosh-director/spec/unit/bosh/director/postgres_thread_safety_patch_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/postgres_thread_safety_patch_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+RSpec.describe Bosh::Director::Config, '#apply_postgres_thread_safety_patch' do
+  # Reset idempotency guard so tests are independent
+  before { described_class.instance_variable_set(:@postgres_thread_safety_patched, nil) }
+  after  { described_class.instance_variable_set(:@postgres_thread_safety_patched, nil) }
+
+  let(:fake_adapter) do
+    Class.new do
+      def execute_query(sql, args)
+        [sql, args]
+      end
+      private :execute_query
+    end
+  end
+
+  context 'when adapter is postgres and Sequel::Postgres::Adapter is defined' do
+    before { stub_const('Sequel::Postgres::Adapter', fake_adapter) }
+
+    it 'prepends a module that passes String.new(sql).freeze to prevent cross-thread SQL corruption' do
+      described_class.send(:apply_postgres_thread_safety_patch, 'postgres')
+
+      original_sql = 'SELECT * FROM templates INNER JOIN release_versions_templates ON id = 1'
+      result = fake_adapter.new.send(:execute_query, original_sql, nil)
+
+      expect(result[0]).to eq(original_sql), 'SQL content must be preserved'
+      expect(result[0].object_id).not_to eq(original_sql.object_id),
+        'Expected a fresh String.new copy to isolate thread buffers and prevent ' \
+        '(conn: NNNNN) prefix injection into the actual SQL sent to Postgres'
+      expect(result[0]).to be_frozen,
+        'Expected the SQL copy to be frozen so in-place C-level mutations raise FrozenError ' \
+        'rather than silently corrupting concurrent threads'
+    end
+
+    it 'passes args through to the underlying execute_query unmodified' do
+      described_class.send(:apply_postgres_thread_safety_patch, 'postgres')
+
+      query_args = [42, 'bar']
+      result = fake_adapter.new.send(:execute_query, 'SELECT 1', query_args)
+
+      expect(result[1]).to be(query_args), 'args must be passed through without modification'
+    end
+
+    it 'is idempotent — applies the patch only once even when called multiple times' do
+      2.times { described_class.send(:apply_postgres_thread_safety_patch, 'postgres') }
+
+      patched_count = fake_adapter.ancestors.take_while { |m| m != fake_adapter }
+                                  .count { |m| m.private_method_defined?(:execute_query) }
+
+      expect(patched_count).to eq(1),
+        'Patch must not be stacked — applied exactly once regardless of call count'
+    end
+  end
+
+  context 'when adapter is not postgres (e.g. mysql2)' do
+    before { stub_const('Sequel::Postgres::Adapter', fake_adapter) }
+
+    ["mysql2", "sqlite", nil].each do |adapter|
+      it "does not apply the patch for adapter=#{adapter.inspect}" do
+        described_class.send(:apply_postgres_thread_safety_patch, adapter)
+
+        patched_count = fake_adapter.ancestors.take_while { |m| m != fake_adapter }
+                                    .count { |m| m.private_method_defined?(:execute_query) }
+
+        expect(patched_count).to eq(0),
+          "Patch must not be applied when adapter is #{adapter.inspect}"
+        expect(described_class.instance_variable_get(:@postgres_thread_safety_patched)).to be_nil
+      end
+    end
+  end
+
+  context 'when adapter is postgres but Sequel::Postgres::Adapter is not yet defined' do
+    before { hide_const('Sequel::Postgres::Adapter') }
+
+    it 'does not raise an error' do
+      expect { described_class.send(:apply_postgres_thread_safety_patch, 'postgres') }.not_to raise_error
+    end
+
+    it 'does not set the patched flag (safe to call again if adapter loads later)' do
+      described_class.send(:apply_postgres_thread_safety_patch, 'postgres')
+      expect(described_class.instance_variable_get(:@postgres_thread_safety_patched)).to be_nil
+    end
+  end
+
+  it 'is obsolete on Ruby 4.0+ and must be removed' do
+    # The shared-string mutation bug does not reproduce on Ruby 4.0+.
+    # This test fails intentionally when the runtime is upgraded, prompting removal of:
+    #   - Config#apply_postgres_thread_safety_patch
+    #   - its call site in Config#configure_db
+    expect(Gem::Version.new(RUBY_VERSION)).to be < Gem::Version.new('4.0'),
+      "Ruby #{RUBY_VERSION} >= 4.0: the Sequel postgres thread-safety patch in " \
+      'Config#apply_postgres_thread_safety_patch is no longer needed. ' \
+      'Remove the method and its call in configure_db.'
+  end
+end

--- a/src/bosh-director/spec/unit/bosh/director/sequel_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/sequel_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+RSpec.describe 'Bosh::Director sequel extensions' do
+  # -------------------------------------------------------------------------
+  # Upstream Sequel gem behaviour pinning
+  #
+  # These tests confirm that Sequel still exhibits the cached-shared-string
+  # behaviour that makes Config#apply_postgres_thread_safety_patch necessary.
+  #
+  # If any of these expectations start FAILING after a Sequel gem upgrade it
+  # means the upstream library has resolved the issue and the monkey patch
+  # can be removed.
+  # -------------------------------------------------------------------------
+  describe 'Sequel::Dataset#select_sql upstream caching behaviour' do
+    let(:db) { Sequel.mock }
+
+    it 'returns the SAME String object on successive calls (shared cache)' do
+      dataset = db[:templates]
+
+      sql1 = dataset.select_sql
+      sql2 = dataset.select_sql
+
+      expect(sql1).to be(sql2),
+        'Sequel::Dataset#select_sql is expected to return the SAME cached String object ' \
+        'on every call. If this fails after a Sequel upgrade the upstream caching has ' \
+        'changed and Config#apply_postgres_thread_safety_patch may no longer be needed.'
+    end
+
+    it 'the cached SQL string is mutable (not frozen)' do
+      sql = db[:templates].select_sql
+
+      expect(sql).not_to be_frozen,
+        'The cached SQL string is expected to be mutable. If this fails after a Sequel ' \
+        'upgrade the upstream gem now protects against in-place mutation and the monkey ' \
+        'patch may no longer be needed.'
+    end
+
+    it 'concurrent callers receive the same object_id, demonstrating the shared-buffer race' do
+      dataset = db[:templates]
+      ids = Array.new(4) { dataset.select_sql.object_id }
+
+      expect(ids.uniq.length).to eq(1),
+        'All concurrent callers are expected to get the SAME String object (same object_id). ' \
+        'If this fails the upstream caching behaviour has changed.'
+    end
+  end
+
+  describe 'String.new(sql) thread-safety pattern' do
+    # Root cause: Dataset#select_sql caches and returns the SAME mutable String object
+    # to all concurrent callers. Sequel's log_connection_yield prepends "(conn: NNNNN)"
+    # in-place to that shared string, which gets injected into the SQL sent to Postgres:
+    #   PG::SyntaxError: ERROR: syntax error at or near "conn"
+    #
+    # Fix: String.new(sql) performs memcpy, giving each execute_query call its own
+    # independent C-level buffer — concurrent PQexec calls cannot interfere.
+    #
+    # This patch is applied in Config#apply_postgres_thread_safety_patch after
+    # Sequel.connect (when Sequel::Postgres::Adapter is first loaded).
+    # See config_spec.rb for integration-level coverage.
+
+    it 'ensures each invocation receives a fresh String object, not the shared cache' do
+      received_sqls = []
+      shared_sql = 'SELECT * FROM templates INNER JOIN release_versions_templates ON id = 1'
+
+      base_capture = Module.new do
+        define_method(:execute_query) { |sql, _args| received_sqls << sql }
+      end
+
+      string_new_patch = Module.new do
+        define_method(:execute_query) { |sql, args| super(String.new(sql).freeze, args) }
+      end
+
+      klass = Class.new
+      klass.include(base_capture)
+      klass.prepend(string_new_patch)
+      obj = klass.new
+
+      obj.send(:execute_query, shared_sql, nil)
+      obj.send(:execute_query, shared_sql, nil)
+
+      expect(received_sqls.all? { |s| s == shared_sql }).to be(true),
+        'SQL content must be preserved across the copy'
+      expect(received_sqls.map(&:object_id)).not_to include(shared_sql.object_id),
+        'No received string should be the original shared object (would allow cross-thread mutation)'
+      expect(received_sqls.map(&:object_id).uniq.length).to eq(2),
+        'Each invocation must receive a distinct String object (independent buffer per call)'
+      expect(received_sqls).to all(be_frozen),
+        'Each copy must be frozen so in-place C-level mutations raise FrozenError ' \
+        'rather than silently corrupting concurrent threads'
+    end
+
+    it 'passes args through to super unmodified' do
+      received_args = :unset
+
+      base_capture = Module.new do
+        define_method(:execute_query) { |_sql, args| received_args = args }
+      end
+
+      string_new_patch = Module.new do
+        define_method(:execute_query) { |sql, args| super(String.new(sql).freeze, args) }
+      end
+
+      klass = Class.new
+      klass.include(base_capture)
+      klass.prepend(string_new_patch)
+
+      query_args = [1, 'foo']
+      klass.new.send(:execute_query, 'SELECT 1', query_args)
+
+      expect(received_args).to be(query_args), 'args must be passed through without modification'
+    end
+  end
+end


### PR DESCRIPTION
Sequel's Dataset#select_sql caches and returns the same mutable String object to all concurrent callers. Under high concurrency, log_connection_yield prepends "(conn: NNNNN)" in-place to that shared buffer, which is then sent verbatim to Postgres as SQL:
  PG::SyntaxError: ERROR: syntax error at or near "conn"

Add apply_postgres_thread_safety_patch to Config#configure_db, called after Sequel.connect when the postgres adapter is loaded. The patch prepends a module onto Sequel::Postgres::Adapter that wraps execute_query to pass String.new(sql).freeze to super, giving each call its own frozen independent C-level string buffer so concurrent PQexec calls cannot interfere.

An idempotency guard prevents double-application if configure_db is called multiple times during startup.

Specs pin the upstream Sequel caching behaviour so any gem upgrade that fixes the issue upstream will alert us to remove the patch. Unit tests cover: String.new.freeze isolation, args passthrough, idempotency, and no-op for non-postgres adapters.

We have a threading test that exposes the issue. The corruption occurs in the form of SQL the query string being mutated before being sent to Postgres. Examples of the mutated thread are this string being sent to Postgres
(conn: 152) SELECT * FROM "bug_templates" INNER JOIN "join_r...

The string corruption occurs in all of the tested 3.3 ruby release; 3.3.9, 3.3.11, 3.4.9

The string corruption does not occur in ruby 4.0.5

This patch will be short lived until the bump to ruby 4.0

[TNZ-104200, TNZ-103317]
ai-assisted=yes

### What is this change about?

A customer reported Postgres failures caused by a syntax error in the received SQL string.  This seems to have
been caused by a concurrency problem that was mutating a string. This patches the symptom of the failure.
The long term fix is to bumnp ruby to 4.0+

### Please provide contextual information.

We created an issue with the sequel gem but it appears that ruby is the real cuplrit.
https://github.com/jeremyevans/sequel/issues/2368

### What tests have you run against this PR?
cd src/spec
bundle exec rake spec:unit:parallel

### How should this change be described in bosh release notes?

A temporary fix to mitigate a string corruption race condition that only affects the ruby 3.3 releases

### Does this PR introduce a breaking change?

No

### Tag your pair, your PM, and/or team!
@aramprice 
