### PR TITLE
Fix PostgresVersionHelper#local_version on macOS

### DIFF
--- a/src/spec/integration_support/postgres_version_helper.rb
+++ b/src/spec/integration_support/postgres_version_helper.rb
@@ -17,7 +17,7 @@ module IntegrationSupport
       end
 
       def local_version
-        `postgres --version`.chomp.split(' ').last
+        `postgres --version`.chomp.split(' ')[2].split('.')[0]
       end
 
       def release_major_version


### PR DESCRIPTION
Due to changes in Homebrew's postgress version string the existing implimentation has begun returning `(Homebrew)` instead of a major-version number. This commit updates the helper to fix this.

Verified that it continues to work on Linux (docker: ubuntu-noble, and bosh-integration-psotgres image).

Created in service of locally testing: https://github.com/cloudfoundry/bosh/pull/2811
