### PR TITLE
Ruby upgrade

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-if command -v lorri &> /dev/null; then
-   eval "$(lorri direnv)"
-fi

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,7 +4,8 @@ anchors:
   - &brats_env_name brats-bosh-main
   - &ubuntu_base ubuntu:noble
   - &integration_image ghcr.io/cloudfoundry/bosh/integration
-  - &director_ruby_version ruby-3.3
+  - &director_ruby_version ruby-3.4
+  - &director_ruby_package director-ruby-3.4
   - &git_user_name CF-Bosh CI-Bot
   - &git_user_email cf-bosh-ci-bot@localhost
 
@@ -1065,7 +1066,7 @@ jobs:
             version: current-version
           params:
             PACKAGES:
-              - director-ruby-3.3
+              - *director_ruby_package
               - nginx
           on_success:
             do:

--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -47,7 +47,7 @@ packages:
 - nginx
 - libpq
 - mysql
-- director-ruby-3.3
+- director-ruby-3.4
 - s3cli
 - azure-storage-cli
 - davcli

--- a/jobs/director/templates/env.erb
+++ b/jobs/director/templates/env.erb
@@ -1,6 +1,6 @@
-source /var/vcap/packages/director-ruby-3.3/bosh/runtime.env
+source /var/vcap/packages/director-ruby-3.4/bosh/runtime.env
 export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
-export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/3.3.0
+export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/3.4.0
 
 <% if_p('env.http_proxy') do |http_proxy| %>
 export HTTP_PROXY=<%= http_proxy %>

--- a/jobs/health_monitor/spec
+++ b/jobs/health_monitor/spec
@@ -13,7 +13,7 @@ templates:
 
 packages:
   - health_monitor
-  - director-ruby-3.3
+  - director-ruby-3.4
 
 properties:
   #

--- a/jobs/health_monitor/templates/bpm.yml
+++ b/jobs/health_monitor/templates/bpm.yml
@@ -4,7 +4,7 @@ health_monitor_config = {
   "executable" => "/var/vcap/jobs/health_monitor/bin/health_monitor",
   "env" => {
     "BUNDLE_GEMFILE" => "/var/vcap/packages/health_monitor/Gemfile",
-    "GEM_HOME" => "/var/vcap/packages/health_monitor/gem_home/ruby/3.3.0",
+    "GEM_HOME" => "/var/vcap/packages/health_monitor/gem_home/ruby/3.4.0",
   },
   "unsafe" => {
     "unrestricted_volumes" => [

--- a/jobs/health_monitor/templates/health_monitor
+++ b/jobs/health_monitor/templates/health_monitor
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-source /var/vcap/packages/director-ruby-3.3/bosh/runtime.env
+source /var/vcap/packages/director-ruby-3.4/bosh/runtime.env
 exec /var/vcap/packages/health_monitor/bin/bosh-monitor -c /var/vcap/jobs/health_monitor/config/health_monitor.yml

--- a/jobs/nats/spec
+++ b/jobs/nats/spec
@@ -18,7 +18,7 @@ templates:
 
 packages:
   - nats
-  - director-ruby-3.3
+  - director-ruby-3.4
 
 properties:
   nats.listen_address:

--- a/jobs/nats/templates/bosh_nats_sync
+++ b/jobs/nats/templates/bosh_nats_sync
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-source /var/vcap/packages/director-ruby-3.3/bosh/runtime.env
+source /var/vcap/packages/director-ruby-3.4/bosh/runtime.env
 exec /var/vcap/packages/nats/bin/bosh-nats-sync -c /var/vcap/jobs/nats/config/bosh_nats_sync_config.yml

--- a/jobs/nats/templates/bpm.yml
+++ b/jobs/nats/templates/bpm.yml
@@ -6,7 +6,7 @@ bosh_nats_sync_config = {
   "ephemeral_disk" => true,
   "env" => {
     "BUNDLE_GEMFILE" => "/var/vcap/packages/nats/Gemfile",
-    "GEM_HOME" => "/var/vcap/packages/nats/gem_home/ruby/3.3.0",
+    "GEM_HOME" => "/var/vcap/packages/nats/gem_home/ruby/3.4.0",
   },
   "unsafe" => {
     "privileged" => true,

--- a/packages/director/packaging
+++ b/packages/director/packaging
@@ -5,7 +5,7 @@ mkdir -p ${BOSH_INSTALL_TARGET}/{bin,gem_home}
 libpq_dir=/var/vcap/packages/libpq
 mysqlclient_dir=/var/vcap/packages/mysql
 
-source /var/vcap/packages/director-ruby-3.3/bosh/compile.env
+source /var/vcap/packages/director-ruby-3.4/bosh/compile.env
 
 for gemspec in $( find . -maxdepth 2 -name *.gemspec ); do
   gem_name="$( basename "$( dirname "$gemspec" )" )"

--- a/packages/director/spec
+++ b/packages/director/spec
@@ -4,7 +4,7 @@ name: director
 dependencies:
 - libpq
 - mysql
-- director-ruby-3.3
+- director-ruby-3.4
 
 files:
 - bosh-director/**/*

--- a/packages/health_monitor/packaging
+++ b/packages/health_monitor/packaging
@@ -2,7 +2,7 @@ set -e
 
 mkdir -p ${BOSH_INSTALL_TARGET}/{bin,gem_home}
 
-source /var/vcap/packages/director-ruby-3.3/bosh/compile.env
+source /var/vcap/packages/director-ruby-3.4/bosh/compile.env
 
 cat > Gemfile <<EOF
 # Explicitly require vendored version to avoid requiring builtin json gem

--- a/packages/health_monitor/spec
+++ b/packages/health_monitor/spec
@@ -1,7 +1,7 @@
 ---
 name: health_monitor
 dependencies:
-- director-ruby-3.3
+- director-ruby-3.4
 
 files:
 - bosh-monitor/**/*

--- a/packages/nats/packaging
+++ b/packages/nats/packaging
@@ -9,7 +9,7 @@ chmod +x ${BOSH_INSTALL_TARGET}/bin/nats-server
 
 mkdir -p ${BOSH_INSTALL_TARGET}/{bin,gem_home}
 
-source /var/vcap/packages/director-ruby-3.3/bosh/compile.env
+source /var/vcap/packages/director-ruby-3.4/bosh/compile.env
 
 cat > Gemfile <<EOF
 # Explicitly require vendored version to avoid requiring builtin json gem

--- a/packages/nats/spec
+++ b/packages/nats/spec
@@ -2,7 +2,7 @@
 name: nats
 
 dependencies:
-- director-ruby-3.3
+- director-ruby-3.4
 
 files:
 - nats/nats-server-v*-linux-amd64.tar.gz

--- a/src/bosh-director/spec/unit/bosh/director/config_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/config_spec.rb
@@ -434,7 +434,7 @@ describe Bosh::Director::Config do
     describe 'blobstore config fingerprint' do
       it 'returns the sha1 of the blobstore config' do
         described_class.configure(test_config)
-        expect(described_class.blobstore_config_fingerprint).to eq('d8500dc13f23babb7f83d8ebd5995416544df6c1')
+        expect(described_class.blobstore_config_fingerprint).to eq('5a820d1a861d149bae6386893471207113ba32fe')
       end
     end
 


### PR DESCRIPTION
Changes the CI ingested ruby from 3.3 => 3.4

Change the package consumed from 3.3 => 3.4

Will likely require some coordinated changes once https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/bump-packages runs to add the new ruby-3.4 package