### PR TITLE
packaging: copy `.bundle/confg` into package

### DIFF
--- a/packages/director/packaging
+++ b/packages/director/packaging
@@ -36,5 +36,4 @@ bundle config set build.pg \
 bosh_bundle_local
 bosh_generate_runtime_env
 
-cp Gemfile ${BOSH_INSTALL_TARGET}
-cp Gemfile.lock ${BOSH_INSTALL_TARGET}
+cp -vr Gemfile Gemfile.lock .bundle "${BOSH_INSTALL_TARGET}"

--- a/packages/health_monitor/packaging
+++ b/packages/health_monitor/packaging
@@ -23,5 +23,4 @@ done
 bosh_bundle_local
 bosh_generate_runtime_env
 
-cp Gemfile ${BOSH_INSTALL_TARGET}
-cp Gemfile.lock ${BOSH_INSTALL_TARGET}
+cp -vr Gemfile Gemfile.lock .bundle "${BOSH_INSTALL_TARGET}"

--- a/packages/nats/packaging
+++ b/packages/nats/packaging
@@ -30,5 +30,4 @@ done
 bosh_bundle_local
 bosh_generate_runtime_env
 
-cp Gemfile ${BOSH_INSTALL_TARGET}
-cp Gemfile.lock ${BOSH_INSTALL_TARGET}
+cp -vr Gemfile Gemfile.lock .bundle "${BOSH_INSTALL_TARGET}"


### PR DESCRIPTION
This file is created by the `bosh_bundle_local` function used to install gems during packaging, but because the function is not executed while in `$BOSH_INSTALL_TARGET` the `.bundle/` directory is not present in the package.

