### PR TITLE
Specs pass under ruby 3.3 and 3.4

### DIFF
--- a/src/bosh-director/spec/assets/test-director-config.yml
+++ b/src/bosh-director/spec/assets/test-director-config.yml
@@ -41,12 +41,13 @@ cloud:
   plugin: dummy
   properties:
     dir: ...
-     # to be added
+    # to be added
 user_management:
   provider: local
   local:
     users:
-    - {name: admin, password: admin}
+      - name: admin
+        password: admin
 config_server:
   enabled: false
 record_events: true
@@ -57,12 +58,12 @@ agent:
   env:
     bosh:
       blobstores:
-      - provider: 'local'
-        options:
-          'blobstore_path': /path/to/blobstore
-      - provider: 'local'
-        options:
-          'blobstore_path': /path/to/blobstore
+        - provider: 'local'
+          options:
+            'blobstore_path': /path/to/blobstore
+        - provider: 'local'
+          options:
+            'blobstore_path': /path/to/blobstore
 cpi:
   max_supported_api_version: 2
   preferred_api_version: 2

--- a/src/bosh-director/spec/unit/bosh/director/addon/addon_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/addon/addon_spec.rb
@@ -439,7 +439,7 @@ module Bosh::Director
           end
 
           it 'errors' do
-            error_string = "Required property 'name' was not specified in object ({\"jobs\"=>[\"addon-name\"]})"
+            error_string = "Required property 'name' was not specified in object (#{{ "jobs" => ["addon-name"] }})" # rubocop:disable Lint/LiteralInInterpolation
             expect { Addon.parse(addon_hash) }.to raise_error(ValidationMissingField, error_string)
           end
         end

--- a/src/bosh-director/spec/unit/bosh/director/addon/filter_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/addon/filter_spec.rb
@@ -19,8 +19,7 @@ module Bosh::Director
               addon_include.applies?('anything', [], instance_group)
             end.to raise_error(
               AddonIncompleteFilterJobSection,
-              'Job {"name"=>"", "release"=>"release_name"} in runtime '\
-              "config's #{type} section must have both name and release.",
+              "Job #{{ "name" => "", "release" => "release_name" }} in runtime config's #{type} section must have both name and release.", # rubocop:disable Lint/LiteralInInterpolation
             )
           end
         end
@@ -35,8 +34,7 @@ module Bosh::Director
               addon_include.applies?('anything', [], instance_group)
             end.to raise_error(
               AddonIncompleteFilterJobSection,
-              'Job {"name"=>"job-name", "release"=>""} in runtime '\
-              "config's #{type} section must have both name and release.",
+              "Job #{{ "name" => "job-name", "release" => "" }} in runtime config's #{type} section must have both name and release.", # rubocop:disable Lint/LiteralInInterpolation
             )
           end
         end
@@ -51,7 +49,7 @@ module Bosh::Director
               expect do
                 addon_include.applies?('anything', [], instance_group)
               end.to raise_error AddonIncompleteFilterStemcellSection,
-                                 "Stemcell {\"os\"=>\"\"} in runtime config's #{type} section must have an os name."
+                                 "Stemcell #{{"os" => ""}} in runtime config's #{type} section must have an os name." # rubocop:disable Lint/LiteralInInterpolation
             end
           end
 

--- a/src/bosh-director/spec/unit/bosh/director/agent_broadcaster_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/agent_broadcaster_spec.rb
@@ -133,7 +133,7 @@ module Bosh::Director
         context 'and agent succeeds within retry count' do
           it 'retries broadcasting to failed agents' do
             expect(per_spec_logger).to receive(:info).with('agent_broadcaster: sync_dns: sending to 2 agents ["agent-1", "agent-2"]')
-            expect(per_spec_logger).to receive(:error).with('agent_broadcaster: sync_dns[agent-2]: received unexpected response {"value"=>"unsynced"}')
+            expect(per_spec_logger).to receive(:error).with("agent_broadcaster: sync_dns[agent-2]: received unexpected response #{{ "value" => "unsynced" }}") # rubocop:disable Lint/LiteralInInterpolation
             expect(per_spec_logger).to receive(:info).with('agent_broadcaster: sync_dns: attempted 2 agents in 10ms (1 successful, 1 failed, 0 unresponsive)')
 
             expect(AgentClient).to receive(:with_agent_id)

