### PR TITLE
Fix timing-sensitive flake in NATSSync::Runner spec

### DIFF
--- a/src/bosh-nats-sync/spec/nats_sync/runner_spec.rb
+++ b/src/bosh-nats-sync/spec/nats_sync/runner_spec.rb
@@ -58,13 +58,18 @@ describe NATSSync::Runner do
       error = StandardError.new('exception')
       error.set_backtrace(['backtrace'])
 
+      shutdown_called = false
+      mutex = Mutex.new
+      cond = ConditionVariable.new
       allow(user_sync_instance).to receive(:execute_users_sync).and_raise(error)
       allow(user_sync_class).to receive(:reload_nats_server_config)
       allow(user_sync_class).to receive(:new).and_return(user_sync_instance)
-      Thread.new do
-        subject.run
+      allow(scheduler).to receive(:shutdown).and_wrap_original do |original|
+        mutex.synchronize { shutdown_called = true; cond.signal }
+        original.call
       end
-      sleep(2)
+      Thread.new { subject.run }
+      mutex.synchronize { cond.wait(mutex, 10) unless shutdown_called }
     end
 
     context 'when an error occurs' do

--- a/src/bosh-nats-sync/spec/nats_sync/runner_spec.rb
+++ b/src/bosh-nats-sync/spec/nats_sync/runner_spec.rb
@@ -27,13 +27,16 @@ describe NATSSync::Runner do
 
     let(:file_path) { '/var/vcap/data/nats/auth.json' }
     before do
-      allow(user_sync_instance).to receive(:execute_users_sync)
+      called = false
+      mutex = Mutex.new
+      cond = ConditionVariable.new
+      allow(user_sync_instance).to receive(:execute_users_sync) do
+        mutex.synchronize { called = true; cond.signal }
+      end
       allow(user_sync_class).to receive(:reload_nats_server_config)
       allow(user_sync_class).to receive(:new).and_return(user_sync_instance)
-      Thread.new do
-        subject.run
-      end
-      sleep(2)
+      Thread.new { subject.run }
+      mutex.synchronize { cond.wait(mutex, 10) unless called }
     end
 
     it 'should start UsersSync.execute_nats_sync function with the same parameters defined in the file' do

--- a/src/bosh-nats-sync/spec/nats_sync/runner_spec.rb
+++ b/src/bosh-nats-sync/spec/nats_sync/runner_spec.rb
@@ -65,8 +65,9 @@ describe NATSSync::Runner do
       allow(user_sync_class).to receive(:reload_nats_server_config)
       allow(user_sync_class).to receive(:new).and_return(user_sync_instance)
       allow(scheduler).to receive(:shutdown).and_wrap_original do |original|
-        mutex.synchronize { shutdown_called = true; cond.signal }
         original.call
+      ensure
+        mutex.synchronize { shutdown_called = true; cond.signal }
       end
       Thread.new { subject.run }
       mutex.synchronize { cond.wait(mutex, 10) unless shutdown_called }


### PR DESCRIPTION
## Summary

- Replaces the fragile `sleep(2)` in `runner_spec.rb` with a `Mutex`/`ConditionVariable` wait that blocks until `execute_users_sync` is actually called (up to a 10-second timeout)
- The `bump-deps` job has been failing on builds 238–240 because in a loaded CI environment the Rufus Scheduler thread doesn't always get CPU time to fire its first 1-second interval within the fixed 2-second window, causing the spec to observe 0 calls

## Test plan

- [x] Patched the failing spec directly in build 240's container and confirmed `3 examples, 0 failures`
- [x] Re-ran the full `spec:unit:parallel` suite in the same container: `7265 examples, 0 failures, 11 pendings` (exit code 0)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)