### PR TITLE
Remove unused remove-health-monitor BATs ops file

### DIFF
--- a/ci/bats/ops/remove-health-monitor.yml
+++ b/ci/bats/ops/remove-health-monitor.yml
@@ -1,2 +1,0 @@
-- path: /instance_groups/name=bosh/jobs/name=health_monitor
-  type: remove


### PR DESCRIPTION
### What is this change about?

Deletes `ci/bats/ops/remove-health-monitor.yml`, which has never been referenced in any CI pipeline task since it was added in 2017. Keeping it implies `health_monitor` is intentionally skipped in BATs - it isn't.

### Please provide contextual information.

https://github.com/cloudfoundry/bosh/issues/2796

### What tests have you run against this PR?

None needed - deleting an unused file.

### How should this change be described in bosh release notes?

Not applicable.

### Does this PR introduce a breaking change?

No.
