### PR TITLE
Fix PostgreSQL out-of-space in integration tests

### DIFF
--- a/ci/tasks/test-rake-task.sh
+++ b/ci/tasks/test-rake-task.sh
@@ -90,6 +90,7 @@ start_db() {
       export POSTGRES_ROOT="/tmp/postgres"
       export PGDATA="${POSTGRES_ROOT}/data"
       export PGLOGS="/tmp/log/postgres"
+      export PGWAL="/tmp/postgres_wal"
       export PGCLIENTENCODING="UTF8"
 
       # Ensure ${POSTGRES_ROOT} is its own 512M tmpfs mount before any other
@@ -119,13 +120,16 @@ start_db() {
       chown postgres:postgres "${POSTGRES_ROOT}"
 
       if [ ! -f "${PGDATA}/PG_VERSION" ]; then # PostgreSQL hasn't been initialized
+        rm -rf "${PGWAL}"
+        mkdir -p "${PGWAL}"
+        chown postgres:postgres "${PGWAL}"
         run_as postgres mkdir -p "${PGDATA}" "${PGLOGS}"
 
         POSTGRES_PASSWORD_FILE="${POSTGRES_ROOT}/bosh-postgres.password"
         echo "${DB_PASSWORD}" > "${POSTGRES_PASSWORD_FILE}"
         chown postgres:postgres "${POSTGRES_PASSWORD_FILE}"
         chown -R postgres:postgres "${PGDATA}"
-        run_as postgres "$(which initdb)" -U postgres -D "${PGDATA}" --pwfile "${POSTGRES_PASSWORD_FILE}"
+        run_as postgres "$(which initdb)" -U postgres -D "${PGDATA}" -X "${PGWAL}" --pwfile "${POSTGRES_PASSWORD_FILE}"
 
         # NOTE: certificates can only moved to ${PGDATA}/ _after_ `initdb` is run
         echo "Copy 'src/spec/assets/sandbox/database/database_server/{private_key,certificate.pem}' to '${PGDATA}'"
@@ -150,7 +154,7 @@ start_db() {
           echo "hostssl all all localhost password"
         } >> "${POSTGRES_PG_HBA}"
 
-        chown -R postgres:postgres "${PGDATA}" "${PGLOGS}"
+        chown -R postgres:postgres "${PGDATA}" "${PGLOGS}" "${PGWAL}"
       fi
 
       # Ensure the log directory exists; it is created during init but may be
@@ -182,6 +186,8 @@ start_db() {
         -c "ALTER SYSTEM SET fsync = off"
       run_as postgres "$(which psql)" -h "${DB_HOST}" -p "${DB_PORT}" -U postgres \
         -c "ALTER SYSTEM SET synchronous_commit = off"
+      run_as postgres "$(which psql)" -h "${DB_HOST}" -p "${DB_PORT}" -U postgres \
+        -c "ALTER SYSTEM SET full_page_writes = off"
       run_as postgres "$(which psql)" -h "${DB_HOST}" -p "${DB_PORT}" -U postgres \
         -c "SELECT pg_reload_conf()"
 


### PR DESCRIPTION
### What is this change about?

Fixes a `No space left on device` error during high-concurrency PostgreSQL integration tests (notably the `bosh-agent` pipeline).

**The problem:** #2770 moved the PostgreSQL data dir to a 512MB `tmpfs` (with `fsync=off`, `synchronous_commit=off`) for performance parity with MySQL, and #2773 switched teardown to `TRUNCATE`. But WAL is still written to `pg_wal` *inside* `PGDATA`, so under high concurrency it fills the 512MB `tmpfs` and Postgres hard-crashes. This passed in `bosh` only because `PARALLEL_TEST_MULTIPLY_PROCESSES` is throttled to `0.6`; it failed consistently in `bosh-agent` where concurrency is higher.

**The fix:** relocate the WAL directory *off* the tmpfs entirely via `initdb -X /tmp/postgres_wal`, so WAL no longer competes with table data for the 512MB budget.

An earlier revision of this PR instead tried to cap WAL in place with `max_wal_size = 128MB` / `min_wal_size = 32MB`. That was replaced because `max_wal_size` is a *soft* limit — Postgres overshoots it during checkpoints under exactly the write pressure that triggers the failure, so it can't guarantee the tmpfs won't fill. Relocation removes WAL from the tmpfs budget deterministically. Because `fsync` and `synchronous_commit` are already off, WAL writes stay in the OS page cache and flush lazily, so moving them to the container's disk-backed overlay (`/tmp`, which is per-container ephemeral storage in Concourse — not the 512MB tmpfs and not shared across runs) costs effectively nothing. `full_page_writes = off` is retained to further reduce WAL volume.

### Please provide contextual information.

- Builds on #2770 (tmpfs data dir) and #2773 (TRUNCATE teardown).
- Story: TNZ-88995.

### What tests have you run against this PR?

- Local: `bash -n ci/tasks/test-rake-task.sh` and `shellcheck ci/tasks/test-rake-task.sh` both pass clean.
- CI: the `test-rake-task` PostgreSQL jobs — the definitive check is the `bosh-agent` postgres run that was failing with ENOSPC.

### How should this change be described in bosh release notes?

N/A — CI/test-infrastructure only; no operator-facing impact.

### Does this PR introduce a breaking change?

No.

### Tag your pair, your PM, and/or team!

_(reviewer suggested by CodeRabbit: `@aramprice`)_

### AI Review Feedback

- `wal_level = minimal` (requires restart, conflicts with default `max_wal_senders`) — removed in an earlier commit; thread resolved.
- `max_wal_size` won't hard-cap the tmpfs — addressed by relocating the WAL off the tmpfs entirely (exactly what the comment recommended); thread resolved.
