### PR TITLE
Use ruby package's runtime.env generation func

### DIFF
--- a/jobs/director/templates/env.erb
+++ b/jobs/director/templates/env.erb
@@ -1,6 +1,7 @@
 source /var/vcap/packages/director-ruby-4.0/bosh/runtime.env
+source /var/vcap/packages/director/bosh/runtime.env
+
 export BUNDLE_GEMFILE=/var/vcap/packages/director/Gemfile
-export GEM_HOME=/var/vcap/packages/director/gem_home/ruby/4.0.6
 
 <% if_p('env.http_proxy') do |http_proxy| %>
 export HTTP_PROXY=<%= http_proxy %>

--- a/jobs/health_monitor/templates/bpm.yml
+++ b/jobs/health_monitor/templates/bpm.yml
@@ -2,9 +2,7 @@
 health_monitor_config = {
   "name" => "health_monitor",
   "executable" => "/var/vcap/jobs/health_monitor/bin/health_monitor",
-  "env" => {
-    "BUNDLE_GEMFILE" => "/var/vcap/packages/health_monitor/Gemfile",
-  },
+  "env" => {},
   "unsafe" => {
     "unrestricted_volumes" => [
     {

--- a/jobs/health_monitor/templates/health_monitor
+++ b/jobs/health_monitor/templates/health_monitor
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 source /var/vcap/packages/director-ruby-4.0/bosh/runtime.env
-export GEM_HOME=/var/vcap/packages/health_monitor/gem_home/ruby/4.0.6
-exec /var/vcap/packages/health_monitor/bin/bosh-monitor -c /var/vcap/jobs/health_monitor/config/health_monitor.yml
+source /var/vcap/packages/health_monitor/bosh/runtime.env
+
+export BUNDLE_GEMFILE=/var/vcap/packages/health_monitor/Gemfile
+
+exec /var/vcap/packages/health_monitor/bin/bosh-monitor \
+  -c /var/vcap/jobs/health_monitor/config/health_monitor.yml

--- a/jobs/nats/templates/bosh_nats_sync
+++ b/jobs/nats/templates/bosh_nats_sync
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 source /var/vcap/packages/director-ruby-4.0/bosh/runtime.env
-export GEM_HOME=/var/vcap/packages/nats/gem_home/ruby/4.0.6
-exec /var/vcap/packages/nats/bin/bosh-nats-sync -c /var/vcap/jobs/nats/config/bosh_nats_sync_config.yml
+source /var/vcap/packages/nats/bosh/runtime.env
+
+export BUNDLE_GEMFILE=/var/vcap/packages/nats/Gemfile
+
+exec /var/vcap/packages/nats/bin/bosh-nats-sync \
+  -c /var/vcap/jobs/nats/config/bosh_nats_sync_config.yml

--- a/jobs/nats/templates/bpm.yml
+++ b/jobs/nats/templates/bpm.yml
@@ -4,9 +4,6 @@ bosh_nats_sync_config = {
   "name" => "bosh_nats_sync",
   "executable" => "/var/vcap/jobs/nats/bin/bosh_nats_sync",
   "ephemeral_disk" => true,
-  "env" => {
-    "BUNDLE_GEMFILE" => "/var/vcap/packages/nats/Gemfile",
-  },
   "unsafe" => {
     "privileged" => true,
     "host_pid_namespace" => true,

--- a/packages/director/packaging
+++ b/packages/director/packaging
@@ -34,6 +34,7 @@ bundle config set build.pg \
   --with-pg-include=$libpq_dir/include
 
 bosh_bundle_local
+bosh_generate_runtime_env
 
 cp Gemfile ${BOSH_INSTALL_TARGET}
 cp Gemfile.lock ${BOSH_INSTALL_TARGET}

--- a/packages/health_monitor/packaging
+++ b/packages/health_monitor/packaging
@@ -21,6 +21,7 @@ for gemspec in $( find . -maxdepth 2 -name *.gemspec ); do
 done
 
 bosh_bundle_local
+bosh_generate_runtime_env
 
 cp Gemfile ${BOSH_INSTALL_TARGET}
 cp Gemfile.lock ${BOSH_INSTALL_TARGET}

--- a/packages/nats/packaging
+++ b/packages/nats/packaging
@@ -28,6 +28,7 @@ for gemspec in $( find . -maxdepth 2 -name *.gemspec ); do
 done
 
 bosh_bundle_local
+bosh_generate_runtime_env
 
 cp Gemfile ${BOSH_INSTALL_TARGET}
 cp Gemfile.lock ${BOSH_INSTALL_TARGET}


### PR DESCRIPTION
- remove hard-coded GEM_HOME
- move BUNDLE_GEMFILE out of BPM into start scripts

Requires https://github.com/cloudfoundry/bosh-package-ruby-release/pull/66

**AND** ruby-package pipelines need to be (manually) run to regenerate various files.