### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,9 @@
 name: go
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: lint


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/bosh/security/code-scanning/40](https://github.com/cloudfoundry/bosh/security/code-scanning/40)

Add an explicit `permissions` block in `.github/workflows/go.yml` at the workflow root so it applies to all jobs unless overridden. For this lint-only workflow, `contents: read` is the minimal appropriate permission and aligns with CodeQL’s recommendation.

Best single fix without changing functionality:
- Edit `.github/workflows/go.yml`
- Insert after the `on:` declaration (before `jobs:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or extra definitions are needed (YAML workflow file only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
