### PR TITLE
Restore postgres thread-safety patch; root cause is pg, not Ruby 3

### DIFF
--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -383,7 +383,7 @@ module Bosh::Director
       # Reported upstream: https://github.com/ged/ruby-pg/issues/738
       #
       # WHY SEQUEL MAKES IT REPRODUCIBLE HERE:
-      # Two Sequel behaviours combine into an near-ideal trigger. Dataset#select_sql
+      # Two Sequel behaviours combine into a near-ideal trigger. Dataset#select_sql
       # caches and returns the same unfrozen String to every concurrent caller, and
       # log_connection_yield concurrently allocates a same-size "(conn: N) <sql>" string
       # for the debug log (we enable this below via log_connection_info). That log string

--- a/src/bosh-director/lib/bosh/director/config.rb
+++ b/src/bosh-director/lib/bosh/director/config.rb
@@ -350,6 +350,8 @@ module Bosh::Director
 
         db = wait_for_db_connection(connection_config, connection_wait_timeout)
 
+        apply_postgres_thread_safety_patch(connection_config['adapter'])
+
         Bosh::Common.retryable(sleep: DEFAULT_DB_CONNECTION_RETRY_INTERVAL, tries: 20, on: [Exception]) do
           db.extension :connection_validator
           true
@@ -363,6 +365,65 @@ module Bosh::Director
         end
 
         db
+      end
+
+      # Mitigates a use-after-free in the pg gem's C extension that corrupts the SQL
+      # sent to Postgres, surfacing as:
+      #   PG::SyntaxError: ERROR: syntax error at or near "conn"
+      #   LINE 1: (conn: 20600) SELECT "templates".* FROM "templates" INNER JOIN ...
+      # and, less often, as a SIGSEGV inside PG::Connection#exec.
+      #
+      # ROOT CAUSE (pg, not Sequel and not Ruby):
+      # pg_cstr_enc() in ext/pg_connection.c hands libpq a raw char* pointing straight
+      # into a Ruby String's own memory, then releases the GVL for the duration of the
+      # send. Nothing pins that String. Under Ruby 3.2+ variable-width allocation a
+      # string this size lives embedded in its object slot, so a GC in another thread
+      # can relocate or free those bytes while libpq is still reading them. Whatever
+      # lands in the vacated slot is what Postgres receives.
+      # Reported upstream: https://github.com/ged/ruby-pg/issues/738
+      #
+      # WHY SEQUEL MAKES IT REPRODUCIBLE HERE:
+      # Two Sequel behaviours combine into an near-ideal trigger. Dataset#select_sql
+      # caches and returns the same unfrozen String to every concurrent caller, and
+      # log_connection_yield concurrently allocates a same-size "(conn: N) <sql>" string
+      # for the debug log (we enable this below via log_connection_info). That log string
+      # is what most often refills the freed slot, which is why the corruption shows up
+      # as a "(conn: N)" prefix inside the SQL rather than as random bytes.
+      #
+      # WHY THIS IS STILL NEEDED ON RUBY 4:
+      # This patch was previously removed on the assumption that Ruby 4.0 fixed it,
+      # because the bug was much harder to hit there. That assumption was wrong. The
+      # defect is in pg's C extension, and nothing in Ruby 4.0 changes the fact that
+      # pg passes libpq an unpinned pointer into Ruby-managed memory across a GVL
+      # release. A CI reproducer confirmed the corruption on Ruby 4.0.6 (bosh-283.1.3,
+      # director-ruby-4.0) with stock pg 1.6.3 — Ruby 4 only lengthens the time to
+      # reproduce, it does not remove the race. The same reproducer run against a pg
+      # built with the proposed upstream fix was clean.
+      #
+      # THE MITIGATION:
+      # String.new(sql) forces a real memcpy into a fresh buffer (unlike dup, which is
+      # copy-on-write and still shares the bytes GC can move), and .freeze keeps that
+      # buffer from being reallocated. Each execute_query call therefore hands libpq a
+      # private buffer that no other thread is racing to relocate.
+      #
+      # REMOVE THIS once the director ships a pg gem containing the upstream fix for
+      # ruby-pg#738 — not merely on the next Ruby upgrade.
+      #
+      # Must run after Sequel.connect (when the postgres adapter module is first loaded).
+      # Guarded against double-application in case configure_db is called more than once.
+      def apply_postgres_thread_safety_patch(adapter_name)
+        return unless %w[postgres postgresql].include?(adapter_name)
+        return unless defined?(Sequel::Postgres::Adapter)
+        return if @postgres_thread_safety_patched
+
+        @postgres_thread_safety_patched = true
+        Sequel::Postgres::Adapter.prepend(Module.new do
+          private
+
+          def execute_query(sql, args)
+            super(String.new(sql).freeze, args)
+          end
+        end)
       end
 
       def wait_for_db_connection(connection_config, timeout)

