### PR TITLE
Pass UAA JWT public key to integration sandbox components

### DIFF
--- a/src/spec/assets/sandbox/director_test.yml.erb
+++ b/src/spec/assets/sandbox/director_test.yml.erb
@@ -90,23 +90,8 @@ user_management:
   uaa:
     symmetric_key: uaa-secret-key
     # public key of `uaa.jwt.policy.keys.key1.signingKey` from src/spec/assets/uaa_config/asymmetric/uaa.yml
-    # To Generate:
-    # openssl rsa -pubout -in <(yq .uaa.jwt.policy.keys.key1.signingKey src/spec/assets/uaa_config/asymmetric/uaa.yml)
     public_key: |
-      -----BEGIN PUBLIC KEY-----
-      MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA06hlEn4/NMWtnele3C5j
-      PZm3P55/9jppIQXF/BP0OGaAMoRNZEafv6nH1b8btc4zs0dx52Y7xmOpeRqnXDeD
-      3E2uTW0tgjsLQU8BbjlXRrKkzvUiYZqkaCkCMxcX5OcBvhT4Km+/1u4AGuFq9sS2
-      Pdv+IAWEOsYbJjPl3lZn2uiQCCX5P5z5JkGbQ/7mBSi/ja1SogP1MBzRLf6VyHpE
-      q7zvVnfm+oBsvPu2RC0EM14kL/TktQwyAvpL4TWunhE7gAh4j0fMNgmBfW9NG328
-      E2+i+1ag+WyFzSy0rJQHgV0ImEtjhmj0E0C1ysI4Fpy5gew0ZrtsFwnXcKV39xMS
-      EG3JLzV3h+QZ4BS9nBi/G8lLF3bWO/B0WTuYDWdkLm1ng3K/Oz0KhVkVG5Igu9FD
-      k6EkD62SsMYUMl++3/EMrtNxxvJQDSOOf59/o3BQplbl6qOG6Mpji3ZggxyRYgRS
-      iC7PPqJAKYrP3zCzeXyQEMMYxuOcmRR3W6aY341v+9Hs4w+zNJZ2DnB+r6Jaqhpi
-      sSiu1yzT0nzkesdv47UNLaTkt0fFMbnvkUSvtz3ZRK5MqVAgjBMULqobz5ASPPe0
-      RBg7V6023PHtyNxsJpxsobRG2aril4+7OOspiWSHIuoV1vm1IDs2utHak0GHY0Nc
-      MBYj/GcsUXZhHBDbjHk07IsCAwEAAQ==
-      -----END PUBLIC KEY-----
+<%= uaa_jwt_public_key.strip.split("\n").map { |l| "      #{l}" }.join("\n") %>
     url: <%= uaa_url %>
   <% else %>
   local:
@@ -156,6 +141,8 @@ config_server:
     client_id: <%= config_server_uaa_client_id %>
     client_secret: <%= config_server_uaa_client_secret %>
     ca_cert_path: <%= config_server_uaa_ca_cert_path %>
+    public_key: |
+<%= uaa_jwt_public_key.strip.split("\n").map { |l| "      #{l}" }.join("\n") %>
 <% end %>
 
 generate_vm_passwords: <%= generate_vm_passwords %>

--- a/src/spec/assets/sandbox/health_monitor.yml.erb
+++ b/src/spec/assets/sandbox/health_monitor.yml.erb
@@ -15,6 +15,8 @@ director: &director
   client_id: hm
   client_secret: secret
   director_ca_cert: <%= certificate_path %>
+  uaa_public_key: |
+<%= uaa_jwt_public_key.strip.split("\n").map { |l| "    #{l}" }.join("\n") %>
 
 intervals:
   poll_director: 5

--- a/src/spec/assets/sandbox/health_monitor_with_json_logging.yml.erb
+++ b/src/spec/assets/sandbox/health_monitor_with_json_logging.yml.erb
@@ -15,6 +15,8 @@ director: &director
   client_id: hm
   client_secret: secret
   director_ca_cert: <%= certificate_path %>
+  uaa_public_key: |
+<%= uaa_jwt_public_key.strip.split("\n").map { |l| "    #{l}" }.join("\n") %>
 
 intervals:
   poll_director: 5

--- a/src/spec/integration_support/config_server_helper.rb
+++ b/src/spec/integration_support/config_server_helper.rb
@@ -12,7 +12,8 @@ module IntegrationSupport
           'client_id' => sandbox.director_config.config_server_uaa_client_id,
           'client_secret' => sandbox.director_config.config_server_uaa_client_secret,
           'url' => sandbox.director_config.config_server_uaa_url,
-          'ca_cert_path' => sandbox.director_config.config_server_uaa_ca_cert_path
+          'ca_cert_path' => sandbox.director_config.config_server_uaa_ca_cert_path,
+          'public_key' => sandbox.director_config.uaa_jwt_public_key
       }
     end
 

--- a/src/spec/integration_support/director_config.rb
+++ b/src/spec/integration_support/director_config.rb
@@ -1,3 +1,4 @@
+require 'yaml'
 require 'integration_support/constants'
 require 'integration_support/uaa_service'
 
@@ -108,6 +109,13 @@ module IntegrationSupport
       @agent_wait_timeout = attrs.fetch(:agent_wait_timeout, 600)
       @preferred_cpi_api_version = attrs.fetch(:preferred_cpi_api_version)
       @keep_unreachable_vms = attrs.fetch(:keep_unreachable_vms, false)
+    end
+
+    def uaa_jwt_public_key
+      @uaa_jwt_public_key ||= YAML.load_file(
+        File.join(IntegrationSupport::Constants::BOSH_REPO_SRC_DIR,
+                  'spec', 'assets', 'uaa_config', 'asymmetric', 'uaa.yml'),
+      ).dig('uaa', 'jwt', 'policy', 'keys', 'key1', 'publicKey')
     end
 
     def render(template_path)

--- a/src/spec/integration_support/sandbox.rb
+++ b/src/spec/integration_support/sandbox.rb
@@ -700,6 +700,10 @@ module IntegrationSupport
       IntegrationSupport::UaaService::ROOT_CERT
     end
 
+    def uaa_jwt_public_key
+      @uaa_jwt_public_key ||= director_config.uaa_jwt_public_key
+    end
+
     attr_reader :director_tmp_path, :task_logs_dir
   end
 end


### PR DESCRIPTION
Add a uaa_jwt_public_key helper to Sandbox that reads the RSA public key from the asymmetric uaa.yml test fixture. Wire it into the sandbox config templates so the Director (config_server.uaa and user_management.uaa) and Health Monitor receive the key and can verify token signatures, eliminating the "Decoding token without verifying" warning during integration tests.

- [ ] https://bosh.ci.cloudfoundry.org/builds/370435094
