### PR TITLE
clean up stale terraform state

### DIFF
--- a/ci/bats/tasks/destroy-director.sh
+++ b/ci/bats/tasks/destroy-director.sh
@@ -26,8 +26,16 @@ export BOSH_ENVIRONMENT
 export BOSH_CA_CERT
 export BOSH_CLIENT_SECRET
 
-bosh-cli deployments --column name --json \
-  | jq -r ".Tables[0].Rows[].name" \
-  | xargs -n1 -I % bosh-cli -n -d '%' delete-deployment --force
-bosh-cli clean-up -n --all
-bosh-cli delete-env -n director-state/director.yml -l director-state/director-creds.yml
+# Attempt to clean up deployments — skip gracefully if director is unreachable
+if bosh-cli env 2>/dev/null; then
+  bosh-cli deployments --column name --json \
+    | jq -r '.Tables[0].Rows[].name // empty' \
+    | xargs -r -I% bosh-cli -n -d '%' delete-deployment --force
+  bosh-cli clean-up -n --all
+else
+  echo "Director is unreachable, skipping deployment and release cleanup"
+fi
+
+# --skip-drain: bypass drain/pre-stop scripts in case director jobs are unhealthy.
+# delete-env still contacts the BOSH agent for graceful stop, then deletes via CPI.
+bosh-cli delete-env --skip-drain -n director-state/director.yml -l director-state/director-creds.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -501,6 +501,13 @@ jobs:
                 terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
                 vars:
                   name: bats
+              on_failure:
+                task: delete-stale-terraform-state
+                file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
+                image: integration-image
+                params:
+                  GCP_JSON_KEY: ((gcp_json_key))
+                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bats.tfstate
             - task: cleanup-leftover-environments
               file: bosh-ci/ci/tasks/cleanup-leftovers.yml
               image: integration-image
@@ -527,6 +534,12 @@ jobs:
           # other env filters (e.g. bats-fips) or persistent GCS buckets in the project.
           LEFTOVERS_FILTER: bats
           GCP_JSON_KEY: ((gcp_json_key))
+      - task: delete-stale-terraform-state
+        file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
+        image: integration-image
+        params:
+          GCP_JSON_KEY: ((gcp_json_key))
+          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bats.tfstate
 
   - name: bats-fips
     old_name: fips-bats
@@ -596,6 +609,13 @@ jobs:
                 terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
                 vars:
                   name: fips-director
+              on_failure:
+                task: delete-stale-terraform-state
+                file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
+                image: integration-image
+                params:
+                  GCP_JSON_KEY: ((gcp_json_key))
+                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/fips-director.tfstate
             - task: cleanup-leftover-environments
               file: bosh-ci/ci/tasks/cleanup-leftovers.yml
               image: integration-image
@@ -625,6 +645,12 @@ jobs:
           # (e.g. "fips" alone would match bosh-core-stemcells-candidate-fips).
           LEFTOVERS_FILTER: fips-director
           GCP_JSON_KEY: ((gcp_json_key))
+      - task: delete-stale-terraform-state
+        file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
+        image: integration-image
+        params:
+          GCP_JSON_KEY: ((gcp_json_key))
+          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/fips-director.tfstate
 
   - name: brats-acceptance
     serial: true
@@ -689,6 +715,13 @@ jobs:
             terraform_source: bosh-ci/ci/shared/brats/terraform
             vars: *brats-terraform-vars
             action: destroy
+          on_failure:
+            task: delete-stale-terraform-state
+            file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
+            image: integration-image
+            params:
+              GCP_JSON_KEY: ((gcp_json_key))
+              TERRAFORM_STATE_URI: gs://bosh-director-pipeline/brats-terraform/brats-bosh-main.tfstate
 
   - name: brats-performance
     serial: true
@@ -822,6 +855,13 @@ jobs:
                 terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
                 vars:
                   name: upgrade-postgres
+              on_failure:
+                task: delete-stale-terraform-state
+                file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
+                image: integration-image
+                params:
+                  GCP_JSON_KEY: ((gcp_json_key))
+                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/upgrade-postgres.tfstate
             - task: cleanup-leftover-environments
               file: bosh-ci/ci/tasks/cleanup-leftovers.yml
               image: integration-image
@@ -843,6 +883,12 @@ jobs:
         params:
           LEFTOVERS_FILTER: upgrade-postgres
           GCP_JSON_KEY: ((gcp_json_key))
+      - task: delete-stale-terraform-state
+        file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
+        image: integration-image
+        params:
+          GCP_JSON_KEY: ((gcp_json_key))
+          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/upgrade-postgres.tfstate
 
   - name: upgrade-mysql
     serial: true
@@ -926,6 +972,13 @@ jobs:
                 terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
                 vars:
                   name: upgrade-mysql
+              on_failure:
+                task: delete-stale-terraform-state
+                file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
+                image: integration-image
+                params:
+                  GCP_JSON_KEY: ((gcp_json_key))
+                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/upgrade-mysql.tfstate
             - task: cleanup-leftover-environments
               file: bosh-ci/ci/tasks/cleanup-leftovers.yml
               image: integration-image
@@ -947,6 +1000,12 @@ jobs:
         params:
           LEFTOVERS_FILTER: upgrade-mysql
           GCP_JSON_KEY: ((gcp_json_key))
+      - task: delete-stale-terraform-state
+        file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
+        image: integration-image
+        params:
+          GCP_JSON_KEY: ((gcp_json_key))
+          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/upgrade-mysql.tfstate
 
   - name: delivery
     plan:

--- a/ci/tasks/delete-stale-terraform-state.sh
+++ b/ci/tasks/delete-stale-terraform-state.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+echo "${GCP_JSON_KEY}" > /tmp/gcp-key.json
+gcloud auth activate-service-account --key-file=/tmp/gcp-key.json
+
+# A missing state file means it was already cleaned up by a prior successful
+# terraform destroy, which is fine.
+gcloud storage rm "${TERRAFORM_STATE_URI}" || true

--- a/ci/tasks/delete-stale-terraform-state.yml
+++ b/ci/tasks/delete-stale-terraform-state.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+
+inputs:
+  - name: bosh-ci
+
+run:
+  path: bosh-ci/ci/tasks/delete-stale-terraform-state.sh
+
+params:
+  GCP_JSON_KEY:
+  TERRAFORM_STATE_URI:


### PR DESCRIPTION
This cleans up terraform state in cases where the underlying resources have already been deleted so terraform is failing to tear things down. It also runs after leftovers cleanup.