### PR TITLE
Use hard-coded GEM_HOME

### DIFF
--- a/jobs/director/templates/env.erb
+++ b/jobs/director/templates/env.erb
@@ -1,6 +1,6 @@
 source /var/vcap/packages/director-ruby-4.0/bosh/runtime.env
 export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
-export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/$(ruby -e 'puts Gem.ruby_api_version')
+export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/4.0.6
 
 <% if_p('env.http_proxy') do |http_proxy| %>
 export HTTP_PROXY=<%= http_proxy %>

--- a/jobs/health_monitor/templates/health_monitor
+++ b/jobs/health_monitor/templates/health_monitor
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 source /var/vcap/packages/director-ruby-4.0/bosh/runtime.env
-export GEM_HOME=/var/vcap/packages/health_monitor/gem_home/ruby/$(ruby -e 'puts Gem.ruby_api_version')
+export GEM_HOME=/var/vcap/packages/health_monitor/gem_home/ruby/4.0.6
 exec /var/vcap/packages/health_monitor/bin/bosh-monitor -c /var/vcap/jobs/health_monitor/config/health_monitor.yml

--- a/jobs/nats/templates/bosh_nats_sync
+++ b/jobs/nats/templates/bosh_nats_sync
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 source /var/vcap/packages/director-ruby-4.0/bosh/runtime.env
-export GEM_HOME=/var/vcap/packages/nats/gem_home/ruby/$(ruby -e 'puts Gem.ruby_api_version')
+export GEM_HOME=/var/vcap/packages/nats/gem_home/ruby/4.0.6
 exec /var/vcap/packages/nats/bin/bosh-nats-sync -c /var/vcap/jobs/nats/config/bosh_nats_sync_config.yml


### PR DESCRIPTION
Using `ruby` to extract the Ruby version has issues with compile v. runtime. Use hard-coded version for now.