--- a/src/bosh-director/spec/unit/bosh/director/api/instance_lookup_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/api/instance_lookup_spec.rb
@@ -60,7 +60,7 @@ module Bosh::Director
           it 'raises' do
             expect {
               instance_lookup.by_filter(id: 987654321)
-            }.to raise_error(InstanceNotFound, "No instances matched {:id=>987654321}")
+            }.to raise_error(InstanceNotFound, "No instances matched #{{ :id => 987654321 }}") # rubocop:disable Lint/LiteralInInterpolation
           end
         end
       end

--- a/src/bosh-director/spec/unit/bosh/director/config_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/config_spec.rb
@@ -435,7 +435,6 @@ describe Bosh::Director::Config do
       it 'returns the sha1 of the blobstore config' do
         described_class.configure(test_config)
         expect(described_class.blobstore_config_fingerprint).to eq('d8500dc13f23babb7f83d8ebd5995416544df6c1')
-
       end
     end
 

--- a/src/bosh-director/spec/unit/bosh/director/core/templates/source_erb_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/core/templates/source_erb_spec.rb
@@ -36,14 +36,15 @@ module Bosh::Director::Core::Templates
           allow(logger).to receive(:debug)
         end
 
-        let(:original_error) { "undefined method `no_method' for nil" }
+        # Ruby 3.3 uses `method_name'; Ruby 3.4+ uses 'method_name'
+        let(:original_error) { "undefined method [`|']no_method' for nil" }
 
         let(:expected_message) do