--- a/src/bosh-director/spec/unit/bosh/director/postgres_thread_safety_patch_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/postgres_thread_safety_patch_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+RSpec.describe Bosh::Director::Config, '#apply_postgres_thread_safety_patch' do
+  # Reset idempotency guard so tests are independent
+  before { described_class.instance_variable_set(:@postgres_thread_safety_patched, nil) }
+  after  { described_class.instance_variable_set(:@postgres_thread_safety_patched, nil) }
+
+  let(:fake_adapter) do
+    Class.new do
+      def execute_query(sql, args)
+        [sql, args]
+      end
+      private :execute_query
+    end
+  end
+
+  context 'when adapter is postgres and Sequel::Postgres::Adapter is defined' do
+    before { stub_const('Sequel::Postgres::Adapter', fake_adapter) }
+
+    it 'prepends a module that passes String.new(sql).freeze to prevent cross-thread SQL corruption' do
+      described_class.send(:apply_postgres_thread_safety_patch, 'postgres')
+
+      original_sql = 'SELECT * FROM templates INNER JOIN release_versions_templates ON id = 1'
+      result = fake_adapter.new.send(:execute_query, original_sql, nil)
+
+      expect(result[0]).to eq(original_sql), 'SQL content must be preserved'
+      expect(result[0].object_id).not_to eq(original_sql.object_id),
+        'Expected a fresh String.new copy to isolate thread buffers and prevent ' \
+        '(conn: NNNNN) prefix injection into the actual SQL sent to Postgres'
+      expect(result[0]).to be_frozen,
+        'Expected the SQL copy to be frozen so in-place C-level mutations raise FrozenError ' \
+        'rather than silently corrupting concurrent threads'
+    end
+
+    it 'passes args through to the underlying execute_query unmodified' do
+      described_class.send(:apply_postgres_thread_safety_patch, 'postgres')
+
+      query_args = [42, 'bar']
+      result = fake_adapter.new.send(:execute_query, 'SELECT 1', query_args)
+
+      expect(result[1]).to be(query_args), 'args must be passed through without modification'
+    end
+
+    it 'is idempotent — applies the patch only once even when called multiple times' do
+      2.times { described_class.send(:apply_postgres_thread_safety_patch, 'postgres') }
+
+      patched_count = fake_adapter.ancestors.take_while { |m| m != fake_adapter }
+                                  .count { |m| m.private_method_defined?(:execute_query) }
+
+      expect(patched_count).to eq(1),
+        'Patch must not be stacked — applied exactly once regardless of call count'
+    end
+  end
+
+  context 'when adapter is not postgres (e.g. mysql2)' do
+    before { stub_const('Sequel::Postgres::Adapter', fake_adapter) }
+
+    ["mysql2", "sqlite", nil].each do |adapter|
+      it "does not apply the patch for adapter=#{adapter.inspect}" do
+        described_class.send(:apply_postgres_thread_safety_patch, adapter)
+
+        patched_count = fake_adapter.ancestors.take_while { |m| m != fake_adapter }
+                                    .count { |m| m.private_method_defined?(:execute_query) }
+
+        expect(patched_count).to eq(0),
+          "Patch must not be applied when adapter is #{adapter.inspect}"
+        expect(described_class.instance_variable_get(:@postgres_thread_safety_patched)).to be_nil
+      end
+    end
+  end
+
+  context 'when adapter is postgres but Sequel::Postgres::Adapter is not yet defined' do
+    before { hide_const('Sequel::Postgres::Adapter') }
+
+    it 'does not raise an error' do
+      expect { described_class.send(:apply_postgres_thread_safety_patch, 'postgres') }.not_to raise_error
+    end
+
+    it 'does not set the patched flag (safe to call again if adapter loads later)' do
+      described_class.send(:apply_postgres_thread_safety_patch, 'postgres')
+      expect(described_class.instance_variable_get(:@postgres_thread_safety_patched)).to be_nil
+    end
+  end
+
+  # Tripwire: fires when the vendored pg gem moves past the last version we
+  # reviewed, so someone re-checks whether the upstream fix has landed.
+  #
+  # This patch mitigates a use-after-free in the pg gem's C extension, NOT a Ruby
+  # or Sequel defect: pg hands libpq a raw pointer into a Ruby String and then
+  # releases the GVL, so GC can relocate or free those bytes mid-send.
+  # See Config#apply_postgres_thread_safety_patch for the full explanation.
+  #
+  # An earlier version of this spec asserted the bug was gone on Ruby 4.0+. That
+  # was wrong — the patch was removed on that basis and the corruption was later
+  # reproduced on Ruby 4.0.6 with stock pg 1.6.3. Do NOT key this tripwire on the
+  # Ruby version again; the fix has to come from pg.
+  LAST_REVIEWED_PG_VERSION = '1.6.3'.freeze
+
+  it "fails when pg is upgraded past #{LAST_REVIEWED_PG_VERSION} so ruby-pg#738 can be re-checked" do
+    require 'pg'
+
+    current = Gem.loaded_specs['pg']&.version || Gem::Version.new(PG::VERSION)
+    reviewed = Gem::Version.new(LAST_REVIEWED_PG_VERSION)
+
+    expect(current).to be <= reviewed, <<~MSG
+      pg has been upgraded to #{current} (last reviewed: #{reviewed}).
+
+      Check whether the fix for https://github.com/ged/ruby-pg/issues/738 is in this
+      release. The fix copies the query into a pg-owned buffer before the GVL is
+      released, so libpq no longer holds a pointer into relocatable Ruby String memory.
+      Look for the memcpy/ALLOC_N guard around gvl_PQsendQuery in pgconn_send_query and
+      gvl_PQexec in pgconn_sync_exec, in ext/pg_connection.c.
+
+      If the fix IS included:
+        - remove Config#apply_postgres_thread_safety_patch and its call in configure_db
+        - delete this spec file and sequel_spec.rb's String.new(sql) coverage
+
+      If the fix is NOT included:
+        - bump LAST_REVIEWED_PG_VERSION in this spec to #{current}
+        - keep the patch and wait for the next pg release
+    MSG
+  end
+end

