### PR TITLE
Resolute pipeline

### DIFF
--- a/ci/bats/tasks/deploy-director.sh
+++ b/ci/bats/tasks/deploy-director.sh
@@ -35,11 +35,11 @@ fi
 
 "bosh-ci/ci/bats/iaas/${BAT_INFRASTRUCTURE}/director-vars" > director-vars.json
 
-# Name the director after its per-env terraform network (e.g. bats, fips-director,
-# upgrade-postgres, upgrade-mysql). The GCP CPI derives VM network tags from the
-# director name, so a per-env name keeps the "bats" substring off VMs in the
-# upgrade/fips jobs and prevents the bats job's `leftovers --filter bats` cleanup
-# from deleting them. Falls back to bats-director if metadata is unavailable.
+# Name the director after its per-env terraform network (e.g. bosh-bats-noble,
+# bosh-bats-jammy-fips, bosh-upgrade-postgres-noble). The GCP CPI derives VM
+# network tags from the director name, so a per-env name keeps each job's
+# `leftovers --filter <env name>` cleanup from reaching another job's VMs.
+# Falls back to bats-director if metadata is unavailable.
 director_name="bats-director"
 if [[ -e environment/metadata ]]; then
   network_name="$(jq -r '.network // empty' environment/metadata)"
@@ -48,15 +48,28 @@ if [[ -e environment/metadata ]]; then
   fi
 fi
 
+# local-bosh-release-tarball.yml comes after $DEPLOY_ARGS so the release under
+# test always wins: ops files such as bosh-deployment's
+# misc/use-compiled-*-releases.yml replace /releases/name=bosh with a shipped
+# release, which would otherwise silently swap out the candidate.
 bosh-cli interpolate bosh-deployment/bosh.yml \
   -o "bosh-deployment/${BAT_INFRASTRUCTURE}/cpi.yml" \
   -o bosh-deployment/jumpbox-user.yml \
-  -o bosh-deployment/local-bosh-release-tarball.yml \
   -v director_name="${director_name}" \
   -v local_bosh_release="$(realpath bosh-release/*.tgz)" \
   --vars-file director-vars.json \
   $DEPLOY_ARGS \
+  -o bosh-deployment/local-bosh-release-tarball.yml \
   > director.yml
