### PR TITLE
make bpm optional for bosh director workers

### DIFF
--- a/jobs/director/monit
+++ b/jobs/director/monit
@@ -5,21 +5,39 @@ check process director
   group vcap
 
 <% (1..(p('director.workers'))).each do |index| %>
+<% if p('director.use_bpm_for_workers') %>
 check process worker_<%= index %>
   with pidfile /var/vcap/sys/run/bpm/director/worker_<%= index %>.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start director -p worker_<%= index %>"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop director -p worker_<%= index %>"
   group vcap
   depends on director
+<% else %>
+check process worker_<%= index %>
+  with pidfile /var/vcap/sys/run/director/worker_<%= index %>.pid
+  start program "/var/vcap/jobs/director/bin/worker_ctl worker_<%= index %> start"
+  stop program "/var/vcap/jobs/director/bin/worker_ctl worker_<%= index %> stop"
+  group vcap
+  depends on director
+<% end %>
 <% end %>
 
 <% (1..(p('director.dynamic_disks_workers'))).each do |index| %>
+<% if p('director.use_bpm_for_workers') %>
 check process dynamic_disks_worker_<%= index %>
   with pidfile /var/vcap/sys/run/bpm/director/dynamic_disks_worker_<%= index %>.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start director -p dynamic_disks_worker_<%= index %>"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop director -p dynamic_disks_worker_<%= index %>"
   group vcap
   depends on director
+<% else %>
+check process dynamic_disks_worker_<%= index %>
+  with pidfile /var/vcap/sys/run/director/dynamic_disks_worker_<%= index %>.pid
+  start program "/var/vcap/jobs/director/bin/worker_ctl dynamic_disks_worker_<%= index %> start"
+  stop program "/var/vcap/jobs/director/bin/worker_ctl dynamic_disks_worker_<%= index %> stop"
+  group vcap
+  depends on director
+<% end %>
 <% end %>
 
 check process director_scheduler

--- a/jobs/director/spec
+++ b/jobs/director/spec
@@ -40,6 +40,7 @@ templates:
   uaa_server_ca.cert.erb: config/uaa_server_ca.cert
   utils.sh: helpers/utils.sh
   worker: bin/worker
+  worker_ctl.erb: bin/worker_ctl
 
 packages:
 - director
@@ -80,6 +81,14 @@ properties:
   director.enable_dedicated_status_worker:
     description: "Separate worker for 'bosh vms' and 'bosh ssh'"
     default: false
+  director.use_bpm_for_workers:
+    description: >
+      When true, run director worker processes under BPM. Defaults to true and
+      should remain true in all normal deployments. Set to false only for
+      compatibility with the warden CPI, which cannot run workers inside BPM
+      containers because it requires privileged /dev access. Deprecated: this
+      escape hatch will be removed once warden CPI support is dropped.
+    default: true
   director.puma_workers:
     description: Number of puma workers
     default: 3

--- a/jobs/director/templates/bpm.yml
+++ b/jobs/director/templates/bpm.yml
@@ -51,34 +51,36 @@ config = {
   "processes" => [director_config, nginx_config, scheduler_config, sync_dns_config, metrics_server_config],
 }
 
-(1..(p('director.workers'))).each do |index|
-  queue = "normal,urgent"
-  if p('director.enable_dedicated_status_worker') && p('director.workers') > 1 && index == 1
-    queue = "urgent"
+if p('director.use_bpm_for_workers')
+  (1..(p('director.workers'))).each do |index|
+    queue = "normal,urgent"
+    if p('director.enable_dedicated_status_worker') && p('director.workers') > 1 && index == 1
+      queue = "urgent"
+    end
+    worker = {
+      "name" => "worker_#{index}",
+      "executable" => "/var/vcap/jobs/director/bin/worker",
+      "args" => ["worker_#{index}"],
+      "ephemeral_disk" => true,
+      "persistent_disk" => true,
+      "env" => worker_thread_env.merge("QUEUE" => queue),
+    }
+    worker["unsafe"] = {"unrestricted_volumes" => worker_cpi_volumes.map(&:dup)} unless worker_cpi_volumes.empty?
+    config["processes"] << worker
   end
-  worker = {
-    "name" => "worker_#{index}",
-    "executable" => "/var/vcap/jobs/director/bin/worker",
-    "args" => ["worker_#{index}"],
-    "ephemeral_disk" => true,
-    "persistent_disk" => true,
-    "env" => worker_thread_env.merge("QUEUE" => queue),
-  }
-  worker["unsafe"] = {"unrestricted_volumes" => worker_cpi_volumes.map(&:dup)} unless worker_cpi_volumes.empty?
-  config["processes"] << worker
-end
 
