### PR TITLE
address flakes in ci

### DIFF
--- a/src/spec/integration/director_scheduler_spec.rb
+++ b/src/spec/integration/director_scheduler_spec.rb
@@ -65,7 +65,6 @@ describe 'director_scheduler', type: :integration do
           event['user'] == 'scheduler' && event['object_type'] != 'lock'
         end
 
-        expect(events.length).to eq(2 * deployment_hash['instance_groups'][0]['instances'])
         event = {
           'id' => /[0-9]{1,}/,
           'time' => 'xxx xxx xx xx:xx:xx UTC xxxx',

--- a/src/spec/integration/links/network_resolution_spec.rb
+++ b/src/spec/integration/links/network_resolution_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'network resolution', type: :integration do
-  with_reset_sandbox_before_all
+  with_reset_sandbox_before_each
 
   def should_contain_network_for_job(job, template, pattern)
     my_api_instance = director.instance(job, '0', deployment_name: 'simple')

--- a/src/spec/shared/shared_support/mysql.rb
+++ b/src/spec/shared/shared_support/mysql.rb
@@ -61,7 +61,7 @@ module SharedSupport
     end
 
     def sql_results_for(sql, this_db_name = db_name)
-      %x{#{sql_cmd(sql, this_db_name)} 2> /dev/null}.lines.to_a[1..-1] || []
+      %x{#{sql_cmd(sql, this_db_name)} -N 2> /dev/null}.lines
     end
 
     def sql_cmd(sql, this_db_name)


### PR DESCRIPTION
- network tests go back to before each as they're modifying state
- remove event length assertion so we get a better failure message if the extra events show up again
- clean up mysql cmd to not emit a table header