### PR TITLE
Fail BATs teardown task if cleanup fails

### DIFF
--- a/ci/bats/tasks/destroy-director.sh
+++ b/ci/bats/tasks/destroy-director.sh
@@ -26,8 +26,6 @@ export BOSH_ENVIRONMENT
 export BOSH_CA_CERT
 export BOSH_CLIENT_SECRET
 
-set +e
-
 bosh-cli deployments --column name --json \
   | jq -r ".Tables[0].Rows[].name" \
   | xargs -n1 -I % bosh-cli -n -d '%' delete-deployment --force


### PR DESCRIPTION
We observe many orphaned disks in our GCP account. We shuld cleanup properly to avoid unnecessary costs. 

