### PR TITLE
Switch config-server resource to config-server-release repo

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1879,9 +1879,8 @@ resources:
   - name: config-server
     type: git
     source:
-      uri: git@github.com:cloudfoundry/config-server.git
-      branch: develop
-      private_key: ((github_deploy_key_config-server.private_key))
+      uri: https://github.com/cloudfoundry/config-server-release.git
+      branch: main
 
   #
   # BATS

--- a/src/spec/integration_support/config_server_service.rb
+++ b/src/spec/integration_support/config_server_service.rb
@@ -6,7 +6,7 @@ module IntegrationSupport
 
     LOCAL_CONFIG_SERVER_FILE_NAME = "bosh-config-server-executable"
 
-    SOURCE_DIR = File.join(IntegrationSupport::Constants::BOSH_REPO_PARENT_DIR, 'config-server')
+    SOURCE_DIR = File.join(IntegrationSupport::Constants::BOSH_REPO_PARENT_DIR, 'config-server', 'src', 'config-server')
 
     # Keys and Certs
     CERTS_DIR = File.join(IntegrationSupport::Constants::SANDBOX_ASSETS_DIR, 'config_server', 'certs')
@@ -47,7 +47,7 @@ module IntegrationSupport
     end
 
     def self.build_binary
-      raise "The config-server source must be a sibling to the BOSH Director repo" unless File.exist?(SOURCE_DIR)
+      raise "The config-server source must be available at #{SOURCE_DIR} (from config-server-release repo)" unless File.exist?(SOURCE_DIR)
 
       Dir.chdir(SOURCE_DIR) do
         system('go build .') || raise('Unable to build config-server')


### PR DESCRIPTION
The cloudfoundry/config-server repo has been archived; its contents were merged into cloudfoundry/config-server-release. Update the pipeline resource to use HTTPS against the new repo (removing the SSH deploy key), target the main branch, and update SOURCE_DIR in config_server_service.rb to point to src/config-server within the release repo where the Go source now lives.

