### PR TITLE
CI: append random suffix to GCP Cloud SQL database instance name

### DIFF
--- a/ci/bats/iaas/gcp/terraform/main.tf
+++ b/ci/bats/iaas/gcp/terraform/main.tf
@@ -88,9 +88,14 @@ resource "google_compute_firewall" "bosh-internal" {
   target_tags = ["bosh-deployed", "test-stemcells-bats", "test-stemcells-ipv4"]
 }
 
+resource "random_id" "mysql_db_name_suffix" {
+  count       = var.create_mysql_db ? 1 : 0
+  byte_length = 4
+}
+
 resource "google_sql_database_instance" "mysql-db" {
   count            = var.create_mysql_db ? 1 : 0
-  name             = "${var.name}-mysql-db"
+  name             = "${var.name}-mysql-db-${random_id.mysql_db_name_suffix[0].hex}"
   database_version = "MYSQL_8_0"
   region           = var.region
   deletion_protection = false


### PR DESCRIPTION
Prevent 'Error waiting for Create Instance' failures in the Concourse 'upgrade-mysql' job when builds are triggered within a short window.

Google Cloud SQL enforces a 7-to-10-day moratorium on reusing the name of a recently-deleted database instance. When integration builds are triggered frequently (such as builds 344 and 345), Terraform's apply step fails because the previously-destroyed name 'upgrade-mysql-mysql-db' is still locked by GCP's resource-reclamation pipeline.

Appending a 4-byte `random_id` suffix bypasses the name reservation lock while keeping resource names fully compatible with our leftover environment cleanup filter (`upgrade-mysql`).

References:
- Official GCP Error Documentation: https://cloud.google.com/sql/docs/error-messages
- Concourse Build Failure: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/upgrade-mysql/builds/345
- Historical Occurrence Pattern (identified via fly-search): Builds 319, 325, 344, 345