### PR TITLE
brats: fix upgrade from postgres 13 test

### DIFF
--- a/ci/shared/brats/test-acceptance.yml
+++ b/ci/shared/brats/test-acceptance.yml
@@ -39,4 +39,4 @@ params:
   # one fails loudly instead of quietly testing another line's stemcell.
   DIRECTOR_STEMCELL_OS:
   STEMCELL_OS:
-  START_INNER_BOSH_TIMEOUT: "" # default is 25m
+  START_INNER_BOSH_TIMEOUT: "" # default is 30m

--- a/src/brats/acceptance/blobstore_test.go
+++ b/src/brats/acceptance/blobstore_test.go
@@ -29,7 +29,8 @@ var _ = Describe("Blobstore", func() {
 				fmt.Sprintf("-v agent_blobstore_endpoint=%s://%s:25250", schema, utils.InnerDirectorIP()),
 			)
 
-			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.27")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36")
 			utils.UploadStemcell(candidateWardenLinuxStemcellPath)
 
 			session := utils.Bosh("-n", "deploy", utils.AssetPath("syslog-manifest.yml"),
@@ -112,7 +113,8 @@ var _ = Describe("Blobstore", func() {
 				fmt.Sprintf("-o %s", utils.BoshDeploymentAssetPath("enable-signed-urls.yml")),
 				fmt.Sprintf("-o %s", utils.AssetPath("ops-enable-signed-urls-cpi.yml")),
 			)
-			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.27")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36")
 			utils.UploadStemcell(candidateWardenLinuxStemcellPath)
 
 			By("compiling (by deploying)")
@@ -153,7 +155,8 @@ var _ = Describe("Blobstore", func() {
 			utils.StartInnerBosh(
 				fmt.Sprintf("-o %s", utils.BoshDeploymentAssetPath("enable-signed-urls.yml")),
 			)
-			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.27")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36")
 			utils.UploadStemcell(candidateWardenLinuxStemcellPath)
 
 			By("compiling (by deploying)")

--- a/src/brats/assets/postgres-13-manifest.yml
+++ b/src/brats/assets/postgres-13-manifest.yml
@@ -5,7 +5,7 @@ instance_groups:
   azs: [z1]
   instances: 1
   jobs:
-  - name: postgres
+  - name: postgres-13
     release: bosh
   - name: bpm
     release: bpm
@@ -27,9 +27,9 @@ stemcells:
 
 releases:
 - name: "bosh"
-  version: "276.1.1"
-  url: "https://bosh.io/d/github.com/cloudfoundry/bosh?v=276.1.1"
-  sha1: "f9a625dd8a8fc6e01f1641390ced3ac0fee31523"
+  version: "283.1.4"
+  url: "https://bosh.io/d/github.com/cloudfoundry/bosh?v=283.1.4"
+  sha1: "sha256:90ff361c730572b5beb275555f0f536c7d739ce94c946616e49bffc895cc3dc8"
 - name: bpm
   version: latest
 

--- a/src/brats/assets/syslog-manifest.yml
+++ b/src/brats/assets/syslog-manifest.yml
@@ -4,6 +4,8 @@ name: syslog-deployment
 releases:
 - name: syslog
   version: latest
+- name: bpm
+  version: latest
 
 stemcells:
 - alias: default
@@ -39,7 +41,11 @@ instance_groups:
   networks:
   - {name: default}
   jobs:
+  - name: bpm
+    release: bpm
   - name: syslog_forwarder
     release: syslog
     consumes:
       syslog_storer: { from: syslog_storer }
+    properties:
+      use_bpm: true

--- a/src/brats/utils/utils.go
+++ b/src/brats/utils/utils.go
@@ -74,7 +74,7 @@ func Bootstrap() {
 	AssertEnvExists("BOSH_ENVIRONMENT")
 	AssertEnvExists("BOSH_DEPLOYMENT_PATH")
 
-	startInnerBoshTimeoutString := LoadEnvOrDefault("START_INNER_BOSH_TIMEOUT", "25m")
+	startInnerBoshTimeoutString := LoadEnvOrDefault("START_INNER_BOSH_TIMEOUT", "30m")
 	var err error
 	startInnerBoshTimeout, err = time.ParseDuration(startInnerBoshTimeoutString)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What is this change about?

Postgres 10 does not compile on Resolute. This test was pulling in a version of postgres 13 that itself pulled in Postgres 10 for upgrade purposes. Switching to a version where postgres 13 does not include postgres 10.

### What tests have you run against this PR?

I've manually validated the steps this test goes through using the manifests from the repo.

### Does this PR introduce a breaking change?

No