### PR TITLE
CI: Properly namespace directors

### DIFF
--- a/ci/bats/tasks/deploy-director.sh
+++ b/ci/bats/tasks/deploy-director.sh
@@ -35,11 +35,24 @@ fi
 
 "bosh-ci/ci/bats/iaas/${BAT_INFRASTRUCTURE}/director-vars" > director-vars.json
 
+# Name the director after its per-env terraform network (e.g. bats, fips-director,
+# upgrade-postgres, upgrade-mysql). The GCP CPI derives VM network tags from the
+# director name, so a per-env name keeps the "bats" substring off VMs in the
+# upgrade/fips jobs and prevents the bats job's `leftovers --filter bats` cleanup
+# from deleting them. Falls back to bats-director if metadata is unavailable.
+director_name="bats-director"
+if [[ -e environment/metadata ]]; then
+  network_name="$(jq -r '.network // empty' environment/metadata)"
+  if [[ -n "${network_name}" ]]; then
+    director_name="${network_name}"
+  fi
+fi
+
 bosh-cli interpolate bosh-deployment/bosh.yml \
   -o "bosh-deployment/${BAT_INFRASTRUCTURE}/cpi.yml" \
   -o bosh-deployment/jumpbox-user.yml \
   -o bosh-deployment/local-bosh-release-tarball.yml \
-  -v director_name=bats-director \
+  -v director_name="${director_name}" \
   -v local_bosh_release="$(realpath bosh-release/*.tgz)" \
   --vars-file director-vars.json \
   $DEPLOY_ARGS \


### PR DESCRIPTION
The cleanup-leftover-environemnts task in the bats job was unintentionally targeting directors from other jobs that run concurrently, leading to failures of those jobs or the cleanup.

This happened because each job shared the same deploy-director script, which named the director "bats-director", and the leftover filter used was just "bats".  Instead, use the name of the environment to name the director.

As an additional upside, now all the other *-cleanup-leftovers jobs will correctly clean up their own directors as well.