### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,5 +1,7 @@
 name: Run Specs
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   unit_specs:


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/bosh/security/code-scanning/23](https://github.com/cloudfoundry/bosh/security/code-scanning/23)

Add an explicit top-level `permissions` block in `.github/workflows/ruby.yml` so all jobs inherit least-privilege defaults.  
Best fix (without changing functionality): set:

- `contents: read`

This is sufficient for `actions/checkout` and test execution in this workflow. Place it near the top of the file (after `on:` is conventional), so both `unit_specs` and `unit_specs-director` inherit it automatically. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
