### PR TITLE
docs: fix typo protocal -> protocol

### DIFF
--- a/src/bosh-monitor/lib/bosh/monitor/plugins/README.md
+++ b/src/bosh-monitor/lib/bosh/monitor/plugins/README.md
@@ -18,7 +18,7 @@ The Consul plugin works by forwarding nats heartbeat events and alerts to a cons
 | events_api           | The events api endpoint defaults to /v1/event/fire/                                                                       |
 | ttl_api              | The Check update and registration endpoint defaults to /v1/agent/check/                                                   |
 | port                 | Defaults to 8500                                                                                                          |
-| protocal             | Defaults to HTTP                                                                                                          |
+| protocol             | Defaults to HTTP                                                                                                          |
 | params               | Can be used to pass access token "token=MYACCESSTOKEN"                                                                    |
 | ttl                  | TTL Checks will be used if a ttl period is set here. Example "120s"                                                       |
 | events               | If set to true heartbeats will be forwarded as events                                                                     |


### PR DESCRIPTION
One-word typo fix in `src/bosh-monitor/lib/bosh/monitor/plugins/README.md:21` — a table row label reading `protocal` → `protocol`.