-(1..(p('director.dynamic_disks_workers'))).each do |index|
-  worker = {
-    "name" => "dynamic_disks_worker_#{index}",
-    "executable" => "/var/vcap/jobs/director/bin/worker",
-    "args" => ["dynamic_disks_worker_#{index}"],
-    "ephemeral_disk" => true,
-    "persistent_disk" => true,
-    "env" => worker_thread_env.merge("QUEUE" => "dynamic_disks"),
-  }
-  worker["unsafe"] = {"unrestricted_volumes" => worker_cpi_volumes.map(&:dup)} unless worker_cpi_volumes.empty?
-  config["processes"] << worker
+  (1..(p('director.dynamic_disks_workers'))).each do |index|
+    worker = {
+      "name" => "dynamic_disks_worker_#{index}",
+      "executable" => "/var/vcap/jobs/director/bin/worker",
+      "args" => ["dynamic_disks_worker_#{index}"],
+      "ephemeral_disk" => true,
+      "persistent_disk" => true,
+      "env" => worker_thread_env.merge("QUEUE" => "dynamic_disks"),
+    }
+    worker["unsafe"] = {"unrestricted_volumes" => worker_cpi_volumes.map(&:dup)} unless worker_cpi_volumes.empty?
+    config["processes"] << worker
+  end
 end
 
 YAML.dump(config)

--- a/jobs/director/templates/worker_ctl.erb
+++ b/jobs/director/templates/worker_ctl.erb
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+NAME="$1"
+ACTION="$2"
+RUNAS=vcap
+
+RUN_DIR=/var/vcap/sys/run/director
+LOG_DIR=/var/vcap/sys/log/director
+PIDFILE=${RUN_DIR}/${NAME}.pid
+
+# Postgres (libpq)
+LD_LIBRARY_PATH=/var/vcap/packages/libpq/lib:${LD_LIBRARY_PATH:-}
+
+# MySQL
+PATH=/var/vcap/packages/mysql/bin:$PATH
+LD_LIBRARY_PATH=/var/vcap/packages/mysql/lib/mysql:${LD_LIBRARY_PATH:-}
+
+source /var/vcap/jobs/director/env
+
+PATH=$PATH:/var/vcap/jobs/director/bin
+export PATH LD_LIBRARY_PATH
+export LANG=en_US.UTF-8
+
+export TMPDIR=/var/vcap/data/director/tmp
+
+# Determine the queue for this worker based on its name, mirroring the logic in
+# bpm.yml so both paths send jobs to the same queues.
+case "${NAME}" in
+  dynamic_disks_worker_*)
+    export QUEUE="dynamic_disks"
+    ;;
+  worker_1)
+<% if (p('director.enable_dedicated_status_worker')) && (p('director.workers') > 1) %>
+    export QUEUE="urgent"
+<% else %>
+    export QUEUE="normal,urgent"
+<% end %>
+    ;;
+  *)
+    export QUEUE="normal,urgent"
+    ;;
+esac
+
+# previous value was 16777216, lowered because of: https://bugs.ruby-lang.org/issues/17583
+export RUBY_THREAD_VM_STACK_SIZE=15000000
+export RUBY_THREAD_MACHINE_STACK_SIZE=15000000
+
+function pid_exists {
+  ps -p $1 &> /dev/null
+  return $?
+}
+
+function kill_process {
+  PID=$1
+  kill -TERM $PID
+
+  TRIES=0
+  while pid_exists $PID; do
+    TRIES=$(( $TRIES + 1 ))
+    kill -TERM $PID
+    if [ $TRIES -gt 100 ]; then
+      kill -9 $PID
+      break
+    fi
+    sleep 0.1
+  done
+}
+
+function list_child_processes {
+  ps -eo pid,command |
+    grep bosh-director-worker |
+    grep -- "-n $1" |
+    awk '{print $1}' |
+    grep -v ^$1$
+}
+
+case ${ACTION} in
+  start)
+    mkdir -p $RUN_DIR $LOG_DIR $TMPDIR
+    chown -R $RUNAS:$RUNAS $RUN_DIR $LOG_DIR $TMPDIR
+
+    echo $$ > $PIDFILE
+
+    exec setpriv --reuid=$RUNAS --regid=$RUNAS --clear-groups \
+      -- /var/vcap/packages/director/bin/bosh-director-worker \
+      -c /var/vcap/jobs/director/config/director.yml -n $NAME \
+      >>$LOG_DIR/${NAME}.stdout.log \
+      2>>$LOG_DIR/${NAME}.stderr.log
+    ;;
+
+  stop)
+    if [ -f "${PIDFILE}" ]; then
+      PID=$(head -1 "${PIDFILE}")
+      kill_process $PID
+      for CHILD in $(list_child_processes $NAME); do
+        kill_process $CHILD
+      done
+      rm -f "${PIDFILE}"
+    fi
+    ;;
+
+  *)
+    echo "Usage: worker_ctl <worker_name> {start|stop}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
The warden CPI does not work under BPM for multiple reasons:
* needs priveledged container to run sudo, but then must setpriv to run as vcap so the blobstore-config can be accessed by the director
* needs /dev/ bind mounted into access loopback devices, but bind mounting /dev in causes other problems

Long term deprecating the warden CPI in favor of the docker CPI makes the most sense. In the short term this will do.

### Does this PR introduce a breaking change?

No