### PR TITLE
docker-cpi image: extract start-docker from start-bosh

### DIFF
--- a/ci/dockerfiles/docker-cpi/Dockerfile
+++ b/ci/dockerfiles/docker-cpi/Dockerfile
@@ -18,7 +18,7 @@ RUN docker_gpg="/etc/apt/trusted.gpg.d/docker.gpg" \
 # https://github.com/docker/cli/issues/4807
 # As of 02/01/2024 a change in the "/etc/init.d/docker" script shipped with docker v25
 # is preventing the cpi image to work.
-# when start-bosh runs `service docker start` it errors with:
+# when start-docker runs `service docker start` it errors with:
 # "/etc/init.d/docker: 62: ulimit: error setting limit (Invalid argument)"
 # disable resetting ulimit. Pre v25 the script contained `ulimit -n 1048576`
 # the default in our base image is:
@@ -38,6 +38,9 @@ COPY local-releases.yml /usr/local/ops-files/local-releases.yml
 RUN mkdir -p /usr/local/releases \
     && curl -o /usr/local/releases/bosh.tgz "$(bosh int /usr/local/bosh-deployment/bosh.yml --path /releases/name=bosh/url)" \
     && curl -o /usr/local/releases/bpm.tgz "$(bosh int /usr/local/bosh-deployment/bosh.yml --path /releases/name=bpm/url)"
+
+COPY start-docker.sh /usr/local/bin/start-docker
+RUN chmod +x /usr/local/bin/start-docker
 
 COPY start-bosh.sh /usr/local/bin/start-bosh
 RUN chmod +x /usr/local/bin/start-bosh

--- a/ci/dockerfiles/docker-cpi/README.md
+++ b/ci/dockerfiles/docker-cpi/README.md
@@ -19,7 +19,7 @@ stopped on exit. Otherwise the concourse task may hang.
 
 A simple example usage:
 
-```
+```bash
 #!/usr/bin/env bash
 
 set -ex
@@ -34,7 +34,7 @@ bosh -d cf deploy ...
 
 `. start-bosh` will also allow passing additional command line args into the `create-env` command that will be run. So, to start a customized director, you could use something like:
 
-```
+```bash
 #!/usr/bin/env bash
 
 set -ex
@@ -45,4 +45,37 @@ source /tmp/local-bosh/director/env
 
 bosh upload-stemcell ...
 bosh -d cf deploy ...
+```
+
+## `. start-docker`
+
+For "I need a docker daemon, not a director". `start-bosh` sources it; anything
+that only wants a dockerd in a Concourse container can too. It exports:
+
+| Variable | Value |
+|---|---|
+| `OUTER_CONTAINER_IP` | the container's `eth0` address |
+| `DOCKER_HOST` | `tcp://${OUTER_CONTAINER_IP}:4243` |
+| `DOCKER_TLS_VERIFY` | `1` |
+| `DOCKER_CERT_PATH` | a `mktemp -d` holding the generated CA and client certs |
+| `DOCKER_NETWORK_NAME` | `director_network` |
+| `DOCKER_NETWORK_CIDR` | `10.245.0.0/16` |
+| `DOCKER_TLS_JSON` | path to a `{ca, certificate, private_key}` JSON blob |
+
+The network name and CIDR are fixed: `start-bosh` places the director's gateway
+and IP inside that CIDR.
+
+Like `start-bosh` it must be sourced, so that the daemon runs in the current
+shell's process group and can be stopped on exit.
+
+```bash
+#!/usr/bin/env bash
+
+set -ex
+
+trap 'service docker stop' EXIT
+
+. start-docker
+
+docker run ...
 ```

--- a/ci/dockerfiles/docker-cpi/start-bosh.sh
+++ b/ci/dockerfiles/docker-cpi/start-bosh.sh
@@ -15,225 +15,14 @@ BOSH_DEPLOYMENT_PATH="${BOSH_DEPLOYMENT_PATH:-/usr/local/bosh-deployment}"
 BOSH_DIRECTOR_IP="10.245.0.3"
 BOSH_ENVIRONMENT="docker-director"
 