--- a/src/bosh-director/spec/unit/bosh/director/sequel_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/sequel_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Bosh::Director sequel extensions' do
     # Ruby String's memory and then releases the GVL, so GC can relocate or free those
     # bytes while libpq is still reading them (https://github.com/ged/ruby-pg/issues/738).
     #
-    # Sequel supplies an near-ideal trigger rather than the defect itself. Dataset#select_sql
+    # Sequel supplies a near-ideal trigger rather than the defect itself. Dataset#select_sql
     # caches and returns the SAME unfrozen String to all concurrent callers, and
     # log_connection_yield concurrently allocates a same-size "(conn: NNNNN) <sql>" string
     # for the debug log. That log string is what usually refills the freed slot, which is

--- a/src/bosh-director/spec/unit/bosh/director/sequel_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/sequel_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe 'Bosh::Director sequel extensions' do
   # These tests confirm that Sequel still exhibits the cached-shared-string
   # behaviour that makes Config#apply_postgres_thread_safety_patch necessary.
   #
-  # If any of these expectations start FAILING after a Sequel gem upgrade it
-  # means the upstream library has resolved the issue and the monkey patch
-  # can be removed.
+  # If these expectations start failing after a Sequel gem upgrade, this known
+  # trigger has changed. Keep the monkey patch until the pg defect itself is fixed.
   # -------------------------------------------------------------------------
   describe 'Sequel::Dataset#select_sql upstream caching behaviour' do
     let(:db) { Sequel.mock }

