### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,5 +1,7 @@
 name: Run Specs
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   unit_specs:


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/bosh/security/code-scanning/31](https://github.com/cloudfoundry/bosh/security/code-scanning/31)

Add an explicit `permissions` block at the workflow root so it applies to both jobs consistently. The minimal least-privilege setting needed here is:

- `contents: read`

This preserves functionality (`actions/checkout` can still read repository contents) while preventing unintended write-capable token scopes.

Edit **`.github/workflows/ruby.yml`** near the top, directly after `on:` (or before `jobs:`), and add:

```yml
permissions:
  contents: read
```

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
