### PR TITLE
Add AI review feedback section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,3 +22,9 @@ _Does this introduce changes that would require operators to take care in order 
 
 ### Tag your pair, your PM, and/or team!
 _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
+
+### AI Review Feedback
+
+_All AI review comments (CodeRabbit, and Copilot when assigned) must be resolved before human reviewers will look at the PR. For each comment, either:_
+- _Make the suggested change, or_
+- _Reply to the comment explaining why it does not apply, then resolve the thread._


### PR DESCRIPTION
## Summary

- Adds a new **AI Review Feedback** section to the PR template
- Clarifies that all CodeRabbit and Copilot (when assigned) review comments must be resolved before human reviewers will look at the PR
- Each comment must either result in a code change, or a reply explaining why it does not apply with the thread resolved