### PR TITLE
brats: bump to syslog release that works in docker

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2134,6 +2134,7 @@ resources:
       branch: *branch_name
       paths:
         - ci
+        - src/brats
 
   - name: bosh-ci-dockerfiles
     type: git
@@ -2199,8 +2200,8 @@ resources:
   - name: bosh-disaster-recovery-acceptance-tests
     type: git
     source:
-      uri: https://github.com/cloudfoundry-incubator/bosh-disaster-recovery-acceptance-tests.git
-      branch: master
+      uri: https://github.com/cloudfoundry/bosh-disaster-recovery-acceptance-tests.git
+      branch: main
 
   - name: bbr-cli-binary
     type: github-release

--- a/src/brats/acceptance/blobstore_test.go
+++ b/src/brats/acceptance/blobstore_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Blobstore", func() {
 				fmt.Sprintf("-v agent_blobstore_endpoint=%s://%s:25250", schema, utils.InnerDirectorIP()),
 			)
 
-			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.27")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.28")
 			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36")
 			utils.UploadStemcell(candidateWardenLinuxStemcellPath)
 
@@ -113,7 +113,7 @@ var _ = Describe("Blobstore", func() {
 				fmt.Sprintf("-o %s", utils.BoshDeploymentAssetPath("enable-signed-urls.yml")),
 				fmt.Sprintf("-o %s", utils.AssetPath("ops-enable-signed-urls-cpi.yml")),
 			)
-			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.27")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.28")
 			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36")
 			utils.UploadStemcell(candidateWardenLinuxStemcellPath)
 
@@ -155,7 +155,7 @@ var _ = Describe("Blobstore", func() {
 			utils.StartInnerBosh(
 				fmt.Sprintf("-o %s", utils.BoshDeploymentAssetPath("enable-signed-urls.yml")),
 			)
-			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.27")
+			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=12.3.28")
 			utils.UploadRelease("https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=1.4.36")
 			utils.UploadStemcell(candidateWardenLinuxStemcellPath)
 


### PR DESCRIPTION
syslog v12.3.28 has [fixes that lets syslog release update apparmor profiles when running under docker](https://github.com/cloudfoundry/syslog-release/pull/254).

### Does this PR introduce a breaking change?

No