--- a/src/bosh-director/spec/unit/bosh/director/sequel_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/sequel_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+
+RSpec.describe 'Bosh::Director sequel extensions' do
+  # -------------------------------------------------------------------------
+  # Upstream Sequel gem behaviour pinning
+  #
+  # These tests confirm that Sequel still exhibits the cached-shared-string
+  # behaviour that makes Config#apply_postgres_thread_safety_patch necessary.
+  #
+  # If any of these expectations start FAILING after a Sequel gem upgrade it
+  # means the upstream library has resolved the issue and the monkey patch
+  # can be removed.
+  # -------------------------------------------------------------------------
+  describe 'Sequel::Dataset#select_sql upstream caching behaviour' do
+    let(:db) { Sequel.mock }
+
+    it 'returns the SAME String object on successive calls (shared cache)' do
+      dataset = db[:templates]
+
+      sql1 = dataset.select_sql
+      sql2 = dataset.select_sql
+
+      expect(sql1).to be(sql2),
+        'Sequel::Dataset#select_sql is expected to return the SAME cached String object ' \
+        'on every call. If this fails after a Sequel upgrade the upstream caching has ' \
+        'changed and Config#apply_postgres_thread_safety_patch may no longer be needed.'
+    end
+
+    it 'the cached SQL string is mutable (not frozen)' do
+      sql = db[:templates].select_sql
+
+      expect(sql).not_to be_frozen,
+        'The cached SQL string is expected to be mutable. If this fails after a Sequel ' \
+        'upgrade the upstream gem now protects against in-place mutation and the monkey ' \
+        'patch may no longer be needed.'
+    end
+
+    it 'concurrent callers receive the same object_id, demonstrating the shared-buffer race' do
+      dataset = db[:templates]
+      ids = Array.new(4) { dataset.select_sql.object_id }
+
+      expect(ids.uniq.length).to eq(1),
+        'All concurrent callers are expected to get the SAME String object (same object_id). ' \
+        'If this fails the upstream caching behaviour has changed.'
+    end
+  end
+
+  describe 'String.new(sql) thread-safety pattern' do
+    # Root cause is in the pg gem, not Sequel: pg passes libpq a raw pointer into a
+    # Ruby String's memory and then releases the GVL, so GC can relocate or free those
+    # bytes while libpq is still reading them (https://github.com/ged/ruby-pg/issues/738).
+    #
+    # Sequel supplies an near-ideal trigger rather than the defect itself. Dataset#select_sql
+    # caches and returns the SAME unfrozen String to all concurrent callers, and
+    # log_connection_yield concurrently allocates a same-size "(conn: NNNNN) <sql>" string
+    # for the debug log. That log string is what usually refills the freed slot, which is
+    # why the corruption surfaces as:
+    #   PG::SyntaxError: ERROR: syntax error at or near "conn"
+    #
+    # Mitigation: String.new(sql) forces a real memcpy (unlike dup, which is copy-on-write
+    # and still shares the bytes GC can move), giving each execute_query call a private
+    # buffer no other thread is racing to relocate.
+    #
+    # This patch is applied in Config#apply_postgres_thread_safety_patch after
+    # Sequel.connect (when Sequel::Postgres::Adapter is first loaded).
+    # See config_spec.rb for integration-level coverage.
+
+    it 'ensures each invocation receives a fresh String object, not the shared cache' do
+      received_sqls = []
+      shared_sql = 'SELECT * FROM templates INNER JOIN release_versions_templates ON id = 1'
+
+      base_capture = Module.new do
+        define_method(:execute_query) { |sql, _args| received_sqls << sql }
+      end
+
+      string_new_patch = Module.new do
+        define_method(:execute_query) { |sql, args| super(String.new(sql).freeze, args) }
+      end
+
+      klass = Class.new
+      klass.include(base_capture)
+      klass.prepend(string_new_patch)
+      obj = klass.new
+
+      obj.send(:execute_query, shared_sql, nil)
+      obj.send(:execute_query, shared_sql, nil)
+
+      expect(received_sqls.all? { |s| s == shared_sql }).to be(true),
+        'SQL content must be preserved across the copy'
+      expect(received_sqls.map(&:object_id)).not_to include(shared_sql.object_id),
+        'No received string should be the original shared object (would allow cross-thread mutation)'
+      expect(received_sqls.map(&:object_id).uniq.length).to eq(2),
+        'Each invocation must receive a distinct String object (independent buffer per call)'
+      expect(received_sqls).to all(be_frozen),
+        'Each copy must be frozen so in-place C-level mutations raise FrozenError ' \
+        'rather than silently corrupting concurrent threads'
+    end
+
+    it 'passes args through to super unmodified' do
+      received_args = :unset
+
+      base_capture = Module.new do
+        define_method(:execute_query) { |_sql, args| received_args = args }
+      end
+
+      string_new_patch = Module.new do
+        define_method(:execute_query) { |sql, args| super(String.new(sql).freeze, args) }
+      end
+
+      klass = Class.new
+      klass.include(base_capture)
+      klass.prepend(string_new_patch)
+
+      query_args = [1, 'foo']
+      klass.new.send(:execute_query, 'SELECT 1', query_args)
+
+      expect(received_args).to be(query_args), 'args must be passed through without modification'
+    end
+  end
+end


