### PR TITLE
Derive GEM_HOME from ruby binary instead of hardcoding the version

### DIFF
--- a/jobs/director/templates/env.erb
+++ b/jobs/director/templates/env.erb
@@ -1,6 +1,6 @@
 source /var/vcap/packages/director-ruby-4.0/bosh/runtime.env
 export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
-export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/4.0.0
+export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/$(ruby -e 'puts Gem.ruby_api_version')
 
 <% if_p('env.http_proxy') do |http_proxy| %>
 export HTTP_PROXY=<%= http_proxy %>

--- a/jobs/health_monitor/templates/bpm.yml
+++ b/jobs/health_monitor/templates/bpm.yml
@@ -4,7 +4,6 @@ health_monitor_config = {
   "executable" => "/var/vcap/jobs/health_monitor/bin/health_monitor",
   "env" => {
     "BUNDLE_GEMFILE" => "/var/vcap/packages/health_monitor/Gemfile",
-    "GEM_HOME" => "/var/vcap/packages/health_monitor/gem_home/ruby/4.0.0",
   },
   "unsafe" => {
     "unrestricted_volumes" => [

--- a/jobs/health_monitor/templates/health_monitor
+++ b/jobs/health_monitor/templates/health_monitor
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 source /var/vcap/packages/director-ruby-4.0/bosh/runtime.env
+export GEM_HOME=/var/vcap/packages/health_monitor/gem_home/ruby/$(ruby -e 'puts Gem.ruby_api_version')
 exec /var/vcap/packages/health_monitor/bin/bosh-monitor -c /var/vcap/jobs/health_monitor/config/health_monitor.yml

--- a/jobs/nats/templates/bosh_nats_sync
+++ b/jobs/nats/templates/bosh_nats_sync
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 source /var/vcap/packages/director-ruby-4.0/bosh/runtime.env
+export GEM_HOME=/var/vcap/packages/nats/gem_home/ruby/$(ruby -e 'puts Gem.ruby_api_version')
 exec /var/vcap/packages/nats/bin/bosh-nats-sync -c /var/vcap/jobs/nats/config/bosh_nats_sync_config.yml

--- a/jobs/nats/templates/bpm.yml
+++ b/jobs/nats/templates/bpm.yml
@@ -6,7 +6,6 @@ bosh_nats_sync_config = {
   "ephemeral_disk" => true,
   "env" => {
     "BUNDLE_GEMFILE" => "/var/vcap/packages/nats/Gemfile",
-    "GEM_HOME" => "/var/vcap/packages/nats/gem_home/ruby/4.0.0",
   },
   "unsafe" => {
     "privileged" => true,


### PR DESCRIPTION
## Problem

When the director was switched to Ruby 4.0, three job templates hardcoded `ruby/4.0.0` as the `GEM_HOME` path suffix:

| File | Hardcoded value |
|---|---|
| `jobs/director/templates/env.erb` | `ruby/4.0.0` |
| `jobs/health_monitor/templates/bpm.yml` | `ruby/4.0.0` |
| `jobs/nats/templates/bpm.yml` | `ruby/4.0.0` |

Ruby 3.x always reports `Gem.ruby_api_version` as `X.Y.0` (patch = 0), so the hardcoded suffix worked before. Ruby 4.0.x changed this — it now includes the patch version: `4.0.5`, `4.0.6`, etc. Gems are bundled into `gem_home/ruby/4.0.6` but the director looked in `gem_home/ruby/4.0.0`, causing every Ruby-dependent job to fail to start:

```
not running after update: director, worker_1, worker_2, worker_3, health_monitor, credhub
```

Observed failures: brats-performance/564, bosh-disaster-recovery-acceptance-tests/568.

## Fix

Replace the hardcoded version suffix with a shell command substitution that asks the ruby binary from the package itself:

```bash
$(ruby -e 'puts Gem.ruby_api_version')
```

`ruby` is already in `PATH` when these expressions are evaluated because each script sources `runtime.env` from `director-ruby-4.0` first. The value is resolved at runtime and will automatically track any future Ruby 4.0.x patch bump without requiring a manual update.

Changes:
- `jobs/director/templates/env.erb` — fixes `director`, `scheduler`, `sync-dns`, `metrics-server`, and all worker processes (they all source this file)
- `jobs/health_monitor/templates/health_monitor` — dynamic `GEM_HOME` added after sourcing `runtime.env`
- `jobs/health_monitor/templates/bpm.yml` — hardcoded `GEM_HOME` removed (superseded by the startup script)
- `jobs/nats/templates/bosh_nats_sync` — dynamic `GEM_HOME` added after sourcing `runtime.env`
- `jobs/nats/templates/bpm.yml` — hardcoded `GEM_HOME` removed (superseded by the startup script)