+
+# Belt and braces for the ordering above, so a future ops file cannot quietly
+# deploy the wrong release.
+release_url="$(bosh-cli int director.yml --path /releases/name=bosh/url)"
+if [[ "${release_url}" != file://* ]]; then
+  echo "FATAL: director would deploy ${release_url}, not the candidate under test." >&2
+  echo "Something in DEPLOY_ARGS replaced /releases/name=bosh after local-bosh-release-tarball.yml." >&2
+  exit 1
+fi
 
 bosh-cli create-env \
   --state director-state.json \

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -20,19 +20,37 @@ groups:
       - integration-postgres-hotswap
       - integration-mysql
       - candidate-release
-      - create-bosh-candidate-release-compiled
-      - bats
-      - bats-cleanup-leftovers
-      - bats-fips
-      - bats-fips-cleanup-leftovers
-      - brats-acceptance
-      - brats-performance
-      - bosh-disaster-recovery-acceptance-tests
-      - upgrade-postgres
-      - upgrade-postgres-cleanup-leftovers
-      - upgrade-mysql
-      - upgrade-mysql-cleanup-leftovers
+      - create-bosh-candidate-release-compiled-noble
+      - bats-noble
+      - bats-noble-cleanup-leftovers
+      - bats-jammy-fips
+      - bats-jammy-fips-cleanup-leftovers
+      - brats-acceptance-noble
+      - brats-performance-noble
+      - bdrats-noble
+      - upgrade-postgres-noble
+      - upgrade-postgres-noble-cleanup-leftovers
+      - upgrade-mysql-noble
+      - upgrade-mysql-noble-cleanup-leftovers
       - delivery
+
+  - name: stemcell-noble
+    jobs:
+      - create-bosh-candidate-release-compiled-noble
+      - bats-noble
+      - bats-noble-cleanup-leftovers
+      - brats-acceptance-noble
+      - brats-performance-noble
+      - bdrats-noble
+      - upgrade-postgres-noble
+      - upgrade-postgres-noble-cleanup-leftovers
+      - upgrade-mysql-noble
+      - upgrade-mysql-noble-cleanup-leftovers
+
+  - name: stemcell-jammy-fips
+    jobs:
+      - bats-jammy-fips
+      - bats-jammy-fips-cleanup-leftovers
 
   - name: cut-release
     jobs:
@@ -435,7 +453,8 @@ jobs:
           file: "release/bosh-dev-release.tgz"
 
 
-  - name: create-bosh-candidate-release-compiled
+  - name: create-bosh-candidate-release-compiled-noble
+    old_name: create-bosh-candidate-release-compiled
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -450,26 +469,27 @@ jobs:
       - task: export-release
         file: bosh-deployment/ci/tasks/shared/bosh-agent-compile.yml
         image: ubuntu-noble-stemcell-registry-image
-      - put: bosh-candidate-release-compiled
+      - put: bosh-candidate-release-compiled-noble
         params:
           file: "compiled-release/*.tgz"
 
-  - name: bats
+  - name: bats-noble
+    old_name: bats
     serial: true
-    serial_groups: [ bats ]
+    serial_groups: [ bats-noble ]
     plan:
       - do:
           - in_parallel:
               - get: bosh-ci
               - get: integration-image
               - get: bosh-candidate-release-tarballs
-                passed: [ create-bosh-candidate-release-compiled ]
+                passed: [ create-bosh-candidate-release-compiled-noble ]
               - get: bosh-release
-                resource: bosh-candidate-release-compiled
+                resource: bosh-candidate-release-compiled-noble
                 trigger: true
-                passed: [ create-bosh-candidate-release-compiled ]
+                passed: [ create-bosh-candidate-release-compiled-noble ]
               - get: stemcell
-                resource: gcp-stemcell
+                resource: gcp-stemcell-noble
               - get: bosh-cli
                 params:
                   globs:
@@ -477,7 +497,7 @@ jobs:
               - get: bats
               - get: bosh-deployment
               - get: bosh
-                passed: [ create-bosh-candidate-release-compiled ]
+                passed: [ create-bosh-candidate-release-compiled-noble ]
           - put: terraform
             resource: gcp-terraform
             params:
@@ -496,6 +516,7 @@ jobs:
                   GCP_JSON_KEY: ((gcp_json_key))
                   DEPLOY_ARGS: |-
                     -o bosh-deployment/external-ip-not-recommended.yml
+                    -o bosh-ci/ci/bats/ops/use-custom-stemcell.yml
               - task: prepare-bats-config
                 file: bosh-ci/ci/bats/iaas/gcp/prepare-bats-config.yml
                 image: integration-image
@@ -536,9 +557,10 @@ jobs:
                 LEFTOVERS_FILTER: bosh-bats-noble
                 GCP_JSON_KEY: ((gcp_json_key))
 
-  - name: bats-cleanup-leftovers
+  - name: bats-noble-cleanup-leftovers
+    old_name: bats-cleanup-leftovers
     serial: true
-    serial_groups: [ bats ]
+    serial_groups: [ bats-noble ]
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -562,10 +584,10 @@ jobs:
           GCP_JSON_KEY: ((gcp_json_key))
           TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-bats-noble.tfstate
 
-  - name: bats-fips
-    old_name: fips-bats
+  - name: bats-jammy-fips
+    old_name: bats-fips
     serial: true
-    serial_groups: [ bats-fips ]
+    serial_groups: [ bats-jammy-fips ]
     plan:
       - do:
           - in_parallel:
@@ -575,11 +597,11 @@ jobs:
               - get: bosh-release
                 resource: bosh-candidate-release-tarballs
                 trigger: true
-                passed: [ create-bosh-candidate-release-compiled ]
-              - get: bosh-candidate-release-compiled
-                passed: [ create-bosh-candidate-release-compiled ]
+                passed: [ create-bosh-candidate-release-compiled-noble ]
+              - get: bosh-candidate-release-compiled-noble
+                passed: [ create-bosh-candidate-release-compiled-noble ]
               - get: stemcell
-                resource: gcp-stemcell-fips
+                resource: gcp-stemcell-jammy-fips
               - get: bosh-cli
                 params:
                   globs:
@@ -587,7 +609,7 @@ jobs:
               - get: bats
               - get: bosh-deployment
               - get: bosh
-                passed: [ create-bosh-candidate-release-compiled ]
+                passed: [ create-bosh-candidate-release-compiled-noble ]
           - put: terraform
             resource: gcp-terraform
             params:
@@ -648,10 +670,10 @@ jobs:
                 LEFTOVERS_FILTER: bosh-bats-jammy-fips
                 GCP_JSON_KEY: ((gcp_json_key))
 
-  - name: bats-fips-cleanup-leftovers
-    old_name: fips-bats-cleanup-leftovers
+  - name: bats-jammy-fips-cleanup-leftovers
+    old_name: bats-fips-cleanup-leftovers
     serial: true
-    serial_groups: [ bats-fips ]
+    serial_groups: [ bats-jammy-fips ]
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -675,27 +697,28 @@ jobs:
           GCP_JSON_KEY: ((gcp_json_key))
           TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-bats-jammy-fips.tfstate
 
-  - name: brats-acceptance
+  - name: brats-acceptance-noble
+    old_name: brats-acceptance
     serial: true
     plan:
       - in_parallel:
           - get: bosh-ci
           - get: integration-image
           - get: bosh
-            passed: [ create-bosh-candidate-release-compiled ]
+            passed: [ create-bosh-candidate-release-compiled-noble ]
           - get: bosh-dns-release
           - get: stemcell
-            resource: warden-stemcell
+            resource: warden-stemcell-noble
           - get: director-stemcell
-            resource: warden-stemcell
+            resource: warden-stemcell-noble
           - get: bosh-candidate-release-tarballs
-            passed: [ create-bosh-candidate-release-compiled ]
+            passed: [ create-bosh-candidate-release-compiled-noble ]
           - get: bosh-release
             resource: bosh-candidate-release-tarballs
-            passed: [ create-bosh-candidate-release-compiled ]
-          - get: bosh-candidate-release-compiled
+            passed: [ create-bosh-candidate-release-compiled-noble ]
+          - get: bosh-candidate-release-compiled-noble
             trigger: true
-            passed: [ create-bosh-candidate-release-compiled ]
+            passed: [ create-bosh-candidate-release-compiled-noble ]
           - get: bosh-deployment
           - get: docker-cpi-image
       - do:
@@ -751,23 +774,24 @@ jobs:
               GCP_JSON_KEY: ((gcp_json_key))
               TERRAFORM_STATE_URI: gs://bosh-director-pipeline/brats-terraform/bosh-brats-noble.tfstate
 
-  - name: brats-performance
+  - name: brats-performance-noble
+    old_name: brats-performance
     serial: true
     plan:
       - in_parallel:
           - get: bosh-ci
           - get: integration-image
           - get: bosh
-            passed: [ create-bosh-candidate-release-compiled ]
+            passed: [ create-bosh-candidate-release-compiled-noble ]
           - get: bosh-release
-            resource: bosh-candidate-release-compiled
+            resource: bosh-candidate-release-compiled-noble
             trigger: true
           - get: cf-deployment
           - get: docker-cpi-image
           - get: stemcell
-            resource: warden-stemcell
+            resource: warden-stemcell-noble
           - get: director-stemcell
-            resource: warden-stemcell
+            resource: warden-stemcell-noble
       - do:
           - task: test-brats-performance
             image: docker-cpi-image
@@ -777,21 +801,22 @@ jobs:
               DIRECTOR_STEMCELL_OS: ubuntu-noble
               STEMCELL_OS: ubuntu-noble
 
-  - name: bosh-disaster-recovery-acceptance-tests
+  - name: bdrats-noble
+    old_name: bosh-disaster-recovery-acceptance-tests
     plan:
       - in_parallel:
           - get: bosh-ci
           - get: integration-image
           - get: bosh
-            passed: [ create-bosh-candidate-release-compiled ]
+            passed: [ create-bosh-candidate-release-compiled-noble ]
           - get: stemcell
-            resource: warden-stemcell
+            resource: warden-stemcell-noble
           - get: bosh-candidate-release-tarballs
-            passed: [ create-bosh-candidate-release-compiled ]
+            passed: [ create-bosh-candidate-release-compiled-noble ]
           - get: bosh-release
-            resource: bosh-candidate-release-compiled
+            resource: bosh-candidate-release-compiled-noble
             trigger: true
-            passed: [ create-bosh-candidate-release-compiled ]
+            passed: [ create-bosh-candidate-release-compiled-noble ]
           - get: bosh-disaster-recovery-acceptance-tests
           - get: bosh-deployment
           - get: bbr-cli-binary
@@ -806,27 +831,28 @@ jobs:
             params:
               STEMCELL_OS: ubuntu-noble
 
-  - name: upgrade-postgres
+  - name: upgrade-postgres-noble
+    old_name: upgrade-postgres
     serial: true
-    serial_groups: [ upgrade-postgres ]
+    serial_groups: [ upgrade-postgres-noble ]
     plan:
       - do:
           - in_parallel:
               - get: bosh-ci
               - get: integration-image
               - get: bosh
-                passed: [ create-bosh-candidate-release-compiled ]
+                passed: [ create-bosh-candidate-release-compiled-noble ]
               - get: stemcell
-                resource: gcp-stemcell
+                resource: gcp-stemcell-noble
               - get: bosh-deployment
               - get: bosh-cli
                 params:
                   globs:
                     - "bosh-cli-*-linux-amd64"
               - get: bosh-release
-                resource: bosh-candidate-release-compiled
+                resource: bosh-candidate-release-compiled-noble
                 trigger: true
-                passed: [ create-bosh-candidate-release-compiled ]
+                passed: [ create-bosh-candidate-release-compiled-noble ]
               - get: last-released-bosh-release
               - get: zookeeper-release
           - put: terraform
@@ -899,8 +925,9 @@ jobs:
                 LEFTOVERS_FILTER: bosh-upgrade-postgres-noble
                 GCP_JSON_KEY: ((gcp_json_key))
 
-  - name: upgrade-postgres-cleanup-leftovers
-    serial_groups: [ upgrade-postgres ]
+  - name: upgrade-postgres-noble-cleanup-leftovers
+    old_name: upgrade-postgres-cleanup-leftovers
+    serial_groups: [ upgrade-postgres-noble ]
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -920,27 +947,28 @@ jobs:
           GCP_JSON_KEY: ((gcp_json_key))
           TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-upgrade-postgres-noble.tfstate
 
-  - name: upgrade-mysql
+  - name: upgrade-mysql-noble
+    old_name: upgrade-mysql
     serial: true
-    serial_groups: [ upgrade-mysql ]
+    serial_groups: [ upgrade-mysql-noble ]
     plan:
       - do:
           - in_parallel:
               - get: bosh-ci
               - get: integration-image
               - get: bosh
-                passed: [ create-bosh-candidate-release-compiled ]
+                passed: [ create-bosh-candidate-release-compiled-noble ]
               - get: stemcell
-                resource: gcp-stemcell
+                resource: gcp-stemcell-noble
               - get: bosh-deployment
               - get: bosh-cli
                 params:
                   globs:
                     - "bosh-cli-*-linux-amd64"
               - get: bosh-release
-                resource: bosh-candidate-release-compiled
+                resource: bosh-candidate-release-compiled-noble
                 trigger: true
-                passed: [ create-bosh-candidate-release-compiled ]
+                passed: [ create-bosh-candidate-release-compiled-noble ]
               - get: last-released-bosh-release
               - get: zookeeper-release
           - put: terraform
@@ -1016,8 +1044,9 @@ jobs:
                 LEFTOVERS_FILTER: bosh-upgrade-mysql-noble
                 GCP_JSON_KEY: ((gcp_json_key))
 
-  - name: upgrade-mysql-cleanup-leftovers
-    serial_groups: [ upgrade-mysql ]
+  - name: upgrade-mysql-noble-cleanup-leftovers
+    old_name: upgrade-mysql-cleanup-leftovers
+    serial_groups: [ upgrade-mysql-noble ]
     plan:
       - in_parallel:
           - get: bosh-ci
@@ -1043,11 +1072,11 @@ jobs:
           - get: bosh
             trigger: true
             passed:
-              - bats
-              - brats-acceptance
-              - bosh-disaster-recovery-acceptance-tests
-              - upgrade-postgres
-              - upgrade-mysql
+              - bats-noble
+              - brats-acceptance-noble
+              - bdrats-noble
+              - upgrade-postgres-noble
+              - upgrade-mysql-noble
 
   - name: finalize-release
     disable_manual_trigger: true
@@ -1908,7 +1937,7 @@ resources:
       json_key: ((bosh_director_oss_ci_service_account_json))
       versioned_file: "bosh-dev-release.tgz"
 
-  - name: bosh-candidate-release-compiled
+  - name: bosh-candidate-release-compiled-noble
     type: gcs-resource
     source:
       bucket: bosh-ci-candidate-compiled-releases
@@ -1999,12 +2028,12 @@ resources:
     source:
       uri: https://github.com/cloudfoundry/cf-deployment
 
-  - name: gcp-stemcell
+  - name: gcp-stemcell-noble
     type: bosh-io-stemcell
     source:
       name: bosh-google-kvm-ubuntu-noble
 
-  - name: gcp-stemcell-fips
+  - name: gcp-stemcell-jammy-fips
     type: bosh-io-stemcell
     source:
       name: bosh-google-kvm-ubuntu-jammy-fips-go_agent
@@ -2012,7 +2041,7 @@ resources:
         access_key: ((hmac_accesskey))
         secret_key: ((hmac_secret))
 
-  - name: warden-stemcell
+  - name: warden-stemcell-noble
     type: bosh-io-stemcell
     source:
       name: bosh-warden-boshlite-ubuntu-noble

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -481,10 +481,10 @@ jobs:
           - put: terraform
             resource: gcp-terraform
             params:
-              env_name: bats
+              env_name: bosh-bats-noble
               terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
               vars:
-                name: bats
+                name: bosh-bats-noble
           - do:
               - task: deploy-director
                 file: bosh-ci/ci/bats/tasks/deploy-director.yml
@@ -514,24 +514,26 @@ jobs:
               no_get: true
               params:
                 action: destroy
-                env_name: bats
+                env_name: bosh-bats-noble
                 terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
                 vars:
-                  name: bats
+                  name: bosh-bats-noble
               on_failure:
                 task: delete-stale-terraform-state
                 file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
                 image: integration-image
                 params:
                   GCP_JSON_KEY: ((gcp_json_key))
-                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bats.tfstate
+                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-bats-noble.tfstate
             - task: cleanup-leftover-environments
               file: bosh-ci/ci/tasks/cleanup-leftovers.yml
               image: integration-image
               params:
-                # NOTE: leftovers uses substring matching. This filter must not match
-                # other env filters (e.g. bats-fips) or persistent GCS buckets in the project.
-                LEFTOVERS_FILTER: bats
+                # NOTE: leftovers uses substring matching. Env names are "bosh-" plus
+                # the job name, and every stemcell-specific name carries its stemcell
+                # line, so no filter matches another env of ours and none is broad
+                # enough to reach another pipeline's resources in this GCP project.
+                LEFTOVERS_FILTER: bosh-bats-noble
                 GCP_JSON_KEY: ((gcp_json_key))
 
   - name: bats-cleanup-leftovers
@@ -547,16 +549,18 @@ jobs:
         file: bosh-ci/ci/tasks/cleanup-leftovers.yml
         image: integration-image
         params:
-          # NOTE: leftovers uses substring matching. This filter must not match
-          # other env filters (e.g. bats-fips) or persistent GCS buckets in the project.
-          LEFTOVERS_FILTER: bats
+          # NOTE: leftovers uses substring matching. Env names are "bosh-" plus
+          # the job name, and every stemcell-specific name carries its stemcell
+          # line, so no filter matches another env of ours and none is broad
+          # enough to reach another pipeline's resources in this GCP project.
+          LEFTOVERS_FILTER: bosh-bats-noble
           GCP_JSON_KEY: ((gcp_json_key))
       - task: delete-stale-terraform-state
         file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
         image: integration-image
         params:
           GCP_JSON_KEY: ((gcp_json_key))
-          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bats.tfstate
+          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-bats-noble.tfstate
 
   - name: bats-fips
     old_name: fips-bats
@@ -587,10 +591,10 @@ jobs:
           - put: terraform
             resource: gcp-terraform
             params:
-              env_name: fips-director
+              env_name: bosh-bats-jammy-fips
               terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
               vars:
-                name: fips-director
+                name: bosh-bats-jammy-fips
           - do:
               - task: deploy-director
                 file: bosh-ci/ci/bats/tasks/deploy-director.yml
@@ -622,25 +626,26 @@ jobs:
               no_get: true
               params:
                 action: destroy
-                env_name: fips-director
+                env_name: bosh-bats-jammy-fips
                 terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
                 vars:
-                  name: fips-director
+                  name: bosh-bats-jammy-fips
               on_failure:
                 task: delete-stale-terraform-state
                 file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
                 image: integration-image
                 params:
                   GCP_JSON_KEY: ((gcp_json_key))
-                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/fips-director.tfstate
+                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-bats-jammy-fips.tfstate
             - task: cleanup-leftover-environments
               file: bosh-ci/ci/tasks/cleanup-leftovers.yml
               image: integration-image
               params:
-                # NOTE: leftovers uses substring matching. This filter must not be a
-                # substring of other env filters or persistent GCS buckets in the project
-                # (e.g. "fips" alone would match bosh-core-stemcells-candidate-fips).
-                LEFTOVERS_FILTER: fips-director
+                # NOTE: leftovers uses substring matching. Env names are "bosh-" plus
+                # the job name, and every stemcell-specific name carries its stemcell
+                # line, so no filter matches another env of ours and none is broad
+                # enough to reach another pipeline's resources in this GCP project.
+                LEFTOVERS_FILTER: bosh-bats-jammy-fips
                 GCP_JSON_KEY: ((gcp_json_key))
 
   - name: bats-fips-cleanup-leftovers
@@ -657,17 +662,18 @@ jobs:
         file: bosh-ci/ci/tasks/cleanup-leftovers.yml
         image: integration-image
         params:
-          # NOTE: leftovers uses substring matching. This filter must not be a
-          # substring of other env filters or persistent GCS buckets in the project
-          # (e.g. "fips" alone would match bosh-core-stemcells-candidate-fips).
-          LEFTOVERS_FILTER: fips-director
+          # NOTE: leftovers uses substring matching. Env names are "bosh-" plus
+          # the job name, and every stemcell-specific name carries its stemcell
+          # line, so no filter matches another env of ours and none is broad
+          # enough to reach another pipeline's resources in this GCP project.
+          LEFTOVERS_FILTER: bosh-bats-jammy-fips
           GCP_JSON_KEY: ((gcp_json_key))
       - task: delete-stale-terraform-state
         file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
         image: integration-image
         params:
           GCP_JSON_KEY: ((gcp_json_key))
-          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/fips-director.tfstate
+          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-bats-jammy-fips.tfstate
 
   - name: brats-acceptance
     serial: true
@@ -695,7 +701,12 @@ jobs:
       - do:
           - put: brats-terraform
             params:
-              env_name: &brats_env_name brats-bosh-main
+              # Spelled out at each use, like every other env in this pipeline:
+              # the env name is the one thing that must change when a job is
+              # copied for another stemcell line, so a shared anchor for it
+              # would survive the copy unnoticed. The credentials below are
+              # identical across lines, so those stay anchored.
+              env_name: bosh-brats-noble
               terraform_source: bosh-ci/ci/shared/brats/terraform
               vars: &brats-terraform-vars
                 aws_access_key_id: ((brats_rds_terraform_aws_access_key.username))
@@ -728,7 +739,7 @@ jobs:
           put: brats-terraform
           no_get: true
           params:
-            env_name: *brats_env_name
+            env_name: bosh-brats-noble
             terraform_source: bosh-ci/ci/shared/brats/terraform
             vars: *brats-terraform-vars
             action: destroy
@@ -738,7 +749,7 @@ jobs:
             image: integration-image
             params:
               GCP_JSON_KEY: ((gcp_json_key))
-              TERRAFORM_STATE_URI: gs://bosh-director-pipeline/brats-terraform/brats-bosh-main.tfstate
+              TERRAFORM_STATE_URI: gs://bosh-director-pipeline/brats-terraform/bosh-brats-noble.tfstate
 
   - name: brats-performance
     serial: true
@@ -792,6 +803,8 @@ jobs:
             image: warden-cpi-image
             file: bosh-ci/ci/tasks/test-bdrats.yml
             privileged: true
+            params:
+              STEMCELL_OS: ubuntu-noble
 
   - name: upgrade-postgres
     serial: true
@@ -819,10 +832,10 @@ jobs:
           - put: terraform
             resource: gcp-terraform
             params:
-              env_name: upgrade-postgres
+              env_name: bosh-upgrade-postgres-noble
               terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
               vars:
-                name: upgrade-postgres
+                name: bosh-upgrade-postgres-noble
       - do:
           - task: deploy-previous-version
             image: integration-image
@@ -868,22 +881,22 @@ jobs:
               no_get: true
               params:
                 action: destroy
-                env_name: upgrade-postgres
+                env_name: bosh-upgrade-postgres-noble
                 terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
                 vars:
-                  name: upgrade-postgres
+                  name: bosh-upgrade-postgres-noble
               on_failure:
                 task: delete-stale-terraform-state
                 file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
                 image: integration-image
                 params:
                   GCP_JSON_KEY: ((gcp_json_key))
-                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/upgrade-postgres.tfstate
+                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-upgrade-postgres-noble.tfstate
             - task: cleanup-leftover-environments
               file: bosh-ci/ci/tasks/cleanup-leftovers.yml
               image: integration-image
               params:
-                LEFTOVERS_FILTER: upgrade-postgres
+                LEFTOVERS_FILTER: bosh-upgrade-postgres-noble
                 GCP_JSON_KEY: ((gcp_json_key))
 
   - name: upgrade-postgres-cleanup-leftovers
@@ -898,14 +911,14 @@ jobs:
         file: bosh-ci/ci/tasks/cleanup-leftovers.yml
         image: integration-image
         params:
-          LEFTOVERS_FILTER: upgrade-postgres
+          LEFTOVERS_FILTER: bosh-upgrade-postgres-noble
           GCP_JSON_KEY: ((gcp_json_key))
       - task: delete-stale-terraform-state
         file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
         image: integration-image
         params:
           GCP_JSON_KEY: ((gcp_json_key))
-          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/upgrade-postgres.tfstate
+          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-upgrade-postgres-noble.tfstate
 
   - name: upgrade-mysql
     serial: true
@@ -933,10 +946,10 @@ jobs:
           - put: terraform
             resource: gcp-terraform
             params:
-              env_name: upgrade-mysql
+              env_name: bosh-upgrade-mysql-noble
               terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
               vars:
-                name: upgrade-mysql
+                name: bosh-upgrade-mysql-noble
                 create_mysql_db: true
       - do:
           - task: deploy-previous-version
@@ -985,22 +998,22 @@ jobs:
               no_get: true
               params:
                 action: destroy
-                env_name: upgrade-mysql
+                env_name: bosh-upgrade-mysql-noble
                 terraform_source: bosh-ci/ci/bats/iaas/gcp/terraform
                 vars:
-                  name: upgrade-mysql
+                  name: bosh-upgrade-mysql-noble
               on_failure:
                 task: delete-stale-terraform-state
                 file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
                 image: integration-image
                 params:
                   GCP_JSON_KEY: ((gcp_json_key))
-                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/upgrade-mysql.tfstate
+                  TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-upgrade-mysql-noble.tfstate
             - task: cleanup-leftover-environments
               file: bosh-ci/ci/tasks/cleanup-leftovers.yml
               image: integration-image
               params:
-                LEFTOVERS_FILTER: upgrade-mysql
+                LEFTOVERS_FILTER: bosh-upgrade-mysql-noble
                 GCP_JSON_KEY: ((gcp_json_key))
 
   - name: upgrade-mysql-cleanup-leftovers
@@ -1015,14 +1028,14 @@ jobs:
         file: bosh-ci/ci/tasks/cleanup-leftovers.yml
         image: integration-image
         params:
-          LEFTOVERS_FILTER: upgrade-mysql
+          LEFTOVERS_FILTER: bosh-upgrade-mysql-noble
           GCP_JSON_KEY: ((gcp_json_key))
       - task: delete-stale-terraform-state
         file: bosh-ci/ci/tasks/delete-stale-terraform-state.yml
         image: integration-image
         params:
           GCP_JSON_KEY: ((gcp_json_key))
-          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/upgrade-mysql.tfstate
+          TERRAFORM_STATE_URI: gs://bosh-director-pipeline/bats-terraform/bosh-upgrade-mysql-noble.tfstate
 
   - name: delivery
     plan:

--- a/ci/shared/brats/test-acceptance.yml
+++ b/ci/shared/brats/test-acceptance.yml
@@ -34,5 +34,9 @@ params:
   GCP_POSTGRES_EXTERNAL_DB_PASSWORD: replace-me
   GCP_POSTGRES_EXTERNAL_DB_NAME: replace-me
   GCP_PRIVATE_NETWORK_NAME: replace-me
-  STEMCELL_OS: ""
+  # Both are read by test-acceptance.sh under `set -u` and are left unbound on
+  # purpose: every job sets them explicitly for its stemcell line, so a missing
+  # one fails loudly instead of quietly testing another line's stemcell.
+  DIRECTOR_STEMCELL_OS:
+  STEMCELL_OS:
   START_INNER_BOSH_TIMEOUT: "" # default is 25m

--- a/ci/shared/brats/test-performance.yml
+++ b/ci/shared/brats/test-performance.yml
@@ -13,6 +13,11 @@ inputs:
 params:
   FOCUS_SPEC:
   START_INNER_BOSH_TIMEOUT: "" # default is 25m
+  # Both are read by test-performance.sh under `set -u` and are left unbound on
+  # purpose: every job sets them explicitly for its stemcell line, so a missing
+  # one fails loudly instead of quietly testing another line's stemcell.
+  DIRECTOR_STEMCELL_OS:
+  STEMCELL_OS:
 
 run:
   path: bosh-ci/ci/shared/brats/test-performance.sh

--- a/ci/tasks/test-bdrats.sh
+++ b/ci/tasks/test-bdrats.sh
@@ -43,7 +43,6 @@ source /tmp/local-bosh/director/env
 BOSH_SSH_KEY="$(bosh int /tmp/local-bosh/director/creds.yml --path /jumpbox_ssh/private_key --json | jq .Blocks[0])"
 BOSH_HOST="${BOSH_ENVIRONMENT}"
 
-stemcell_os="$(cut -d- -f8-9 < stemcell/url | sed 's/\.tgz//')"
 bosh_ca_cert_json_value="$(awk '{printf "%s\\n", $0}' "${BOSH_CA_CERT}")"
 
 cat > integration-config.json <<EOF
@@ -56,7 +55,7 @@ cat > integration-config.json <<EOF
   "bosh_ca_cert": "${bosh_ca_cert_json_value}",
   "timeout_in_minutes": 30,
   "stemcell_src": "${STEMCELL_PATH}",
-  "stemcell_os": "${stemcell_os}",
+  "stemcell_os": "${STEMCELL_OS}",
   "include_deployment_testcase": true,
   "include_truncate_db_blobstore_testcase": true
 }

--- a/ci/tasks/test-bdrats.yml
+++ b/ci/tasks/test-bdrats.yml
@@ -12,3 +12,8 @@ inputs:
 
 run:
   path: bosh-ci/ci/tasks/test-bdrats.sh
+
+params:
+  # Left unbound on purpose: every job sets it explicitly for its stemcell line,
+  # so a missing one fails loudly instead of quietly testing another line.
+  STEMCELL_OS:


### PR DESCRIPTION
### What is this change about?

This PR is getting the bosh pipeline ready for a Resolute stemcell line. Instead of reproducing the pain of the hard Noble cutover we're making stemcell lines conceptually an array wherever possible. This cleans up the current tests to go into either -noble or -jammy-fips, and makes room for adding a -resolute. 

- Rename every terraform env / leftovers filter / tfstate path to
      "bosh-" + job name + stemcell line (e.g. bats -> bosh-bats-noble,
      fips-director -> bosh-bats-jammy-fips). The leftovers tool matches
      by substring, so short names like "bats" risked one job's teardown
      deleting another job's live GCP resources. Long, line-specific names
      make that impossible by construction, and replace four warning
      comments with one statement of the rule.
- Declare DIRECTOR_STEMCELL_OS / STEMCELL_OS in the brats task files.
      The scripts already required them but the task files didn't say so.
      Left unbound so a job that forgets one fails loudly instead of
      quietly testing the wrong stemcell.
- Pass the stemcell OS to bdrats as a parameter instead of guessing it
      by chopping the download URL into hyphen-separated fields, which
      produced wrong answers for names like ubuntu-jammy-fips.
- Apply the candidate bosh release last when building the bats
      director manifest, and fail the job if the manifest ends up pointing
      at anything other than the local candidate. Previously an added ops
      file could silently swap the release under test for a shipped one
      and the job would pass having tested nothing.
- Until now "bats" implicitly meant Noble and "bats-fips" meant
Jammy-FIPS, so a third stemcell line had no obvious name to take.
Every job and resource that puts a stemcell under test now says which
one: bats -> bats-noble, bats-fips -> bats-jammy-fips,
brats-acceptance -> brats-acceptance-noble, gcp-stemcell ->
gcp-stemcell-noble, and so on. The long
bosh-disaster-recovery-acceptance-tests job becomes bdrats-noble,
which also stops the job and its git resource sharing a name.
- Renamed jobs carry old_name so Concourse keeps their build history,
and every passed:, serial_groups: and group listing was updated in
step.
- Two new groups, stemcell-noble and stemcell-jammy-fips, collect the
jobs belonging to each line, so adding a line is adding a group and
copying the jobs it lists.
- bats-jammy-fips already deploys its director onto the stemcell the job
fetched; bats-noble instead got whatever bosh-deployment currently
defaults to, which happened to be the same stemcell by coincidence.
Both bats jobs now use the same ops file, so every stemcell line
tests one stemcell in both roles and a new line needs no extra flag.
### Please provide contextual information.

### What tests have you run against this PR?

None, it's all pipeline changes that will be flown after this is merged.

### Does this PR introduce a breaking change?

No