-
-function generate_certs() {
-  local certs_dir
-  certs_dir="${1}"
-
-  pushd "${certs_dir}" > /dev/null
-    cat <<EOF > ./bosh-vars.yml
----
-variables:
-- name: docker_ca
-  type: certificate
-  options:
-    is_ca: true
-    common_name: ca
-- name: docker_tls
-  type: certificate
-  options:
-    extended_key_usage: [server_auth]
-    common_name: $OUTER_CONTAINER_IP
-    alternative_names: [$OUTER_CONTAINER_IP]
-    ca: docker_ca
-- name: client_docker_tls
-  type: certificate
-  options:
-    extended_key_usage: [client_auth]
-    common_name: $OUTER_CONTAINER_IP
-    alternative_names: [$OUTER_CONTAINER_IP]
-    ca: docker_ca
-EOF
-
-   bosh int ./bosh-vars.yml --vars-store=./certs.yml
-   bosh int ./certs.yml --path=/docker_ca/ca > ./ca.pem
-   bosh int ./certs.yml --path=/docker_tls/certificate > ./server-cert.pem
-   bosh int ./certs.yml --path=/docker_tls/private_key > ./server-key.pem
-   bosh int ./certs.yml --path=/client_docker_tls/certificate > ./cert.pem
-   bosh int ./certs.yml --path=/client_docker_tls/private_key > ./key.pem
-    # generate certs in json format
-    #
-   ruby -e 'puts File.read("./ca.pem").split("\n").join("\\n")' > "${certs_dir}/ca_json_safe.pem"
-   ruby -e 'puts File.read("./cert.pem").split("\n").join("\\n")' > "${certs_dir}/client_certificate_json_safe.pem"
-   ruby -e 'puts File.read("./key.pem").split("\n").join("\\n")' > "${certs_dir}/client_private_key_json_safe.pem"
-  popd > /dev/null
-}
-
-function sanitize_cgroups() {
-  mkdir -p /sys/fs/cgroup
-  mountpoint -q /sys/fs/cgroup || \
-    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
-
-  if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
-    # cgroups v2: enable nesting (based on moby/moby hack/dind)
-    mkdir -p /sys/fs/cgroup/init
-    # Loop to handle races from concurrent process creation (e.g. docker exec)
-    while ! {
-      xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs 2>/dev/null || :
-      sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
-        > /sys/fs/cgroup/cgroup.subtree_control
-    }; do true; done
-    return
-  fi
-
-  mount -o remount,rw /sys/fs/cgroup
-
-  sed -e 1d /proc/cgroups | while read -r sys enabled; do
-    if [ "$enabled" != "1" ]; then
-      # subsystem disabled; skip
-      continue
-    fi
-
-    grouping="$(cut -d: -f2 < /proc/self/cgroup | grep "\\<$sys\\>")"
-    if [ -z "$grouping" ]; then
-      # subsystem not mounted anywhere; mount it on its own
-      grouping="$sys"
-    fi
-
-    mountpoint="/sys/fs/cgroup/$grouping"
-
-    mkdir -p "$mountpoint"
-
-    # clear out existing mount to make sure new one is read-write
-    if mountpoint -q "$mountpoint"; then
-      umount "$mountpoint"
-    fi
-
-    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
-
-    if [ "$grouping" != "$sys" ]; then
-      if [ -L "/sys/fs/cgroup/$sys" ]; then
-        rm "/sys/fs/cgroup/$sys"
-      fi
-
-      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
-    fi
-  done
-}
-
-function start_docker() {
-  local certs_dir
-  certs_dir="${1}"
-  generate_certs "${certs_dir}"
-  mkdir -p /var/log
-  mkdir -p /var/run
-
-  # Raise inotify limits so nested containers running systemd don't exhaust
-  # file descriptors. Systemd and containerd's cgroup-v2 event monitor both
-  # use inotify; the default max_user_instances (128) was too low.
-  sysctl -w fs.inotify.max_user_instances=1024
-  sysctl -w fs.inotify.max_user_watches=524288
-  sysctl -w net.ipv4.ip_forward=1
-
-  sanitize_cgroups
-
-  # systemd inside nested Docker containers requires shared mount propagation
-  mount --make-rshared /
-
-  # ensure systemd cgroup is present (cgroups v1 only)
-  if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
-    mkdir -p /sys/fs/cgroup/systemd
-    if ! mountpoint -q /sys/fs/cgroup/systemd ; then
-      mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
-    fi
-  fi
-
-  # check for /proc/sys being mounted readonly, as systemd does
-  if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
-    mount -o remount,rw /proc/sys
-  fi
-
-  gcp_internal_dns="169.254.169.254"
-  local mtu
-  mtu=$(cat "/sys/class/net/$(ip route get "${gcp_internal_dns}"|awk '{ print $5 }')/mtu")
-
-  [[ ! -d /etc/docker ]] && mkdir /etc/docker
-  cat <<EOF > /etc/docker/daemon.json
-{
-  "hosts": ["${DOCKER_HOST}"],
-  "tls": true,
-  "tlscert": "${certs_dir}/server-cert.pem",
-  "tlskey": "${certs_dir}/server-key.pem",
-  "tlscacert": "${certs_dir}/ca.pem",
-  "mtu": ${mtu},
-  "dns": ["${gcp_internal_dns}"],
-  "data-root": "/scratch/docker",
-  "tlsverify": true,
-  "ip-forward-no-drop": true
-}
-EOF
-
-  service docker start
-
-  rc=1
-  for i in $(seq 1 100); do
-    echo "waiting for docker to come up... (${i})"
-    sleep 1
-    set +e
-    docker info
-    rc=$?
-    set -e
-    if [ "$rc" -eq "0" ]; then
-        break
-    fi
-  done
-
-  if [ "$rc" -ne "0" ]; then
-    exit 1
-  fi
-
-  echo "${certs_dir}"
-}
-
 function main() {
-  OUTER_CONTAINER_IP=$(
-    ip addr \
-    | grep 'inet ' \
-    | grep eth0 \
-    | cut -d/ -f 1 \
-    | cut -d' ' -f6
-  )
-  export OUTER_CONTAINER_IP
-
-  if [[ "${OUTER_CONTAINER_IP}" == *$'\n'* ]] ; then
-    echo "OUTER_CONTAINER_IP had more than one ip: '${OUTER_CONTAINER_IP}'" >&2
-    exit 1
-  fi
-
-  local certs_dir
-  certs_dir=$(mktemp -d)
+  # Brings up the docker daemon and exports DOCKER_HOST, DOCKER_NETWORK_NAME,
+  # DOCKER_NETWORK_CIDR and DOCKER_TLS_JSON.
+  # shellcheck disable=SC1091
+  source /usr/local/bin/start-docker
 
   local local_bosh_dir
   local_bosh_dir="/tmp/local-bosh/director"
-  mkdir -p ${local_bosh_dir}
-
-  docker_env_file="${local_bosh_dir}/docker-env"
-  {
-    echo "export DOCKER_HOST=\"tcp://${OUTER_CONTAINER_IP}:4243\""
-    echo "export DOCKER_TLS_VERIFY=\"1\""
-    echo "export DOCKER_CERT_PATH=\"${certs_dir}\""
-  } > "${docker_env_file}"
-  echo "Source '${docker_env_file}' to run docker" >&2
-  source "${local_bosh_dir}/docker-env"
-
-  start_docker "${certs_dir}"
-
-  local docker_network_name="director_network"
-  local docker_network_cidr="10.245.0.0/16"
-  if docker network ls | grep -q "${docker_network_name}"; then
-    echo "A docker network named '${docker_network_name}' already exists, skipping creation" >&2
-  else
-    docker network create -d bridge --subnet="${docker_network_cidr}" "${docker_network_name}"
-  fi
-
-  docker_tls_json="${local_bosh_dir}/docker_tls.json"
-  cat <<EOF > "${docker_tls_json}"
-{
-  "ca": "$(cat "${certs_dir}/ca_json_safe.pem")",
-  "certificate": "$(cat "${certs_dir}/client_certificate_json_safe.pem")",
-  "private_key": "$(cat "${certs_dir}/client_private_key_json_safe.pem")"
-}
-EOF
 
   # shellcheck disable=SC2068,SC2086
   bosh int "${BOSH_DEPLOYMENT_PATH}/bosh.yml" \
@@ -242,12 +31,12 @@ EOF
     -o /usr/local/ops-files/local-releases.yml \
     ${ADDITIONAL_DIRECTOR_OPS_FILES:-} \
     -v director_name=docker \
-    -v internal_cidr="${docker_network_cidr}" \
+    -v internal_cidr="${DOCKER_NETWORK_CIDR}" \
     -v internal_gw=10.245.0.1 \
     -v internal_ip="${BOSH_DIRECTOR_IP}" \
     -v docker_host="${DOCKER_HOST}" \
-    -v network="${docker_network_name}" \
-    -v docker_tls="$(cat "${docker_tls_json}")" \
+    -v network="${DOCKER_NETWORK_NAME}" \
+    -v docker_tls="$(cat "${DOCKER_TLS_JSON}")" \
     ${@} > "${local_bosh_dir}/bosh-director.yml"
 
   bosh create-env "${local_bosh_dir}/bosh-director.yml" \
@@ -264,7 +53,7 @@ EOF
 
   bosh_env_file="${local_bosh_dir}/bosh-env"
   {
-    echo "source \"${docker_env_file}\""
+    echo "source \"${local_bosh_dir}/docker-env\""
     echo "export BOSH_DIRECTOR_IP=\"${BOSH_DIRECTOR_IP}\""
     echo "export BOSH_ENVIRONMENT=\"${BOSH_ENVIRONMENT}\""
     echo "export BOSH_CLIENT=\"admin\""
@@ -281,7 +70,7 @@ EOF
   bosh -n update-cloud-config \
     "${BOSH_DEPLOYMENT_PATH}/docker/cloud-config.yml" \
     -o "/usr/local/ops-files/gcp-internal-dns-ops.yml" \
-    -v network="${docker_network_name}"
+    -v network="${DOCKER_NETWORK_NAME}"
 }
 
 # shellcheck disable=SC2068

--- a/ci/dockerfiles/docker-cpi/start-docker.sh
+++ b/ci/dockerfiles/docker-cpi/start-docker.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# Brings up a docker daemon inside a Concourse container and exports everything
+# a caller needs to talk to it:
+#
+#   OUTER_CONTAINER_IP  DOCKER_HOST  DOCKER_TLS_VERIFY  DOCKER_CERT_PATH
+#   DOCKER_NETWORK_NAME  DOCKER_NETWORK_CIDR  DOCKER_TLS_JSON
+#
+# Must be sourced, not executed: the exports and the daemon's process group both
+# need to live in the caller's shell.
+
+function generate_certs() {
+  local certs_dir
+  certs_dir="${1}"
+
+  pushd "${certs_dir}" > /dev/null
+    cat <<EOF > ./bosh-vars.yml
+---
+variables:
+- name: docker_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: ca
+- name: docker_tls
+  type: certificate
+  options:
+    extended_key_usage: [server_auth]
+    common_name: $OUTER_CONTAINER_IP
+    alternative_names: [$OUTER_CONTAINER_IP]
+    ca: docker_ca
+- name: client_docker_tls
+  type: certificate
+  options:
+    extended_key_usage: [client_auth]
+    common_name: $OUTER_CONTAINER_IP
+    alternative_names: [$OUTER_CONTAINER_IP]
+    ca: docker_ca
+EOF
+
+   bosh int ./bosh-vars.yml --vars-store=./certs.yml
+   bosh int ./certs.yml --path=/docker_ca/ca > ./ca.pem
+   bosh int ./certs.yml --path=/docker_tls/certificate > ./server-cert.pem
+   bosh int ./certs.yml --path=/docker_tls/private_key > ./server-key.pem
+   bosh int ./certs.yml --path=/client_docker_tls/certificate > ./cert.pem
+   bosh int ./certs.yml --path=/client_docker_tls/private_key > ./key.pem
+    # generate certs in json format
+    #
+   ruby -e 'puts File.read("./ca.pem").split("\n").join("\\n")' > "${certs_dir}/ca_json_safe.pem"
+   ruby -e 'puts File.read("./cert.pem").split("\n").join("\\n")' > "${certs_dir}/client_certificate_json_safe.pem"
+   ruby -e 'puts File.read("./key.pem").split("\n").join("\\n")' > "${certs_dir}/client_private_key_json_safe.pem"
+  popd > /dev/null
+}
+
+function sanitize_cgroups() {
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    # cgroups v2: enable nesting (based on moby/moby hack/dind)
+    mkdir -p /sys/fs/cgroup/init
+    # Loop to handle races from concurrent process creation (e.g. docker exec)
+    while ! {
+      xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs 2>/dev/null || :
+      sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+        > /sys/fs/cgroup/cgroup.subtree_control
+    }; do true; done
+    return
+  fi
+
+  mount -o remount,rw /sys/fs/cgroup
+
+  sed -e 1d /proc/cgroups | while read -r sys enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cut -d: -f2 < /proc/self/cgroup | grep "\\<$sys\\>")"
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+}
+
+function start_docker() {
+  local certs_dir
+  certs_dir="${1}"
+  generate_certs "${certs_dir}"
+  mkdir -p /var/log
+  mkdir -p /var/run
+
+  # Raise inotify limits so nested containers running systemd don't exhaust
+  # file descriptors. Systemd and containerd's cgroup-v2 event monitor both
+  # use inotify; the default max_user_instances (128) was too low.
+  sysctl -w fs.inotify.max_user_instances=1024
+  sysctl -w fs.inotify.max_user_watches=524288
+  sysctl -w net.ipv4.ip_forward=1
+
+  sanitize_cgroups
+
+  # systemd inside nested Docker containers requires shared mount propagation
+  mount --make-rshared /
+
+  # ensure systemd cgroup is present (cgroups v1 only)
+  if [ ! -f /sys/fs/cgroup/cgroup.controllers ]; then
+    mkdir -p /sys/fs/cgroup/systemd
+    if ! mountpoint -q /sys/fs/cgroup/systemd ; then
+      mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+    fi
+  fi
+
+  # check for /proc/sys being mounted readonly, as systemd does
+  if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+    mount -o remount,rw /proc/sys
+  fi
+
+  gcp_internal_dns="169.254.169.254"
+  local mtu
+  mtu=$(cat "/sys/class/net/$(ip route get "${gcp_internal_dns}"|awk '{ print $5 }')/mtu")
+
+  [[ ! -d /etc/docker ]] && mkdir /etc/docker
+  cat <<EOF > /etc/docker/daemon.json
+{
+  "hosts": ["${DOCKER_HOST}"],
+  "tls": true,
+  "tlscert": "${certs_dir}/server-cert.pem",
+  "tlskey": "${certs_dir}/server-key.pem",
+  "tlscacert": "${certs_dir}/ca.pem",
+  "mtu": ${mtu},
+  "dns": ["${gcp_internal_dns}"],
+  "data-root": "/scratch/docker",
+  "tlsverify": true,
+  "ip-forward-no-drop": true
+}
+EOF
+
+  service docker start
+
+  rc=1
+  for i in $(seq 1 100); do
+    echo "waiting for docker to come up... (${i})"
+    sleep 1
+    set +e
+    docker info
+    rc=$?
+    set -e
+    if [ "$rc" -eq "0" ]; then
+        break
+    fi
+  done
+
+  if [ "$rc" -ne "0" ]; then
+    exit 1
+  fi
+
+  echo "${certs_dir}"
+}
+
+function start_docker_main() {
+  OUTER_CONTAINER_IP=$(
+    ip addr \
+    | grep 'inet ' \
+    | grep eth0 \
+    | cut -d/ -f 1 \
+    | cut -d' ' -f6
+  )
+  export OUTER_CONTAINER_IP
+
+  if [[ "${OUTER_CONTAINER_IP}" == *$'\n'* ]] ; then
+    echo "OUTER_CONTAINER_IP had more than one ip: '${OUTER_CONTAINER_IP}'" >&2
+    exit 1
+  fi
+
+  local certs_dir
+  certs_dir=$(mktemp -d)
+
+  local local_bosh_dir
+  local_bosh_dir="/tmp/local-bosh/director"
+  mkdir -p ${local_bosh_dir}
+
+  docker_env_file="${local_bosh_dir}/docker-env"
+  {
+    echo "export DOCKER_HOST=\"tcp://${OUTER_CONTAINER_IP}:4243\""
+    echo "export DOCKER_TLS_VERIFY=\"1\""
+    echo "export DOCKER_CERT_PATH=\"${certs_dir}\""
+  } > "${docker_env_file}"
+  echo "Source '${docker_env_file}' to run docker" >&2
+  # shellcheck disable=SC1090
+  source "${docker_env_file}"
+
+  start_docker "${certs_dir}"
+
+  # Fixed, not overridable: start-bosh's internal_gw and BOSH_DIRECTOR_IP are
+  # addresses within this CIDR.
+  export DOCKER_NETWORK_NAME="director_network"
+  export DOCKER_NETWORK_CIDR="10.245.0.0/16"
+  if docker network ls --format '{{.Name}}' | grep -qx "${DOCKER_NETWORK_NAME}"; then
+    echo "A docker network named '${DOCKER_NETWORK_NAME}' already exists, skipping creation" >&2
+  else
+    docker network create -d bridge --subnet="${DOCKER_NETWORK_CIDR}" "${DOCKER_NETWORK_NAME}"
+  fi
+
+  export DOCKER_TLS_JSON="${local_bosh_dir}/docker_tls.json"
+  cat <<EOF > "${DOCKER_TLS_JSON}"
+{
+  "ca": "$(cat "${certs_dir}/ca_json_safe.pem")",
+  "certificate": "$(cat "${certs_dir}/client_certificate_json_safe.pem")",
+  "private_key": "$(cat "${certs_dir}/client_private_key_json_safe.pem")"
+}
+EOF
+}
+
+# Called bare, not with ${@}: when sourced, $@ is the caller's args
+# (start-bosh's create-env flags), which are not ours to consume.
+start_docker_main


### PR DESCRIPTION
We want to use the docker-cpi image in the bosh-cli pipeline, but it needs to test the cli's create-env behavior so needs to start docker but not bosh.

This is an additive change. Start-bosh's interface, behavior and output artifacts are unchanged.

### Does this PR introduce a breaking change?

No

