### PR TITLE
bdrats: run on the docker CPI, and actually apply local-stemcell.yml

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -830,14 +830,14 @@ jobs:
           - get: bbr-cli-binary
             params:
               globs: [ "bbr*-linux-amd64" ]
-          - get: warden-cpi-image
+          - get: docker-cpi-image
       - do:
           - task: test-bdrats
-            image: warden-cpi-image
+            image: docker-cpi-image
             file: bosh-ci/ci/tasks/test-bdrats.yml
             privileged: true
             params:
-              STEMCELL_OS: ubuntu-noble
+              DIRECTOR_OPS_FILES: ""
 
   - name: upgrade-postgres-noble
     old_name: upgrade-postgres
@@ -1300,14 +1300,14 @@ jobs:
           - get: bbr-cli-binary
             params:
               globs: [ "bbr*-linux-amd64" ]
-          - get: warden-cpi-image
+          - get: docker-cpi-image
       - do:
           - task: test-bdrats
-            image: warden-cpi-image
+            image: docker-cpi-image
             file: bosh-ci/ci/tasks/test-bdrats.yml
             privileged: true
             params:
-              STEMCELL_OS: ubuntu-resolute
+              DIRECTOR_OPS_FILES: "docker/use-resolute.yml misc/use-compiled-resolute-releases.yml"
 
   - name: delivery
     plan:

--- a/ci/tasks/test-bdrats.sh
+++ b/ci/tasks/test-bdrats.sh
@@ -16,10 +16,19 @@ chmod +x "${BBR_BINARY_PATH}"
 export OVERRIDDEN_BOSH_DEPLOYMENT="${src_dir}/bosh-deployment"
 if [[ -e ${OVERRIDDEN_BOSH_DEPLOYMENT}/bosh.yml ]];then
   export BOSH_DEPLOYMENT_PATH=${OVERRIDDEN_BOSH_DEPLOYMENT}
+else
+  export BOSH_DEPLOYMENT_PATH=/usr/local/bosh-deployment
 fi
 
 STEMCELL_PATH="${PWD}/stemcell/$(basename stemcell/*.tgz)"
 STEMCELL_SHA1=$(sha1sum "${STEMCELL_PATH}" | awk '{print $1}')
+
+STEMCELL_OS="$(tar -Oxzf "${STEMCELL_PATH}" stemcell.MF \
+  | awk '/^operating_system:/ {gsub(/"/, "", $2); print $2}')"
+if [[ -z "${STEMCELL_OS}" ]]; then
+  echo "no operating_system in $(basename "${STEMCELL_PATH}")'s stemcell.MF" >&2
+  exit 1
+fi
 
 cat > "${BOSH_DEPLOYMENT_PATH}/local-stemcell.yml" <<'OPSEOF'
 - name: stemcell
@@ -30,18 +39,43 @@ cat > "${BOSH_DEPLOYMENT_PATH}/local-stemcell.yml" <<'OPSEOF'
     sha1: ((local_stemcell_sha1))
 OPSEOF
 
+director_ops_args=()
+for f in ${DIRECTOR_OPS_FILES}; do
+  director_ops_args+=(-o "${BOSH_DEPLOYMENT_PATH}/${f}")
+done
+
+# uaa.yml, credhub.yml and bbr.yml append releases, so DIRECTOR_OPS_FILES comes
+# after them to rewrite those URLs too. The candidate release and the stemcell
+# under test come last, so no earlier ops file can replace the artifacts being
+# tested.
+#
+# Sourced rather than executed so the docker service can be stopped on exit; 
+# see ci/dockerfiles/docker-cpi/README.md.
 source start-bosh \
-  -o bbr.yml \
-  -o local-bosh-release-tarball.yml \
-  -o hm/disable.yml \
+  -o "${BOSH_DEPLOYMENT_PATH}/uaa.yml" \
+  -o "${BOSH_DEPLOYMENT_PATH}/credhub.yml" \
+  -o "${BOSH_DEPLOYMENT_PATH}/bbr.yml" \
+  -o "${BOSH_DEPLOYMENT_PATH}/hm/disable.yml" \
+  "${director_ops_args[@]+"${director_ops_args[@]}"}" \
+  -o "${BOSH_DEPLOYMENT_PATH}/local-bosh-release-tarball.yml" \
+  -o "${BOSH_DEPLOYMENT_PATH}/local-stemcell.yml" \
   -v local_bosh_release="${BOSH_RELEASE_PATH}"\
   -v local_stemcell_url="file://${STEMCELL_PATH}" \
   -v local_stemcell_sha1="${STEMCELL_SHA1}"
 
-source /tmp/local-bosh/director/env
+source /tmp/local-bosh/director/bosh-env
+
+# check that the items being tested are the local copies
+for path in /releases/name=bosh/url /resource_pools/name=vms/stemcell/url; do
+  url="$(bosh int /tmp/local-bosh/director/bosh-director.yml --path "${path}")"
+  if [[ "${url}" != file://* ]]; then
+    echo "expected ${path} to be a local file, got '${url}'" >&2
+    exit 1
+  fi
+done
 
 BOSH_SSH_KEY="$(bosh int /tmp/local-bosh/director/creds.yml --path /jumpbox_ssh/private_key --json | jq .Blocks[0])"
-BOSH_HOST="${BOSH_ENVIRONMENT}"
+BOSH_HOST="${BOSH_DIRECTOR_IP}"
 
 bosh_ca_cert_json_value="$(awk '{printf "%s\\n", $0}' "${BOSH_CA_CERT}")"
 

--- a/ci/tasks/test-bdrats.yml
+++ b/ci/tasks/test-bdrats.yml
@@ -14,6 +14,6 @@ run:
   path: bosh-ci/ci/tasks/test-bdrats.sh
 
 params:
-  # Left unbound on purpose: every job sets it explicitly for its stemcell line,
-  # so a missing one fails loudly instead of quietly testing another line.
-  STEMCELL_OS:
+  # Space-separated bosh-deployment-relative ops files giving the director
+  # releases compiled for the stemcell line under test.
+  DIRECTOR_OPS_FILES:


### PR DESCRIPTION
### What is this change about?

 Resolute doesn't work on the warden CPI yet, and in general we want to standardize on the docker CPI and deprecate the warden CPI. So moving this build to use Docker.

Also fixes a silent bug: local-stemcell.yml was written but never passed with -o (omitted in 2e006f1b81), so the director ran on warden/cpi.yml's pinned stemcell instead of the tarball the job fetched.

Candidate release and stemcell are applied last so nothing can replace them, plus two assertions to keep this class of failure loud: the tarball's operating_system must match STEMCELL_OS, and the rendered director manifest's release and stemcell URLs must both be file://.

### What tests have you run against this PR?

I've run a one off concourse task validating the tests pass when run under Docker.

### Does this PR introduce a breaking change?

No