### PR TITLE
ci: pipeline fixes

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2134,6 +2134,7 @@ resources:
       branch: *branch_name
       paths:
         - ci
+        - src/brats
 
   - name: bosh-ci-dockerfiles
     type: git
@@ -2199,8 +2200,8 @@ resources:
   - name: bosh-disaster-recovery-acceptance-tests
     type: git
     source:
-      uri: https://github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests.git
-      branch: master
+      uri: https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests.git
+      branch: main
 
   - name: bbr-cli-binary
     type: github-release


### PR DESCRIPTION
- add bdrats path to the ci resource since were running brats out of the ci path
- bosh-disaster-recovery-acceptance-tests has moved to cloudfoundry and master has been renamed to main.

### What tests have you run against this PR?

Changes have been flown and are working.

### Does this PR introduce a breaking change?

No