### PR TITLE
Spec ignores `Stemcell#deployments` order

### DIFF
--- a/src/bosh-director/spec/unit/bosh/director/api/stemcell_manager_spec.rb
+++ b/src/bosh-director/spec/unit/bosh/director/api/stemcell_manager_spec.rb
@@ -234,14 +234,14 @@ module Bosh::Director
         )
       end
       it 'returns a list of all stemcells with the api_version' do
-        expect(subject.find_all_stemcells).to eq([
+        expect(subject.find_all_stemcells).to match([
               {
                 'name' => 'fake-stemcell-1',
                 'operating_system' => 'stemcell_os-1',
                 'version' => 'stemcell_version-1',
                 'cid' => 'cloud-id-1',
                 'cpi' => "",
-                'deployments' => [{name: 'first'}, {name: 'second'}],
+                'deployments' => contain_exactly({name: 'first'}, {name: 'second'}),
                 'api_version' => nil,
                 'id' => 1,
               },
@@ -266,7 +266,6 @@ module Bosh::Director
                 'id' => 3,
               },
               ])
-
       end
     end
 


### PR DESCRIPTION
Lack of consistent order can cause tests to flake:
```
  1) Bosh::Director::Api::StemcellManager#find_all_stemcells returns a list of all stemcells with the api_version
     Failure/Error:
       expect(subject.find_all_stemcells).to eq([
             {
               'name' => 'fake-stemcell-1',
               'operating_system' => 'stemcell_os-1',
               'version' => 'stemcell_version-1',
               'cid' => 'cloud-id-1',
               'cpi' => "",
               'deployments' => [{name: 'first'}, {name: 'second'}],
               'api_version' => nil,
               'id' => 1,

       expected: [{"api_version" => nil, "cid" => "cloud-id-1", "cpi" => "", "deployments" => [{name: "first"}, {name: "second"}], "id" => 1, "name" => "fake-stemcell-1", "operating_system" => "stemcell_os-1", "version" => "stemcell_version-1"}, {"api_version" => 2, "cid" => "cloud-id-2", "cpi" => "cpi2", "deployments" => [], "id" => 2, "name" => "fake-stemcell-2", "operating_system" => "stemcell_os-2", "version" => "stemcell_version-2"}, {"api_version" => nil, "cid" => "cloud-id-3", "cpi" => "cpi3", "deployments" => [], "id" => 3, "name" => "fake-stemcell-3", "operating_system" => "stemcell_os-3", "version" => "stemcell_version-3"}]
            got: [{"api_version" => nil, "cid" => "cloud-id-1", "cpi" => "", "deployments" => [{name: "second"}, {name: "first"}], "id" => 1, "name" => "fake-stemcell-1", "operating_system" => "stemcell_os-1", "version" => "stemcell_version-1"}, {"api_version" => 2, "cid" => "cloud-id-2", "cpi" => "cpi2", "deployments" => [], "id" => 2, "name" => "fake-stemcell-2", "operating_system" => "stemcell_os-2", "version" => "stemcell_version-2"}, {"api_version" => nil, "cid" => "cloud-id-3", "cpi" => "cpi3", "deployments" => [], "id" => 3, "name" => "fake-stemcell-3", "operating_system" => "stemcell_os-3", "version" => "stemcell_version-3"}]

       (compared using ==)

       Diff:
       @@ -1,7 +1,7 @@
        [{"api_version" => nil,
          "cid" => "cloud-id-1",
          "cpi" => "",
       -  "deployments" => [{name: "first"}, {name: "second"}],
       +  "deployments" => [{name: "second"}, {name: "first"}],
          "id" => 1,
          "name" => "fake-stemcell-1",
          "operating_system" => "stemcell_os-1",
     # ./spec/unit/bosh/director/api/stemcell_manager_spec.rb:237:in 'block (3 levels) in <module:Director>'
     # ./spec/spec_helper.rb:67:in 'block in SpecHelper.reset_database'
     # ./spec/spec_helper.rb:66:in 'SpecHelper.reset_database'
     # ./spec/spec_helper.rb:156:in 'block (2 levels) in <top (required)>'
```
Ref: https://github.com/cloudfoundry/bosh/actions/runs/32180838892/job/95853212851?pr=2809#step:7:44
