### PR TITLE
cpi images: enable `ssh --director`

### DIFF
--- a/ci/dockerfiles/docker-cpi/start-bosh.sh
+++ b/ci/dockerfiles/docker-cpi/start-bosh.sh
@@ -257,6 +257,9 @@ EOF
   bosh int "${local_bosh_dir}/creds.yml" --path /director_ssl/ca > "${local_bosh_dir}/ca.crt"
   bosh_client_secret="$(bosh int "${local_bosh_dir}/creds.yml" --path /admin_password)"
 
+  mbus_bootstrap_cert="$(bosh int "${local_bosh_dir}/creds.yml" --path /mbus_bootstrap_ssl/certificate)"
+  mbus_bootstrap_pass="$(bosh int "${local_bosh_dir}/creds.yml" --path /mbus_bootstrap_password)"
+
   bosh -e "${BOSH_DIRECTOR_IP}" --ca-cert "${local_bosh_dir}/ca.crt" alias-env "${BOSH_ENVIRONMENT}"
 
   bosh_env_file="${local_bosh_dir}/bosh-env"
@@ -267,6 +270,8 @@ EOF
     echo "export BOSH_CLIENT=\"admin\""
     echo "export BOSH_CLIENT_SECRET=\"${bosh_client_secret}\""
     echo "export BOSH_CA_CERT=\"${local_bosh_dir}/ca.crt\""
+    echo "export BOSH_AGENT_CERTIFICATE=\"${mbus_bootstrap_cert}\""
+    echo "export BOSH_AGENT_ENDPOINT=\"https://mbus:${mbus_bootstrap_pass}@${BOSH_DIRECTOR_IP}:6868\""
   } > "${bosh_env_file}"
 
   echo "Source '${bosh_env_file}' to run bosh" >&2

--- a/ci/dockerfiles/warden-cpi/start-bosh.sh
+++ b/ci/dockerfiles/warden-cpi/start-bosh.sh
@@ -52,11 +52,16 @@ pushd "${BOSH_DEPLOYMENT_PATH:-/usr/local/bosh-deployment}" > /dev/null
     > "${local_bosh_dir}/ca.crt"
   bosh_client_secret="$(bosh int "${local_bosh_dir}/creds.yml" --path /admin_password)"
 
+  mbus_bootstrap_cert="$(bosh int "${local_bosh_dir}/creds.yml" --path /mbus_bootstrap_ssl/certificate)"
+  mbus_bootstrap_pass="$(bosh int "${local_bosh_dir}/creds.yml" --path /mbus_bootstrap_password)"
+
   cat <<EOF > "${local_bosh_dir}/env"
 export BOSH_ENVIRONMENT="${BOSH_DIRECTOR_IP}"
 export BOSH_CLIENT=admin
 export BOSH_CLIENT_SECRET=${bosh_client_secret}
 export BOSH_CA_CERT="${local_bosh_dir}/ca.crt"
+export BOSH_AGENT_CERTIFICATE="${mbus_bootstrap_cert}"
+export BOSH_AGENT_ENDPOINT="https://mbus:${mbus_bootstrap_pass}@${BOSH_DIRECTOR_IP}:6868"
 
 EOF
 


### PR DESCRIPTION
Add ENV vars necessary to enable `bosh ssh --director` to work from CPI container images (docker, warden).

