### PR TITLE
CI: Bump brats rds postgres version

### DIFF
--- a/ci/shared/brats/terraform/aws_postgres.tf
+++ b/ci/shared/brats/terraform/aws_postgres.tf
@@ -2,7 +2,7 @@ resource "aws_db_instance" "postgres" {
   allocated_storage      = 20
   storage_type           = "gp2"
   engine                 = "postgres"
-  engine_version         = "15.10"
+  engine_version         = "15.18"
   instance_class         = "db.t4g.micro"
   skip_final_snapshot    = true
   db_name                = var.database_name


### PR DESCRIPTION
AWS no longer supports 15.10.  Bump to 15.18, which is the latest version of 15 available.

ref: https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-release-calendar.html#PostgreSQL.Concepts.VersionMgmt.Supported