### PR TITLE
Explicitly wait for OuterBosh operations to complete

### DIFF
--- a/src/brats/performance/performance_suite_test.go
+++ b/src/brats/performance/performance_suite_test.go
@@ -11,6 +11,8 @@ import (
 	"brats/utils"
 )
 
+const outerBoshTimeout = 10 * time.Minute
+
 func TestPerformance(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Performance Suite")
@@ -18,12 +20,16 @@ func TestPerformance(t *testing.T) {
 
 var _ = SynchronizedBeforeSuite(func() {
 	utils.Bootstrap()
-	utils.OuterBosh("upload-release", utils.AssertEnvExists("BOSH_DIRECTOR_TARBALL_PATH"))
+	directorTarballPath := utils.AssertEnvExists("BOSH_DIRECTOR_TARBALL_PATH")
+	session := utils.OuterBosh("upload-release", directorTarballPath)
+	Eventually(session, outerBoshTimeout).Should(gexec.Exit(0))
+
 	directorReleasePath := utils.AssertEnvExists("BOSH_DIRECTOR_RELEASE_PATH")
-	session := utils.OuterBosh("create-release", "--dir", directorReleasePath)
-	Eventually(session, 1*time.Minute).Should(gexec.Exit())
+	session = utils.OuterBosh("create-release", "--dir", directorReleasePath)
+	Eventually(session, outerBoshTimeout).Should(gexec.Exit(0))
+
 	session = utils.OuterBosh("upload-release", "--dir", directorReleasePath, "--rebase")
-	Eventually(session, 1*time.Minute).Should(gexec.Exit())
+	Eventually(session, outerBoshTimeout).Should(gexec.Exit(0))
 }, func() {
 	utils.Bootstrap()
 })


### PR DESCRIPTION
Attempts to address:
```
  Task 6 | 01:11:44 | Extracting release: Extracting release  [FAILED] in [SynchronizedBeforeSuite] - /tmp/build/139c56f7/bosh-ci/src/brats/performance/performance_suite_test.go:26 @ 08/25/26 01:11:47.218
[SynchronizedBeforeSuite] [FAILED] [92.065 seconds]
[SynchronizedBeforeSuite]
/tmp/build/139c56f7/bosh-ci/src/brats/performance/performance_suite_test.go:19

  [FAILED] Timed out after 60.000s.
  Expected process to exit.  It did not.
  In [SynchronizedBeforeSuite] at: /tmp/build/139c56f7/bosh-ci/src/brats/performance/performance_suite_test.go:26 @ 08/25/26 01:11:47.218
```
^ https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-director/jobs/brats-performance-noble/builds/610#L6a80684f:502:509