-          "Error filling in template 'source-filename.erb' (line 1: #{original_error})"
+          /Error filling in template 'source-filename.erb' \(line 1: #{original_error}\)/
         end
 
         it 'logs the error and the new message with the original backtrace' do
-          expect(logger).to receive(:debug).with("#<NoMethodError: #{original_error}>")
+          expect(logger).to receive(:debug).with(/#<NoMethodError: #{original_error}>/)
           expect(logger).to receive(:debug) do |message|
             expect(message).to include(expected_message)
             expect(message).to include("fake-job-name/source-filename.erb:1:in 'get_binding'")

--- a/src/bosh-director/spec/unit/bosh/director/cpi_config/cpi_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/cpi_config/cpi_spec.rb
@@ -19,7 +19,7 @@ module Bosh::Director
           end
 
           it 'errors' do
-            expect { cpi }.to raise_error ValidationMissingField, "Required property 'name' was not specified in object ({\"type\"=>\"cpi-type\"})"
+            expect { cpi }.to raise_error ValidationMissingField, "Required property 'name' was not specified in object (#{{ "type" => "cpi-type" }})" # rubocop:disable Lint/LiteralInInterpolation
           end
         end
 
@@ -29,7 +29,7 @@ module Bosh::Director
           end
 
           it 'errors' do
-            expect { cpi }.to raise_error ValidationMissingField, "Required property 'type' was not specified in object ({\"name\"=>\"cpi-name\"})"
+            expect { cpi }.to raise_error ValidationMissingField, "Required property 'type' was not specified in object (#{{ "name" => "cpi-name" }})" # rubocop:disable Lint/LiteralInInterpolation
           end
         end
 

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/deployment_spec_parser_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/deployment_spec_parser_spec.rb
@@ -85,7 +85,7 @@ module Bosh::Director
               parsed_deployment.stemcells
             end.to raise_error Bosh::Director::ValidationMissingField,
                                "Required property 'alias' was not specified in object " \
-                               '({"name"=>"bosh-aws-xen-hvm-ubuntu-trusty-go_agent", "version"=>"1234"})'
+                               "(#{{ "name" => "bosh-aws-xen-hvm-ubuntu-trusty-go_agent", "version" => "1234" }})" # rubocop:disable Lint/LiteralInInterpolation
           end
         end
 

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/instance_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/instance_spec.rb
@@ -355,7 +355,7 @@ module Bosh::Director::DeploymentPlan
 
             it 'should log the change' do
               expect(per_spec_logger).to receive(:debug)
-                .with('cloud_properties_changed? changed FROM: {"a"=>"b"} TO: {"abcd"=>"wera", "baz"=>"bang", "a"=>"b"}')
+                .with("cloud_properties_changed? changed FROM: #{{ 'a' => 'b' }} TO: #{{ 'abcd' => 'wera', 'baz' => 'bang', 'a' => 'b' }}") # rubocop:disable Lint/LiteralInInterpolation
               instance.cloud_properties_changed?
             end
           end

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/planner_factory_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/planner_factory_spec.rb
@@ -83,14 +83,16 @@ module Bosh
 
           it 'logs the migrated manifests' do
             planner
+            # rubocop:disable Lint/LiteralInInterpolation
             expected_deployment_manifest_log = <<~LOGMESSAGE
               Deployment manifest:
-              {"name"=>"simple", "releases"=>[{"name"=>"bosh-release", "version"=>"0.1-dev"}], "stemcells"=>[{"name"=>"ubuntu-stemcell", "version"=>"1", "alias"=>"default", "os"=>"stemcell-os"}], "update"=>{"canaries"=>2, "canary_watch_time"=>4000, "max_in_flight"=>1, "update_watch_time"=>20}, "instance_groups"=>[{"name"=>"foobar", "stemcell"=>"default", "vm_type"=>"a", "instances"=>3, "networks"=>[{"name"=>"a"}], "jobs"=>[{"name"=>"foobar", "release"=>"bosh-release", "properties"=>{}}]}]}
+              #{{ "name" => "simple", "releases" => [{ "name" => "bosh-release", "version" => "0.1-dev" }], "stemcells" => [{ "name" => "ubuntu-stemcell", "version" => "1", "alias" => "default", "os" => "stemcell-os" }], "update" => { "canaries" => 2, "canary_watch_time" => 4000, "max_in_flight" => 1, "update_watch_time" => 20 }, "instance_groups" => [{ "name" => "foobar", "stemcell" => "default", "vm_type" => "a", "instances" => 3, "networks" => [{ "name" => "a" }], "jobs" => [{ "name" => "foobar", "release" => "bosh-release", "properties" => {} }] }] }}
             LOGMESSAGE
             expected_cloud_manifest_log = <<~LOGMESSAGE
               Cloud config manifest:
-              {"networks"=>[{"name"=>"a", "subnets"=>[{"range"=>"192.168.1.0/24", "gateway"=>"192.168.1.1", "dns"=>["192.168.1.1", "192.168.1.2"], "static"=>["192.168.1.10"], "reserved"=>[], "cloud_properties"=>{}}]}], "compilation"=>{"workers"=>1, "network"=>"a", "cloud_properties"=>{}}, "vm_types"=>[{"name"=>"a", "cloud_properties"=>{}}]}
+              #{{ "networks" => [{ "name" => "a", "subnets" => [{ "range" => "192.168.1.0/24", "gateway" => "192.168.1.1", "dns" => ["192.168.1.1", "192.168.1.2"], "static" => ["192.168.1.10"], "reserved" => [], "cloud_properties" => {} }] }], "compilation" => { "workers" => 1, "network" => "a", "cloud_properties" => {} }, "vm_types" => [{ "name" => "a", "cloud_properties" => {} }] }}
             LOGMESSAGE
+            # rubocop:enable Lint/LiteralInInterpolation
             expect(logger_io.string).to include(expected_deployment_manifest_log)
             expect(logger_io.string).to include(expected_cloud_manifest_log)
           end

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/release_version_exported_from_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/release_version_exported_from_spec.rb
@@ -22,7 +22,7 @@ module Bosh::Director::DeploymentPlan
           ReleaseVersionExportedFrom.parse('version' => '0.5.2')
         end.to raise_error(
           Bosh::Director::ValidationMissingField,
-          "Required property 'os' was not specified in object ({\"version\"=>\"0.5.2\"})",
+          "Required property 'os' was not specified in object (#{{ "version" => "0.5.2" }})", # rubocop:disable Lint/LiteralInInterpolation
         )
       end
 
@@ -31,7 +31,7 @@ module Bosh::Director::DeploymentPlan
           ReleaseVersionExportedFrom.parse('os' => 'stemcell-os')
         end.to raise_error(
           Bosh::Director::ValidationMissingField,
-          "Required property 'version' was not specified in object ({\"os\"=>\"stemcell-os\"})",
+          "Required property 'version' was not specified in object (#{{ "os" => "stemcell-os" }})", # rubocop:disable Lint/LiteralInInterpolation
         )
       end
     end

--- a/src/bosh-director/spec/unit/bosh/director/deployment_plan/stemcell_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/deployment_plan/stemcell_spec.rb
@@ -22,7 +22,7 @@ describe Bosh::Director::DeploymentPlan::Stemcell do
       expect do
         Bosh::Director::DeploymentPlan::Stemcell.parse(valid_spec)
       end.to raise_error(Bosh::Director::ValidationMissingField,
-                         "Required property 'version' was not specified in object ({\"name\"=>\"stemcell-name\"})")
+                         "Required property 'version' was not specified in object (#{{ "name" => "stemcell-name" }})") # rubocop:disable Lint/LiteralInInterpolation
     end
 
     context 'os and name' do
@@ -48,7 +48,7 @@ describe Bosh::Director::DeploymentPlan::Stemcell do
           valid_spec.delete('os')
           expect { Bosh::Director::DeploymentPlan::Stemcell.parse(valid_spec) }.to raise_error(
             Bosh::Director::ValidationMissingField,
-            "Required property 'os' or 'name' was not specified in object ({\"version\"=>\"0.5.2\"})",
+            "Required property 'os' or 'name' was not specified in object (#{{ "version" => "0.5.2" }})", # rubocop:disable Lint/LiteralInInterpolation
           )
         end
       end

--- a/src/bosh-director/spec/unit/bosh/director/errand/errand_provider_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/errand/errand_provider_spec.rb
@@ -410,7 +410,7 @@ module Bosh::Director
             it 'only creates an errand for the requested slug' do
               expect do
                 subject.get(deployment_name, 'errand-job-name', keep_alive, instance_slugs)
-              end.to raise_error('No instances match selection criteria: [{"group"=>"bogus-group-name", "id"=>"0"}]')
+              end.to raise_error("No instances match selection criteria: [#{{ "group" => "bogus-group-name", "id" => "0" }}]") # rubocop:disable Lint/LiteralInInterpolation
             end
           end
         end

--- a/src/bosh-director/spec/unit/bosh/director/errand/lifecycle_errand_step_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/errand/lifecycle_errand_step_spec.rb
@@ -105,13 +105,13 @@ module Bosh::Director
 
     describe '#state_hash' do
       it 'returns digest of instance uuid, configuration_hash, and package_spec' do
-        expect(errand_step.state_hash).to eq(::Digest::SHA1.hexdigest('321-cbaabc123{"successful"=>"package_spec"}'))
+        expect(errand_step.state_hash).to eq(::Digest::SHA1.hexdigest("321-cbaabc123#{{ "successful" => "package_spec" }}")) # rubocop:disable Lint/LiteralInInterpolation
       end
 
       describe 'when the instance configuration hash is nil' do
         let(:instance_configuration_hash) { nil }
         it 'returns digest of instance uuid, and package_spec' do
-          expect(errand_step.state_hash).to eq(::Digest::SHA1.hexdigest('321-cba{"successful"=>"package_spec"}'))
+          expect(errand_step.state_hash).to eq(::Digest::SHA1.hexdigest("321-cba#{{ "successful" => "package_spec" }}")) # rubocop:disable Lint/LiteralInInterpolation
         end
       end
     end

--- a/src/bosh-director/spec/unit/bosh/director/errand/lifecycle_service_step_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/errand/lifecycle_service_step_spec.rb
@@ -36,14 +36,14 @@ module Bosh::Director
 
     describe '#state_hash' do
       it 'returns digest of instance uuid, configuration_hash, and package_spec' do
-        expect(errand_step.state_hash).to eq(::Digest::SHA1.hexdigest('321-cbaabc123{"successful"=>"package_spec"}'))
+        expect(errand_step.state_hash).to eq(::Digest::SHA1.hexdigest("321-cbaabc123#{{ "successful" => "package_spec" }}")) # rubocop:disable Lint/LiteralInInterpolation
       end
 
-      context 'when the instance confuguration hash is nil' do
+      context 'when the instance configuration hash is nil' do
         let(:instance_configuration_hash) { nil }
 
         it 'returns digest of instance uuid and package spec' do
-          expect(errand_step.state_hash).to eq(::Digest::SHA1.hexdigest('321-cba{"successful"=>"package_spec"}'))
+          expect(errand_step.state_hash).to eq(::Digest::SHA1.hexdigest("321-cba#{{ "successful" => "package_spec" }}")) # rubocop:disable Lint/LiteralInInterpolation
         end
       end
     end

--- a/src/bosh-director/spec/unit/bosh/director/errand/runner_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/errand/runner_spec.rb
@@ -328,7 +328,7 @@ module Bosh::Director
         end
 
         context 'when agent does not support run_errand command' do
-          let(:error) { RpcRemoteException.new('unknown message {"method"=>"run_errand", "error"=>"details"}') }
+          let(:error) { RpcRemoteException.new("unknown message #{{ "method" => "run_errand", "error" => "details" }}") } # rubocop:disable Lint/LiteralInInterpolation
 
           before do
             allow(agent_client).to receive(:run_errand).with('fake-job-name').and_raise(error)
@@ -343,14 +343,14 @@ module Bosh::Director
             expect(task_result).to_not receive(:write)
             expect {
               subject.run(instance)
-            }.to raise_error(Bosh::Director::RpcRemoteException, /unknown message {"method"=>"run_errand", "error"=>"details"}/)
+            }.to raise_error(Bosh::Director::RpcRemoteException, /unknown message #{{ "method" => "run_errand", "error" => "details" }}/)# rubocop:disable Lint/LiteralInInterpolation
           end
 
           it 'does not try to fetch logs from the agent because we did not run errand' do
             expect(logs_fetcher).to_not receive(:fetch)
             expect {
               subject.run(instance)
-            }.to raise_error(Bosh::Director::RpcRemoteException, /unknown message {"method"=>"run_errand", "error"=>"details"}/)
+            }.to raise_error(Bosh::Director::RpcRemoteException, /unknown message #{{ "method" => "run_errand", "error" => "details" }}/) # rubocop:disable Lint/LiteralInInterpolation
           end
         end
 

--- a/src/bosh-director/spec/unit/bosh/director/runtime_config/release_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/runtime_config/release_spec.rb
@@ -32,7 +32,7 @@ module Bosh::Director
           end
 
           it 'errors' do
-            expect { release }.to raise_error ValidationMissingField, "Required property 'name' was not specified in object ({\"version\"=>\"42\"})"
+            expect { release }.to raise_error ValidationMissingField, "Required property 'name' was not specified in object (#{{ "version" => "42" }})" # rubocop:disable Lint/LiteralInInterpolation
           end
         end
 
@@ -42,7 +42,7 @@ module Bosh::Director
           end
 
           it 'errors' do
-            expect { release }.to raise_error ValidationMissingField, "Required property 'version' was not specified in object ({\"name\"=>\"blarg\"})"
+            expect { release }.to raise_error ValidationMissingField, "Required property 'version' was not specified in object (#{{ "name" => "blarg" }})" # rubocop:disable Lint/LiteralInInterpolation
           end
         end
 

--- a/src/spec/integration/cli_deployment_process_spec.rb
+++ b/src/spec/integration/cli_deployment_process_spec.rb
@@ -300,7 +300,7 @@ lines',
 
         expect do
           bosh_runner.run("deploy #{deployment_manifest.path}", deployment_name: 'simple')
-        end.to raise_error(/Required stemcell {"name"=>"ubuntu-stemcell", "version"=>"1"} not found for cpi/)
+        end.to raise_error(/Required stemcell #{{ "name" => "ubuntu-stemcell", "version" => "1" }} not found for cpi/) # rubocop:disable Lint/LiteralInInterpolation
 
         bosh_runner.run("upload-stemcell --fix #{stemcell_filename}")
 

--- a/src/spec/integration/deploy_instance_groups_job_spec.rb
+++ b/src/spec/integration/deploy_instance_groups_job_spec.rb
@@ -74,8 +74,7 @@ describe 'deploy instance_groups job', type: :integration do
 
     instance = director.instance('foobar', '0')
     template = instance.read_job_template('foobar', 'bin/foobar_ctl')
-    expected_rendered_template = '"test_property={"q2GB"=>"foo", "q428GB"=>"foo", ' \
-      '"q46GB"=>"foo", "q4GB"=>"foo", "q64GB"=>"foo", "q82GB"=>"foo", "q8GB"=>"foo"}"'
+    expected_rendered_template = "\"test_property=#{{ "q2GB" => "foo", "q428GB" => "foo", "q46GB" => "foo", "q4GB" => "foo", "q64GB" => "foo", "q82GB" => "foo", "q8GB" => "foo" }}\""
     expect(template).to include(expected_rendered_template)
 
     output = deploy(manifest_hash: manifest_hash)


### PR DESCRIPTION
Some textual output in Ruby 3.4 has been change which caused hard-coded expectations to be incorrect, e.g. Hash's string representation changed spacing.
This commit resolves this difference by relying on Ruby's interpolation for objects, rather than hard-coding a specific iterpolation into specs.

Should fix (most) failures in: https://github.com/cloudfoundry/bosh/pull/2748