### PR DESCRIPTION
Reinstates Config#apply_postgres_thread_safety_patch, removed in 55726b5706 ("Remove sequel patch in preparation for Ruby 4.0") on the assumption that upgrading the director to Ruby 4.0 made it unnecessary. That assumption was wrong and the mitigation is still required.

The defect is a use-after-free in the pg gem's C extension, not in Ruby and not in Sequel. pg_cstr_enc() in ext/pg_connection.c hands libpq a raw char* pointing into a Ruby String's own memory and then releases the GVL for the duration of the send. Nothing pins that String, and under Ruby 3.2+ variable-width allocation a string this size is embedded in its object slot, so a GC in another thread can relocate or free the bytes libpq is still reading. Whatever lands in the vacated slot is what Postgres receives: PG::SyntaxError: ERROR: syntax error at or near "conn" LINE 1: (conn: 20600) SELECT "templates".* FROM "templates" INNER JOIN ... When the slot is unmapped instead, the process takes SIGSEGV inside PG::Connection#exec.

Nothing in Ruby 4.0 changes that pg passes an unpinned pointer across a GVL release. A CI reproducer confirmed the corruption on Ruby 4.0.6 with stock pg 1.6.3 (bosh-283.1.3, director-ruby-4.0, 16 procs x 32 threads); Ruby 4 only lengthens the time to reproduce. The same workload against a pg built with the proposed upstream fix ran clean, as did this String.new mitigation.

Sequel is the trigger rather than the cause: Dataset#select_sql returns one unfrozen String to all concurrent callers, while log_connection_yield concurrently allocates a same-size "(conn: N) <sql>" string for the debug log (enabled here via log_connection_info). That log string is what usually refills the freed slot, which is why the corruption reads as a "(conn: N)" prefix. A sequel-free reproducer hits the same fault with only pg loaded.

String.new(sql) forces a real memcpy -- unlike dup, which is copy-on-write and still shares the bytes GC can move -- and .freeze keeps the buffer from being reallocated, so each execute_query hands libpq a private buffer.

Reported upstream as https://github.com/ged/ruby-pg/issues/738. The removal tripwire is re-keyed off the pg version carrying that fix instead of the Ruby version, so this cannot be dropped again on a Ruby upgrade alone.

### What is this change about?

Reinstating a temporary monkey patch to mitigate a pg bug. It was initially believed to be a ruby issue that would be resolved in ruby 4.

### Please provide contextual information.

Issue filed
https://github.com/ged/ruby-pg/issues/738

### What tests have you run against this PR?

There are unit tests included in 2 spec files:
bosh-director/spec/unit/bosh/director/postgres_thread_safety_patch_spec.rb
bosh-director/spec/unit/bosh/director/sequel_spec.rb

### How should this change be described in bosh release notes?

Temporary monkey patch to mitigate a pg bug. It was initially believed to be a ruby issue that would be resolved in ruby 4.

### Does this PR introduce a breaking change?

No
### Tag your pair, your PM, and/or team!
@aramprice 

### AI Review Feedback

_All AI review comments (CodeRabbit, and Copilot when assigned) must be resolved before human reviewers will look at the PR. For each comment, either:_
- _Make the suggested change, or_
- _Reply to the comment explaining why it does not apply, then resolve the thread._
