### PR TITLE
brats: run syslog-forwarder under bpm

### DIFF
--- a/ci/shared/brats/test-acceptance.yml
+++ b/ci/shared/brats/test-acceptance.yml
@@ -39,4 +39,4 @@ params:
   # one fails loudly instead of quietly testing another line's stemcell.
   DIRECTOR_STEMCELL_OS:
   STEMCELL_OS:
-  START_INNER_BOSH_TIMEOUT: "" # default is 25m
+  START_INNER_BOSH_TIMEOUT: "" # default is 30m

--- a/src/brats/acceptance/blobstore_test.go
+++ b/src/brats/acceptance/blobstore_test.go
@@ -29,7 +29,8 @@ var _ = Describe("Blobstore", func() {
 				fmt.Sprintf("-v agent_blobstore_endpoint=%s://%s:25250", schema, utils.InnerDirectorIP()),
 			)
 
-			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.27")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36")
 			utils.UploadStemcell(candidateWardenLinuxStemcellPath)
 
 			session := utils.Bosh("-n", "deploy", utils.AssetPath("syslog-manifest.yml"),
@@ -112,7 +113,8 @@ var _ = Describe("Blobstore", func() {
 				fmt.Sprintf("-o %s", utils.BoshDeploymentAssetPath("enable-signed-urls.yml")),
 				fmt.Sprintf("-o %s", utils.AssetPath("ops-enable-signed-urls-cpi.yml")),
 			)
-			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.27")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36")
 			utils.UploadStemcell(candidateWardenLinuxStemcellPath)
 
 			By("compiling (by deploying)")
@@ -153,7 +155,8 @@ var _ = Describe("Blobstore", func() {
 			utils.StartInnerBosh(
 				fmt.Sprintf("-o %s", utils.BoshDeploymentAssetPath("enable-signed-urls.yml")),
 			)
-			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.27")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36")
 			utils.UploadStemcell(candidateWardenLinuxStemcellPath)
 
 			By("compiling (by deploying)")

--- a/src/brats/assets/syslog-manifest.yml
+++ b/src/brats/assets/syslog-manifest.yml
@@ -4,6 +4,8 @@ name: syslog-deployment
 releases:
 - name: syslog
   version: latest
+- name: bpm
+  version: latest
 
 stemcells:
 - alias: default
@@ -39,7 +41,11 @@ instance_groups:
   networks:
   - {name: default}
   jobs:
+  - name: bpm
+    release: bpm
   - name: syslog_forwarder
     release: syslog
     consumes:
       syslog_storer: { from: syslog_storer }
+    properties:
+      use_bpm: true

--- a/src/brats/utils/utils.go
+++ b/src/brats/utils/utils.go
@@ -74,7 +74,7 @@ func Bootstrap() {
 	AssertEnvExists("BOSH_ENVIRONMENT")
 	AssertEnvExists("BOSH_DEPLOYMENT_PATH")
 
-	startInnerBoshTimeoutString := LoadEnvOrDefault("START_INNER_BOSH_TIMEOUT", "25m")
+	startInnerBoshTimeoutString := LoadEnvOrDefault("START_INNER_BOSH_TIMEOUT", "30m")
 	var err error
 	startInnerBoshTimeout, err = time.ParseDuration(startInnerBoshTimeoutString)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- this is necessary to get brats passing on Resolute
- it's ok for it to run under BPM on all stemcell lines, since we're controlling the manifest and there will not be other copies of BPM to conflict
- up the compile timeout a little, hopefully 30 minutes is enough even when when CI is overloaded

### What tests have you run against this PR?

None, need to test it in CI

### Does this PR introduce a breaking change?

No